### PR TITLE
Fix database location

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes a problem introduced in `3.56.0 <v3.56.0>` where
+setting the hypothesis home directory (through currently undocumented
+means) would no longer result in the default database location living
+in the new home directory.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This release fixes a problem introduced in `3.56.0 <v3.56.0>` where
+This release fixes a problem introduced in :ref:`3.56.0 <v3.56.0>` where
 setting the hypothesis home directory (through currently undocumented
 means) would no longer result in the default database location living
 in the new home directory.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -131,10 +131,7 @@ class settings(settingsMeta('settings', (object,), {})):
 
     def __getattr__(self, name):
         if name in all_settings:
-            d = all_settings[name].default
-            if inspect.isfunction(d):
-                d = d()
-            return d
+            return all_settings[name].default
         else:
             raise AttributeError('settings has no attribute %s' % (name,))
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -61,7 +61,14 @@ class settingsProperty(object):
             return self
         else:
             try:
-                return obj.__dict__[self.name]
+                result = obj.__dict__[self.name]
+                # This is a gross hack, but it preserves the old behaviour that
+                # you can change the storage directory and it will be reflected
+                # in the default database.
+                if self.name == 'database' and result is not_set:
+                    from hypothesis.database import ExampleDatabase
+                    result = ExampleDatabase(not_set)
+                return result
             except KeyError:
                 raise AttributeError(self.name)
 
@@ -511,7 +518,7 @@ def _validate_database(db, __from_db_file=False):
 
 settings.define_setting(
     'database',
-    default=lambda: _validate_database(not_set),
+    default=not_set,
     show_default=False,
     description="""
 An instance of hypothesis.database.ExampleDatabase that will be

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -34,7 +34,7 @@ def run():
 
     new_home = mkdtemp()
     set_hypothesis_home_dir(new_home)
-    assert hypothesis.settings.default.startswith(new_home)
+    assert settings.default.startswith(new_home)
 
     charmap()
     assert os.path.exists(charmap_file()), charmap_file()

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -34,7 +34,7 @@ def run():
 
     new_home = mkdtemp()
     set_hypothesis_home_dir(new_home)
-    assert settings.default.startswith(new_home)
+    assert settings.default.database.path.startswith(new_home)
 
     charmap()
     assert os.path.exists(charmap_file()), charmap_file()

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -32,7 +32,9 @@ def run():
     filterwarnings('ignore', category=ImportWarning)
     filterwarnings('ignore', category=FutureWarning, module='pandas._version')
 
-    set_hypothesis_home_dir(mkdtemp())
+    new_home = mkdtemp()
+    set_hypothesis_home_dir(new_home)
+    assert hypothesis.settings.default.startswith(new_home)
 
     charmap()
     assert os.path.exists(charmap_file()), charmap_file()


### PR DESCRIPTION
Calculating the database default location at setting import time subtly broke our test suite by making it so that the example database was no longer isolated between runs. This might have affected other people as well, but the APIs for this were not currently documented (but I know some people are using them unofficially).

The fix for this a mess, and I think signposts that we really need to figure out how this all should work, but this at least gets us back to the previous behaviour.