### PR TITLE
Filter internal calls from failing stateful tracebacks

### DIFF
--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -188,16 +188,16 @@ class GenericStateMachine(object):
             try:
                 run_state_machine_as_test(state_machine_class)
             except Exception as e:
-                _0, _1, exc_tb = sys.exc_info()
+                # Filter out internal calls from the traceback.
+                exc_type, exc_value, exc_tb = sys.exc_info()
                 tuple_tb = traceback.extract_tb(exc_tb)
                 for entry in tuple_tb:
-                    filename, lineno, func_name, text = entry
-
+                    filename = entry[0]
                     if __file__.replace('.pyc','.py') in filename:
                         exc_tb = exc_tb.tb_next
                     else:
                         break
-                raise _0, _1, exc_tb
+                raise exc_type, exc_value, exc_tb
 
         runTest.is_hypothesis_test = True
         StateMachineTestCase.runTest = runTest

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -192,7 +192,8 @@ class GenericStateMachine(object):
                 tuple_tb = traceback.extract_tb(exc_tb)
                 for entry in tuple_tb:
                     filename, lineno, func_name, text = entry
-                    if __file__ in filename:
+
+                    if __file__.replace('.pyc','.py') in filename:
                         exc_tb = exc_tb.tb_next
                     else:
                         break

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -27,6 +27,7 @@ execution to date.
 from __future__ import division, print_function, absolute_import
 
 import inspect
+import sys
 import traceback
 from unittest import TestCase
 
@@ -184,7 +185,18 @@ class GenericStateMachine(object):
         # We define this outside of the class and assign it because you can't
         # assign attributes to instance method values in Python 2
         def runTest(self):
-            run_state_machine_as_test(state_machine_class)
+            try:
+                run_state_machine_as_test(state_machine_class)
+            except Exception as e:
+                _0, _1, exc_tb = sys.exc_info()
+                tuple_tb = traceback.extract_tb(exc_tb)
+                for entry in tuple_tb:
+                    filename, lineno, func_name, text = entry
+                    if __file__ in filename:
+                        exc_tb = exc_tb.tb_next
+                    else:
+                        break
+                raise _0, _1, exc_tb
 
         runTest.is_hypothesis_test = True
         StateMachineTestCase.runTest = runTest
@@ -200,6 +212,9 @@ class GenericStateMachine(object):
             StateMachineTestCase
         )
         return StateMachineTestCase
+
+
+
 
 
 GenericStateMachine.find_breaking_runner = classmethod(find_breaking_runner)

--- a/tests/nocover/test_stateful_traceback.py
+++ b/tests/nocover/test_stateful_traceback.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+TESTSUITE = """
+from hypothesis.stateful import RuleBasedStateMachine, rule
+
+class FailingMachine(RuleBasedStateMachine):
+    @rule()
+    def my_rule(self):
+        assert False
+
+TestFailingMachine = FailingMachine.TestCase
+"""
+
+
+def test_internal_calls_suppressed(testdir):
+    """
+    Test to make sure that no internal calls are included in a failing
+    test's traceback.
+    """
+    script = testdir.makepyfile(TESTSUITE)
+    result = testdir.runpytest(script)
+    out = '\n'.join(result.stdout.lines)
+    assert 'stateful.py' not in out


### PR DESCRIPTION
I initially tried @Zac-HD suggestion of adding `__tracebackhide__ = True` but that needed to be added to every calling function in the test which seemed repetitive. Instead, I just filtered the traceback looking for instances of the `stateful.py` file name.

I added a test that I copied from `tests/pytest/test_reporting.py` and modified.