### PR TITLE
Fix HYPOTHESIS_VERBOSITY_LEVEL breakage

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release fixes a problem that was introduced in `3.56.0 <v3.56.0>`:
+Use of the ``HYPOTHESIS_VERBOSITY_LEVEL`` environment variable was, rather
+than deprecated, actually broken due to being read before various setup 
+the deprecation path needed was done. It now works correctly (and emits a
+deprecation warning).

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -617,16 +617,18 @@ class Verbosity(IntEnum):
     def _get_default():
         var = os.getenv('HYPOTHESIS_VERBOSITY_LEVEL')
         if var is not None:  # pragma: no cover
-            note_deprecation(
+            try:
+                result = Verbosity[var]
+            except KeyError:
+                raise InvalidArgument('No such verbosity level %r' % (var,))
+
+            warnings.warn(HypothesisDeprecationWarning(
                 'The HYPOTHESIS_VERBOSITY_LEVEL environment variable is '
                 'deprecated, and will be ignored by a future version of '
                 'Hypothesis.  Configure your verbosity level via a '
                 'settings profile instead.'
-            )
-            try:
-                return Verbosity[var]
-            except KeyError:
-                raise InvalidArgument('No such verbosity level %r' % (var,))
+            ))
+            return result
         return Verbosity.normal
 
     def __repr__(self):

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -17,6 +17,9 @@
 
 from __future__ import division, print_function, absolute_import
 
+import os
+import sys
+import subprocess
 from contextlib import contextmanager
 
 from hypothesis import find, given
@@ -93,3 +96,27 @@ def test_includes_intermediate_results_in_verbose_mode():
     lines = o.getvalue().splitlines()
     assert len([l for l in lines if u'example' in l]) > 2
     assert len([l for l in lines if u'AssertionError' in l])
+
+
+PRINT_VERBOSITY = """
+import warnings
+warnings.resetwarnings()
+
+from hypothesis import settings
+
+if __name__ == '__main__':
+    print("VERBOSITY", settings.default.verbosity.name)
+"""
+
+
+def test_picks_up_verbosity_from_environment(tmpdir):
+    script = tmpdir.join('printdebug.py')
+    script.write(PRINT_VERBOSITY)
+    environ = dict(os.environ)
+
+    environ['HYPOTHESIS_VERBOSITY_LEVEL'] = 'debug'
+    output = subprocess.check_output([
+        sys.executable, str(script)
+    ], env=environ).decode('ascii')
+
+    assert 'VERBOSITY debug' in output


### PR DESCRIPTION
Apparently the deprecation of this in #1211 didn't so much deprecate it as outright break it, because the `note_deprecation` function was not defined at the point it was called. This fixes that problem.