### PR TITLE
Switch over to multishrinking as the default

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This is a refactoring release that hopefully shouldn't have much user visible
+effect. It changes how Hypothesis handles shrinking when there are multiple
+failures to report. It may in some cases change which examples are found or
+how fast it finds them, but the effect is unlikely to be noticeable.


### PR DESCRIPTION
This chunk of work which has been vaguely on my radar as a thing I was going to need to do for a while but is super low priority (subtype: I'll need this for a thing in a month or two). For some reason my brain shoved it to the front of the priority queue this morning with absolutely no sensible justification. So, uh, sorry to anyone who is waiting on me for anything actually important.

Starting points:

* When failing, we have multiple possible bugs and we want to shrink all of them. The way this previously worked was that we just shrunk each of them in turn. This is not a totally unreasonable thing to do, although id does mean that if we stop the shrink early the work can be somewhat oddly distributed, with some things fully shrunk and some things not shrunk at all.
* I'm going to be wanting to add other things like this, so it would be nice to have the idea of shrinking multiple things at once available as a proper API.

Which leads to the multishrink API. Core idea of multishrink is that we're shrinking with respect to not just a predicate but also a *classifier*. We want to simultaneously find the smallest example of each possible classifier outcome.

We do this by repeatedly trying a *single* shrink pass on the largest example across all our current best examples. If that didn't shrink it, we mark it as done. This effectively means we're optimising for "making the worst example better", which I think is a reasonable choice but don't have any super principled argument in favour of over our previous greedier approach.

I suspect the tradeoff is going to roughly be "They're both about the same when things are going well, but sometimes the worst example is worst for a reason" and that we might see differences in the following circumstances:

* We'll get more interesting slippage occurring by focusing on harder targets (mostly or entirely good).
* When we trigger bad shrinking behaviour in the worst example due to e.g. unhandled exponential time pathologies everything else will suffer too. Bad, but in general I would like to solve these by handling those slow downs, so making them more visible isn't wholly bad.