### PR TITLE
Improve inference in builds() and from_type() for attrs classes

### DIFF
--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -21,3 +21,4 @@ exclude_lines =
     __copy__
     __deepcopy__
     except ImportError:
+    if PY2:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds a new mechanism to infer strategies for classes
+defined using :pypi:`attrs`, based on the the type, converter, or
+validator of each attribute.  This inference is now built in to
+:func:`~hypothesis.strategies.builds` and :func:`~hypothesis.strategies.from_type`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -4,3 +4,6 @@ This release adds a new mechanism to infer strategies for classes
 defined using :pypi:`attrs`, based on the the type, converter, or
 validator of each attribute.  This inference is now built in to
 :func:`~hypothesis.strategies.builds` and :func:`~hypothesis.strategies.from_type`.
+
+On Python 2, :func:`~hypothesis.strategies.from_type` no longer generates
+instances of ``int`` when passed ``long``, or vice-versa.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -71,6 +71,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'pytest': ('https://docs.pytest.org/en/stable/', None),
     'django': ('https://django.readthedocs.io/en/stable/', None),
+    'attrs': ('http://www.attrs.org/en/stable/', None),
 }
 
 autodoc_mock_imports = ['pandas']

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -32,7 +32,7 @@ from collections import namedtuple
 
 try:
     from collections import OrderedDict, Counter
-except ImportError:  # pragma: no cover
+except ImportError:
     from ordereddict import OrderedDict  # type: ignore
     from counter import Counter  # type: ignore
 
@@ -144,12 +144,14 @@ else:
         assert i >= 0
         result = bytearray(size)
         j = size - 1
+        arg = i
         while i and j >= 0:
             result[j] = i & 255
             i >>= 8
             j -= 1
         if i:
-            raise OverflowError('int too big to convert')
+            raise OverflowError('i=%r cannot be represented in %r bytes'
+                                % (arg, size))
         return hbytes(result)
 
     int_to_byte = chr

--- a/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
@@ -34,7 +34,7 @@ def from_attrs(target, args, kwargs, to_infer):
     fields = attr.fields(target)
     kwargs = {k: v for k, v in kwargs.items() if v is not infer}
     for name in to_infer:
-        kwargs[name] = from_attrs_attribute(getattr(fields, name))
+        kwargs[name] = from_attrs_attribute(getattr(fields, name), target)
     # We might make this strategy more efficient if we added a layer here that
     # retries drawing if validation fails, for improved composition.
     # The treatment of timezones in datetimes() provides a precedent.
@@ -43,7 +43,7 @@ def from_attrs(target, args, kwargs, to_infer):
     )
 
 
-def from_attrs_attribute(attrib):
+def from_attrs_attribute(attrib, target):
     """Infer a strategy from the metadata on an attr.Attribute object."""
     # Try inferring from the default argument.  Note that this will only help
     # the user passed `infer` to builds() for this attribute, but in that case
