### PR TITLE
Handle small max_examples correctly.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,7 @@
 RELEASE_TYPE: patch
 
 This release fixes a problem introduced in `3.56.0 <v3.56.0>` where
-setting :obj:`~hypothesis.settings.max_examples` to ``1`` test failing with
-``Unsatisfiable``. This problem could also occur in other harder to trigger
-circumstances (e.g. by setting it to a low value, having a hard to satisfy
-assumption, and disabling health checks).
+setting :obj:`~hypothesis.settings.max_examples` to ``1`` would result in tests
+failing with ``Unsatisfiable``. This problem could also occur in other harder
+to trigger circumstances (e.g. by setting it to a low value, having a hard to
+satisfy assumption, and disabling health checks).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,7 @@
 RELEASE_TYPE: patch
 
 This release fixes a problem introduced in `3.56.0 <v3.56.0>` where
-a low value for ``max_examples`` would result in a test failing with
-``Unsatisfiable``.
+setting :obj:`~hypothesis.settings.max_examples` to ``1`` test failing with
+``Unsatisfiable``. This problem could also occur in other harder to trigger
+circumstances (e.g. by setting it to a low value, having a hard to satisfy
+assumption, and disabling health checks).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a problem introduced in `3.56.0 <v3.56.0>` where
+a low value for ``max_examples`` would result in a test failing with
+``Unsatisfiable``.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This release fixes a problem introduced in `3.56.0 <v3.56.0>` where
+This release fixes a problem introduced in :ref:`3.56.0 <v3.56.0>` where
 setting :obj:`~hypothesis.settings.max_examples` to ``1`` would result in tests
 failing with ``Unsatisfiable``. This problem could also occur in other harder
 to trigger circumstances (e.g. by setting it to a low value, having a hard to

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -776,7 +776,7 @@ class StateForActualGivenExecution(object):
                 ) % (
                     self.settings.timeout, runner.valid_examples),
                     self.settings)
-            if runner.valid_examples <= 1 and not (
+            if runner.valid_examples == 0 and not (
                 runner.exit_reason == ExitReason.finished and
                 self.at_least_one_success
             ):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -450,7 +450,6 @@ class StateForActualGivenExecution(object):
         self.test_runner = test_runner
         self.search_strategy = search_strategy
         self.settings = settings
-        self.at_least_one_success = False
         self.last_exception = None
         self.falsifying_examples = ()
         self.__was_flaky = False
@@ -683,7 +682,6 @@ class StateForActualGivenExecution(object):
                     'Tests run under @given should return None, but '
                     '%s returned %r instead.'
                 ) % (self.test.__name__, result), HealthCheck.return_value)
-            self.at_least_one_success = True
             return False
         except UnsatisfiedAssumption:
             data.mark_invalid()
@@ -776,10 +774,7 @@ class StateForActualGivenExecution(object):
                 ) % (
                     self.settings.timeout, runner.valid_examples),
                     self.settings)
