### PR TITLE
Clean up unused imports and import *.  Add _all_ at top level.

### DIFF
--- a/hypothesis/__init__.py
+++ b/hypothesis/__init__.py
@@ -1,1 +1,13 @@
-from hypothesis.verifier import falsify, Unfalsifiable, Verifier,assume
+from hypothesis.verifier import (
+        falsify,
+        Unfalsifiable,
+        Verifier,
+        assume,
+)
+
+__all__ = [
+        'falsify',
+        'Unfalsifiable',
+        'Verifier',
+        'assume',
+]

--- a/hypothesis/statefultesting.py
+++ b/hypothesis/statefultesting.py
@@ -1,7 +1,9 @@
-from functools import wraps
-from random import choice
-from hypothesis.verifier import Verifier
-from hypothesis.searchstrategy import *
+from hypothesis.searchstrategy import (
+        SearchStrategy,
+        SearchStrategies,
+        MappedSearchStrategy,
+        one_of,
+)
 from collections import namedtuple
 import hypothesis
 

--- a/hypothesis/verifier.py
+++ b/hypothesis/verifier.py
@@ -1,7 +1,6 @@
-from hypothesis.searchstrategy import SearchStrategy, SearchStrategies
+from hypothesis.searchstrategy import SearchStrategies
 from hypothesis.flags import Flags
 
-from itertools import islice
 from random import random
 
 def assume(condition):


### PR DESCRIPTION
Using import \* makes it much harder to reason about the code, both for
humans and for tools kike pyflakes, so it's best avoided.

However, it's good to support use of import \* for libraries; it's
particularly useful for use from a repl; **all** ensures that only the
right symbols get exported by import *, and stops pyflakes complaining
that the imports were unused.