@@ -93,8 +93,8 @@ def from_attrs_attribute(attrib):
     # when we try to get a value but have lost track of where this was created.
     if strat.is_empty:
         raise ResolutionFailed(
-            'Cannot infer a strategy from the default, vaildator, type, or '
-            'converter for %r' % (attrib,))
+            'Cannot infer a strategy from the default, validator, type, or '
+            'converter for attribute=%r of class=%r' % (attrib, target))
     return strat
 
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from functools import reduce
+from itertools import chain
+from collections import defaultdict
+
+import attr
+
+import hypothesis.strategies as st
+from hypothesis.errors import ResolutionFailed
+from hypothesis.internal.compat import get_type_hints
+from hypothesis.utils.conventions import infer
+
+
+def from_attrs(target, args, kwargs, to_infer):
+    fields = attr.fields(target)
+    kwargs = {k: v for k, v in kwargs.items() if v is not infer}
+    for name in to_infer:
+        kwargs[name] = from_attrs_attribute(getattr(fields, name))
+    # TODO: add a layer here that retries drawing if validation fails, for
+    # improved composition.  Precedent: timezones for datetimes().
+    return st.tuples(st.tuples(*args), st.fixed_dictionaries(kwargs)).map(
+        lambda value: target(*value[0], **value[1])
+    )
+
+
+def from_attrs_attribute(attrib):
+    """Infer a strategy from an attr.Attribute object."""
+    # Various things we know.  Updated below, then inferred to a strategy
+    base = st.nothing()  # updated to none() if None is a possibility
+    default = st.nothing()  # A strategy for the default value, if any
+    in_collections = []  # list of in_ validator collections to sample from
+    # value must be instance of all these types or tuples thereof
+    types = defaultdict(list)  # maps type to list of locations, for error msgs
+
+    # Try inferring from the default argument
+    if isinstance(attrib.default, attr.Factory):
+        if not getattr(attrib.default, 'takes_self', False):  # new in 17.1
+            default = st.builds(attrib.default.factory)
+    elif attrib.default is not attr.NOTHING:
+        default = st.just(attrib.default)
+
+    # Try inferring from the field type
+    if getattr(attrib, 'type', None) is not None:
+        types[attrib.type].append('type')
+
+    # Try inferring from the converter, if any
+    converter = getattr(attrib, 'converter', None)
+    if isinstance(converter, type):
+        # Could this ever work but give incorrect inference?
+        types[converter].append('converter')
+    elif callable(converter):
+        hints = get_type_hints(converter)
+        if 'return' in hints:
+            types[hints['return']].append('converter')
+
+    # Try inferring type or exact values from attrs provided validators
+    if attrib.validator is not None:
+        validator = attrib.validator
+        if isinstance(validator, attr.validators._OptionalValidator):
+            base, validator = st.none(), validator.validator
+        if isinstance(validator, attr.validators._AndValidator):
+            vs = validator._validators
+        else:
+            vs = [validator]
+        for v in vs:
+            if isinstance(v, attr.validators._InValidator):
+                in_collections.append(v.options)
+            elif isinstance(v, attr.validators._InstanceOfValidator):
+                types[v.type].append('instance_of')
+
+    # Get the valid values to sample, or empty strat
+    sample = st.one_of(*map(st.sampled_from, in_collections))
+    if len(in_collections) >= 2:
+        # Note: not exhaustive if in_ members are strings (dubious upstream).
+        # See https://github.com/python-attrs/attrs/issues/382
+        sample = st.sampled_from(list(ordered_intersection(in_collections)))
+
+    # Derive a strategy from the observed types, if that's an improvement.
+    # Note to future contributors: tempting to filter the in_ values based on
+    # type; bad ideas as we try a few extra things to get a usable type hint.
+    type_strat = st.nothing()
+    if types and not in_collections:
+        type_tuples = [k if isinstance(k, tuple) else (k,) for k in types]
+        type_strat = st.one_of(
+            *map(st.from_type, ordered_intersection(type_tuples))
+        )
+
+    strat = base | default | sample | type_strat
+    if strat.is_empty:
+        raise ResolutionFailed(
+            'Cannot infer a strategy from the default, vaildator, type, or '
+            'converter for %r' % (attrib,))
+    return strat
+
+
+def ordered_intersection(in_):
+    assert in_
+    intersection = reduce(set.intersection, in_, set(in_[0]))
+    for x in chain.from_iterable(in_):
+        if x in intersection:
+            yield x
+            intersection.remove(x)

--- a/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
@@ -19,63 +19,50 @@ from __future__ import division, print_function, absolute_import
 
 from functools import reduce
 from itertools import chain
-from collections import defaultdict
 
 import attr
 
 import hypothesis.strategies as st
 from hypothesis.errors import ResolutionFailed
-from hypothesis.internal.compat import get_type_hints
+from hypothesis.internal.compat import string_types, get_type_hints
 from hypothesis.utils.conventions import infer
 
 
 def from_attrs(target, args, kwargs, to_infer):
