### PR TITLE
Replace max_shrinks=0 with Phase setting in our tests

### DIFF
--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -22,6 +22,7 @@ import sys
 from hypothesis import find, given, assume, reject
 from hypothesis import settings as Settings
 from hypothesis.errors import NoSuchExample, Unsatisfiable
+from tests.common.utils import no_shrink
 
 TIME_INCREMENT = 0.01
 
@@ -76,7 +77,7 @@ def find_any(
     settings = Settings(
         settings,
         max_examples=10000,
-        max_shrinks=0000,
+        phases=no_shrink,
         database=None,
     )
 
@@ -101,7 +102,7 @@ def assert_no_examples(strategy, condition=None):
             assume(condition(x))
 
     try:
-        result = find(strategy, predicate, settings=Settings(max_shrinks=1))
+        result = find(strategy, predicate, settings=Settings(phases=no_shrink))
         assert False, 'Expected no results but found %r' % (result,)
     except (Unsatisfiable, NoSuchExample):
         pass

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -23,9 +23,12 @@ import contextlib
 from io import BytesIO, StringIO
 
 from hypothesis.errors import HypothesisDeprecationWarning
+from hypothesis._settings import Phase
 from hypothesis.reporting import default, with_reporter
 from hypothesis.internal.compat import PY2
 from hypothesis.internal.reflection import proxies
+
+no_shrink = tuple(set(Phase) - {Phase.shrink})
 
 
 @contextlib.contextmanager

--- a/hypothesis-python/tests/cover/test_database_usage.py
+++ b/hypothesis-python/tests/cover/test_database_usage.py
@@ -20,8 +20,8 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import Verbosity, core, find, given, assume, settings, \
-    unlimited
+from hypothesis import Verbosity, HealthCheck, core, find, given, assume, \
+    settings, unlimited
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from tests.common.utils import all_values, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
@@ -83,7 +83,7 @@ def test_trashes_invalid_examples():
             find(
                 st.binary(min_size=100),
                 lambda x: assume(not finicky) and has_a_non_zero_byte(x),
-                settings=settings(database=database, max_shrinks=10),
+                settings=settings(database=database),
                 database_key=key
             )
         except Unsatisfiable:
@@ -137,7 +137,7 @@ def test_clears_out_everything_smaller_than_the_interesting_example():
 
     @settings(
         database=database, verbosity=Verbosity.quiet, max_examples=100,
-        timeout=unlimited, max_shrinks=100
+        timeout=unlimited, suppress_health_check=[HealthCheck.hung_test],
     )
     @given(st.binary(min_size=10, max_size=10))
     def test(b):

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -22,6 +22,7 @@ import pytest
 from hypothesis import Verbosity, HealthCheck, given, assume, reject, \
     example, settings
 from hypothesis.errors import Flaky, Unsatisfiable, UnsatisfiedAssumption
+from tests.common.utils import no_shrink
 from hypothesis.strategies import lists, booleans, integers, composite, \
     random_module
 
@@ -103,7 +104,7 @@ def test_failure_sequence_inducing(building, testing, rnd):
     @given(integers().map(build))
     @settings(
         verbosity=Verbosity.quiet, database=None,
-        suppress_health_check=HealthCheck.all(), max_shrinks=0
+        suppress_health_check=HealthCheck.all(), phases=no_shrink
     )
     def test(x):
         try:

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -26,7 +26,7 @@ import hypothesis.strategies as st
 from hypothesis import HealthCheck, given, settings
 from hypothesis.errors import InvalidArgument, FailedHealthCheck
 from hypothesis.control import assume
-from tests.common.utils import checks_deprecated_behaviour
+from tests.common.utils import no_shrink, checks_deprecated_behaviour
 from hypothesis.internal.compat import int_from_bytes
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
@@ -108,7 +108,7 @@ class fails_regularly(SearchStrategy):
 
 def test_filtering_most_things_fails_a_health_check():
     @given(fails_regularly())
-    @settings(database=None, max_shrinks=0)
+    @settings(database=None, phases=no_shrink)
     def test(x):
         pass
 

--- a/hypothesis-python/tests/cover/test_integer_ranges.py
+++ b/hypothesis-python/tests/cover/test_integer_ranges.py
@@ -44,7 +44,7 @@ class interval(SearchStrategy):
 def test_intervals_shrink_to_center(inter, rnd):
     lower, center, upper = inter
     s = interval(lower, upper, center)
-    with settings(database=None, max_shrinks=2000, timeout=unlimited):
+    with settings(database=None, timeout=unlimited):
         assert find(s, lambda x: True) == center
         if lower < center:
             assert find(s, lambda x: x < center) == center - 1

--- a/hypothesis-python/tests/cover/test_interleaving.py
+++ b/hypothesis-python/tests/cover/test_interleaving.py
@@ -26,14 +26,13 @@ from tests.common.utils import checks_deprecated_behaviour
 def test_can_eval_stream_inside_find():
     @given(st.streaming(st.integers(min_value=0)), st.random_module())
     @settings(
-        buffer_size=200, max_shrinks=5, max_examples=10,
+        buffer_size=200, max_examples=10,
         suppress_health_check=HealthCheck.all())
     def test(stream, rnd):
         x = find(
             st.lists(st.integers(min_value=0), min_size=10),
             lambda t: any(t > s for (t, s) in zip(t, stream)),
-            settings=settings(
-                database=None, max_shrinks=2000, max_examples=2000)
+            settings=settings(database=None, max_examples=2000)
         )
         note('x: %r' % (x,))
         note('Evalled: %r' % (stream,))

--- a/hypothesis-python/tests/cover/test_nesting.py
+++ b/hypothesis-python/tests/cover/test_nesting.py
@@ -21,6 +21,7 @@ from pytest import raises
 
 import hypothesis.strategies as st
 from hypothesis import Verbosity, given, settings
+from tests.common.utils import no_shrink
 
 
 def test_nesting_1():
@@ -29,7 +30,7 @@ def test_nesting_1():
     def test_blah(x):
         @given(st.integers())
         @settings(
-            max_examples=100, max_shrinks=0, database=None,
+            max_examples=100, phases=no_shrink, database=None,
             verbosity=Verbosity.quiet)
         def test_nest(y):
             if y >= x:

--- a/hypothesis-python/tests/cover/test_randomization.py
+++ b/hypothesis-python/tests/cover/test_randomization.py
@@ -23,10 +23,11 @@ from pytest import raises
 
 import hypothesis.strategies as st
 from hypothesis import Verbosity, find, given, settings
+from tests.common.utils import no_shrink
 
 
 def test_seeds_off_random():
-    s = settings(max_shrinks=0, database=None)
+    s = settings(phases=no_shrink, database=None)
     r = random.getstate()
     x = find(st.integers(), lambda x: True, settings=s)
     random.setstate(r)
@@ -40,7 +41,7 @@ def test_nesting_with_control_passes_health_check():
     def test_blah(x, rnd):
         @given(st.integers())
         @settings(
-            max_examples=100, max_shrinks=0, database=None,
+            max_examples=100, phases=no_shrink, database=None,
             verbosity=Verbosity.quiet)
         def test_nest(y):
             assert y < x

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -28,7 +28,7 @@ from hypothesis import PrintSettings, given, reject, example, settings, \
     __version__, reproduce_failure
 from hypothesis.core import decode_failure, encode_failure
 from hypothesis.errors import DidNotReproduce, InvalidArgument
-from tests.common.utils import capture_out
+from tests.common.utils import no_shrink, capture_out
 
 
 @given(st.binary() | st.binary(min_size=100))
@@ -147,7 +147,7 @@ def test_does_print_reproduction_for_simple_data_examples_by_default():
 
 
 def test_does_not_print_reproduction_for_large_data_examples_by_default():
-    @settings(max_shrinks=0)
+    @settings(phases=no_shrink)
     @given(st.data())
     def test(data):
         b = data.draw(st.binary(min_size=1000, max_size=1000))

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -154,25 +154,27 @@ def test_will_reload_profile_when_default_is_absent():
 def test_load_profile():
     settings.load_profile('default')
     assert settings.default.max_examples == 100
-    assert settings.default.max_shrinks == 500
+    assert settings.default.stateful_step_count == 50
 
-    settings.register_profile('test', settings(max_examples=10), max_shrinks=5)
+    settings.register_profile(
+        'test', settings(max_examples=10), stateful_step_count=5
+    )
     settings.load_profile('test')
 
     assert settings.default.max_examples == 10
-    assert settings.default.max_shrinks == 5
+    assert settings.default.stateful_step_count == 5
 
     settings.load_profile('default')
 
     assert settings.default.max_examples == 100
-    assert settings.default.max_shrinks == 500
+    assert settings.default.stateful_step_count == 50
 
 
 @checks_deprecated_behaviour
 def test_nonstring_profile_names_deprecated():
-    settings.register_profile(5, max_shrinks=5)
+    settings.register_profile(5, stateful_step_count=5)
     settings.load_profile(5)
-    assert settings.default.max_shrinks == 5
+    assert settings.default.stateful_step_count == 5
 
 
 def test_loading_profile_keeps_expected_behaviour():

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -25,7 +25,8 @@ import hypothesis.reporting as reporting
 from hypothesis import Verbosity, HealthCheck, note, seed, given, assume, \
     reject, settings
 from hypothesis.errors import Unsatisfiable
-from tests.common.utils import fails, raises, fails_with, capture_out
+from tests.common.utils import fails, raises, no_shrink, fails_with, \
+    capture_out
 from hypothesis.strategies import data, just, sets, text, lists, binary, \
     builds, floats, one_of, booleans, integers, frozensets, sampled_from
 
@@ -437,7 +438,7 @@ def test_when_set_to_no_simplifies_runs_failing_example_twice():
     failing = [0]
 
     @given(integers())
-    @settings(max_shrinks=0, max_examples=100)
+    @settings(phases=no_shrink, max_examples=100)
     def foo(x):
         if x > 11:
             note('Lo')

--- a/hypothesis-python/tests/nocover/test_boundary_exploration.py
+++ b/hypothesis-python/tests/nocover/test_boundary_exploration.py
@@ -23,12 +23,13 @@ import hypothesis.strategies as st
 from hypothesis import Verbosity, HealthCheck, find, given, reject, \
     settings
 from hypothesis.errors import NoSuchExample
+from tests.common.utils import no_shrink
 
 
 @pytest.mark.parametrize('strat', [st.text(min_size=5)])
 @settings(
-    max_shrinks=0, deadline=None, suppress_health_check=[
-        HealthCheck.too_slow, HealthCheck.hung_test]
+    phases=no_shrink, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.hung_test]
 )
 @given(st.data())
 def test_explore_arbitrary_function(strat, data):
