### PR TITLE
Prefix tags of Python releases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is a release with no functionality changes that moves Hypothesis over to
+a new release tagging scheme.

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -66,6 +66,9 @@ assert __version__ is not None
 assert __version_info__ is not None
 
 
+PYTHON_TAG_PREFIX = 'hypothesis-python-'
+
+
 def latest_version():
     versions = []
 
@@ -74,6 +77,8 @@ def latest_version():
         # a large number of historic tags with a different format for versions)
         # so we parse each tag as a triple of ints (MAJOR, MINOR, PATCH)
         # and skip any tag that doesn't match that.
+        if t.startswith(PYTHON_TAG_PREFIX):
+            t = t[len(PYTHON_TAG_PREFIX):]
         assert t == t.strip()
         parts = t.split('.')
         if len(parts) != 3:
@@ -153,7 +158,7 @@ def create_tag_and_push():
         'remote', 'add', 'ssh-origin',
         'git@github.com:HypothesisWorks/hypothesis.git'
     )
-    git('tag', __version__)
+    git('tag', PYTHON_TAG_PREFIX + __version__)
 
     subprocess.check_call([
         'ssh-agent', 'sh', '-c',


### PR DESCRIPTION
This changes our tagging scheme for releasing Hypothesis for Python to prefix the tags with `hypothesis-python`, in line with #1224.

I originally started with a much deeper refactoring of this that tried to make this more generic and it rather got away from me, so this is instead a minimal viable change that just moves over our existing tagging.