+    """An internal version of builds(), specialised for Attrs classes."""
     fields = attr.fields(target)
     kwargs = {k: v for k, v in kwargs.items() if v is not infer}
     for name in to_infer:
         kwargs[name] = from_attrs_attribute(getattr(fields, name))
-    # TODO: add a layer here that retries drawing if validation fails, for
-    # improved composition.  Precedent: timezones for datetimes().
+    # We might make this strategy more efficient if we added a layer here that
+    # retries drawing if validation fails, for improved composition.
+    # The treatment of timezones in datetimes() provides a precedent.
     return st.tuples(st.tuples(*args), st.fixed_dictionaries(kwargs)).map(
         lambda value: target(*value[0], **value[1])
     )
 
 
 def from_attrs_attribute(attrib):
-    """Infer a strategy from an attr.Attribute object."""
-    # Various things we know.  Updated below, then inferred to a strategy
-    base = st.nothing()  # updated to none() if None is a possibility
-    default = st.nothing()  # A strategy for the default value, if any
-    in_collections = []  # list of in_ validator collections to sample from
-    # value must be instance of all these types or tuples thereof
-    types = defaultdict(list)  # maps type to list of locations, for error msgs
-
-    # Try inferring from the default argument
+    """Infer a strategy from the metadata on an attr.Attribute object."""
+    # Try inferring from the default argument.  Note that this will only help
+    # the user passed `infer` to builds() for this attribute, but in that case
+    # we use it as the minimal example.
+    default = st.nothing()
     if isinstance(attrib.default, attr.Factory):
         if not getattr(attrib.default, 'takes_self', False):  # new in 17.1
             default = st.builds(attrib.default.factory)
     elif attrib.default is not attr.NOTHING:
         default = st.just(attrib.default)
 
-    # Try inferring from the field type
-    if getattr(attrib, 'type', None) is not None:
-        types[attrib.type].append('type')
-
-    # Try inferring from the converter, if any
-    converter = getattr(attrib, 'converter', None)
-    if isinstance(converter, type):
-        # Could this ever work but give incorrect inference?
-        types[converter].append('converter')
-    elif callable(converter):
-        hints = get_type_hints(converter)
-        if 'return' in hints:
-            types[hints['return']].append('converter')
-
-    # Try inferring type or exact values from attrs provided validators
+    # Try inferring None, exact values, or type from attrs provided validators.
+    null = st.nothing()  # updated to none() on seeing an OptionalValidator
+    in_collections = []  # list of in_ validator collections to sample from
+    validator_types = set()  # type constraints to pass to types_to_strategy()
     if attrib.validator is not None:
         validator = attrib.validator
         if isinstance(validator, attr.validators._OptionalValidator):
-            base, validator = st.none(), validator.validator
+            null = st.none()
+            validator = validator.validator
         if isinstance(validator, attr.validators._AndValidator):
             vs = validator._validators
         else:
@@ -87,26 +74,22 @@ def from_attrs_attribute(attrib):
                 else:
                     in_collections.append(v.options)
             elif isinstance(v, attr.validators._InstanceOfValidator):
-                types[v.type].append('instance_of')
+                validator_types.add(v.type)
 
-    # Get the valid values to sample, or empty strat
-    sample = st.one_of(*map(st.sampled_from, in_collections))
-    if len(in_collections) >= 2:
-        # Note: not exhaustive if in_ members are strings (dubious upstream).
-        # See https://github.com/python-attrs/attrs/issues/382
+    # This is the important line.  We compose the final strategy from various
+    # parts.  The default value, if any, is the minimal shrink, followed by
+    # None (again, if allowed).  We then prefer to sample from values passed
+    # to an in_ validator if available, but infer from a type otherwise.
+    # Pick one because (sampled_from((1, 2)) | from_type(int)) would usually
+    # fail validation by generating e.g. zero!
+    if in_collections:
         sample = st.sampled_from(list(ordered_intersection(in_collections)))
