### PR TITLE
Add more tests for shrinker and fix internal assertion error

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug where an internal assertion error could sometimes be
+triggered while shrinking a failing test.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -39,6 +39,9 @@ class Status(IntEnum):
     VALID = 2
     INTERESTING = 3
 
+    def __repr__(self):
+        return 'Status.%s' % (self.name,)
+
 
 @attr.s(slots=True)
 class Example(object):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -108,6 +108,7 @@ class ConjectureData(object):
         self.start_time = benchmark_time()
         self.events = set()
         self.forced_indices = set()
+        self.forced_blocks = set()
         self.capped_indices = {}
         self.interesting_origin = None
         self.tags = set()
@@ -277,6 +278,7 @@ class ConjectureData(object):
         original = self.index
         self.__write(string)
         self.forced_indices.update(hrange(original, self.index))
+        self.forced_blocks.add(len(self.blocks) - 1)
         return string
 
     def __check_capacity(self, n):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -36,19 +36,22 @@ from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.conjecture.engine import Negated, Shrinker, \
     RunIsComplete, ConjectureRunner, universal
+from hypothesis.internal.entropy import deterministic_PRNG
+
 
 SOME_LABEL = calc_label_from_name('some label')
 
 
 def run_to_buffer(f):
-    runner = ConjectureRunner(f, settings=settings(
-        max_examples=5000, buffer_size=1024,
-        database=None, suppress_health_check=HealthCheck.all(),
-    ))
-    runner.run()
-    assert runner.interesting_examples
-    last_data, = runner.interesting_examples.values()
-    return hbytes(last_data.buffer)
+    with deterministic_PRNG():
+        runner = ConjectureRunner(f, settings=settings(
+            max_examples=5000, buffer_size=1024,
+            database=None, suppress_health_check=HealthCheck.all(),
+        ))
+        runner.run()
+        assert runner.interesting_examples
+        last_data, = runner.interesting_examples.values()
+        return hbytes(last_data.buffer)
 
 
 def test_can_index_results():

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -31,13 +31,12 @@ from tests.common.utils import no_shrink, all_values, \
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from tests.common.strategies import SLOW, HardToShrink
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
+from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     ConjectureData
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.conjecture.engine import Negated, Shrinker, \
     RunIsComplete, ConjectureRunner, universal
-from hypothesis.internal.entropy import deterministic_PRNG
-
 
 SOME_LABEL = calc_label_from_name('some label')
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -27,6 +27,7 @@ from hypothesis import strategies as st
 from tests.common.utils import no_shrink, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
+from hypothesis.internal.entropy import deterministic_PRNG
 from tests.cover.test_conjecture_engine import run_to_buffer
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import RunIsComplete, \
@@ -130,15 +131,14 @@ def test_regression_1():
     # specific exception inside one of the shrink passes. It's unclear how
     # useful this regression test really is, but nothing else caught the
     # problem.
-    random.seed(0)
+    with deterministic_PRNG():
+        @run_to_buffer
+        def x(data):
+            data.write(hbytes(b'\x01\x02'))
+            data.write(hbytes(b'\x01\x00'))
+            v = data.draw_bits(41)
+            if v >= 512 or v == 254:
+                data.mark_interesting()
+        assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
 
-    @run_to_buffer
-    def x(data):
-        data.write(hbytes(b'\x01\x02'))
-        data.write(hbytes(b'\x01\x00'))
-        v = data.draw_bits(41)
-        if v >= 512 or v == 254:
-            data.mark_interesting()
-    assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
-
-    assert int_from_bytes(x[-2:]) in (254, 512)
+        assert int_from_bytes(x[-2:]) in (254, 512)

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -17,6 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import random
 from random import Random
 
 import pytest
@@ -25,8 +26,8 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from tests.common.utils import no_shrink, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
-from hypothesis.internal.compat import hbytes, hrange
-from tests.cover.test_conjecture_engine import run_to_buffer
+from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
+from tests.cover.test_conjecture_engine import run_to_buffer, slow_shrinker
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import RunIsComplete, \
     ConjectureRunner
@@ -122,3 +123,22 @@ def test_exhaustive_enumeration_of_partial_buffer():
                 node = runner.tree[node][b]
             assert node in runner.dead
     assert len(seen) == 256
+
+
+def test_regression_1():
+    # This is a really hard to reproduce bug that previously triggered a very
+    # specific exception inside one of the shrink passes. It's unclear how
+    # useful this regression test really is, but nothing else caught the
+    # problem.
+    random.seed(0)
+
+    @run_to_buffer
+    def x(data):
+        data.write(hbytes(b'\x01\x02'))
+        data.write(hbytes(b'\x01\x00'))
+        v = data.draw_bits(41)
+        if v >= 512 or v == 254:
+            data.mark_interesting()
+    assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
+
+    assert int_from_bytes(x[-2:]) in (254, 512)

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import random
 from random import Random
 
 import pytest
@@ -27,7 +26,6 @@ from hypothesis import strategies as st
 from tests.common.utils import no_shrink, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
-from hypothesis.internal.entropy import deterministic_PRNG
 from tests.cover.test_conjecture_engine import run_to_buffer
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import RunIsComplete, \
@@ -131,14 +129,13 @@ def test_regression_1():
     # specific exception inside one of the shrink passes. It's unclear how
     # useful this regression test really is, but nothing else caught the
     # problem.
