### PR TITLE
Further documentation tweaks

### DIFF
--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -665,7 +665,7 @@ also improved, leading to better error messages in many cases involving
 --------------------
 
 This release fixes a bug in the shrinker that prevented the optimisations in
-3.44.6 from working in some cases. It would not have worked correctly when
+:ref:`3.44.6 <v3.44.6>` from working in some cases. It would not have worked correctly when
 filtered examples were nested (e.g. with a set of integers in some range).
 
 This would not have resulted in any correctness problems, but shrinking may
@@ -826,7 +826,7 @@ would show up normally.
 3.44.0 - 2017-12-17
 -------------------
 
-This release adds a new feature: The :ref:`@reproduce_failure <reproduce_failure>`,
+This release adds a new feature: The :ref:`@reproduce_failure decorator <reproduce_failure>`,
 designed to make it easy to use Hypothesis's binary format for examples to
 reproduce a problem locally without having to share your example database
 between machines.
@@ -1106,8 +1106,8 @@ The following are now deprecated:
 * Passing :attr:`~hypothesis.HealthCheck.random_module` to
   :attr:`~hypothesis.settings.suppress_health_check`. This hasn't done anything
   for a long time, but was never explicitly deprecated. Hypothesis always seeds
-  the random module when running @given tests, so this is no longer an error
-  and suppressing it doesn't do anything.
+  the random module when running :func:`@given <hypothesis.given>` tests, so this
+  is no longer an error and suppressing it doesn't do anything.
 * Passing non-:class:`~hypothesis.HealthCheck` values in
   :attr:`~hypothesis.settings.suppress_health_check`. This was previously
   allowed but never did anything useful.
@@ -2271,7 +2271,7 @@ reliable iteration order.
 3.8.3 - 2017-05-09
 ------------------
 
-This release removes a version check for older versions of pytest when using
+This release removes a version check for older versions of :pypi:`pytest` when using
 the Hypothesis pytest plugin. The pytest plugin will now run unconditionally
 on all versions of pytest. This breaks compatibility with any version of pytest
 prior to 2.7.0 (which is more than two years old).
@@ -2317,10 +2317,9 @@ properties such as indexing support or repeated iteration.
 3.7.4 - 2017-04-22
 ------------------
 
-This is a bug fix release for a single bug:
-
-* In :ref:`3.7.3 <v3.7.3>`, using :func:`@example <hypothesis.example>` and a pytest fixture in the same test could
-  cause the test to fail to fill the arguments, and throw a TypeError.
+This patch fixes a bug in :ref:`3.7.3 <v3.7.3>`, where using
+:func:`@example <hypothesis.example>` and a pytest fixture in the same test
+could cause the test to fail to fill the arguments, and throw a TypeError.
 
 .. _v3.7.3:
 
@@ -2508,7 +2507,7 @@ This is a feature release.
 
 * :func:`~hypothesis.strategies.fractions` and :func:`~hypothesis.strategies.decimals` strategies now support min_value and max_value
   parameters. Thanks go to Anne Mulhern for the development of this feature.
-* The Hypothesis pytest plugin now supports a --hypothesis-show-statistics parameter
+* The Hypothesis pytest plugin now supports a ``--hypothesis-show-statistics`` parameter
   that gives detailed statistics about the tests that were run. Huge thanks to
   Jean-Louis Fuchs and Adfinis-SyGroup for funding the development of this feature.
 * There is a new :func:`~hypothesis.event` function that can be used to add custom statistics.
@@ -2561,7 +2560,7 @@ This is a bug fix release for a single bug:
 This release is entirely provided by `Lucas Wiman <https://github.com/lucaswiman>`_:
 
 Strategies constructed by :func:`~hypothesis.extra.django.models` will now respect much more of
-Django's validations out of the box. Wherever possible full_clean() should
+Django's validations out of the box. Wherever possible :meth:`~django:django.db.models.Model.full_clean` should
 succeed.
 
 In particular:

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -437,12 +437,11 @@ and should be rewritten as:
 .. code:: python
 
     from unittest import TestCase
