### PR TITLE
More fine grained checking of whether we need to run a task

### DIFF
--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -120,11 +120,15 @@ def point_of_divergence():
     return merge_base('HEAD', 'origin/master')
 
 
-def has_source_changes():
+def has_changes(files):
     return subprocess.call([
         'git', 'diff', '--no-patch', '--exit-code', point_of_divergence(),
-        'HEAD', '--', PYTHON_SRC,
+        'HEAD', '--', *files,
     ]) != 0
+
+
+def has_source_changes():
+    return has_changes(PYTHON_SRC)
 
 
 def has_uncommitted_changes(filename):
@@ -337,26 +341,6 @@ def update_for_pending_release():
     )
 
 
-def could_affect_tests(path):
-    """Does this file have any effect on test results?"""
-    # RST files are the input to some tests -- in particular, the
-    # documentation build and doctests.  Both of those jobs are always run,
-    # so we can ignore their effect here.
-    #
-    # IPython notebooks aren't currently used in any tests.
-    if path.endswith(('.rst', '.ipynb')):
-        return False
-
-    # These files exist but have no effect on tests.
-    if path in ('CITATION', 'LICENSE.txt', ):
-        return False
-
-    # We default to marking a file "interesting" unless we know otherwise --
-    # it's better to run tests that could have been skipped than skip tests
-    # when they needed to be run.
-    return True
-
-
 def changed_files_from_master():
     """Returns a list of files which have changed between a branch and
     master."""
@@ -368,46 +352,6 @@ def changed_files_from_master():
         if filepath:
             files.add(filepath)
     return files
-
-
-def should_run_ci_task(task):
-    """Given a task name, should we run this task?"""
-    if not IS_PULL_REQUEST:
-        print('We only skip tests if the job is a pull request.')
-        return True
-
-    # These tests are usually fast; we always run them rather than trying
-    # to keep up-to-date rules of exactly which changed files mean they
-    # should run.
-    if task in [
-        'check-pyup-yml',
-        'check-release-file',
-        'check-shellcheck',
-        'documentation',
-        'lint',
-    ]:
-        print('We always run the %s task.' % task)
-        return True
-
-    # The remaining tasks are all some sort of test of Hypothesis
-    # functionality.  Since it's better to run tests when we don't need to
-    # than skip tests when it was important, we remove any files which we
-    # know are safe to ignore, and run tests if there's anything left.
-    changed_files = changed_files_from_master()
-
-    interesting_changed_files = [
-        f for f in changed_files if could_affect_tests(f)
-    ]
-
-    if interesting_changed_files:
-        print(
-            'Changes to the following files mean we need to run tests: %s' %
-            ', '.join(interesting_changed_files)
-        )
-        return True
-    else:
-        print('There are no changes which would need a test run.')
-        return False
 
 
 SECRETS_BASE = os.path.join(ROOT, 'secrets')

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -128,7 +128,7 @@ def has_changes(files):
 
 
 def has_python_source_changes():
-    return has_changes(PYTHON_SRC)
+    return has_changes([PYTHON_SRC])
 
 
 def has_uncommitted_changes(filename):

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -127,7 +127,7 @@ def has_changes(files):
     ]) != 0
 
 
-def has_source_changes():
+def has_python_source_changes():
     return has_changes(PYTHON_SRC)
 
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -206,7 +206,7 @@ def deploy():
 
 @task()
 def check_release_file():