@@ -43,8 +44,7 @@ def test_explore_arbitrary_function(strat, data):
     try:
         find(
             strat, predicate,
-            settings=settings(
-                database=None, verbosity=Verbosity.quiet, max_shrinks=1000)
+            settings=settings(database=None, verbosity=Verbosity.quiet)
         )
     except NoSuchExample:
         reject()

--- a/hypothesis-python/tests/nocover/test_collective_minimization.py
+++ b/hypothesis-python/tests/nocover/test_collective_minimization.py
@@ -47,7 +47,7 @@ def test_can_collectively_minimize(spec):
         xs = find(
             lists(spec, min_size=n, max_size=n),
             distinct_reprs,
-            settings=settings(max_shrinks=100, max_examples=2000))
+            settings=settings(max_examples=2000))
         assert len(xs) == n
         assert 2 <= len(set((map(repr, xs)))) <= 3
     except NoSuchExample:

--- a/hypothesis-python/tests/nocover/test_deferred_strategies.py
+++ b/hypothesis-python/tests/nocover/test_deferred_strategies.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 from hypothesis import Verbosity, find, note, given, settings
 from hypothesis import strategies as st
 from hypothesis.errors import NoSuchExample, Unsatisfiable
+from tests.common.utils import no_shrink
 from hypothesis.internal.compat import hrange
 
 
