### PR TITLE
Add Python 3.7 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ env:
         - TASK=check-pypy
         - TASK=check-py27
         - TASK=check-py36
+        - TASK=check-py37
         - TASK=check-quality
 
         # Less important tests that will probably

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ PY273=$(BUILD_RUNTIMES)/snakepit/python2.7.3
 PY34=$(BUILD_RUNTIMES)/snakepit/python3.4
 PY35=$(BUILD_RUNTIMES)/snakepit/python3.5
 PY36=$(BUILD_RUNTIMES)/snakepit/python3.6
+PY37=$(BUILD_RUNTIMES)/snakepit/python3.7
 PYPY=$(BUILD_RUNTIMES)/snakepit/pypy
 
 BEST_PY3=$(PY36)
@@ -65,6 +66,9 @@ $(PY35):
 
 $(PY36):
 	scripts/retry.sh scripts/install.sh 3.6
+
+$(PY37):
+	scripts/retry.sh scripts/install.sh 3.7
 
 
 $(PYPY):
@@ -139,6 +143,9 @@ check-py35: $(PY35) $(TOX)
 
 check-py36: $(BEST_PY3) $(TOX)
 	$(call run_tox,py36-full)
+
+check-py37: $(PY37) $(TOX)
+	$(TOX) --recreate -e py37-full
 
 check-pypy: $(PYPY) $(TOX)
 	$(call run_tox,pypy-full)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,py}-{brief,prettyquick,full,custom}
+envlist = py{27,34,35,36,37,py}-{brief,prettyquick,full,custom}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,6 +101,9 @@ for var in "$@"; do
     3.6)
       install 3.6.1 python3.6
       ;;
+    3.7)
+      install 3.7.0b3 python3.7
+      ;;
     pypy)
       install pypy2.7-5.8.0 pypy
       ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,9 @@
 # have to go through and you should feel free to use this to avoid some of
 # that suffering in advance.
 
-set -e
-set -x
+set -o errexit
+set -o nounset
+set -o xtrace
 
 # OS X seems to have some weird Localse problems on Travis. This attempts to set
 # the Locale to known good ones during install


### PR DESCRIPTION
Resolves #1148.

It's quite possible (maybe likely!) this won't work in its current state, but let's get it into Travis and see what happens.