### PR TITLE
Don't count empty intervals as discards

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-This release fixes a somewhat obscure condition under which you could
-occasionally see a failing test trigger an assertion error inside Hypothesis
-instead of failing normally.
+This release fixes a somewhat obscure condition (:issue:`1230`) under which you
+could occasionally see a failing test trigger an assertion error inside
+Hypothesis instead of failing normally.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a somewhat obscure condition under which you could
+occasionally see a failing test trigger an assertion error inside Hypothesis
+instead of failing normally.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -201,6 +201,15 @@ class ConjectureData(object):
         k = self.example_stack.pop()
         ex = self.examples[k]
         ex.end = self.index
+
+        # We don't want to count empty examples as discards even if the flag
+        # says we should. This leads to situations like
+        # https://github.com/HypothesisWorks/hypothesis/issues/1230
+        # where it can look like we should discard data but there's nothing
+        # useful for us to do.
+        if self.index == ex.start:
+            discard = False
+
         ex.discarded = discard
 
         if discard:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1773,6 +1773,8 @@ class Shrinker(object):
             ):
                 discarded.append((ex.start, ex.end))
 
+        assert discarded
+
         attempt = bytearray(self.shrink_target.buffer)
         for u, v in reversed(discarded):
             del attempt[u:v]

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -118,3 +118,11 @@ def test_does_not_double_freeze_in_interval_close():
         x.draw(BigStrategy())
     assert x.frozen
     assert not any(eg.end is None for eg in x.examples)
+
+
+def test_empty_discards_do_not_count():
+    x = ConjectureData.for_buffer(b'')
+    x.start_example(label=1)
+    x.stop_example(discard=True)
+    x.freeze()
+    assert not x.has_discards

--- a/hypothesis-python/tests/cover/test_regressions.py
+++ b/hypothesis-python/tests/cover/test_regressions.py
@@ -19,8 +19,8 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
+from hypothesis import Verbosity, seed, given, assume, settings
 from hypothesis import strategies as st
-from hypothesis import Verbosity, given, settings, assume, seed
 
 
 def strat():

--- a/hypothesis-python/tests/cover/test_regressions.py
+++ b/hypothesis-python/tests/cover/test_regressions.py
@@ -19,8 +19,8 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
-from hypothesis import Verbosity, given, settings
 from hypothesis import strategies as st
+from hypothesis import Verbosity, given, settings, assume, seed
 
 
 def strat():
@@ -77,3 +77,27 @@ def test_mock_injection():
     test_foo_spec(Bar())
     test_foo_spec(Mock(Bar))
     test_foo_spec(Mock())
+
+
+def test_regression_issue_1230():
+    strategy = st.builds(
+        lambda x, y: dict((list(x.items()) + list(y.items()))),
+        st.fixed_dictionaries({'0': st.text()}),
+        st.builds(
+            lambda dictionary, keys: {key: dictionary[key] for key in keys},
+            st.fixed_dictionaries({
+                '1': st.lists(elements=st.sampled_from(['a']))
+            }),
+            st.sets(elements=st.sampled_from(['1']))
+        )
+    )
+
+    @seed(81581571036124932593143257836081491416)
+    @settings(database=None)
+    @given(strategy)
+    def test_false_is_false(params):
+        assume(params.get('0') not in ('', '\x00'))
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        test_false_is_false()


### PR DESCRIPTION
Fixes #1230.

The root cause of this bug is that sometimes we would think we had data to discard as part of the fast-path for discarding values that were rejected during filter etc, but it all consisted of empty intervals so there wasn't actually any data in there. This could happen if you had something like a `sets(just(x))` that had to be non-empty in the final result.