-    if tools.has_source_changes():
+    if tools.has_python_source_changes():
         if not tools.has_release():
             print(
                 'There are source changes but no RELEASE.rst. Please create '

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -37,13 +37,28 @@ from hypothesistooling.scripts import pip_tool
 TASKS = {}
 
 
-def task(fn):
-    name = fn.__name__.replace('_', '-')
-    TASKS[name] = fn
-    return fn
+def task(if_changed=()):
+    if isinstance(if_changed, str):
+        if_changed = (if_changed,)
+
+    def accept(fn):
+        def wrapped():
+            if if_changed and tools.IS_PULL_REQUEST:
+                if not tools.has_changes(if_changed):
+                    print('Skipping task due to no changes in %s' % (
+                        ', '.join(if_changed),
+                    ))
+                    return
+            fn()
+        wrapped.__name__ = fn.__name__
+
+        name = fn.__name__.replace('_', '-')
+        TASKS[name] = wrapped
+        return wrapped
+    return accept
 
 
-@task
+@task()
 def lint():
     pip_tool(
         'flake8',
@@ -52,12 +67,12 @@ def lint():
     )
 
 
-@task
+@task(if_changed=tools.PYTHON_SRC)
 def check_type_hints():
     pip_tool('mypy', tools.PYTHON_SRC)
 
 
-@task
+@task()
 def check_pyup_yml():
     with open(tools.PYUP_FILE, 'r') as i:
         data = yaml.safe_load(i.read())
@@ -73,7 +88,7 @@ DIST = os.path.join(tools.HYPOTHESIS_PYTHON, 'dist')
 PENDING_STATUS = ('started', 'created')
 
 
-@task
+@task()
 def deploy():
     os.chdir(tools.HYPOTHESIS_PYTHON)
 
@@ -189,7 +204,7 @@ def deploy():
     sys.exit(0)
 
 
-@task
+@task()
 def check_release_file():
     if tools.has_source_changes():
         if not tools.has_release():
@@ -201,7 +216,7 @@ def check_release_file():
         tools.parse_release_file()
 
 
-@task
+@task()
 def check_shellcheck():
     install.ensure_shellcheck()
     subprocess.check_call([install.SHELLCHECK] + [
@@ -210,7 +225,7 @@ def check_shellcheck():
     ])
 
 
-@task
+@task()
 def check_rst():
     rst = glob('*.rst') + glob('guides/*.rst')
     docs = glob('hypothesis-python/docs/*.rst')
@@ -219,7 +234,7 @@ def check_rst():
     pip_tool('flake8', '--select=W191,W291,W292,W293,W391', *(rst + docs))
 
 
-@task
+@task()
 def check_secrets():
     if os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true':
         sys.exit(0)
@@ -253,7 +268,7 @@ HEADER = """
 }
 
 
-@task
+@task()
 def format():
     def should_format_file(path):
         if os.path.basename(path) in (
@@ -322,7 +337,7 @@ VALID_STARTS = (
 )
 
 
-@task
+@task()
 def check_format():
     format()
     n = max(map(len, VALID_STARTS))
@@ -345,12 +360,12 @@ def check_not_changed():
     subprocess.check_call(['git', 'diff', '--exit-code'])
 
 
-@task
+@task()
 def fix_doctests():
     fd.main()
 
 
-@task
+@task()
 def compile_requirements(upgrade=False):
     if upgrade:
         extra = ['--upgrade']
@@ -364,12 +379,12 @@ def compile_requirements(upgrade=False):
         pip_tool('pip-compile', *extra, f, '--output-file', base + '.txt')
 
 
-@task
+@task()
 def upgrade_requirements():
     compile_requirements(upgrade=True)
 
 
-@task
+@task()
 def check_requirements():
     compile_requirements()
     check_not_changed()
@@ -387,7 +402,7 @@ def update_changelog_for_docs():
     tools.update_changelog_and_version()
 
 
-@task
+@task(if_changed=tools.HYPOTHESIS_PYTHON)
 def documentation():
     os.chdir(tools.HYPOTHESIS_PYTHON)
     try:
@@ -402,7 +417,7 @@ def documentation():
         ])
 
 
-@task
+@task(if_changed=tools.HYPOTHESIS_PYTHON)
 def doctest():
     os.chdir(tools.HYPOTHESIS_PYTHON)
     env = dict(os.environ)
@@ -442,7 +457,7 @@ PY36 = '3.6.5'
 PYPY2 = 'pypy2.7-5.10.0'
 
 
-@task
+@task()
 def install_core():
     install.python_executable(PY27)
     install.python_executable(PY36)
@@ -457,43 +472,46 @@ for n in [PY27, PY34, PY35, PY36]:
     ALIASES[n] = 'python%s.%s' % (major, minor)
 
 
-@task
+python_tests = task(if_changed=(tools.PYTHON_SRC, tools.PYTHON_TESTS))
+
+
+@python_tests
 def check_py27():
     run_tox('py27-full', PY27)
 
 
-@task
+@python_tests
 def check_py34():
     run_tox('py34-full', PY34)
 
 
-@task
+@python_tests
 def check_py35():
     run_tox('py35-full', PY35)
 
 
-@task
+@python_tests
 def check_py36():
     run_tox('py36-full', PY36)
 
 
-@task
+@python_tests
 def check_pypy():
     run_tox('pypy-full', PYPY2)
 
 
-@task
+@python_tests
 def check_py27_typing():
     run_tox('py27typing', PY27)
 
 
-@task
+@python_tests
 def check_pypy_with_tracer():
     run_tox('pypy-with-tracer', PYPY2)
 
 
 def standard_tox_task(name):
-    TASKS['check-' + name] = lambda: run_tox(name, PY36)
+    TASKS['check-' + name] = python_tests(lambda: run_tox(name, PY36))
 
 
 standard_tox_task('nose')
@@ -506,23 +524,32 @@ standard_tox_task('django111')
 for n in [19, 20, 21, 22, 23]:
     standard_tox_task('pandas%d' % (n,))
 
-standard_tox_task('examples3')
 standard_tox_task('coverage')
 standard_tox_task('pure-tracer')
 
 
-@task
+@task()
 def check_quality():
     run_tox('quality', PY36)
     run_tox('quality2', PY27)
 
 
-@task
+examples_task = task(if_changed=(tools.PYTHON_SRC, os.path.join(
+    tools.HYPOTHESIS_PYTHON, 'examples')
+))
+
+
+@examples_task
 def check_examples2():
     run_tox('examples2', PY27)
 
 
-@task
+@examples_task
+def check_examples3():
+    run_tox('examples2', PY36)
+
+
+@python_tests
 def check_unicode():
     run_tox('unicode', PY27)
 
@@ -538,8 +565,6 @@ if __name__ == '__main__':
     task_to_run = os.environ.get('TASK')
     if task_to_run is None:
         task_to_run = sys.argv[1]
-    if not tools.should_run_ci_task(task_to_run):
-        sys.exit(0)
     try:
         TASKS[task_to_run]()
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
More work on plan "Get build times down when we start having multiple projects in the repo".

This adds more fine grained annotations to the tasks that generalises the previous `should_run_ci_task` logic, so tasks will only run if the part of the repo they depend on has changed.

This is still pretty coarse grained - e.g. changing any source file or any test will run all the tests - but should handle the use case of e.g. not building hypothesis-python for hypothesis-ruby tests.