### PR TITLE
Deprecate more settings to clarify and simplify the system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,7 @@ env:
         # pass whenever the above do but are still
         # worth testing.
         - TASK=check-unicode
-        - TASK=check-ancient-pip
         - TASK=check-pure-tracer
-        - TASK=check-py273
         - TASK=check-py27-typing
         - TASK=check-py34
         - TASK=check-py35

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -5,3 +5,5 @@ easier to use.
 
 - Deprecated settings that no longer have any effect are no longer
   shown in the ``__repr__`` unless set to a non-default value.
+- :obj:`~hypothesis.settings.perform_health_check` is deprecated, as it
+  duplicates :obj:`~hypothesis.settings.suppress_health_check`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -7,3 +7,6 @@ easier to use.
   shown in the ``__repr__`` unless set to a non-default value.
 - :obj:`~hypothesis.settings.perform_health_check` is deprecated, as it
   duplicates :obj:`~hypothesis.settings.suppress_health_check`.
+- :obj:`~hypothesis.settings.max_iterations` is deprecated and disabled,
+  because we can usually get better behaviour from an internal heuristic
+  than a user-controlled setting.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -14,3 +14,6 @@ easier to use.
   disabled, due to overlap with the
   :obj:`~hypothesis.settings.HealthCheck.filter_too_much` healthcheck
   and poor interaction with :obj:`~hypothesis.settings.max_examples`.
+- :envvar:`HYPOTHESIS_VERBOSITY_LEVEL` was never documented, but is
+  now explicitly deprecated.  Set :obj:`~hypothesis.settings.verbosity`
+  through the profile system instead.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release should make the :class:`~hypothesis.settings` feature
+easier to use.
+
+- Deprecated settings that no longer have any effect are no longer
+  shown in the ``__repr__`` unless set to a non-default value.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -19,3 +19,5 @@ knowledge of our internals (:issue:`535`).
 - :envvar:`HYPOTHESIS_VERBOSITY_LEVEL` was never documented, but is
   now explicitly deprecated.  Set :obj:`~hypothesis.settings.verbosity`
   through the profile system instead.
+- Examples tried by :func:`~hypothesis.find` are now reported at ``debug``
+  verbosity level (as well as ``verbose`` level).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,9 @@
 RELEASE_TYPE: minor
 
-This release should make the :class:`~hypothesis.settings` feature
-easier to use.
+This release deprecates several redundant or internally oriented
+:class:`~hypothesis.settings`, working towards an orthogonal set of
+configuration options that are widely useful *without* requiring any
+knowledge of our internals (:issue:`535`).
 
 - Deprecated settings that no longer have any effect are no longer
   shown in the ``__repr__`` unless set to a non-default value.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -10,3 +10,7 @@ easier to use.
 - :obj:`~hypothesis.settings.max_iterations` is deprecated and disabled,
   because we can usually get better behaviour from an internal heuristic
   than a user-controlled setting.
+- :obj:`~hypothesis.settings.min_satisfying_examples` is deprecated and
+  disabled, due to overlap with the
+  :obj:`~hypothesis.settings.HealthCheck.filter_too_much` healthcheck
+  and poor interaction with :obj:`~hypothesis.settings.max_examples`.

--- a/hypothesis-python/docs/healthchecks.rst
+++ b/hypothesis-python/docs/healthchecks.rst
@@ -21,7 +21,7 @@ To selectively disable health checks, use the
 :obj:`~hypothesis.settings.suppress_health_check` setting.
 The argument for this parameter is a list with elements drawn from any of
 the class-level attributes of the HealthCheck class.
-Using a value of ``list(HealthCheck)`` will disable all health checks.
+Using a value of ``HealthCheck.all()`` will disable all health checks.
 
 .. module:: hypothesis
 .. autoclass:: HealthCheck

--- a/hypothesis-python/docs/healthchecks.rst
+++ b/hypothesis-python/docs/healthchecks.rst
@@ -21,9 +21,7 @@ To selectively disable health checks, use the
 :obj:`~hypothesis.settings.suppress_health_check` setting.
 The argument for this parameter is a list with elements drawn from any of
 the class-level attributes of the HealthCheck class.
-
-To disable all health checks, set the :obj:`~hypothesis.settings.perform_health_check`
-to False.
+Using a value of ``list(HealthCheck)`` will disable all health checks.
 
 .. module:: hypothesis
 .. autoclass:: HealthCheck

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -140,17 +140,15 @@ You can also copy settings from other settings:
 .. doctest::
 
     >>> s = settings(max_examples=10)
-    >>> t = settings(s, max_iterations=20)
+    >>> t = settings(s, derandomize=False)
     >>> s.max_examples
     10
-    >>> t.max_iterations
-    20
-    >>> s.max_iterations
-    1000
-    >>> s.max_shrinks
-    500
-    >>> t.max_shrinks
-    500
+    >>> t.max_examples
+    10
+    >>> s.derandomize
+    True
+    >>> t.derandomize
+    False
 
 ----------------
 Default settings

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -134,21 +134,20 @@ values. Any absent ones will be set to defaults:
     >>> settings(max_examples=10).max_examples
     10
 
-
-You can also copy settings from other settings:
+You can also pass a 'parent' settings object as the first argument,
+and any settings you do not specify as keyword arguments will be
+copied from the parent settings:
 
 .. doctest::
 
-    >>> s = settings(max_examples=10)
-    >>> t = settings(s, derandomize=False)
-    >>> s.max_examples
-    10
-    >>> t.max_examples
-    10
-    >>> s.derandomize
+    >>> parent = settings(max_examples=10)
+    >>> child = settings(parent, deadline=200)
+    >>> parent.max_examples == child.max_examples == 10
     True
