### PR TITLE
Only use tags whose name start with hypothesis-python for versions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is another release with no functionality changes as part of changes to
+Hypothesis's new release tagging scheme.

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -85,7 +85,6 @@ def latest_version():
 
     _, latest = max(versions)
 
-    assert latest in tags()
     return latest
 
 

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -73,21 +73,14 @@ def latest_version():
     versions = []
 
     for t in tags():
-        # All versions get tags but not all tags are versions (and there are
-        # a large number of historic tags with a different format for versions)
-        # so we parse each tag as a triple of ints (MAJOR, MINOR, PATCH)
-        # and skip any tag that doesn't match that.
         if t.startswith(PYTHON_TAG_PREFIX):
             t = t[len(PYTHON_TAG_PREFIX):]
+        else:
+            continue
         assert t == t.strip()
         parts = t.split('.')
-        if len(parts) != 3:
-            continue
-        try:
-            v = tuple(map(int, parts))
-        except ValueError:
-            continue
-
+        assert len(parts) == 3
+        v = tuple(map(int, parts))
         versions.append((v, t))
 
     _, latest = max(versions)

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -116,14 +116,11 @@ def merge_base(a, b):
     ]).strip()
 
 
-def has_source_changes(version=None):
-    if version is None:
-        version = latest_version()
-
+def has_source_changes():
     # Check where we branched off from the version. We're only interested
     # in whether *we* introduced any source changes, so we check diff from
     # there rather than the diff to the other side.
-    point_of_divergence = merge_base('HEAD', version)
+    point_of_divergence = merge_base('HEAD', 'origin/master')
 
     return subprocess.call([
         'git', 'diff', '--no-patch', '--exit-code', point_of_divergence,

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -116,14 +116,13 @@ def merge_base(a, b):
     ]).strip()
 
 
-def has_source_changes():
-    # Check where we branched off from the version. We're only interested
-    # in whether *we* introduced any source changes, so we check diff from
-    # there rather than the diff to the other side.
-    point_of_divergence = merge_base('HEAD', 'origin/master')
+def point_of_divergence():
+    return merge_base('HEAD', 'origin/master')
 
+
+def has_source_changes():
     return subprocess.call([
-        'git', 'diff', '--no-patch', '--exit-code', point_of_divergence,
+        'git', 'diff', '--no-patch', '--exit-code', point_of_divergence(),
         'HEAD', '--', PYTHON_SRC,
     ]) != 0
 
@@ -189,7 +188,7 @@ def modified_files():
     files = set()
     for command in [
         ['git', 'diff', '--name-only', '--diff-filter=d',
-            latest_version(), 'HEAD'],
+            point_of_divergence(), 'HEAD'],
         ['git', 'diff', '--name-only']
     ]:
         diff_output = subprocess.check_output(command).decode('ascii')


### PR DESCRIPTION
The sequel to #1273. This now makes tags starting with `hypothesis-python` the only valid releases for versions of Hypothesis for Python (as you may have seen, we now also have backdated versions for all of the previous releases with a numeric tag name. I haven't bothered doing the same for ones that were on the old vX.Y.Z scheme).