### PR TITLE
Update URL in setup.py

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release updates the URL metadata associated with the PyPI package (again).
+It has no other user visible effects.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -86,7 +86,7 @@ setuptools.setup(
     packages=setuptools.find_packages(SOURCE),
     package_dir={'': SOURCE},
     url=(
-        'https://github.com/HypothesisWorks/hypothesis-python/'
+        'https://github.com/HypothesisWorks/hypothesis/'
         'tree/master/hypothesis-python'
     ),
     license='MPL v2',

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -147,7 +147,7 @@ def create_tag_and_push():
     git('config', 'core.sshCommand', 'ssh -i deploy_key')
     git(
         'remote', 'add', 'ssh-origin',
-        'git@github.com:HypothesisWorks/hypothesis-python.git'
+        'git@github.com:HypothesisWorks/hypothesis.git'
     )
     git('tag', __version__)
 


### PR DESCRIPTION
Behold the shiny new renamed repository!

This PR updates the home page URL in the setup.py and also serves to test which of our CI systems have broken horribly by this rename.