### PR TITLE
Typo in macro for pull request link

### DIFF
--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -99,7 +99,7 @@ extlinks = {
     'gh-file': (_repo + 'blob/master/%s', ''),
     'gh-link': (_repo + '%s', ''),
     'issue': (_repo + 'issues/%s', 'issue #'),
-    'pull': (_repo + 'pulls/%s', 'pull request #'),
+    'pull': (_repo + 'pull/%s', 'pull request #'),
     'pypi': ('https://pypi.org/project/%s', ''),
 }
 


### PR DESCRIPTION
The url pattern https://github.com/HypothesisWorks/hypothesis/pulls/154 should be https://github.com/HypothesisWorks/hypothesis/pull/154 . The former goes to a pull request search page and queries for PRs with an author named '154'. See for example https://hypothesis.readthedocs.io/en/latest/development.html

I'm not sure whether this counts as a doc change, and doesn't need release.rst, or if it will trigger the check for release.rst. Creating the PR now in order to get this feedback from the build.