-    >>> t.derandomize
-    False
+    >>> parent.deadline
+    not_set
+    >>> child.deadline
+    200
 
 ----------------
 Default settings

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -405,11 +405,15 @@ counter-example, falsification will terminate.
 
 settings.define_setting(
     'max_iterations',
-    default=1000,
+    default=not_set,
     description="""
 Once this many iterations of the example loop have run, including ones which
 failed to satisfy assumptions and ones which produced duplicates, falsification
 will terminate.
+""",
+    deprecation_message="""
+The max_iterations setting has been disabled, as internal heuristics are more
+useful for this purpose than a user setting.  It no longer has any effect.
 """
 )
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -384,9 +384,7 @@ settings.define_setting(
     'min_satisfying_examples',
     default=not_set,
     description="""
-Raise Unsatisfiable for any tests which do not produce at least this many
-values that pass all :func:`hypothesis.assume` calls and which have not
-exhaustively covered the search space.
+This doesn't actually do anything, but remains for compatibility reasons.
 """,
     deprecation_message="""
 The min_satisfying_examples setting has been deprecated and disabled, due to
@@ -408,9 +406,7 @@ settings.define_setting(
     'max_iterations',
     default=not_set,
     description="""
-Once this many iterations of the example loop have run, including ones which
-failed to satisfy assumptions and ones which produced duplicates, falsification
-will terminate.
+This doesn't actually do anything, but remains for compatibility reasons.
 """,
     deprecation_message="""
 The max_iterations setting has been disabled, as internal heuristics are more
@@ -486,14 +482,9 @@ settings.define_setting(
     'strict',
     default=os.getenv('HYPOTHESIS_STRICT_MODE') == 'true',
     description="""
-If set to True, anything that would cause Hypothesis to issue a warning will
-instead raise an error. Note that new warnings may be added at any time, so
-running with strict set to True means that new Hypothesis releases may validly
-break your code.  Note also that, as strict mode is itself deprecated,
-enabling it is now an error!
-
-You can enable this setting temporarily by setting the HYPOTHESIS_STRICT_MODE
-environment variable to the string 'true'.
+Strict mode has been deprecated in favor of Python's standard warnings
+controls.  Ironically, enabling it is therefore an error - it only exists so
+that users get the right *type* of error!
 """,
     deprecation_message="""
 Strict mode is deprecated and will go away in a future version of Hypothesis.
@@ -619,14 +610,15 @@ class Verbosity(IntEnum):
         var = os.getenv('HYPOTHESIS_VERBOSITY_LEVEL')
         if var is not None:  # pragma: no cover
             note_deprecation(
-                'The $HYPOTHESIS_VERBOSITY_LEVEL environment variable is '
+                'The HYPOTHESIS_VERBOSITY_LEVEL environment variable is '
                 'deprecated, and will be ignored by a future version of '
                 'Hypothesis.  Configure your verbosity level via a '
                 'settings profile instead.'
             )
-            if var not in [v.name for v in list(Verbosity)]:
-                InvalidArgument('No such verbosity level %r' % (var,))
-            return getattr(Verbosity, var)
+            try:
+                return Verbosity[var]
+            except KeyError:
+                raise InvalidArgument('No such verbosity level %r' % (var,))
         return Verbosity.normal
 
     def __repr__(self):

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -382,15 +382,16 @@ class Setting(object):
 
 settings.define_setting(
     'min_satisfying_examples',
-    default=5,
+    default=not_set,
     description="""
 Raise Unsatisfiable for any tests which do not produce at least this many
 values that pass all :func:`hypothesis.assume` calls and which have not
 exhaustively covered the search space.
-
-Note that examples are compared at the level of the underlying byte-stream -
-for example, :func:`~hypothesis.strategies.booleans` contains 256 unique
-examples at this level because it always uses one byte.
+""",
+    deprecation_message="""
+The min_satisfying_examples setting has been deprecated and disabled, due to
+overlap with the filter_too_much healthcheck and poor interaction with the
+max_examples setting.
 """
 )
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1154,7 +1154,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
         runner.exit_reason != ExitReason.finished
     ):
         if settings.timeout > 0 and run_time > settings.timeout:
-            raise Timeout((
+            raise Timeout((  # pragma: no cover
                 'Ran out of time before finding enough valid examples for '
                 '%s. Only %d valid examples found in %.2f seconds.'
             ) % (

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1119,7 +1119,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
         if success:
             successful_examples[0] += 1
 
-        if settings.verbosity == Verbosity.verbose:
+        if settings.verbosity >= Verbosity.verbose:
             if not successful_examples[0]:
                 report(
                     u'Tried non-satisfying example %s' % (nicerepr(result),))

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -678,7 +678,7 @@ class StateForActualGivenExecution(object):
                             arc(filename, source, target)
                             for source, target in covdata.arcs(filename)
                         )
-            if result is not None and self.settings.perform_health_check:
+            if result is not None:
                 fail_health_check(self.settings, (
                     'Tests run under @given should return None, but '
                     '%s returned %r instead.'
@@ -1096,7 +1096,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
         min_satisfying_examples=0,
         max_shrinks=2000,
     )
-    settings = Settings(settings, perform_health_check=False)
+    settings = Settings(settings, suppress_health_check=list(HealthCheck))
 
     if database_key is None and settings.database is not None:
         database_key = function_digest(condition)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1087,7 +1087,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
         max_examples=2000,
         max_shrinks=2000,
     )
-    settings = Settings(settings, suppress_health_check=list(HealthCheck))
+    settings = Settings(settings, suppress_health_check=HealthCheck.all())
 
     if database_key is None and settings.database is not None:
         database_key = function_digest(condition)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -259,9 +259,7 @@ class ConjectureRunner(object):
         if not self.interesting_examples:
             if self.valid_examples >= self.settings.max_examples:
                 self.exit_with(ExitReason.max_examples)
-            if self.call_count >= max(
-                self.settings.max_iterations, self.settings.max_examples
-            ):
+            if self.call_count >= self.settings.max_examples * 10:
                 self.exit_with(ExitReason.max_iterations)
 
         if self.__tree_is_exhausted():

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -637,6 +637,8 @@ class ConjectureRunner(object):
         if Phase.generate not in self.settings.phases:
             return
 
+        self.health_check_state = HealthCheckState()
+
         zero_data = self.cached_test_function(
             hbytes(self.settings.buffer_size))
         if zero_data.status == Status.OVERRUN or (
@@ -657,9 +659,6 @@ class ConjectureRunner(object):
                 'one_of(none(), some_complex_strategy)?',
                 HealthCheck.large_base_example
             )
-
-        if self.settings.perform_health_check:
-            self.health_check_state = HealthCheckState()
 
         count = 0
         while not self.interesting_examples and (

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -635,8 +635,6 @@ class ConjectureRunner(object):
         if Phase.generate not in self.settings.phases:
             return
 
-        self.health_check_state = HealthCheckState()
-
         zero_data = self.cached_test_function(
             hbytes(self.settings.buffer_size))
         if zero_data.status == Status.OVERRUN or (
@@ -657,6 +655,8 @@ class ConjectureRunner(object):
                 'one_of(none(), some_complex_strategy)?',
                 HealthCheck.large_base_example
             )
+
+        self.health_check_state = HealthCheckState()
 
         count = 0
         while not self.interesting_examples and (

--- a/hypothesis-python/src/hypothesis/internal/healthcheck.py
+++ b/hypothesis-python/src/hypothesis/internal/healthcheck.py
@@ -27,8 +27,6 @@ def fail_health_check(settings, message, label):
 
     if label in settings.suppress_health_check:
         return
-    if not settings.perform_health_check:
-        return
     message += (
         '\nSee https://hypothesis.readthedocs.io/en/latest/health'
         'checks.html for more information about this. '

--- a/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
@@ -283,7 +283,6 @@ class SearchStrategy(object):
                 random=random,
                 settings=settings(
                     max_shrinks=0,
-                    max_iterations=1000,
                     database=None,
                     verbosity=Verbosity.quiet,
                 )

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -189,9 +189,7 @@ class GenericStateMachine(object):
             pass
 
         class StateMachineTestCase(TestCase):
-            settings = Settings(
-                min_satisfying_examples=1
-            )
+            settings = Settings()
 
         # We define this outside of the class and assign it because you can't
         # assign attributes to instance method values in Python 2

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -63,9 +63,9 @@ class Statistics(object):
         elif engine.exit_reason == ExitReason.flaky:
             self.exit_reason = 'test was flaky'
         elif engine.exit_reason == ExitReason.max_iterations:
-            self.exit_reason = (
-                'settings.max_examples={}, but < 10% of examples succeeded'
-                .format(engine.settings.max_examples)
+            self.exit_reason = ((
+                'settings.max_examples={}, but < 10% of examples satisfied '
+                'assumptions').format(engine.settings.max_examples)
             )
         else:
             self.exit_reason = (

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -62,6 +62,11 @@ class Statistics(object):
             self.exit_reason = 'nothing left to do'
         elif engine.exit_reason == ExitReason.flaky:
             self.exit_reason = 'test was flaky'
+        elif engine.exit_reason == ExitReason.max_iterations:
+            self.exit_reason = (
+                'settings.max_examples={}, but <10% of examples succeeded'
+                .format(engine.settings.max_examples)
+            )
         else:
             self.exit_reason = (
                 'settings.%s=%r' % (

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -64,7 +64,7 @@ class Statistics(object):
             self.exit_reason = 'test was flaky'
         elif engine.exit_reason == ExitReason.max_iterations:
             self.exit_reason = (
-                'settings.max_examples={}, but <10% of examples succeeded'
+                'settings.max_examples={}, but < 10% of examples succeeded'
                 .format(engine.settings.max_examples)
             )
         else:

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -37,7 +37,6 @@ def minimal(
     settings = Settings(
         settings,
         max_examples=50000,
-        max_iterations=100000,
         max_shrinks=5000,
         database=None,
     )
@@ -77,7 +76,6 @@ def find_any(
     settings = Settings(
         settings,
         max_examples=10000,
-        max_iterations=10000,
         max_shrinks=0000,
         database=None,
     )
@@ -103,10 +101,7 @@ def assert_no_examples(strategy, condition=None):
             assume(condition(x))
 
     try:
-        result = find(
-            strategy, predicate,
-            settings=Settings(max_iterations=100, max_shrinks=1)
-        )
+        result = find(strategy, predicate, settings=Settings(max_shrinks=1))
         assert False, 'Expected no results but found %r' % (result,)
     except (Unsatisfiable, NoSuchExample):
         pass

--- a/hypothesis-python/tests/cover/test_completion.py
+++ b/hypothesis-python/tests/cover/test_completion.py
@@ -17,16 +17,10 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 
 @given(st.data())
 def test_never_draw_anything(data):
-    pass
-
-
-@settings(min_satisfying_examples=1000)
-@given(st.booleans())
-def test_want_more_than_exist(b):
     pass

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -43,7 +43,7 @@ SOME_LABEL = calc_label_from_name('some label')
 def run_to_buffer(f):
     runner = ConjectureRunner(f, settings=settings(
         max_examples=5000, max_shrinks=MAX_SHRINKS, buffer_size=1024,
-        database=None, suppress_health_check=list(HealthCheck),
+        database=None, suppress_health_check=HealthCheck.all(),
     ))
     runner.run()
     assert runner.interesting_examples
@@ -646,7 +646,7 @@ def test_can_increase_number_of_bytes_drawn_in_tail():
 
     runner = ConjectureRunner(
         f, settings=settings(
-            buffer_size=11, suppress_health_check=list(HealthCheck)))
+            buffer_size=11, suppress_health_check=HealthCheck.all()))
 
     runner.run()
 

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -42,8 +42,7 @@ SOME_LABEL = calc_label_from_name('some label')
 
 def run_to_buffer(f):
     runner = ConjectureRunner(f, settings=settings(
-        max_examples=5000, max_iterations=10000, max_shrinks=MAX_SHRINKS,
-        buffer_size=1024,
+        max_examples=5000, max_shrinks=MAX_SHRINKS, buffer_size=1024,
         database=None, suppress_health_check=list(HealthCheck),
     ))
     runner.run()
@@ -137,7 +136,7 @@ def test_terminates_shrinks(n, monkeypatch):
         ConjectureRunner, 'generate_new_examples', generate_new_examples)
 
     runner = ConjectureRunner(slow_shrinker(), settings=settings(
-        max_examples=5000, max_iterations=10000, max_shrinks=n,
+        max_examples=5000, max_shrinks=n,
         database=db, timeout=unlimited,
     ), random=Random(0), database_key=b'key')
     runner.run()
@@ -201,57 +200,10 @@ def test_can_navigate_to_a_valid_example():
         data.draw_bytes(i)
         data.mark_interesting()
     runner = ConjectureRunner(f, settings=settings(
-        max_examples=5000, max_iterations=10000,
-        buffer_size=2,
-        database=None,
+        max_examples=5000, buffer_size=2, database=None,
     ))
     runner.run()
     assert runner.interesting_examples
-
-
-def test_stops_after_max_iterations_when_generating():
-    key = b'key'
-    value = b'rubber baby buggy bumpers'
-    max_iterations = 100
-
-    db = ExampleDatabase(':memory:')
-    db.save(key, value)
-
-    seen = []
-
-    def f(data):
-        seen.append(data.draw_bytes(len(value)))
-        data.mark_invalid()
-
-    runner = ConjectureRunner(f, settings=settings(
-        max_examples=1, max_iterations=max_iterations,
-        database=db, suppress_health_check=list(HealthCheck),
-    ), database_key=key)
-    runner.run()
-    assert len(seen) == max_iterations
-    assert value in seen
-
-
-def test_stops_after_max_iterations_when_reading():
-    key = b'key'
-    max_iterations = 1
-
-    db = ExampleDatabase(':memory:')
-    for i in range(10):
-        db.save(key, hbytes([i]))
-
-    seen = []
-
-    def f(data):
-        seen.append(data.draw_bytes(1))
-        data.mark_invalid()
-
-    runner = ConjectureRunner(f, settings=settings(
-        max_examples=1, max_iterations=max_iterations,
-        database=db,
-    ), database_key=key)
-    runner.run()
-    assert len(seen) == max_iterations
 
 
 def test_stops_after_max_examples_when_reading():
@@ -417,9 +369,7 @@ def test_fully_exhaust_base(monkeypatch):
         seen.add(key)
 
     runner = ConjectureRunner(f, settings=settings(
-        max_examples=10000, max_iterations=10000, max_shrinks=0,
-        buffer_size=1024,
-        database=None,
+        max_examples=10000, max_shrinks=0, buffer_size=1024, database=None,
     ))
 
     for c in hrange(256):
@@ -448,9 +398,7 @@ def test_will_save_covering_examples():
 
     db = InMemoryExampleDatabase()
     runner = ConjectureRunner(tagged, settings=settings(
-        max_examples=100, max_iterations=10000, max_shrinks=0,
-        buffer_size=1024,
-        database=db,
+        max_examples=100, max_shrinks=0, buffer_size=1024, database=db,
     ), database_key=b'stuff')
     runner.run()
     assert len(all_values(db)) == len(tags)
@@ -472,9 +420,7 @@ def test_will_shrink_covering_examples():
 
     db = InMemoryExampleDatabase()
     runner = ConjectureRunner(tagged, settings=settings(
-        max_examples=100, max_iterations=10000, max_shrinks=0,
-        buffer_size=1024,
-        database=db,
+        max_examples=100, max_shrinks=0, buffer_size=1024, database=db,
     ), database_key=b'stuff')
     runner.run()
     saved = set(all_values(db))
@@ -520,8 +466,7 @@ def test_returns_written():
 def fails_health_check(label):
     def accept(f):
         runner = ConjectureRunner(f, settings=settings(
-            max_examples=100, max_iterations=100, max_shrinks=0,
-            buffer_size=1024, database=None,
+            max_examples=100, max_shrinks=0, buffer_size=1024, database=None,
         ))
 
         with pytest.raises(FailedHealthCheck) as e:

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -44,7 +44,7 @@ def run_to_buffer(f):
     runner = ConjectureRunner(f, settings=settings(
         max_examples=5000, max_iterations=10000, max_shrinks=MAX_SHRINKS,
         buffer_size=1024,
-        database=None, perform_health_check=False,
+        database=None, suppress_health_check=list(HealthCheck),
     ))
     runner.run()
     assert runner.interesting_examples
@@ -225,7 +225,7 @@ def test_stops_after_max_iterations_when_generating():
 
     runner = ConjectureRunner(f, settings=settings(
         max_examples=1, max_iterations=max_iterations,
-        database=db, perform_health_check=False,
+        database=db, suppress_health_check=list(HealthCheck),
     ), database_key=key)
     runner.run()
     assert len(seen) == max_iterations
@@ -521,7 +521,7 @@ def fails_health_check(label):
     def accept(f):
         runner = ConjectureRunner(f, settings=settings(
             max_examples=100, max_iterations=100, max_shrinks=0,
-            buffer_size=1024, database=None, perform_health_check=True,
+            buffer_size=1024, database=None,
         ))
 
         with pytest.raises(FailedHealthCheck) as e:
@@ -700,7 +700,8 @@ def test_can_increase_number_of_bytes_drawn_in_tail():
         assert not any(b)
 
     runner = ConjectureRunner(
-        f, settings=settings(buffer_size=11, perform_health_check=False))
+        f, settings=settings(
+            buffer_size=11, suppress_health_check=list(HealthCheck)))
 
     runner.run()
 

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -22,7 +22,7 @@ from collections import Counter
 
 import hypothesis.strategies as st
 import hypothesis.internal.conjecture.utils as cu
-from hypothesis import given, assume, example, settings
+from hypothesis import HealthCheck, given, assume, example, settings
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.conjecture.data import ConjectureData
@@ -151,7 +151,7 @@ def weights(draw):
 @example([Fraction(1, 1), Fraction(3, 5), Fraction(1, 1)])
 @example([Fraction(2, 257), Fraction(2, 5), Fraction(1, 11)])
 @settings(
-    deadline=None, perform_health_check=False,
+    deadline=None, suppress_health_check=list(HealthCheck),
     max_examples=0 if IN_COVERAGE_TESTS else settings.default.max_examples,
 )
 @given(st.lists(weights(), min_size=1))

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -151,7 +151,7 @@ def weights(draw):
 @example([Fraction(1, 1), Fraction(3, 5), Fraction(1, 1)])
 @example([Fraction(2, 257), Fraction(2, 5), Fraction(1, 11)])
 @settings(
-    deadline=None, suppress_health_check=list(HealthCheck),
+    deadline=None, suppress_health_check=HealthCheck.all(),
     max_examples=0 if IN_COVERAGE_TESTS else settings.default.max_examples,
 )
 @given(st.lists(weights(), min_size=1))

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -46,24 +46,21 @@ def test_stops_after_max_examples_if_satisfying():
     assert len(tracker) == max_examples
 
 
-def test_stops_after_max_iterations_if_not_satisfying():
-    tracker = set()
+def test_stops_after_ten_times_max_examples_if_not_satisfying():
+    count = [0]
 
     def track(x):
-        tracker.add(x)
+        count[0] += 1
         reject()
 
     max_examples = 100
-    max_iterations = 200
 
     with pytest.raises(Unsatisfiable):
         find(
             s.integers(0, 10000),
-            track, settings=settings(
-                max_examples=max_examples, max_iterations=max_iterations))
+            track, settings=settings(max_examples=max_examples))
 
-    # May be less because of duplication
-    assert len(tracker) <= max_iterations
+    assert count[0] == 10 * max_examples
 
 
 @checks_deprecated_behaviour

--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -52,20 +52,8 @@ def test_can_find_nans():
         assert 2 <= len(x) <= 3
 
 
-def test_raises_when_no_example():
-    settings = Settings(
-        max_examples=20,
-        min_satisfying_examples=0,
-    )
-    with pytest.raises(NoSuchExample):
-        find(integers(), lambda x: False, settings=settings)
-
-
 def test_condition_is_name():
-    settings = Settings(
-        max_examples=20,
-        min_satisfying_examples=0,
-    )
+    settings = Settings(max_examples=20)
     with pytest.raises(NoSuchExample) as e:
         find(booleans(), lambda x: False, settings=settings)
     assert 'lambda x:' in e.value.args[0]

--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -18,14 +18,12 @@
 from __future__ import division, print_function, absolute_import
 
 import math
-import time
 
 import pytest
 
 from hypothesis import find
 from hypothesis import settings as Settings
-from hypothesis.errors import Timeout, NoSuchExample
-from tests.common.utils import checks_deprecated_behaviour
+from hypothesis.errors import NoSuchExample
 from hypothesis.strategies import lists, floats, booleans, integers, \
     dictionaries
 
@@ -74,14 +72,3 @@ def test_find_dictionary():
     assert len(find(
         dictionaries(keys=integers(), values=integers()),
         lambda xs: any(kv[0] > kv[1] for kv in xs.items()))) == 1
-
-
-@checks_deprecated_behaviour
-def test_times_out():
-    with pytest.raises(Timeout) as e:
-        find(
-            integers(),
-            lambda x: time.sleep(0.05) or False,
-            settings=Settings(timeout=0.01))
-
-    e.value.args[0]

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -19,7 +19,8 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
-from hypothesis import Verbosity, given, assume, reject, example, settings
+from hypothesis import Verbosity, HealthCheck, given, assume, reject, \
+    example, settings
 from hypothesis.errors import Flaky, Unsatisfiable, UnsatisfiedAssumption
 from hypothesis.strategies import lists, booleans, integers, composite, \
     random_module
@@ -102,7 +103,7 @@ def test_failure_sequence_inducing(building, testing, rnd):
     @given(integers().map(build))
     @settings(
         verbosity=Verbosity.quiet, database=None,
-        perform_health_check=False, max_shrinks=0
+        suppress_health_check=list(HealthCheck), max_shrinks=0
     )
     def test(x):
         try:

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -103,7 +103,7 @@ def test_failure_sequence_inducing(building, testing, rnd):
     @given(integers().map(build))
     @settings(
         verbosity=Verbosity.quiet, database=None,
-        suppress_health_check=list(HealthCheck), max_shrinks=0
+        suppress_health_check=HealthCheck.all(), max_shrinks=0
     )
     def test(x):
         try:

--- a/hypothesis-python/tests/cover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/cover/test_given_error_conditions.py
@@ -41,7 +41,7 @@ def test_raises_timeout_on_slow_test():
 
 def test_raises_unsatisfiable_if_all_false():
     @given(integers())
-    @settings(max_examples=50, suppress_health_check=list(HealthCheck))
+    @settings(max_examples=50, suppress_health_check=HealthCheck.all())
     def test_assume_false(x):
         reject()
 

--- a/hypothesis-python/tests/cover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/cover/test_given_error_conditions.py
@@ -21,7 +21,7 @@ import time
 
 import pytest
 
-from hypothesis import given, infer, assume, reject, settings
+from hypothesis import HealthCheck, given, infer, assume, reject, settings
 from hypothesis.errors import Timeout, Unsatisfiable, InvalidArgument
 from tests.common.utils import fails_with, validate_deprecation
 from hypothesis.strategies import booleans, integers
@@ -41,7 +41,7 @@ def test_raises_timeout_on_slow_test():
 
 def test_raises_unsatisfiable_if_all_false():
     @given(integers())
-    @settings(max_examples=50, perform_health_check=False)
+    @settings(max_examples=50, suppress_health_check=list(HealthCheck))
     def test_assume_false(x):
         reject()
 

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -57,7 +57,7 @@ def test_default_health_check_can_weaken_specific():
     def test(x):
         random.choice(x)
 
-    with settings(suppress_health_check=list(HealthCheck)):
+    with settings(suppress_health_check=HealthCheck.all()):
         test()
 
 
@@ -158,7 +158,7 @@ def test_the_slow_test_health_check_can_be_disabled():
 
 def test_the_slow_test_health_only_runs_if_health_checks_are_on():
     @given(st.integers())
-    @settings(suppress_health_check=list(HealthCheck), deadline=None)
+    @settings(suppress_health_check=HealthCheck.all(), deadline=None)
     def a(x):
         time.sleep(1000)
     a()
@@ -166,7 +166,7 @@ def test_the_slow_test_health_only_runs_if_health_checks_are_on():
 
 def test_returning_non_none_does_not_fail_if_health_check_disabled():
     @given(st.integers())
-    @settings(suppress_health_check=list(HealthCheck))
+    @settings(suppress_health_check=HealthCheck.all())
     def a(x):
         return 1
 

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -57,7 +57,7 @@ def test_default_health_check_can_weaken_specific():
     def test(x):
         random.choice(x)
 
-    with settings(perform_health_check=False):
+    with settings(suppress_health_check=list(HealthCheck)):
         test()
 
 
@@ -158,7 +158,7 @@ def test_the_slow_test_health_check_can_be_disabled():
 
 def test_the_slow_test_health_only_runs_if_health_checks_are_on():
     @given(st.integers())
-    @settings(perform_health_check=False, deadline=None)
+    @settings(suppress_health_check=list(HealthCheck), deadline=None)
     def a(x):
         time.sleep(1000)
     a()
@@ -166,7 +166,7 @@ def test_the_slow_test_health_only_runs_if_health_checks_are_on():
 
 def test_returning_non_none_does_not_fail_if_health_check_disabled():
     @given(st.integers())
-    @settings(perform_health_check=False)
+    @settings(suppress_health_check=list(HealthCheck))
     def a(x):
         return 1
 

--- a/hypothesis-python/tests/cover/test_interleaving.py
+++ b/hypothesis-python/tests/cover/test_interleaving.py
@@ -17,7 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis import find, note, given, settings
+from hypothesis import HealthCheck, find, note, given, settings
 from hypothesis import strategies as st
 from tests.common.utils import checks_deprecated_behaviour
 
@@ -27,7 +27,7 @@ def test_can_eval_stream_inside_find():
     @given(st.streaming(st.integers(min_value=0)), st.random_module())
     @settings(
         buffer_size=200, max_shrinks=5, max_examples=10,
-        perform_health_check=False)
+        suppress_health_check=list(HealthCheck))
     def test(stream, rnd):
         x = find(
             st.lists(st.integers(min_value=0), min_size=10),

--- a/hypothesis-python/tests/cover/test_interleaving.py
+++ b/hypothesis-python/tests/cover/test_interleaving.py
@@ -27,7 +27,7 @@ def test_can_eval_stream_inside_find():
     @given(st.streaming(st.integers(min_value=0)), st.random_module())
     @settings(
         buffer_size=200, max_shrinks=5, max_examples=10,
-        suppress_health_check=list(HealthCheck))
+        suppress_health_check=HealthCheck.all())
     def test(stream, rnd):
         x = find(
             st.lists(st.integers(min_value=0), min_size=10),

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -20,19 +20,13 @@ from __future__ import division, print_function, absolute_import
 import enum
 import collections
 
-from hypothesis import given, settings
+from hypothesis import given
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import sampled_from
 
 an_enum = enum.Enum('A', 'a b c')
 
 an_ordereddict = collections.OrderedDict([('a', 1), ('b', 2), ('c', 3)])
-
-
-@given(sampled_from((1, 2)))
-@settings(min_satisfying_examples=10)
-def test_can_handle_sampling_from_fewer_than_min_satisfying(v):
-    pass
 
 
 @checks_deprecated_behaviour

--- a/hypothesis-python/tests/cover/test_sets.py
+++ b/hypothesis-python/tests/cover/test_sets.py
@@ -24,7 +24,7 @@ from hypothesis.strategies import sets, floats, randoms, integers
 @given(randoms())
 @settings(max_examples=5, deadline=None)
 def test_can_draw_sets_of_hard_to_find_elements(rnd):
-    rarebool = floats(0, 1).map(lambda x: x <= 0.01)
+    rarebool = floats(0, 1).map(lambda x: x <= 0.05)
     find(
         sets(rarebool, min_size=2), lambda x: True,
         random=rnd, settings=settings(database=None))

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -109,6 +109,12 @@ def test_register_profile_kwarg_settings_is_deprecated():
     assert settings.default.max_examples == 10
 
 
+@checks_deprecated_behaviour
+def test_perform_health_check_setting_is_deprecated():
+    s = settings(suppress_health_check=(), perform_health_check=False)
+    assert s.suppress_health_check
+
+
 def test_can_set_verbosity():
     settings(verbosity=Verbosity.quiet)
     settings(verbosity=Verbosity.normal)

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -152,20 +152,17 @@ def test_load_profile():
     settings.load_profile('default')
     assert settings.default.max_examples == 100
     assert settings.default.max_shrinks == 500
-    assert settings.default.min_satisfying_examples == 5
 
     settings.register_profile('test', settings(max_examples=10), max_shrinks=5)
     settings.load_profile('test')
 
     assert settings.default.max_examples == 10
     assert settings.default.max_shrinks == 5
-    assert settings.default.min_satisfying_examples == 5
 
     settings.load_profile('default')
 
     assert settings.default.max_examples == 100
     assert settings.default.max_shrinks == 500
-    assert settings.default.min_satisfying_examples == 5
 
 
 @checks_deprecated_behaviour

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -220,9 +220,7 @@ bad_machines = (
 )
 
 for m in bad_machines:
-    m.TestCase.settings = Settings(
-        m.TestCase.settings, max_examples=1000, max_iterations=2000
-    )
+    m.TestCase.settings = Settings(m.TestCase.settings, max_examples=1000)
 
 
 cheap_bad_machines = list(bad_machines)

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -451,12 +451,6 @@ def test_when_set_to_no_simplifies_runs_failing_example_twice():
     assert 'Lo' in out.getvalue()
 
 
-@given(integers())
-@settings(max_examples=1)
-def test_should_not_fail_if_max_examples_less_than_min_satisfying(x):
-    pass
-
-
 @given(integers().filter(lambda x: x % 4 == 0))
 def test_filtered_values_satisfy_condition(i):
     assert i % 4 == 0

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -411,7 +411,7 @@ def test_named_tuples_are_of_right_type(litter):
 
 @fails_with(AttributeError)
 @given(integers().map(lambda x: x.nope))
-@settings(suppress_health_check=list(HealthCheck))
+@settings(suppress_health_check=HealthCheck.all())
 def test_fails_in_reify(x):
     pass
 

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -170,34 +170,24 @@ def test_does_not_catch_interrupt_during_falsify():
 
 def test_contains_the_test_function_name_in_the_exception_string():
 
-    calls = [0]
-
     @given(integers())
-    @settings(max_iterations=10, max_examples=10)
+    @settings(max_examples=1)
     def this_has_a_totally_unique_name(x):
-        calls[0] += 1
         reject()
 
     with raises(Unsatisfiable) as e:
         this_has_a_totally_unique_name()
-        print('Called %d times' % tuple(calls))
-
     assert this_has_a_totally_unique_name.__name__ in e.value.args[0]
-
-    calls2 = [0]
 
     class Foo(object):
 
         @given(integers())
-        @settings(max_iterations=10, max_examples=10)
+        @settings(max_examples=1)
         def this_has_a_unique_name_and_lives_on_a_class(self, x):
-            calls2[0] += 1
             reject()
 
     with raises(Unsatisfiable) as e:
         Foo().this_has_a_unique_name_and_lives_on_a_class()
-        print('Called %d times' % tuple(calls2))
-
     assert (
         Foo.this_has_a_unique_name_and_lives_on_a_class.__name__
     ) in e.value.args[0]

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -22,8 +22,8 @@ import threading
 from collections import namedtuple
 
 import hypothesis.reporting as reporting
-from hypothesis import Verbosity, note, seed, given, assume, reject, \
-    settings
+from hypothesis import Verbosity, HealthCheck, note, seed, given, assume, \
+    reject, settings
 from hypothesis.errors import Unsatisfiable
 from tests.common.utils import fails, raises, fails_with, capture_out
 from hypothesis.strategies import data, just, sets, text, lists, binary, \
@@ -421,7 +421,7 @@ def test_named_tuples_are_of_right_type(litter):
 
 @fails_with(AttributeError)
 @given(integers().map(lambda x: x.nope))
-@settings(perform_health_check=False)
+@settings(suppress_health_check=list(HealthCheck))
 def test_fails_in_reify(x):
     pass
 

--- a/hypothesis-python/tests/cover/test_timeout.py
+++ b/hypothesis-python/tests/cover/test_timeout.py
@@ -44,7 +44,7 @@ calls = [0, 0, 0, 0]
 
 
 with validate_deprecation():
-    timeout_settings = settings(timeout=0.2, min_satisfying_examples=2)
+    timeout_settings = settings(timeout=0.2)
 
 
 # The following tests exist to test that verifiers start their timeout

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -19,10 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 from contextlib import contextmanager
 
-import pytest
-
 from hypothesis import find, given
-from hypothesis.errors import InvalidArgument
 from tests.common.utils import fails, capture_out
 from hypothesis._settings import Verbosity, settings
 from hypothesis.reporting import default as default_reporter
@@ -96,39 +93,3 @@ def test_includes_intermediate_results_in_verbose_mode():
     lines = o.getvalue().splitlines()
     assert len([l for l in lines if u'example' in l]) > 2
     assert len([l for l in lines if u'AssertionError' in l])
-
-
-VERBOSITIES = [
-    Verbosity.quiet, Verbosity.normal, Verbosity.verbose, Verbosity.debug
-]
-
-
-def test_verbosity_can_be_accessed_by_name():
-    for f in VERBOSITIES:
-        assert f is Verbosity.by_name(f.name)
-
-
-def test_verbosity_is_sorted():
-    assert VERBOSITIES == sorted(VERBOSITIES)
-
-
-def test_hash_verbosity():
-    x = {}
-    for f in VERBOSITIES:
-        x[f] = f
-    for k, v in x.items():
-        assert k == v
-        assert k is v
-
-
-def test_verbosities_are_inequal():
-    for f in VERBOSITIES:
-        for g in VERBOSITIES:
-            if f is not g:
-                assert f != g
-                assert (f <= g) or (g <= f)
-
-
-def test_verbosity_of_bad_name():
-    with pytest.raises(InvalidArgument):
-        Verbosity.by_name('cabbage')

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -67,7 +67,7 @@ class TestWorkflow(VanillaTestCase):
         class LocalTest(TestCase):
 
             @given(integers().map(break_the_db))
-            @settings(perform_health_check=False)
+            @settings(suppress_health_check=list(HealthCheck))
             def test_does_not_break_other_things(self, unused):
                 pass
 

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -67,7 +67,7 @@ class TestWorkflow(VanillaTestCase):
         class LocalTest(TestCase):
 
             @given(integers().map(break_the_db))
-            @settings(suppress_health_check=list(HealthCheck))
+            @settings(suppress_health_check=HealthCheck.all())
             def test_does_not_break_other_things(self, unused):
                 pass
 

--- a/hypothesis-python/tests/nocover/test_deferred_strategies.py
+++ b/hypothesis-python/tests/nocover/test_deferred_strategies.py
@@ -65,7 +65,7 @@ def test_arbitrary_recursion(strategies):
             try:
                 find(s, lambda x: True, settings=settings(
                     max_shrinks=0, database=None, verbosity=Verbosity.quiet,
-                    max_examples=1, max_iterations=10,
+                    max_examples=1,
                 ))
             except (Unsatisfiable, NoSuchExample):
                 pass

--- a/hypothesis-python/tests/nocover/test_float_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_float_shrinking.py
@@ -22,7 +22,8 @@ from random import Random
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import Verbosity, given, assume, example, settings
+from hypothesis import Verbosity, HealthCheck, given, assume, example, \
+    settings
 from tests.common.debug import minimal
 from hypothesis.internal.compat import ceil
 
@@ -42,7 +43,8 @@ def test_can_shrink_in_variable_sized_context(n):
 
 @example(1.5)
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
-@settings(use_coverage=False, deadline=None, perform_health_check=False)
+@settings(use_coverage=False, deadline=None,
+          suppress_health_check=list(HealthCheck))
 def test_shrinks_downwards_to_integers(f):
     g = minimal(
         st.floats(), lambda x: x >= f, random=Random(0),
@@ -53,7 +55,8 @@ def test_shrinks_downwards_to_integers(f):
 
 @example(1)
 @given(st.integers(1, 2 ** 16 - 1))
-@settings(use_coverage=False, deadline=None, perform_health_check=False)
+@settings(use_coverage=False, deadline=None,
+          suppress_health_check=list(HealthCheck))
 def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats(),

--- a/hypothesis-python/tests/nocover/test_float_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_float_shrinking.py
@@ -44,7 +44,7 @@ def test_can_shrink_in_variable_sized_context(n):
 @example(1.5)
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
 @settings(use_coverage=False, deadline=None,
-          suppress_health_check=list(HealthCheck))
+          suppress_health_check=HealthCheck.all())
 def test_shrinks_downwards_to_integers(f):
     g = minimal(
         st.floats(), lambda x: x >= f, random=Random(0),
@@ -56,7 +56,7 @@ def test_shrinks_downwards_to_integers(f):
 @example(1)
 @given(st.integers(1, 2 ** 16 - 1))
 @settings(use_coverage=False, deadline=None,
-          suppress_health_check=list(HealthCheck))
+          suppress_health_check=HealthCheck.all())
 def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats(),

--- a/hypothesis-python/tests/nocover/test_floating.py
+++ b/hypothesis-python/tests/nocover/test_floating.py
@@ -29,7 +29,7 @@ from tests.common.utils import fails
 from hypothesis.strategies import data, lists, floats
 
 TRY_HARDER = settings(
-    max_examples=1000, max_iterations=2000,
+    max_examples=1000,
     suppress_health_check=[HealthCheck.filter_too_much]
 )
 

--- a/hypothesis-python/tests/nocover/test_integers.py
+++ b/hypothesis-python/tests/nocover/test_integers.py
@@ -44,7 +44,7 @@ def problems(draw):
 
 
 @settings(
-    suppress_health_check=list(HealthCheck), timeout=unlimited, deadline=None,
+    suppress_health_check=HealthCheck.all(), timeout=unlimited, deadline=None,
 )
 @given(problems())
 def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
@@ -66,7 +66,7 @@ def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
             data.mark_interesting()
 
     runner = ConjectureRunner(f, random=Random(0), settings=settings(
-        suppress_health_check=list(HealthCheck), timeout=unlimited,
+        suppress_health_check=HealthCheck.all(), timeout=unlimited,
         phases=(Phase.shrink,), database=None, verbosity=Verbosity.quiet
     ))
 

--- a/hypothesis-python/tests/nocover/test_integers.py
+++ b/hypothesis-python/tests/nocover/test_integers.py
@@ -20,8 +20,8 @@ from __future__ import division, print_function, absolute_import
 from random import Random
 
 import hypothesis.strategies as st
-from hypothesis import Phase, Verbosity, note, given, assume, reject, \
-    settings, unlimited
+from hypothesis import Phase, Verbosity, HealthCheck, note, given, \
+    assume, reject, settings, unlimited
 from hypothesis.internal.compat import ceil, hbytes
 from hypothesis.internal.conjecture.data import StopTest, ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
@@ -44,7 +44,7 @@ def problems(draw):
 
 
 @settings(
-    perform_health_check=False, timeout=unlimited, deadline=None,
+    suppress_health_check=list(HealthCheck), timeout=unlimited, deadline=None,
 )
 @given(problems())
 def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
@@ -66,8 +66,8 @@ def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
             data.mark_interesting()
 
     runner = ConjectureRunner(f, random=Random(0), settings=settings(
-        perform_health_check=False, timeout=unlimited, phases=(Phase.shrink,),
-        database=None, verbosity=Verbosity.quiet
+        suppress_health_check=list(HealthCheck), timeout=unlimited,
+        phases=(Phase.shrink,), database=None, verbosity=Verbosity.quiet
     ))
 
     runner.test_function(ConjectureData.for_buffer(blob))

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -22,7 +22,7 @@ from random import Random
 from flaky import flaky
 
 import hypothesis.strategies as st
-from hypothesis import find, given, example, settings
+from hypothesis import HealthCheck, find, given, example, settings
 from tests.common.debug import find_any
 from hypothesis.internal.compat import integer_types
 
@@ -85,7 +85,8 @@ def test_drawing_many_near_boundary():
 
 @given(st.randoms())
 @settings(
-    max_examples=50, max_shrinks=0, perform_health_check=False, deadline=None
+    max_examples=50, max_shrinks=0, suppress_health_check=list(HealthCheck),
+    deadline=None
 )
 @example(Random(-1363972488426139))
 @example(Random(-4))
@@ -128,7 +129,8 @@ def test_can_form_sets_of_recursive_data():
 
 @given(st.randoms())
 @settings(
-    max_examples=50, max_shrinks=0, perform_health_check=False, deadline=None
+    max_examples=50, max_shrinks=0, suppress_health_check=list(HealthCheck),
+    deadline=None
 )
 def test_can_flatmap_to_recursive_data(rnd):
     stuff = st.lists(st.integers(), min_size=1).flatmap(

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -85,7 +85,7 @@ def test_drawing_many_near_boundary():
 
 @given(st.randoms())
 @settings(
-    max_examples=50, max_shrinks=0, suppress_health_check=list(HealthCheck),
+    max_examples=50, max_shrinks=0, suppress_health_check=HealthCheck.all(),
     deadline=None
 )
 @example(Random(-1363972488426139))
@@ -129,7 +129,7 @@ def test_can_form_sets_of_recursive_data():
 
 @given(st.randoms())
 @settings(
-    max_examples=50, max_shrinks=0, suppress_health_check=list(HealthCheck),
+    max_examples=50, max_shrinks=0, suppress_health_check=HealthCheck.all(),
     deadline=None
 )
 def test_can_flatmap_to_recursive_data(rnd):

--- a/hypothesis-python/tests/nocover/test_strategy_state.py
+++ b/hypothesis-python/tests/nocover/test_strategy_state.py
@@ -72,47 +72,6 @@ class HypothesisSpec(RuleBasedStateMachine):
         self.teardown()
         self.database = ExampleDatabase()
 
-    @rule(strat=strategies, r=integers(), max_shrinks=integers(0, 100))
-    def find_constant_failure(self, strat, r, max_shrinks):
-        with settings(
-            verbosity=Verbosity.quiet, max_examples=1,
-            min_satisfying_examples=0,
-            database=self.database,
-            max_shrinks=max_shrinks,
-        ):
-            @given(strat)
-            @seed(r)
-            def test(x):
-                assert False
-
-            try:
-                test()
-            except (AssertionError, FailedHealthCheck):
-                pass
-
-    @rule(
-        strat=strategies, r=integers(), p=floats(0, 1),
-        max_examples=integers(1, 10), max_shrinks=integers(1, 100)
-    )
-    def find_weird_failure(self, strat, r, max_examples, p, max_shrinks):
-        with settings(
-            verbosity=Verbosity.quiet, max_examples=max_examples,
-            min_satisfying_examples=0,
-            database=self.database,
-            max_shrinks=max_shrinks,
-        ):
-            @given(strat)
-            @seed(r)
-            def test(x):
-                assert Random(
-                    hashlib.md5(repr(x).encode(u'utf-8')).digest()
-                ).random() <= p
-
-            try:
-                test()
-            except (AssertionError, FailedHealthCheck):
-                pass
-
     @rule(target=strategies, spec=sampled_from((
         integers(), booleans(), floats(), complex_numbers(),
         fractions(), decimals(), text(), binary(), none(),
@@ -226,9 +185,7 @@ TestHypothesis = HypothesisSpec.TestCase
 TestHypothesis.settings = settings(
     TestHypothesis.settings,
     stateful_step_count=10 if PYPY else 50,
-    max_shrinks=500,
     timeout=unlimited,
-    min_satisfying_examples=0,
     verbosity=max(TestHypothesis.settings.verbosity, Verbosity.verbose),
     max_examples=10000 if MAIN else 200,
 )

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -107,14 +107,15 @@ def test_timeout_traceback_is_hidden():
 
 
 def get_line_num(token, result, skip_n=0):
+    skipped = 0
     for i, line in enumerate(result.stdout.lines):
         if token in line:
-            if skip_n == 0:
+            if skip_n == skipped:
                 return i
             else:
-                skip_n -= 1
-    assert False, \
-        'Token %r not found (after skipping %r appearances)' % (token, skip_n)
+                skipped += 1
+    assert False, 'Token %r not found (skipped %r of planned %r skips)' % (
+        token, skipped, skip_n)
 
 
 def test_timeout_traceback_is_hidden(testdir):

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -67,7 +67,6 @@ def test_prints_statistics_given_option(testdir):
     assert 'Hypothesis Statistics' in out
     assert 'timeout=0.2' in out
     assert 'max_examples=100' in out
-    assert 'max_iterations=1000' in out
     assert 'HypothesisDeprecationWarning' in out
 
 

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -23,7 +23,7 @@ pytest_plugins = 'pytester'
 
 
 TESTSUITE = """
-from hypothesis import given, settings, assume
+from hypothesis import HealthCheck, given, settings, assume
 from hypothesis.strategies import integers
 import time
 import warnings
@@ -44,7 +44,8 @@ def test_slow(x):
 
 
 @settings(
-    max_examples=1000, min_satisfying_examples=1, perform_health_check=False
+    max_examples=1000, min_satisfying_examples=1,
+    suppress_health_check=list(HealthCheck)
 )
 @given(integers())
 def test_iterations(x):

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -37,16 +37,13 @@ def test_all_valid(x):
     pass
 
 
-@settings(timeout=0.2, min_satisfying_examples=1)
+@settings(timeout=0.2)
 @given(integers())
 def test_slow(x):
     time.sleep(0.1)
 
 
-@settings(
-    max_examples=1000, min_satisfying_examples=1,
-    suppress_health_check=list(HealthCheck)
-)
+@settings(max_examples=1000, suppress_health_check=list(HealthCheck))
 @given(integers())
 def test_iterations(x):
     assume(x % 50 == 0)

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -43,7 +43,7 @@ def test_slow(x):
     time.sleep(0.1)
 
 
-@settings(max_examples=1000, suppress_health_check=list(HealthCheck))
+@settings(max_examples=1000, suppress_health_check=HealthCheck.all())
 @given(integers())
 def test_iterations(x):
     assume(x % 50 == 0)

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -82,7 +82,6 @@ def define_test(specifier, predicate, condition=None):
                 test_function,
                 settings=Settings(
                     max_examples=100,
-                    max_iterations=1000,
                     max_shrinks=0
                 ))
             runner.run()

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -63,7 +63,7 @@ LOTS = 10 ** 6
 
 
 TEST_SETTINGS = settings(
-    database=None, suppress_health_check=list(HealthCheck), max_examples=LOTS,
+    database=None, suppress_health_check=HealthCheck.all(), max_examples=LOTS,
     deadline=None, timeout=unlimited, max_shrinks=LOTS
 )
 

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -22,7 +22,7 @@ from random import Random
 import pytest
 
 import hypothesis.internal.conjecture.utils as cu
-from hypothesis import settings, unlimited
+from hypothesis import HealthCheck, settings, unlimited
 from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.engine import ConjectureData, \
@@ -63,7 +63,7 @@ LOTS = 10 ** 6
 
 
 TEST_SETTINGS = settings(
-    database=None, perform_health_check=False, max_examples=LOTS,
+    database=None, suppress_health_check=list(HealthCheck), max_examples=LOTS,
     deadline=None, timeout=unlimited, max_shrinks=LOTS
 )
 

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -18,7 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
-from hypothesis import Verbosity, note, given, assume, example, settings
+from hypothesis import Verbosity, HealthCheck, note, given, assume, \
+    example, settings
 from hypothesis.internal.compat import hbytes, int_from_bytes
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
@@ -41,7 +42,7 @@ def problem(draw):
 @example((b'\x01', b'', 1))
 @example((b'\x01', b'', 0))
 @settings(
-    deadline=None, perform_health_check=False, max_examples=10,
+    deadline=None, suppress_health_check=list(HealthCheck), max_examples=10,
     max_shrinks=100
 )
 @given(problem())

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -42,7 +42,7 @@ def problem(draw):
 @example((b'\x01', b'', 1))
 @example((b'\x01', b'', 0))
 @settings(
-    deadline=None, suppress_health_check=list(HealthCheck), max_examples=10,
+    deadline=None, suppress_health_check=HealthCheck.all(), max_examples=10,
     max_shrinks=100
 )
 @given(problem())


### PR DESCRIPTION
Per #535, we have too many settings and they can be unhelpful.  Closes #197, where three settings interact, by deprecating and disabling two of them!  Removing `min_satisfying_examples` also closes #534 as it currently stands.

- [x] Deprecated settings are no longer shown in the `settings()` repr, unless set to a non-default value (or having an ongoing effect, ie `timeout`).
- [x] `min_satisfying_examples` and `max_iterations` now do nothing.  Users can still tweak `max_examples`, but we use internal heuristics which are equivalent to the old defaults.
- [x] `perform_health_check` is deprecated in favor of `suppress_health_check`.
- [x] `verbosity` is now an `IntEnum` instead of a custom object, and the `$HYPOTHESIS_VERBOSITY_LEVEL` env var is deprecated in favor of settings profiles (as for `database_file`).
- [x] Carefully go through narrative documentation to make sure we recommend the current best practices / don't recommend any deprecated settings

I have given up on `max_shrinks`, because it turns out that `max_shrinks=0` is *not* equivalent to `phases=list(Phase)[:Phase.shrink]`.  See #1235.