### PR TITLE
Add travis build configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - 2.6
+  - 2.7
+  - 3.2
+  - 3.3
+  - pypy
+
+install: python setup.py install
+
+before_script:
+  - pip install --use-mirrors pytest pytest-timeout
+
+script:
+  - py.test


### PR DESCRIPTION
To enable this, you'll need to go to https://travis-ci.org/, sign up and authorize github, and then tell travis to run on the hypothesis project: http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in has good instructions.

You might want to tweak the set of python versions supported: I enabled this on my fork, and get some interesting errors: it works on python 2.7 and on pypy, though! https://travis-ci.org/rboulton/hypothesis/builds/5747652
