### PR TITLE
Add basic static typing to the Hypothesis API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 venv*
 .cache
 .pytest_cache
+.mypy_cache
 .hypothesis
 docs/_build
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
         - TASK=doctest
         - TASK=check-rst
         - TASK=check-format
+        - TASK=check-type-hints
         - TASK=check-coverage
         - TASK=check-requirements
         - TASK=check-pypy
@@ -65,7 +66,7 @@ env:
         - TASK=deploy
 
 script:
-    - ./build.sh 
+    - ./build.sh
 
 matrix:
     fast_finish: true

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch contains some internal refactoring to run :pypi:`mypy` in CI.
+There are no user-visible changes.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -85,6 +85,7 @@ setuptools.setup(
     author_email='david@drmaciver.com',
     packages=setuptools.find_packages(SOURCE),
     package_dir={'': SOURCE},
+    # package_data={'': ['py.typed']},  # un-comment to release type hints
     url=(
         'https://github.com/HypothesisWorks/hypothesis/'
         'tree/master/hypothesis-python'

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -38,6 +38,9 @@ from hypothesis.internal.reflection import proxies, \
 from hypothesis.internal.validation import try_convert
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
+if False:
+    from typing import Dict, List  # noqa
+
 __all__ = [
     'settings',
 ]
@@ -46,7 +49,7 @@ __all__ = [
 unlimited = UniqueIdentifier('unlimited')
 
 
-all_settings = {}
+all_settings = {}  # type: Dict[str, Setting]
 
 
 class settingsProperty(object):
@@ -113,7 +116,9 @@ class settingsMeta(type):
         default_variable.value = value
 
 
-class settings(settingsMeta('settings', (object,), {})):
+class settings(
+    settingsMeta('settings', (object,), {})  # type: ignore
+):
     """A settings object controls a variety of parameters that are used in
     falsification. These may control both the falsification strategy and the
     details of the data that is generated.
@@ -126,7 +131,7 @@ class settings(settingsMeta('settings', (object,), {})):
         '_construction_complete', 'storage'
     ]
     __definitions_are_locked = False
-    _profiles = {}
+    _profiles = {}  # type: dict
 
     def __getattr__(self, name):
         if name in all_settings:
@@ -498,11 +503,11 @@ warnings.simplefilter('error', HypothesisDeprecationWarning).
 )
 
 
-def _validate_database(db, __from_db_file=False):
+def _validate_database(db, _from_db_file=False):
     from hypothesis.database import ExampleDatabase
     if db is None or isinstance(db, ExampleDatabase):
         return db
-    if __from_db_file or db is not_set:
+    if _from_db_file or db is not_set:
         return ExampleDatabase(db)
     raise InvalidArgument(
         'Arguments to the database setting must be None or an instance of '
@@ -533,7 +538,7 @@ settings.define_setting(
 The file or directory location to save and load previously tried examples;
 `:memory:` for an in-memory cache or None to disable caching entirely.
 """,
-    validator=lambda f: _validate_database(f, __from_db_file=True),
+    validator=lambda f: _validate_database(f, _from_db_file=True),
     deprecation_message="""
 The `database_file` setting is deprecated in favor of the `database`
 setting, and will be removed in a future version.  It only exists at

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -39,12 +39,12 @@ from coverage.files import canonical_filename
 from coverage.collector import Collector
 
 import hypothesis.strategies as st
-from hypothesis import __version__
 from hypothesis.errors import Flaky, Timeout, NoSuchExample, \
     Unsatisfiable, DidNotReproduce, InvalidArgument, DeadlineExceeded, \
     MultipleFailures, FailedHealthCheck, HypothesisWarning, \
     UnsatisfiedAssumption, HypothesisDeprecationWarning
 from hypothesis.control import BuildContext
+from hypothesis.version import __version__
 from hypothesis._settings import Phase, Verbosity, HealthCheck, \
     PrintSettings
 from hypothesis._settings import settings as Settings
@@ -73,6 +73,9 @@ try:
     from coverage.tracer import CFileDisposition as FileDisposition
 except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
+
+if False:
+    from typing import Any, Dict  # noqa
 
 
 running_under_pytest = False
@@ -424,7 +427,7 @@ class Arc(object):
         self.target = target
 
 
-ARC_CACHE = {}
+ARC_CACHE = {}  # type: Dict[str, Dict[Any, Dict[Any, Arc]]]
 
 
 def arc(filename, source, target):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -75,7 +75,7 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict  # noqa
+    from typing import Any, Dict, Callable, Optional  # noqa
 
 
 running_under_pytest = False
@@ -893,6 +893,7 @@ def fake_subTest(self, msg=None, **__):
 
 
 def given(*given_arguments, **given_kwargs):
+    # type: (*SearchStrategy, **SearchStrategy) -> Callable
     """A decorator for turning a test function that accepts arguments into a
     randomized test.
 
@@ -1078,7 +1079,14 @@ def given(*given_arguments, **given_kwargs):
     return run_test_with_generator
 
 
-def find(specifier, condition, settings=None, random=None, database_key=None):
+def find(
+    specifier,  # type: SearchStrategy
+    condition,  # type: Callable[[Any], bool]
+    settings=None,  # type: Settings
+    random=None,   # type: Any
+    database_key=None,  # type: bytes
+):
+    # type: (...) -> Any
     """Returns the minimal example from the given strategy ``specifier`` that
     matches the predicate function ``condition``."""
     settings = settings or Settings(

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -83,7 +83,9 @@ class EDMeta(type):
         return super(EDMeta, self).__call__(*args, **kwargs)
 
 
-class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
+class ExampleDatabase(
+    EDMeta('ExampleDatabase', (object,), {})  # type: ignore
+):
     """Interface class for storage systems.
 
     A key -> multiple distinct values mapping.

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -28,6 +28,11 @@ from hypothesis._settings import note_deprecation
 from hypothesis.configuration import tmpdir, storage_directory
 from hypothesis.internal.compat import hunichr
 
+if False:
+    from typing import Dict, Tuple
+    intervals = Tuple[Tuple[int, int], ...]
+    cache_type = Dict[Tuple[Tuple[str, ...], int, int, intervals], intervals]
+
 
 def charmap_file():
     return os.path.join(
@@ -308,7 +313,7 @@ def _query_for_key(key):
     return result
 
 
-limited_category_index_cache = {}
+limited_category_index_cache = {}  # type: cache_type
 
 
 def query(

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -33,8 +33,11 @@ from collections import namedtuple
 try:
     from collections import OrderedDict, Counter
 except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
-    from counter import Counter
+    from ordereddict import OrderedDict  # type: ignore
+    from counter import Counter  # type: ignore
+
+if False:
+    from typing import Type  # noqa
 
 
 PY2 = sys.version_info[0] == 2
@@ -410,7 +413,7 @@ class compatbytes(bytearray):
         else:
             return r
 
-    __setitem__ = None
+    __setitem__ = None  # type: ignore
 
     def join(self, parts):
         result = bytearray()
@@ -467,7 +470,7 @@ def implements_iterator(it):
 
 
 if PY3:
-    FileNotFoundError = FileNotFoundError
+    FileNotFoundError = FileNotFoundError  # type: Type[IOError]
 else:
     FileNotFoundError = IOError
 
@@ -475,7 +478,7 @@ else:
 # an existing file where you're not allowed to. This is rather less consistent
 # between versions than might be hoped.
 if PY3:
-    FileExistsError = FileExistsError
+    FileExistsError = FileExistsError  # type: Type[IOError]
 
 elif WINDOWS:
     FileExistsError = WindowsError
@@ -519,7 +522,7 @@ else:
     from base64 import b64decode
 
 
-_cases = []
+_cases = []  # type: list
 
 
 def bad_django_TestCase(runner):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -58,7 +58,7 @@ class StructuralTag(object):
     label = attr.ib()
 
 
-STRUCTURAL_TAGS = {}
+STRUCTURAL_TAGS = {}  # type: dict
 
 
 def structural_tag(label):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1018,7 +1018,7 @@ class Negated(object):
         self.tag = tag
 
 
-NEGATED_CACHE = {}
+NEGATED_CACHE = {}  # type: dict
 
 
 def negated(tag):

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -24,6 +24,9 @@ from contextlib import contextmanager
 
 from hypothesis.internal.reflection import proxies
 
+if False:
+    from typing import Set, Dict, Tuple  # noqa
+
 """
 This module implements a custom coverage system that records conditions and
 then validates that every condition has been seen to be both True and False
@@ -37,7 +40,7 @@ When not running with a magic environment variable set, this module disables
 itself and has essentially no overhead.
 """
 
-pretty_file_name_cache = {}
+pretty_file_name_cache = {}  # type: Dict[str, str]
 
 
 def pretty_file_name(f):
@@ -59,7 +62,7 @@ IN_COVERAGE_TESTS = os.getenv('HYPOTHESIS_INTERNAL_COVERAGE') == 'true'
 if IN_COVERAGE_TESTS:
     with open('branch-check', 'w'):
         pass
-    written = set()
+    written = set()  # type: Set[Tuple[str, bool]]
 
     def record_branch(name, value):
         key = (name, value)
@@ -109,7 +112,8 @@ else:
     def check_function(f):
         return f
 
-    @contextmanager
+    # Mypy bug: https://github.com/python/mypy/issues/4117
+    @contextmanager  # type: ignore
     def check(name):
         yield
 

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -28,6 +28,9 @@ from hypothesis.errors import StopTest, DeadlineExceeded, \
 from hypothesis.internal.compat import text_type, binary_type, \
     encoded_filepath
 
+if False:
+    from typing import Dict  # noqa
+
 
 def belongs_to(package):
     root = os.path.dirname(package.__file__)
@@ -50,7 +53,7 @@ def belongs_to(package):
 
 PREVENT_ESCALATION = os.getenv('HYPOTHESIS_DO_NOT_ESCALATE') == 'true'
 
-FILE_CACHE = {}
+FILE_CACHE = {}  # type: Dict[bytes, bool]
 
 
 is_hypothesis_file = belongs_to(hypothesis)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -403,7 +403,7 @@ def eval_directory():
     return storage_directory('eval_source')
 
 
-eval_cache = {}
+eval_cache = {}  # type: dict
 
 
 def source_exec_as_module(source):

--- a/hypothesis-python/src/hypothesis/searchstrategy/collections.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/collections.py
@@ -65,8 +65,8 @@ class ListStrategy(SearchStrategy):
     def __init__(self, elements, min_size=0, max_size=float('inf')):
         SearchStrategy.__init__(self)
         self.min_size = min_size or 0
-        self.max_size = max_size or float('inf')
-        assert 0 <= min_size <= max_size
+        self.max_size = max_size if max_size is not None else float('inf')
+        assert 0 <= self.min_size <= self.max_size
         self.average_size = min(
             max(self.min_size * 2, self.min_size + 5),
             0.5 * (self.min_size + self.max_size),

--- a/hypothesis-python/src/hypothesis/searchstrategy/lazy.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/lazy.py
@@ -22,7 +22,11 @@ from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
-unwrap_cache = {}
+if False:
+    from typing import Dict  # noqa
+
+
+unwrap_cache = {}  # type: Dict[SearchStrategy, SearchStrategy]
 unwrap_depth = 0
 
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
@@ -145,6 +145,21 @@ class SearchStrategy(object):
             else:
                 needs_update = None
 
+            def recur2(strat):
+                def recur_inner(other):
+                    try:
+                        return forced_value(other)
+                    except AttributeError:
+                        pass
+                    listeners[other].add(strat)
+                    try:
+                        return mapping[other]
+                    except KeyError:
+                        needs_update.add(other)
+                        mapping[other] = default
+                        return default
+                return recur_inner
+
             count = 0
             seen = set()
             while needs_update:
@@ -167,20 +182,7 @@ class SearchStrategy(object):
                 to_update = needs_update
                 needs_update = set()
                 for strat in to_update:
-                    def recur(other):
-                        try:
-                            return forced_value(other)
-                        except AttributeError:
-                            pass
-                        listeners[other].add(strat)
-                        try:
-                            return mapping[other]
-                        except KeyError:
-                            needs_update.add(other)
-                            mapping[other] = default
-                            return default
-
-                    new_value = getattr(strat, calculation)(recur)
+                    new_value = getattr(strat, calculation)(recur2(strat))
                     if new_value != mapping[strat]:
                         needs_update.update(listeners[strat])
                         mapping[strat] = new_value
@@ -361,7 +363,7 @@ class SearchStrategy(object):
             self.validate_called = False
             raise
 
-    LABELS = {}
+    LABELS = {}  # type: dict
 
     @property
     def class_label(self):
@@ -529,7 +531,7 @@ class MappedSearchStrategy(SearchStrategy):
     def do_validate(self):
         self.mapped_strategy.validate()
 
-    def pack(self, x):
+    def pack(self, x):  # type: ignore
         """Take a value produced by the underlying mapped_strategy and turn it
         into a value suitable for outputting from this strategy."""
         raise NotImplementedError(

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -154,8 +154,8 @@ except ImportError:  # pragma: no cover
 else:
     _global_type_lookup.update({
         typing.ByteString: st.binary(),
-        typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),
-        typing.io.TextIO: st.builds(io.StringIO, st.text()),
+        typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
+        typing.io.TextIO: st.builds(io.StringIO, st.text()),  # type: ignore
         typing.Reversible: st.lists(st.integers()),
         typing.SupportsAbs: st.complex_numbers(),
         typing.SupportsComplex: st.complex_numbers(),

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -51,6 +51,9 @@ from hypothesis.searchstrategy.strategies import SearchStrategy
 
 STATE_MACHINE_RUN_LABEL = calc_label_from_name('another state machine step')
 
+if False:
+    from typing import Any, Dict, List, Text  # noqa
+
 
 class TestCaseProperty(object):  # pragma: no cover
 
@@ -136,6 +139,8 @@ class GenericStateMachine(object):
     sequence of example choices demonstrating that.
     """
 
+    find_breaking_runner = None  # type: classmethod
+
     def steps(self):
         """Return a SearchStrategy instance the defines the available next
         steps."""
@@ -177,7 +182,7 @@ class GenericStateMachine(object):
         """Called after initializing and after executing each step."""
         pass
 
-    _test_case_cache = {}
+    _test_case_cache = {}  # type: dict
 
     TestCase = TestCaseProperty()
 
@@ -441,18 +446,18 @@ class RuleBasedStateMachine(GenericStateMachine):
     executed.
     """
 
-    _rules_per_class = {}
-    _invariants_per_class = {}
-    _base_rules_per_class = {}
+    _rules_per_class = {}  # type: Dict[type, List[classmethod]]
+    _invariants_per_class = {}  # type: Dict[type, List[classmethod]]
+    _base_rules_per_class = {}  # type: Dict[type, List[classmethod]]
 
     def __init__(self):
         if not self.rules():
             raise InvalidDefinition(u'Type %s defines no rules' % (
                 type(self).__name__,
             ))
-        self.bundles = {}
+        self.bundles = {}  # type: Dict[Text, list]
         self.name_counter = 1
-        self.names_to_values = {}
+        self.names_to_values = {}  # type: Dict[Text, Any]
         self.__stream = CUnicodeIO()
         self.__printer = RepresentationPrinter(self.__stream)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+python_version = 3.6
+platform = linux
+
+strict_optional = True
+follow_imports = silent
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_unused_configs = True
+warn_redundant_casts = True
+
+[mypy-hypothesis.vendor.*]
+ignore_errors = True

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -1,6 +1,7 @@
 flake8
 flake8-docstrings
 isort
+mypy
 pip-tools
 pyformat
 pytest

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -28,6 +28,7 @@ jinja2==2.10              # via pyupio, sphinx
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==4.1.0     # via pytest
+mypy==0.590
 packaging==17.1           # via dparse, pyupio, safety, sphinx
 pip-tools==2.0.1
 pkginfo==1.4.2            # via twine
@@ -58,6 +59,7 @@ sphinxcontrib-websupport==1.0.1  # via sphinx
 tox==3.0.0
 tqdm==4.23.0              # via pyupio, twine
 twine==1.11.0
+typed-ast==1.1.0          # via mypy
 unify==0.4                # via pyformat
 untokenize==0.1.1         # via docformatter, unify
 urllib3==1.22             # via requests

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -53,6 +53,11 @@ def lint():
 
 
 @task
+def check_type_hints():
+    pip_tool('mypy', tools.PYTHON_SRC)
+
+
+@task
 def check_pyup_yml():
     with open(tools.PYUP_FILE, 'r') as i:
         data = yaml.safe_load(i.read())


### PR DESCRIPTION
This is the first batch of work toward #200.  I suggest reviewing the commits separately:

- Configuration, including marking the package as supporting type checking
- Changes to make the new `check-types` job pass in Travis
- Add basic type hints to `find`, `@given`, and most of `hypothesis.strategies`

By "basic" hints, I mean that they are correct but not particularly specific.   The obvious chunks of future work are to make `SearchStrategy` generic in the type of the examples it generates, and to annotate the rest of the API.