-    import inspect
 
     class TestRunTwice(TestCase):
         def execute_example(self, f):
             result = f()
-            if inspect.isfunction(result):
+            if callable(result):
                 result = result()
             return result
 

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -135,22 +135,15 @@ we actually wanted our labels to be unique. Lets change the test to do that.
 .. code:: python
 
     def deduplicate_nodes_by_label(nodes):
-        table = {}
-        for node in nodes:
-            table[node.label] = node
+        table = {node.label: node for node in nodes}
         return list(table.values())
 
-
-    NodeSet = s.lists(NodeStrategy).map(deduplicate_nodes_by_label)
-
-We define a function to deduplicate nodes by labels, and then map that over a strategy
-for lists of nodes to give us a strategy for lists of nodes with unique labels. We can
-now rewrite the test to use that:
-
+We define a function to deduplicate nodes by labels, and can now map that over a strategy
+for lists of nodes to give us a strategy for lists of nodes with unique labels:
 
 .. code:: python
 
-    @given(NodeSet)
+    @given(s.lists(NodeStrategy).map(deduplicate_nodes_by_label))
     def test_sorting_nodes_is_prefix_sorted(xs):
         sort_nodes(xs)
         assert is_prefix_sorted(xs)

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -193,7 +193,7 @@ managed to sort some nodes without getting it completely wrong. Go us.
 Time zone arithmetic
 --------------------
 
-This is an example of some tests for pytz which check that various timezone
+This is an example of some tests for :pypi:`pytz` which check that various timezone
 conversions behave as you would expect them to. These tests should all pass,
 and are mostly a demonstration of some useful sorts of thing to test with
 Hypothesis, and how the :func:`~hypothesis.strategies.datetimes` strategy works.
@@ -369,6 +369,7 @@ hammer their API without their permission).
 All this does is use Hypothesis to generate random JSON data matching the
 format their API asks for and check for 500 errors. More advanced tests which
 then use the result and go on to do other things are definitely also possible.
+The :pypi:`swagger-conformance` package provides an excellent example of this!
 
 .. code:: python
 

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -40,12 +40,9 @@ the same. The following is exactly equivalent:
 Available settings
 ------------------
 
-.. module:: hypothesis
-.. autoclass:: settings
-    :members: max_examples, max_iterations, min_satisfying_examples,
-        max_shrinks, timeout, strict, database_file, stateful_step_count,
-        database, perform_health_check, suppress_health_check, buffer_size,
-        phases, deadline, use_coverage, derandomize
+.. autoclass:: hypothesis.settings
+    :members:
+    :exclude-members: register_profile, get_profile, load_profile
 
 .. _phases:
 

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -245,7 +245,7 @@ by your conftest you can load one with the command line option ``--hypothesis-pr
 
 .. code:: bash
 
-    $ py.test tests --hypothesis-profile <profile-name>
+    $ pytest tests --hypothesis-profile <profile-name>
 
 
 ~~~~~~~~

--- a/hypothesis-python/docs/support.rst
+++ b/hypothesis-python/docs/support.rst
@@ -4,7 +4,8 @@ Help and Support
 
 For questions you are happy to ask in public, the :doc:`Hypothesis community <community>` is a
 friendly place where I or others will be more than happy to help you out. You're also welcome to
-ask questions on Stack Overflow. If you do, please tag them with 'python-hypothesis' so someone
+ask questions on Stack Overflow. If you do, please tag them with
+`'python-hypothesis' <https://stackoverflow.com/questions/tagged/python-hypothesis>`_ so someone
 sees them.
 
 For bugs and enhancements, please file an issue on the :issue:`GitHub issue tracker <>`.


### PR DESCRIPTION
Shortly after #1244 was merged, I discovered that `settings.verbosity` was not documented with all the other attributes.  Now it is, and I've changed from a members whitelist to a wildcard+blacklist to prevent the problem coming back next time we change a setting.

I then did a general sweep for anything else I left out - missing links, confusing language or code examples, weird formatting, etc. and fixed the obvious bits.  Obviously this isn't comprehensive, but it helps :smile: 