-    with deterministic_PRNG():
-        @run_to_buffer
-        def x(data):
-            data.write(hbytes(b'\x01\x02'))
-            data.write(hbytes(b'\x01\x00'))
-            v = data.draw_bits(41)
-            if v >= 512 or v == 254:
-                data.mark_interesting()
-        assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
+    @run_to_buffer
+    def x(data):
+        data.write(hbytes(b'\x01\x02'))
+        data.write(hbytes(b'\x01\x00'))
+        v = data.draw_bits(41)
+        if v >= 512 or v == 254:
+            data.mark_interesting()
+    assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
 
-        assert int_from_bytes(x[-2:]) in (254, 512)
+    assert int_from_bytes(x[-2:]) in (254, 512)

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -27,7 +27,7 @@ from hypothesis import strategies as st
 from tests.common.utils import no_shrink, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
-from tests.cover.test_conjecture_engine import run_to_buffer, slow_shrinker
+from tests.cover.test_conjecture_engine import run_to_buffer
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import RunIsComplete, \
     ConjectureRunner

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -1,0 +1,138 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import random
+
+import attr
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import Verbosity, HealthCheck, note, given, assume, \
+    settings, unlimited
+from hypothesis.internal.compat import hbytes
+from hypothesis.internal.conjecture.data import Status
+from hypothesis.internal.conjecture.engine import ConjectureRunner
+
+
+@attr.s()
+class Write(object):
+    value = attr.ib()
+    child = attr.ib()
+
+
+@attr.s()
+class Branch(object):
+    bits = attr.ib()
+    children = attr.ib(default=attr.Factory(dict))
+
+
+@attr.s()
+class Terminal(object):
+    status = attr.ib()
+    payload = attr.ib(default=None)
+
+
+nodes = st.deferred(lambda: terminals | writes | branches)
+
+
+# Does not include Status.OVERFLOW by design: That happens because of the size
+# of the string, not the input language.
+terminals = st.one_of(
+    st.just(Terminal(Status.VALID)), st.just(Terminal(Status.INVALID)),
+    st.builds(
+        Terminal, status=st.just(Status.INTERESTING),
+        payload=st.integers(0, 10)
+    )
+)
+
+branches = st.builds(Branch, bits=st.integers(1, 64))
+
+writes = st.builds(
+    Write, value=st.binary(min_size=1), child=nodes
+)
+
+
+def run_language_test_for(root, data, seed):
+    random.seed(seed)
+
+    def test(local_data):
+        node = root
+        while not isinstance(node, Terminal):
+            if isinstance(node, Write):
+                local_data.write(hbytes(node.value))
+                node = node.child
+            else:
+                assert isinstance(node, Branch)
+                c = local_data.draw_bits(node.bits)
+                try:
+                    node = node.children[c]
+                except KeyError:
+                    if data is None:
+                        return
+                    node = node.children.setdefault(c, data.draw(nodes))
+        assert isinstance(node, Terminal)
+        if node.status == Status.INTERESTING:
+            local_data.mark_interesting(node.payload)
+        elif node.status == Status.INVALID:
+            local_data.mark_invalid()
+
+    runner = ConjectureRunner(test, settings=settings(
+        max_examples=1, max_shrinks=100, buffer_size=512,
+        database=None, suppress_health_check=HealthCheck.all(),
+        verbosity=Verbosity.quiet,
+    ))
+    try:
+        runner.run()
+    finally:
+        if data is not None:
+            note(root)
+    assume(runner.interesting_examples)
+
+
+@settings(
+    max_examples=100, suppress_health_check=HealthCheck.all(),
+    deadline=None, verbosity=Verbosity.debug, timeout=unlimited,
+    use_coverage=False,
+)
+@given(st.data())
+def test_explore_an_arbitrary_language(data):
+    root = data.draw(writes | branches)
+    seed = data.draw(st.integers(0, 2 ** 64 - 1))
+    run_language_test_for(root, data, seed)
+
+
+@pytest.mark.parametrize(
+    'seed, language', [
+        (0, Write('\x01\x02', Write('\x01\x00', Branch(41, {
+            k: Terminal(Status.INTERESTING)
+            for k in [339838487202, 20255, 543, 512, 254]}))))
+    ]
+)
+def test_run_specific_example(seed, language):
+    """This test recreates individual languages generated with the main test.
+
+    in this file. These are typically manually pruned down a bit - e.g. it's
+    OK to remove VALID nodes because KeyError is treated as if it lead to one
+    in this test (but not in the @given test).
+
+    These tests are likely to be fairly fragile with respect to changes in the
+    underlying engine. Feel free to delete examples if they start failing after
+    a change.
+    """
+    run_language_test_for(language, None, seed)

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -119,15 +119,12 @@ def test_explore_an_arbitrary_language(data):
 
 @pytest.mark.parametrize(
     'seed, language', [
-        (0, Write('\x01\x02', Write('\x01\x00', Branch(41, {
-            k: Terminal(Status.INTERESTING)
-            for k in [339838487202, 20255, 543, 512, 254]}))))
     ]
 )
 def test_run_specific_example(seed, language):
     """This test recreates individual languages generated with the main test.
 
-    in this file. These are typically manually pruned down a bit - e.g. it's
+    These are typically manually pruned down a bit - e.g. it's
     OK to remove VALID nodes because KeyError is treated as if it lead to one
     in this test (but not in the @given test).
 


### PR DESCRIPTION
In searching for #1299 I thought I'd write some tests that target the conjecture runner more directly 
(I also improved the repr for Status because that made the test output much easier to deal with. This isn't user facing because Status is non-public API).

Well I didn't find #1299, but I did find another bug in the same code.

I think one of the lessons from this is that there are actually a lot of very subtle, entirely implicit, and thoroughly undocumented invariants to maintain while shrinking that need to be clearer before other people can do much work on the shrinker. 😢 