@@ -64,7 +65,7 @@ def test_arbitrary_recursion(strategies):
 
             try:
                 find(s, lambda x: True, settings=settings(
-                    max_shrinks=0, database=None, verbosity=Verbosity.quiet,
+                    phases=no_shrink, database=None, verbosity=Verbosity.quiet,
                     max_examples=1,
                 ))
             except (Unsatisfiable, NoSuchExample):

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -35,6 +35,7 @@ import collections
 import hypothesis.internal.reflection as reflection
 from hypothesis import settings as Settings
 from hypothesis.errors import UnsatisfiedAssumption
+from tests.common.utils import no_shrink
 from hypothesis.strategies import just, sets, text, lists, floats, \
     one_of, tuples, booleans, integers, sampled_from
 from hypothesis.internal.conjecture.engine import \
@@ -82,7 +83,7 @@ def define_test(specifier, predicate, condition=None):
                 test_function,
                 settings=Settings(
                     max_examples=100,
-                    max_shrinks=0
+                    phases=no_shrink
                 ))
             runner.run()
             if runner.interesting_examples:

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -86,7 +86,7 @@ class TrialRunner(ConjectureRunner):
 LOTS = 10 ** 6
 
 TRIAL_SETTINGS = settings(
-    max_examples=LOTS, max_shrinks=LOTS, timeout=unlimited, database=None
+    max_examples=LOTS, timeout=unlimited, database=None
 )
 
 

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -64,7 +64,7 @@ LOTS = 10 ** 6
 
 TEST_SETTINGS = settings(
     database=None, suppress_health_check=HealthCheck.all(), max_examples=LOTS,
-    deadline=None, timeout=unlimited, max_shrinks=LOTS
+    deadline=None, timeout=unlimited
 )
 
 

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -43,7 +43,6 @@ def problem(draw):
 @example((b'\x01', b'', 0))
 @settings(
     deadline=None, suppress_health_check=HealthCheck.all(), max_examples=10,
-    max_shrinks=100
 )
 @given(problem())
 def test_avoids_zig_zag_trap(p):
@@ -65,7 +64,7 @@ def test_avoids_zig_zag_trap(p):
 
     runner = ConjectureRunner(
         test_function, database_key=None, settings=settings(
-            database=None, max_shrinks=100, verbosity=Verbosity.debug
+            database=None, verbosity=Verbosity.debug
         )
     )
 


### PR DESCRIPTION
This pull is step one of a two-stage plan to deal with the `max_shrinks` setting (see #1235):

1. Do the easy part, by substantially reducing the use of `max_shrinks` in our own test suite.
2. Leave the hard parts for ~~someone else~~ later!  At least it will be a smaller job after this.