-            if runner.valid_examples == 0 and not (
-                runner.exit_reason == ExitReason.finished and
-                self.at_least_one_success
-            ):
+            if runner.valid_examples == 0:
                 if timed_out:
                     raise Timeout((
                         'Ran out of time before finding a satisfying '

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -259,7 +259,12 @@ class ConjectureRunner(object):
         if not self.interesting_examples:
             if self.valid_examples >= self.settings.max_examples:
                 self.exit_with(ExitReason.max_examples)
-            if self.call_count >= self.settings.max_examples * 10:
+            if self.call_count >= max(
+                self.settings.max_examples * 10,
+                # We have a high-ish default max iterations, so that tests
+                # don't become flaky when max_examples is too low.
+                1000
+            ):
                 self.exit_with(ExitReason.max_iterations)
 
         if self.__tree_is_exhausted():

--- a/hypothesis-python/tests/cover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/cover/test_given_error_conditions.py
@@ -27,18 +27,6 @@ from tests.common.utils import fails_with, validate_deprecation
 from hypothesis.strategies import booleans, integers
 
 
-def test_raises_timeout_on_slow_test():
-    with validate_deprecation():
-        @given(integers())
-        @settings(timeout=0.01)
-        def test_is_slow(x):
-            time.sleep(0.02)
-
-    with validate_deprecation():
-        with pytest.raises(Timeout):
-            test_is_slow()
-
-
 def test_raises_unsatisfiable_if_all_false():
     @given(integers())
     @settings(max_examples=50, suppress_health_check=HealthCheck.all())

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -23,7 +23,7 @@ import traceback
 
 import pytest
 
-from hypothesis import HealthCheck, event, given, example, settings
+from hypothesis import HealthCheck, event, given, assume, example, settings
 from hypothesis import strategies as st
 from hypothesis.statistics import collector
 
@@ -41,6 +41,16 @@ def call_for_statistics(test_function):
             traceback.print_exc()
     assert result[0] is not None
     return result[0]
+
+
+def test_notes_hard_to_satisfy():
+    @given(st.integers())
+    @settings(suppress_health_check=HealthCheck.all())
+    def test(i):
+        assume(i == 0)
+
+    stats = call_for_statistics(test)
+    assert 'satisfied assumptions' in stats.exit_reason
 
 
 def test_can_callback_with_a_string():

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -169,9 +169,11 @@ def test_does_not_catch_interrupt_during_falsify():
 
 
 def test_contains_the_test_function_name_in_the_exception_string():
+    look_for_one = settings(
+        max_examples=1, suppress_health_check=HealthCheck.all())
 
     @given(integers())
-    @settings(max_examples=1)
+    @look_for_one
     def this_has_a_totally_unique_name(x):
         reject()
 
@@ -182,7 +184,7 @@ def test_contains_the_test_function_name_in_the_exception_string():
     class Foo(object):
 
         @given(integers())
-        @settings(max_examples=1)
+        @look_for_one
         def this_has_a_unique_name_and_lives_on_a_class(self, x):
             reject()
 

--- a/hypothesis-python/tests/cover/test_timeout.py
+++ b/hypothesis-python/tests/cover/test_timeout.py
@@ -19,10 +19,8 @@ from __future__ import division, print_function, absolute_import
 
 import time
 
-import pytest
-
 from hypothesis import given, settings
-from hypothesis.errors import Unsatisfiable, HypothesisDeprecationWarning
+from hypothesis.errors import HypothesisDeprecationWarning
 from tests.common.utils import fails, fails_with, validate_deprecation
 from hypothesis.strategies import integers
 
@@ -35,8 +33,7 @@ def test_hitting_timeout_is_deprecated():
             time.sleep(0.05)
 
     with validate_deprecation():
-        with pytest.raises(Unsatisfiable):
-            test_slow_test_times_out()
+        test_slow_test_times_out()
 
 
 # Cheap hack to make test functions which fail on their second invocation

--- a/hypothesis-python/tests/cover/test_timeout.py
+++ b/hypothesis-python/tests/cover/test_timeout.py
@@ -19,8 +19,10 @@ from __future__ import division, print_function, absolute_import
 
 import time
 
-from hypothesis import given, settings
-from hypothesis.errors import HypothesisDeprecationWarning
+import pytest
+
+from hypothesis import given, reject, settings
+from hypothesis.errors import Timeout, HypothesisDeprecationWarning
 from tests.common.utils import fails, fails_with, validate_deprecation
 from hypothesis.strategies import integers
 
@@ -34,6 +36,19 @@ def test_hitting_timeout_is_deprecated():
 
     with validate_deprecation():
         test_slow_test_times_out()
+
+
+def test_slow_unsatisfiable_test():
+    with validate_deprecation():
+        @settings(timeout=0.1)
+        @given(integers())
+        def test_slow_test_times_out(x):
+            time.sleep(0.05)
+            reject()
+
+    with validate_deprecation():
+        with pytest.raises(Timeout):
+            test_slow_test_times_out()
 
 
 # Cheap hack to make test functions which fail on their second invocation

--- a/hypothesis-python/tests/cover/test_unusual_settings_configs.py
+++ b/hypothesis-python/tests/cover/test_unusual_settings_configs.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+from hypothesis import Verbosity, HealthCheck, given, assume, settings
+
+
+@settings(max_examples=1, database=None)
+@given(st.integers())
+def test_single_example(n):
+    pass
+
+
+@settings(
+    max_examples=1, database=None,
+    suppress_health_check=[HealthCheck.filter_too_much],
+    verbosity=Verbosity.debug,
+)
+@given(st.integers())
+def test_hard_to_find_single_example(n):
+    # Numbers are arbitrary, just deliberately unlikely to hit this too soon.
+    assume(n % 50 == 11)

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -86,7 +86,7 @@ def test_output_emitting_unicode(testdir, monkeypatch):
 
 
 TRACEBACKHIDE_TIMEOUT = """
-from hypothesis import given, settings
+from hypothesis import given, settings, reject
 from hypothesis.strategies import integers
 from hypothesis.errors import HypothesisDeprecationWarning
 
@@ -102,6 +102,7 @@ def test_timeout_traceback_is_hidden():
         @settings(timeout=1)
         def inner(i):
             time.sleep(1.1)
+            reject()
         inner()
 """
 


### PR DESCRIPTION
There was an off-by-one error in the logic in #1211 which meant that `max_examples=1` no longer worked. This fixes that.