+        strat = default | null | sample
+    else:
+        strat = default | null | types_to_strategy(attrib, validator_types)
 
-    # Derive a strategy from the observed types, if that's an improvement.
-    # Note to future contributors: tempting to filter the in_ values based on
-    # type; bad ideas as we try a few extra things to get a usable type hint.
-    type_strat = st.nothing()
-    if types and not in_collections:
-        type_tuples = [k if isinstance(k, tuple) else (k,) for k in types]
-        type_strat = st.one_of(
-            *map(st.from_type, ordered_intersection(type_tuples))
-        )
-
-    strat = base | default | sample | type_strat
+    # Better to give a meaningful error here than an opaque "could not draw"
+    # when we try to get a value but have lost track of where this was created.
     if strat.is_empty:
         raise ResolutionFailed(
             'Cannot infer a strategy from the default, vaildator, type, or '
@@ -114,8 +97,35 @@ def from_attrs_attribute(attrib):
     return strat
 
 
+def types_to_strategy(attrib, types):
+    """Find all the type metadata for this attribute, reconcile it, and infer a
+    strategy from the mess."""
+    # Try to add a `type` attribute to the types we observed from validators.
+    if getattr(attrib, 'type', None) is not None:
+        types.add(attrib.type)
+
+    # Similarly, try to find usable types from the converter.
+    converter = getattr(attrib, 'converter', None)
+    if isinstance(converter, type):
+        types.add(converter)
+    elif callable(converter):
+        hints = get_type_hints(converter)
+        if 'return' in hints:
+            types.add(hints['return'])
+
+    if not types:
+        return st.nothing()
+    # Finally, we aggregate down to a type (or types) that is acceptable
+    # according to all of the metadata we have seen.
+    type_tuples = [k if isinstance(k, tuple) else (k,) for k in types]
+    return st.one_of(*map(st.from_type, ordered_intersection(type_tuples)))
+    # TODO: that would be much more useful if it knew about subtypes.
+    # A complete solution should also look at generics - consider a refactor
+    # that pulls some code out of st.from_type...
+
+
 def ordered_intersection(in_):
-    assert in_
+    """Set union of n sequences, ordered for reproducibility across runs."""
     intersection = reduce(set.intersection, in_, set(in_[0]))
     for x in chain.from_iterable(in_):
         if x in intersection:

--- a/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
@@ -82,7 +82,10 @@ def from_attrs_attribute(attrib):
             vs = [validator]
         for v in vs:
             if isinstance(v, attr.validators._InValidator):
-                in_collections.append(v.options)
+                if isinstance(v.options, string_types):
+                    in_collections.append(list(all_substrings(v.options)))
+                else:
+                    in_collections.append(v.options)
             elif isinstance(v, attr.validators._InstanceOfValidator):
                 types[v.type].append('instance_of')
 
@@ -118,3 +121,16 @@ def ordered_intersection(in_):
         if x in intersection:
             yield x
             intersection.remove(x)
+
+
+def all_substrings(s):
+    """Generate all substrings of `s`, in order of length then occurrence.
+    Includes the empty string (first), and any duplicates that are present.
+
+    >>> list(all_substrings('010'))
+    ['', '0', '1', '0', '01', '10', '010']
+    """
+    yield s[:0]
+    for n, _ in enumerate(s):
+        for i in range(len(s) - n):
+            yield s[i:i + n + 1]

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -35,8 +35,8 @@ def type_sorting_key(t):
     if not isinstance(t, type):
         raise InvalidArgument('thing=%s must be a type' % (t,))
     if t is None or t is type(None):  # noqa: E721
-        return -1
-    return issubclass(t, collections.abc.Container)
+        return (-1, repr(t))
+    return (issubclass(t, collections.Container), repr(t))
 
 
 def try_issubclass(thing, maybe_superclass):

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -27,7 +27,7 @@ import collections
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
-from hypothesis.internal.compat import text_type, integer_types
+from hypothesis.internal.compat import PY2, text_type
 
 
 def type_sorting_key(t):
@@ -104,6 +104,7 @@ _global_type_lookup = {
     # Types with core Hypothesis strategies
     type(None): st.none(),
     bool: st.booleans(),
+    int: st.integers(),
     float: st.floats(),
     complex: st.complex_numbers(),
     fractions.Fraction: st.fractions(),
@@ -128,8 +129,12 @@ _global_type_lookup = {
     memoryview: st.binary().map(memoryview),
     # Pull requests with more types welcome!
 }
-for t in integer_types:
-    _global_type_lookup[t] = st.integers()
+
+if PY2:
+    _global_type_lookup.update({
+        int: st.integers().filter(lambda x: isinstance(x, int)),
+        long: st.integers().map(long)  # noqa
+    })
 
 try:
     from hypothesis.extra.pytz import timezones

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -29,6 +29,8 @@ from inspect import isclass, isfunction
 from fractions import Fraction
 from functools import reduce
 
+import attr
+
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.control import note, assume, cleanup, current_build_context
 from hypothesis._settings import note_deprecation
@@ -1072,16 +1074,22 @@ def builds(
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '
                               'builds(), but is only allowed as a keyword arg')
-    hints = get_type_hints(target.__init__ if isclass(target) else target)
-    for kw in [k for k, v in kwargs.items() if v is infer]:
-        if kw not in hints:
-            raise InvalidArgument(
-                'passed %s=infer for %s, but %s has no type annotation'
-                % (kw, target.__name__, kw))
-        kwargs[kw] = from_type(hints[kw])
     required = required_args(target, args, kwargs)
-    for ms in set(hints) & (required or set()):
-        kwargs[ms] = from_type(hints[ms])
+    to_infer = set(k for k, v in kwargs.items() if v is infer)
+    if required or to_infer:
+        if isclass(target) and attr.has(target):
+            # Use our custom introspection for attrs classes
+            from hypothesis.searchstrategy.attrs import from_attrs
+            return from_attrs(target, args, kwargs, required | to_infer)
+        # Otherwise, try using type hints
+        hints = get_type_hints(
+            target.__init__ if isclass(target) else target)
+        if to_infer - set(hints):
+            raise InvalidArgument(
+                'passed infer for %s, but there is no type annotation'
+                % (', '.join(sorted(to_infer - set(hints)))))
+        for kw in set(hints) & (required | to_infer):
+            kwargs[kw] = from_type(hints[kw])
     # Mypy doesn't realise that `infer` is gone from kwargs now
     kwarg_strat = fixed_dictionaries(kwargs)  # type: ignore
     return tuples(tuples(*args), kwarg_strat).map(
@@ -1206,10 +1214,12 @@ def from_type(thing):
     if issubclass(thing, enum.Enum):
         assert len(thing), repr(thing) + ' has no members to sample'
         return sampled_from(thing)
-    # If the constructor has an annotation for every required argument,
-    # we can (and do) use builds() without supplying additional arguments.
+    # If the constructor has an annotation for all required arguments,
+    # or the class was defined with attrs, builds(thing) will work.
+    # (unless inference fails for an argument, but that's the same above too)
     required = required_args(thing)
-    if not required or required.issubset(get_type_hints(thing.__init__)):
+    if not required or required.issubset(get_type_hints(thing.__init__)) or \
+            attr.has(thing):
         return builds(thing)
     # We have utterly failed, and might as well say so now.
     raise ResolutionFailed('Could not resolve %r to a strategy; consider '

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1050,6 +1050,12 @@ def builds(
     value :const:`hypothesis.infer` as a keyword argument to
     builds, instead of a strategy for that argument to the callable.
 
+    If the callable is a class defined with :pypi:`attrs`, missing required
+    arguments may be inferred from the type, converter, or validator (for
+    :func:`~attrs:attr.validators.in_`,
+    :func:`~attrs:attr.validators.optional`, or
+    :func:`~attrs:attr.validators.instance_of` validators) of the attribute.
+
     Examples from this strategy shrink by shrinking the argument values to
     the callable.
     """

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1051,10 +1051,8 @@ def builds(
     builds, instead of a strategy for that argument to the callable.
 
     If the callable is a class defined with :pypi:`attrs`, missing required
-    arguments may be inferred from the type, converter, or validator (for
-    :func:`~attrs:attr.validators.in_`,
-    :func:`~attrs:attr.validators.optional`, or
-    :func:`~attrs:attr.validators.instance_of` validators) of the attribute.
+    arguments will be inferred from the attribute on a best-effort basis,
+    e.g. by checking :ref:`attrs standard validators <attrs:api_validators>`.
 
     Examples from this strategy shrink by shrinking the argument values to
     the callable.

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -37,6 +37,11 @@ class Inferrables(object):
         attr.validators.instance_of(str),
         attr.validators.instance_of((str, int, bool)),
     ])
+    validator_type_has_overlap = attr.ib(validator=[
+        attr.validators.instance_of(str),
+        attr.validators.instance_of((str, list)),
+        attr.validators.instance_of(object),
+    ])
     validator_optional = attr.ib(
         validator=attr.validators.optional(lambda inst, atrib, val: float(val))
     )

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -30,6 +30,9 @@ class Inferrables(object):
     type_ = attr.ib(type=int)
     type_converter = attr.ib(converter=bool)
     validator_type = attr.ib(validator=attr.validators.instance_of(str))
+    validator_type_tuple = attr.ib(
+        validator=attr.validators.instance_of((str, int))
+    )
     validator_type_multiple = attr.ib(validator=[
         attr.validators.instance_of(str),
         attr.validators.instance_of((str, int, bool)),

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -42,6 +42,10 @@ class Inferrables(object):
         attr.validators.in_(list(range(100))),
         attr.validators.in_([1, -1]),
     ])
+    validator_in_multiple_strings = attr.ib(validator=[
+        attr.validators.in_('abcd'),
+        attr.validators.in_(['ab', 'cd']),
+    ])
     has_default = attr.ib(default=0)
     has_default_factory = attr.ib(default=attr.Factory(list))
     has_default_factory_takes_self = attr.ib(  # uninferrable but has default

--- a/hypothesis-python/tests/py2/test_from_type.py
+++ b/hypothesis-python/tests/py2/test_from_type.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+
+@given(st.from_type(int))
+def test_from_int_is_int(x):
+    assert isinstance(x, int)
+
+
+@given(st.from_type(long))
+def test_from_long_is_long(x):
+    assert isinstance(x, long)

--- a/hypothesis-python/tests/py3/test_annotations.py
+++ b/hypothesis-python/tests/py3/test_annotations.py
@@ -17,6 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import attr
 import pytest
 
 import hypothesis.strategies as st
@@ -121,3 +122,22 @@ def test_given_edits_annotations(nargs):
         given(*(nargs * [st.none()]))(pointless_composite))
     assert spec_given.annotations.pop('return') is None
     assert len(spec_given.annotations) == 3 - nargs
+
+
+def a_converter(x) -> int:
+    return int(x)
+
+
+@attr.s
+class Inferrables(object):
+    annot_converter = attr.ib(converter=a_converter)
+
+
+@given(st.builds(Inferrables))
+def test_attrs_inference_builds(c):
+    pass
+
+
+@given(st.from_type(Inferrables))
+def test_attrs_inference_from_type(c):
+    pass


### PR DESCRIPTION
Closes #954.  If you have well-behaved classes defined using attrs, and use the various validation, typing, and conversion features without abusing them too badly, Hypothesis will be a little more magical :sparkles:  

The trick for users - as usual - is to handle everything that static analysis thinks might be a valid input!  It's a good habit in general, and I actually kinda like the tooling pushing me that way :smile: 

(as an implementer, I now remember why I haven't touched inference in a while...)