### PR TITLE
Test Pandas 23 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
     - env: TASK=check-pandas20
     - env: TASK=check-pandas21
     - env: TASK=check-pandas22
+    - env: TASK=check-pandas23
 
     - stage: deploy
       env: TASK=deploy

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -95,6 +95,13 @@ deps =
 commands =
     python -m pytest tests/pandas -n2
 
+[testenv:pandas23]
+deps =
+    -r../requirements/test.txt
+    pandas~=0.23.0
+commands =
+    python -m pytest tests/pandas -n2
+
 
 [testenv:django111]
 commands =

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -32,6 +32,9 @@ from hypothesistooling import fix_doctests as fd
 from hypothesistooling.scripts import pip_tool
 
 TASKS = {}
+BUILD_FILES = tuple(os.path.join(tools.ROOT, f) for f in [
+    'tooling', '.travis.yml',
+])
 
 
 def task(if_changed=()):
@@ -41,7 +44,7 @@ def task(if_changed=()):
     def accept(fn):
         def wrapped():
             if if_changed and tools.IS_PULL_REQUEST:
-                if not tools.has_changes(if_changed):
+                if not tools.has_changes(if_changed + BUILD_FILES):
                     print('Skipping task due to no changes in %s' % (
                         ', '.join(if_changed),
                     ))


### PR DESCRIPTION
Turns out that we have had a defined `check-pandas23` task for a month before [Pandas 0.23 was released](https://pandas.pydata.org/pandas-docs/version/0.23.0/whatsnew.html#v0-23-0)!