### PR TITLE
Add type hints to the public API, with generic Strategy type

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,4 @@ exclude =
     test_imports.py,
     hypothesis-python/tests/py2/*,
     test_lambda_formatting.py
-ignore = D1,D205,D209,D213,D400,D401,D999
+ignore = F811,D1,D205,D209,D213,D400,D401,D999

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch contains further internal work to support Mypy.
+There are no user-visible changes... yet.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -39,7 +39,7 @@ from hypothesis.internal.validation import try_convert
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
 if False:
-    from typing import Dict, List  # noqa
+    from typing import Any, Dict, List  # noqa
 
 __all__ = [
     'settings',
@@ -140,6 +140,7 @@ class settings(
             raise AttributeError('settings has no attribute %s' % (name,))
 
     def __init__(self, parent=None, **kwargs):
+        # type: (settings, **Any) -> None
         if (
             kwargs.get('database', not_set) is not_set and
             kwargs.get('database_file', not_set) is not not_set
@@ -326,6 +327,7 @@ class settings(
 
     @staticmethod
     def register_profile(name, parent=None, **kwargs):
+        # type: (str, settings, **Any) -> None
         """Registers a collection of values to be used as a settings profile.
 
         Settings profiles can be loaded by name - for example, you might
@@ -354,6 +356,7 @@ class settings(
 
     @staticmethod
     def get_profile(name):
+        # type: (str) -> settings
         """Return the profile with the given name."""
         if not isinstance(name, (str, text_type)):
             note_deprecation('name=%r must be a string' % (name,))
@@ -364,6 +367,7 @@ class settings(
 
     @staticmethod
     def load_profile(name):
+        # type: (str) -> None
         """Loads in the settings defined in the profile provided.
 
         If the profile does not exist, InvalidArgument will be raised.
@@ -568,6 +572,7 @@ class HealthCheck(Enum):
 
     @classmethod
     def all(cls):
+        # type: () -> List[HealthCheck]
         bad = (HealthCheck.exception_in_generation, HealthCheck.random_module)
         return [h for h in list(cls) if h not in bad]
 
@@ -623,6 +628,7 @@ class Verbosity(IntEnum):
 
     @staticmethod
     def _get_default():
+        # type: () -> Verbosity
         var = os.getenv('HYPOTHESIS_VERBOSITY_LEVEL')
         if var is not None:  # pragma: no cover
             try:
@@ -792,6 +798,7 @@ settings.lock_further_definitions()
 
 
 def note_deprecation(message, s=None):
+    # type: (str, settings) -> None
     if s is None:
         s = settings.default
     assert s is not None

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -24,12 +24,16 @@ from hypothesis.errors import CleanupFailed, InvalidArgument, \
 from hypothesis.reporting import report
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
+if False:
+    from typing import Any, AnyStr  # noqa
+
 
 def reject():
     raise UnsatisfiedAssumption()
 
 
 def assume(condition):
+    # type: (Any) -> bool
     """Calling ``assume`` is like an :ref:`assert <python:assert>` that marks
     the example as bad, rather than failing the test.
 
@@ -103,6 +107,7 @@ def cleanup(teardown):
 
 
 def note(value):
+    # type: (AnyStr) -> None
     """Report this value in the final execution."""
     context = _current_build_context.value
     if context is None:
@@ -114,6 +119,7 @@ def note(value):
 
 
 def event(value):
+    # type: (AnyStr) -> None
     """Record an event that occurred this test. Statistics on number of test
     runs with each event will be reported at the end if you run Hypothesis in
     statistics reporting mode.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -75,7 +75,8 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict, Callable, Optional  # noqa
+    from typing import Any, Dict, Callable, Optional, Union  # noqa
+    from hypothesis.utils.conventions import UniqueIdentifier  # noqa
 
 
 running_under_pytest = False
@@ -892,8 +893,11 @@ def fake_subTest(self, msg=None, **__):
     yield
 
 
-def given(*given_arguments, **given_kwargs):
-    # type: (*SearchStrategy, **SearchStrategy) -> Callable
+def given(
+    *given_arguments,  # type: Union[SearchStrategy, UniqueIdentifier]
+    **given_kwargs  # type: Union[SearchStrategy, UniqueIdentifier]
+):
+    # type: (...) -> Callable[[Callable[..., None]], Callable[..., None]]
     """A decorator for turning a test function that accepts arguments into a
     randomized test.
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,7 +76,7 @@ except ImportError:  # pragma: no cover
 
 if False:
     from typing import Any, Dict, Callable, Optional, Union  # noqa
-    from hypothesis.utils.conventions import UniqueIdentifier  # noqa
+    from hypothesis.utils.conventions import InferType  # noqa
 
 
 running_under_pytest = False
@@ -894,8 +894,8 @@ def fake_subTest(self, msg=None, **__):
 
 
 def given(
-    *given_arguments,  # type: Union[SearchStrategy, UniqueIdentifier]
-    **given_kwargs  # type: Union[SearchStrategy, UniqueIdentifier]
+    *given_arguments,  # type: Union[SearchStrategy, InferType]
+    **given_kwargs  # type: Union[SearchStrategy, InferType]
 ):
     # type: (...) -> Callable[[Callable[..., None]], Callable[..., None]]
     """A decorator for turning a test function that accepts arguments into a

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -34,7 +34,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
 from hypothesis.provisional import emails, ip4_addr_strings, \
     ip6_addr_strings
-from hypothesis.utils.conventions import UniqueIdentifier
+from hypothesis.utils.conventions import DefaultValueType
 
 if False:
     from datetime import tzinfo  # noqa
@@ -94,7 +94,7 @@ def add_default_field_mapping(field_type, strategy):
     field_mappings()[field_type] = strategy
 
 
-default_value = UniqueIdentifier(u'default_value')
+default_value = DefaultValueType(u'default_value')
 
 
 def validator_to_filter(f):
@@ -171,7 +171,7 @@ def _get_strategy_for_field(f):
 
 def models(
     model,  # type: Type[dm.Model]
-    **field_strategies  # type: Union[st.SearchStrategy[Any], UniqueIdentifier]
+    **field_strategies  # type: Union[st.SearchStrategy[Any], DefaultValueType]
 ):
     # type: (...) -> st.SearchStrategy[Any]
     """Return a strategy for examples of ``model``.
@@ -199,8 +199,10 @@ def models(
 
       shop_strategy = models(Shop, company=models(Company))
     """
-    result = {k: v for k, v in field_strategies.items()
-              if v is not default_value}
+    result = {}
+    for k, v in field_strategies.items():
+        if not isinstance(v, DefaultValueType):
+            result[k] = v
     missed = []  # type: List[Text]
     for f in model._meta.concrete_fields:
         if not (f.name in field_strategies or isinstance(f, dm.AutoField)):

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -36,8 +36,13 @@ from hypothesis.provisional import emails, ip4_addr_strings, \
     ip6_addr_strings
 from hypothesis.utils.conventions import UniqueIdentifier
 
+if False:
+    from datetime import tzinfo  # noqa
+    from typing import Any, Type, Optional, List, Text, Callable, Union  # noqa
+
 
 def get_tz_strat():
+    # type: () -> st.SearchStrategy[Optional[tzinfo]]
     if getattr(django_settings, 'USE_TZ', False):
         return timezones()
     return st.none()
@@ -85,6 +90,7 @@ def field_mappings():
 
 
 def add_default_field_mapping(field_type, strategy):
+    # type: (Type[dm.Field], st.SearchStrategy[Any]) -> None
     field_mappings()[field_type] = strategy
 
 
@@ -92,6 +98,7 @@ default_value = UniqueIdentifier(u'default_value')
 
 
 def validator_to_filter(f):
+    # type: (Type[dm.Field]) -> Callable[[Any], bool]
     """Converts the field run_validators method to something suitable for use
     in filter."""
     def validate(value):
@@ -105,8 +112,9 @@ def validator_to_filter(f):
 
 
 def _get_strategy_for_field(f):
+    # type: (Type[dm.Field]) -> st.SearchStrategy[Any]
     if f.choices:
-        choices = []
+        choices = []  # type: list
         for value, name_or_optgroup in f.choices:
             if isinstance(name_or_optgroup, (list, tuple)):
                 choices.extend(key for key, _ in name_or_optgroup)
@@ -161,7 +169,11 @@ def _get_strategy_for_field(f):
     return strategy
 
 
-def models(model, **field_strategies):
+def models(
+    model,  # type: Type[dm.Model]
+    **field_strategies  # type: Union[st.SearchStrategy[Any], UniqueIdentifier]
+):
+    # type: (...) -> st.SearchStrategy[Any]
     """Return a strategy for examples of ``model``.
 
     .. warning::
@@ -189,7 +201,7 @@ def models(model, **field_strategies):
     """
     result = {k: v for k, v in field_strategies.items()
               if v is not default_value}
-    missed = []
+    missed = []  # type: List[Text]
     for f in model._meta.concrete_fields:
         if not (f.name in field_strategies or isinstance(f, dm.AutoField)):
             result[f.name] = _get_strategy_for_field(f)

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -29,11 +29,16 @@ from hypothesis.internal.compat import hrange, text_type
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
 
+if False:
+    from typing import Any, Union, Sequence, Tuple  # noqa
+    from hypothesis.searchstrategy.strategies import T  # noqa
+
 TIME_RESOLUTIONS = tuple('Y  M  D  h  m  s  ms  us  ns  ps  fs  as'.split())
 
 
 @st.defines_strategy_with_reusable_values
 def from_dtype(dtype):
+    # type: (np.dtype) -> st.SearchStrategy[Any]
     # Compound datatypes, eg 'f4,f4,f4'
     if dtype.names is not None:
         # mapping np.void.type over a strategy is nonsense, so return now.
@@ -47,7 +52,7 @@ def from_dtype(dtype):
 
     # Scalar datatypes
     if dtype.kind == u'b':
-        result = st.booleans()
+        result = st.booleans()  # type: SearchStrategy[Any]
     elif dtype.kind == u'f':
         result = st.floats()
     elif dtype.kind == u'c':
@@ -227,8 +232,14 @@ def fill_for(elements, unique, fill, name=''):
 
 @st.composite
 def arrays(
-    draw, dtype, shape, elements=None, fill=None, unique=False
+    draw,  # type: Any
+    dtype,  # type: Any
+    shape,  # type: Union[int, Sequence[int]]
+    elements=None,  # type: st.SearchStrategy[Any]
+    fill=None,  # type: st.SearchStrategy[Any]
+    unique=False,  # type: bool
 ):
+    # type: (...) -> st.SearchStrategy[np.ndarray]
     """Returns a strategy for generating :class:`numpy's
     ndarrays<numpy.ndarray>`.
 
@@ -320,6 +331,7 @@ def arrays(
 
 @st.defines_strategy
 def array_shapes(min_dims=1, max_dims=3, min_side=1, max_side=10):
+    # type: (int, int, int, int) -> st.SearchStrategy[Tuple[int, ...]]
     """Return a strategy for array shapes (tuples of int >= 1)."""
     order_check('dims', 1, min_dims, max_dims)
     order_check('side', 1, min_side, max_side)
@@ -329,6 +341,7 @@ def array_shapes(min_dims=1, max_dims=3, min_side=1, max_side=10):
 
 @st.defines_strategy
 def scalar_dtypes():
+    # type: () -> st.SearchStrategy[np.dtype]
     """Return a strategy that can return any non-flexible scalar dtype."""
     return st.one_of(boolean_dtypes(),
                      integer_dtypes(), unsigned_integer_dtypes(),
@@ -337,6 +350,7 @@ def scalar_dtypes():
 
 
 def defines_dtype_strategy(strat):
+    # type: (T) -> T
     @st.defines_strategy
     @proxies(strat)
     def inner(*args, **kwargs):
@@ -346,6 +360,7 @@ def defines_dtype_strategy(strat):
 
 @defines_dtype_strategy
 def boolean_dtypes():
+    # type: () -> st.SearchStrategy[np.dtype]
     return st.just('?')
 
 
@@ -374,6 +389,7 @@ def dtype_factory(kind, sizes, valid_sizes, endianness):
 
 @defines_dtype_strategy
 def unsigned_integer_dtypes(endianness='?', sizes=(8, 16, 32, 64)):
+    # type: (str, Sequence[int]) -> st.SearchStrategy[np.dtype]
     """Return a strategy for unsigned integer dtypes.
 
     endianness may be ``<`` for little-endian, ``>`` for big-endian,
@@ -388,6 +404,7 @@ def unsigned_integer_dtypes(endianness='?', sizes=(8, 16, 32, 64)):
 
 @defines_dtype_strategy
 def integer_dtypes(endianness='?', sizes=(8, 16, 32, 64)):
+    # type: (str, Sequence[int]) -> st.SearchStrategy[np.dtype]
     """Return a strategy for signed integer dtypes.
 
     endianness and sizes are treated as for
@@ -398,6 +415,7 @@ def integer_dtypes(endianness='?', sizes=(8, 16, 32, 64)):
 
 @defines_dtype_strategy
 def floating_dtypes(endianness='?', sizes=(16, 32, 64)):
+    # type: (str, Sequence[int]) -> st.SearchStrategy[np.dtype]
     """Return a strategy for floating-point dtypes.
 
     sizes is the size in bits of floating-point number.  Some machines support
@@ -412,6 +430,7 @@ def floating_dtypes(endianness='?', sizes=(16, 32, 64)):
 
 @defines_dtype_strategy
 def complex_number_dtypes(endianness='?', sizes=(64, 128)):
+    # type: (str, Sequence[int]) -> st.SearchStrategy[np.dtype]
     """Return a strategy for complex-number dtypes.
 
     sizes is the total size in bits of a complex number, which consists
@@ -439,6 +458,7 @@ def validate_time_slice(max_period, min_period):
 
 @defines_dtype_strategy
 def datetime64_dtypes(max_period='Y', min_period='ns', endianness='?'):
+    # type: (str, str, str) -> st.SearchStrategy[np.dtype]
     """Return a strategy for datetime64 dtypes, with various precisions from
     year to attosecond."""
     return dtype_factory('datetime64[{}]',
@@ -448,6 +468,7 @@ def datetime64_dtypes(max_period='Y', min_period='ns', endianness='?'):
 
 @defines_dtype_strategy
 def timedelta64_dtypes(max_period='Y', min_period='ns', endianness='?'):
+    # type: (str, str, str) -> st.SearchStrategy[np.dtype]
     """Return a strategy for timedelta64 dtypes, with various precisions from
     year to attosecond."""
     return dtype_factory('timedelta64[{}]',
@@ -457,6 +478,7 @@ def timedelta64_dtypes(max_period='Y', min_period='ns', endianness='?'):
 
 @defines_dtype_strategy
 def byte_string_dtypes(endianness='?', min_len=0, max_len=16):
+    # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating bytestring dtypes, of various lengths
     and byteorder."""
     order_check('len', 0, min_len, max_len)
@@ -466,6 +488,7 @@ def byte_string_dtypes(endianness='?', min_len=0, max_len=16):
 
 @defines_dtype_strategy
 def unicode_string_dtypes(endianness='?', min_len=0, max_len=16):
+    # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating unicode string dtypes, of various
     lengths and byteorder."""
     order_check('len', 0, min_len, max_len)
@@ -474,23 +497,34 @@ def unicode_string_dtypes(endianness='?', min_len=0, max_len=16):
 
 
 @defines_dtype_strategy
-def array_dtypes(subtype_strategy=scalar_dtypes(),
-                 min_size=1, max_size=5, allow_subarrays=False):
+def array_dtypes(
+    subtype_strategy=scalar_dtypes(),  # type: st.SearchStrategy[np.dtype]
+    min_size=1,  # type: int
+    max_size=5,  # type: int
+    allow_subarrays=False,  # type: bool
+):
+    # type: (...) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating array (compound) dtypes, with members
     drawn from the given subtype strategy."""
     order_check('size', 0, min_size, max_size)
-    native_strings = st.text if text_type is str else st.binary
-    elements = st.tuples(native_strings(), subtype_strategy)
+    native_strings = st.text()  # type: SearchStrategy[Any]
+    if text_type is not str:  # pragma: no cover
+        native_strings = st.binary()
+    elements = st.tuples(native_strings, subtype_strategy)
     if allow_subarrays:
-        elements |= st.tuples(native_strings(), subtype_strategy,
+        elements |= st.tuples(native_strings, subtype_strategy,
                               array_shapes(max_dims=2, max_side=2))
     return st.lists(elements=elements, min_size=min_size, max_size=max_size,
                     unique_by=lambda d: d[0])
 
 
 @st.defines_strategy
-def nested_dtypes(subtype_strategy=scalar_dtypes(),
-                  max_leaves=10, max_itemsize=None):
+def nested_dtypes(
+    subtype_strategy=scalar_dtypes(),  # type: st.SearchStrategy[np.dtype]
+    max_leaves=10,  # type: int
+    max_itemsize=None,  # type: int
+):
+    # type: (...) -> st.SearchStrategy[np.dtype]
     """Return the most-general dtype strategy.
 
     Elements drawn from this strategy may be simple (from the

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -42,6 +42,10 @@ except ImportError:  # pragma: no cover
             return False
         return dt == 'category'
 
+if False:
+    from typing import Any, Union, Sequence, Set  # noqa
+    from hypothesis.searchstrategy.strategies import Ex  # noqa
+
 
 def dtype_for_elements_strategy(s):
     return st.shared(
@@ -148,6 +152,7 @@ DEFAULT_MAX_SIZE = 10
 @st.cacheable
 @st.defines_strategy
 def range_indexes(min_size=0, max_size=None):
+    # type: (int, int) -> st.SearchStrategy[pandas.RangeIndex]
     """Provides a strategy which generates an :class:`~pandas.Index` whose
     values are 0, 1, ..., n for some n.
 
@@ -168,7 +173,11 @@ def range_indexes(min_size=0, max_size=None):
 @st.cacheable
 @st.defines_strategy
 def indexes(
-    elements=None, dtype=None, min_size=0, max_size=None, unique=True,
+    elements=None,  # type: st.SearchStrategy[Ex]
+    dtype=None,  # type: Any
+    min_size=0,  # type: int
+    max_size=None,  # type: int
+    unique=True,  # type: bool
 ):
     """Provides a strategy for producing a :class:`pandas.Index`.
 
@@ -203,7 +212,14 @@ def indexes(
 
 
 @st.defines_strategy
-def series(elements=None, dtype=None, index=None, fill=None, unique=False):
+def series(
+    elements=None,  # type: st.SearchStrategy[Ex]
+    dtype=None,  # type: Any
+    index=None,  # type: st.SearchStrategy[Union[Sequence, pandas.Index]]
+    fill=None,  # type: st.SearchStrategy[Ex]
+    unique=False,  # type: bool
+):
+    # type: (...) -> st.SearchStrategy[pandas.Series]
     """Provides a strategy for producing a :class:`pandas.Series`.
 
     Arguments:
@@ -299,7 +315,11 @@ class column(object):
 
 
 def columns(
-    names_or_number, dtype=None, elements=None, fill=None, unique=False
+    names_or_number,  # type: Union[int, Sequence[str]]
+    dtype=None,  # type: Any
+    elements=None,  # type: st.SearchStrategy[Ex]
+    fill=None,  # type: st.SearchStrategy[Ex]
+    unique=False,  # type: bool
 ):
     """A convenience function for producing a list of :class:`column` objects
     of the same general shape.
@@ -310,10 +330,10 @@ def columns(
     be created. All other arguments are passed through verbatim to
     create the columns.
     """
-    try:
+    if isinstance(names_or_number, (int, float)):
+        names = [None] * names_or_number  # type: list
+    else:
         names = list(names_or_number)
-    except TypeError:
-        names = [None] * names_or_number
     return [
         column(
             name=n, dtype=dtype, elements=elements, fill=fill, unique=unique
@@ -323,8 +343,11 @@ def columns(
 
 @st.defines_strategy
 def data_frames(
-    columns=None, rows=None, index=None
+    columns=None,  # type: Sequence[column]
+    rows=None,  # type: st.SearchStrategy[Union[dict, Sequence[Any]]]
+    index=None,  # type: st.SearchStrategy[Ex]
 ):
+    # type: (...) -> st.SearchStrategy[pandas.DataFrame]
     """Provides a strategy for producing a :class:`pandas.DataFrame`.
 
     Arguments:
@@ -464,12 +487,12 @@ def data_frames(
             return rows_only()
 
     assert columns is not None
-    columns = try_convert(tuple, columns, 'columns')
+    cols = try_convert(tuple, columns, 'columns')  # type: Sequence[column]
 
     rewritten_columns = []
-    column_names = set()
+    column_names = set()  # type: Set[str]
 
-    for i, c in enumerate(columns):
+    for i, c in enumerate(cols):
         check_type(column, c, 'columns[%d]' % (i,))
 
         c = copy(c)

--- a/hypothesis-python/src/hypothesis/extra/pytz.py
+++ b/hypothesis-python/src/hypothesis/extra/pytz.py
@@ -36,6 +36,7 @@ __all__ = ['timezones']
 @st.cacheable
 @st.defines_strategy
 def timezones():
+    # type: () -> st.SearchStrategy[dt.tzinfo]
     """Any timezone in the Olsen database, as a pytz tzinfo object.
 
     This strategy minimises to UTC, or the smallest possible fixed
@@ -46,8 +47,10 @@ def timezones():
     # Some timezones have always had a constant offset from UTC.  This makes
     # them simpler than timezones with daylight savings, and the smaller the
     # absolute offset the simpler they are.  Of course, UTC is even simpler!
-    static = [pytz.UTC] + sorted(
-        (t for t in all_timezones if isinstance(t, pytz.tzfile.StaticTzInfo)),
+    static = [pytz.UTC]  # type: list
+    static += sorted(
+        (t for t in all_timezones
+         if isinstance(t, pytz.tzfile.StaticTzInfo)),  # type: ignore
         key=lambda tz: abs(tz.utcoffset(dt.datetime(2000, 1, 1)))
     )
     # Timezones which have changed UTC offset; best ordered by name.

--- a/hypothesis-python/src/hypothesis/internal/renaming.py
+++ b/hypothesis-python/src/hypothesis/internal/renaming.py
@@ -22,8 +22,13 @@ from inspect import cleandoc
 from hypothesis._settings import note_deprecation
 from hypothesis.internal.reflection import proxies
 
+if False:
+    from typing import Callable  # noqa
+    from hypothesis.searchstrategy.strategies import T  # noqa
+
 
 def renamed_arguments(**rename_mapping):
+    # type: (**str) -> Callable[[T], T]
     """Helper function for deprecating arguments that have been renamed to a
     new form.
 

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -52,7 +52,7 @@ if False:
     from typing import TypeVar, Tuple, List, Set, FrozenSet, overload  # noqa
     from typing import Type, Mapping, Text, AnyStr, Optional  # noqa
 
-    from hypothesis.utils.conventions import UniqueIdentifier  # noqa
+    from hypothesis.utils.conventions import InferType  # noqa
     from hypothesis.searchstrategy.strategies import T, Ex  # noqa
     K, V = TypeVar['K'], TypeVar['V']
     # See https://github.com/python/mypy/issues/3186 - numbers.Real is wrong!
@@ -1024,7 +1024,7 @@ def random_module():
 @defines_strategy
 def builds(
     *callable_and_args,  # type: Any
-    **kwargs  # type: Union[SearchStrategy[Any], UniqueIdentifier]
+    **kwargs  # type: Union[SearchStrategy[Any], InferType]
 ):
     # type: (...) -> SearchStrategy[Any]
     """Generates values by drawing from ``args`` and ``kwargs`` and passing

--- a/hypothesis-python/src/hypothesis/utils/conventions.py
+++ b/hypothesis-python/src/hypothesis/utils/conventions.py
@@ -17,6 +17,12 @@
 
 from __future__ import division, print_function, absolute_import
 
+# Notes: we use instances of these objects as singletons which serve as
+# identifiers in various patches of code.  The more specific types
+# (DefaultValueType and InferType) exist so that typecheckers such as Mypy
+# can distinguish them from the others.  DefaultValueType is only used in
+# the Django extra.
+
 
 class UniqueIdentifier(object):
 
@@ -27,5 +33,13 @@ class UniqueIdentifier(object):
         return self.identifier
 
 
-infer = UniqueIdentifier(u'infer')
+class DefaultValueType(UniqueIdentifier):
+    pass
+
+
+class InferType(UniqueIdentifier):
+    pass
+
+
+infer = InferType(u'infer')
 not_set = UniqueIdentifier(u'not_set')

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,8 +3,11 @@ python_version = 3.6
 platform = linux
 
 strict_optional = True
+disallow_untyped_decorators = True
+
 follow_imports = silent
 ignore_missing_imports = True
+
 warn_unused_ignores = True
 warn_unused_configs = True
 warn_redundant_casts = True


### PR DESCRIPTION
Does not *quite* close #200 (next time though! :tada:)

I won't recite the whole motivation here - suffice to say that at least some people like static typing, and so I'd like to let the type-checker find some of their obvious misuses of Hypothesis.

Things not obvious from review:
- Mypy doesn't support arity-specific overloads, which would be useful for `tuples`.
- The `disallow_untyped_decorators` option is indispensable if you don't want a a decorator to erase the type hints on a function.

I would also like to write some tests using `reveal_type` to check that Mypy does in fact infer the expected type for various expressions.  This may go in a later PR, to keep things reviewable - I've confirmed most of this manually, so automated tests would really be for tooling or code regressions.