### PR TITLE
 Move a lot of small build jobs into tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,19 +26,14 @@ env:
         - BUILD_RUNTIMES=$HOME/.runtimes
         - FORMAT_ALL=true
 
-
 jobs:
   include:
     # Prechecks that we want to run first.
     - stage: precheck
-      env: TASK=check-pyup-yml
-    - env: TASK=check-release-file
-    - env: TASK=check-shellcheck
-    - env: TASK=check-secrets
+      env: TASK=check-whole-repo-tests
     - env: TASK=documentation
     - env: TASK=lint
     - env: TASK=doctest
-    - env: TASK=check-rst
     - env: TASK=check-format
     - env: TASK=check-type-hints
     - env: TASK=check-requirements

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -48,6 +48,8 @@ HYPOTHESIS_PYTHON = os.path.join(ROOT, 'hypothesis-python')
 PYTHON_SRC = os.path.join(HYPOTHESIS_PYTHON, 'src')
 PYTHON_TESTS = os.path.join(HYPOTHESIS_PYTHON, 'tests')
 
+REPO_TESTS = os.path.join(ROOT, 'whole-repo-tests')
+
 PYUP_FILE = os.path.join(ROOT, '.pyup.yml')
 
 

--- a/whole-repo-tests/test_pyup_yml.py
+++ b/whole-repo-tests/test_pyup_yml.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import yaml
+from pyup.config import Config
+
+import hypothesistooling as tools
+
+
+def test_pyup_yml_is_valid():
+    with open(tools.PYUP_FILE, 'r') as i:
+        data = yaml.safe_load(i.read())
+    config = Config()
+    config.update_config(data)
+
+    assert config.is_valid_schedule(), \
+        'Schedule %r is invalid' % (config.schedule,)

--- a/whole-repo-tests/test_release_files.py
+++ b/whole-repo-tests/test_release_files.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesistooling as tools
+
+
+def test_release_file_exists_and_is_valid():
+    if tools.has_python_source_changes():
+        assert tools.has_release(), \
+            'There are source changes but no RELEASE.rst. Please create ' \
+            'one to describe your changes.'
+        tools.parse_release_file()

--- a/whole-repo-tests/test_rst_is_valid.py
+++ b/whole-repo-tests/test_rst_is_valid.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+
+import hypothesistooling as tools
+from hypothesistooling.scripts import pip_tool
+
+
+def is_sphinx(f):
+    f = os.path.abspath(f)
+    return f.startswith(os.path.join(tools.HYPOTHESIS_PYTHON, 'docs'))
+
+
+ALL_RST = [
+    f for f in tools.all_files()
+    if os.path.basename(f) != 'RELEASE.rst' and f.endswith('.rst')
+]
+
+
+def test_passes_rst_lint():
+    pip_tool('rst-lint', *[f for f in ALL_RST if not is_sphinx(f)])
+
+
+def test_passes_flake8():
+    pip_tool('flake8', '--select=W191,W291,W292,W293,W391', *ALL_RST)

--- a/whole-repo-tests/test_secrets.py
+++ b/whole-repo-tests/test_secrets.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+
+import pytest
+
+import hypothesistooling as tools
+
+
+@pytest.mark.skipif(
+    os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true',
+    reason='Not running in an environment with travis secure vars'
+)
+def test_can_descrypt_secrets():
+    tools.decrypt_secrets()
+
+    assert os.path.exists(tools.DEPLOY_KEY)

--- a/whole-repo-tests/test_shellcheck.py
+++ b/whole-repo-tests/test_shellcheck.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import subprocess
+
+import hypothesistooling as tools
+import hypothesistooling.installers as install
+
+SCRIPTS = [
+    f for f in tools.all_files()
+    if f.endswith('.sh')
+]
+
+
+def test_all_shell_scripts_are_valid():
+    subprocess.check_call([install.SHELLCHECK, *SCRIPTS], cwd=tools.ROOT)


### PR DESCRIPTION
(Built on top of #1274 so that the build actually works. History will be much cleaner once that's merged and this is rebased, so you may want to hold off on reviewing until then).

One of @alexwlchan's suggestions for build time improvements in #1224 was that we should have fewer small build jobs. This PR adopts the principle that most of these little build jobs are basically tests, and we have this perfectly serviceable test runner right here...

We will go full galaxy brain when we start decorating some of these tests with `@given`, but thankfully we're not there yet.