### PR TITLE
Fix class xx(NamedTuple) introspection

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -199,3 +199,4 @@ their individual contributions.
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)
 * `Zac Hatfield-Dodds <https://www.github.com/Zac-HD>`_ (zac.hatfield.dodds@gmail.com)
+* `James Uther <https://www.github.com/jbu>`_ (james.uther@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,16 @@
+RELEASE_TYPE: minor
+
+Fix class xx(NamedTuple) introspection
+======================================
+
+.. code:: python
+
+class AnnotatedNamedTuple(typing.NamedTuple):
+    a: str
+    i: int
+
+is not buildble by :func:`@build <hypothesis.build>(AnnotedNamedTuple)` because
+they don't have an `__init__` method to introspect and find the argument (field)
+types. Fixed things so that introspection will happen in this case.
+
+Thanks to James Uther for this bug fix

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -5,9 +5,9 @@ Fix class xx(NamedTuple) introspection
 
 .. code:: python
 
-class AnnotatedNamedTuple(typing.NamedTuple):
-    a: str
-    i: int
+    class AnnotatedNamedTuple(typing.NamedTuple):
+        a: str
+        i: int
 
 is not buildble by :func:`@build <hypothesis.build>(AnnotedNamedTuple)` because
 they don't have an `__init__` method to introspect and find the argument (field)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -99,7 +99,7 @@ def required_args(target, args=(), kwargs=()):
     """
     try:
         spec = getfullargspec(
-            target.__init__ if inspect.isclass(target) else target)
+            target.__init__ if inspect.isclass(target) and '__init__' in target.__dict__ else target)
     except TypeError:  # pragma: no cover
         return None
     # self appears in the argspec of __init__ and bound methods, but it's an

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -98,8 +98,10 @@ def required_args(target, args=(), kwargs=()):
     builds() - that is, a tuple of values and a dict of names: values.
     """
     try:
-        spec = getfullargspec(
-            target.__init__ if inspect.isclass(target) and '__init__' in target.__dict__ else target)
+        if inspect.isclass(target) and hasattr(target, '__init__'):
+            spec = getfullargspec(target.__init__)
+        else:
+            spec = getfullargspec(target)
     except TypeError:  # pragma: no cover
         return None
     # self appears in the argspec of __init__ and bound methods, but it's an

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -98,7 +98,8 @@ def required_args(target, args=(), kwargs=()):
     builds() - that is, a tuple of values and a dict of names: values.
     """
     try:
-        if inspect.isclass(target) and hasattr(target, '__init__'):
+        if inspect.isclass(target) and '__init__' in target.__dict__:
+            # Checking dict because NamedTuples don't have an init
             spec = getfullargspec(target.__init__)
         else:
             spec = getfullargspec(target)

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1071,7 +1071,7 @@ def builds(
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '
                               'builds(), but is only allowed as a keyword arg')
-    hints = get_type_hints(target.__init__ if isclass(target) else target)
+    hints = get_type_hints(target.__init__ if isclass(target) and '__init__' in target.__dict__ else target)
     for kw in [k for k, v in kwargs.items() if v is infer]:
         if kw not in hints:
             raise InvalidArgument(

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1071,7 +1071,8 @@ def builds(
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '
                               'builds(), but is only allowed as a keyword arg')
-    if isclass(target) and hasattr(target, '__init__'):
+    if isclass(target) and '__init__' in target.__dict__:
+        # Can't use hasattr because the superclass might have init
         hints = get_type_hints(target.__init__)
     else:
         hints = get_type_hints(target)

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1071,7 +1071,10 @@ def builds(
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '
                               'builds(), but is only allowed as a keyword arg')
-    hints = get_type_hints(target.__init__ if isclass(target) and '__init__' in target.__dict__ else target)
+    if isclass(target) and hasattr(target, '__init__'):
+        hints = get_type_hints(target.__init__)
+    else:
+        hints = get_type_hints(target)
     for kw in [k for k, v in kwargs.items() if v is infer]:
         if kw not in hints:
             raise InvalidArgument(

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -373,7 +373,10 @@ class AnnotatedNamedTuple(typing.NamedTuple):
 
 
 def test_required_args_for_namedtuple():
-    print(st.builds(AnnotatedNamedTuple).example())
+    # NamedTuple doesn't have an __init__ method so we
+    # need to do something a bit different to introspect the
+    # constructor parameters.
+    st.builds(AnnotatedNamedTuple).example()
 
 
 @pytest.mark.parametrize('thing', [

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -372,8 +372,7 @@ class AnnotatedNamedTuple(typing.NamedTuple):
     i: int
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason='new addition')
-def test_required_args():
+def test_required_args_for_namedtuple():
     print(st.builds(AnnotatedNamedTuple).example())
 
 

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -367,6 +367,16 @@ def test_required_args(target, args, kwargs):
               **{k: st.just(v) for k, v in kwargs.items()}).example()
 
 
+class AnnotatedNamedTuple(typing.NamedTuple):
+    a: str
+    i: int
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason='new addition')
+def test_required_args():
+    print(st.builds(AnnotatedNamedTuple).example())
+
+
 @pytest.mark.parametrize('thing', [
     typing.Optional, typing.List, getattr(typing, 'Type', typing.Set)
 ])  # check Type if it's available, otherwise Set is redundant but harmless

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -42,6 +42,14 @@ deps=
 commands=
     python -m pytest tests/cover/ -n2
 
+[testenv:py36]
+basepython=python3.6
+deps=
+    -r../requirements/test.txt
+    -r../requirements/typing.txt
+commands=
+    python -m pytest tests/py3/ -n2
+
 [testenv:unicode]
 basepython=python2.7
 deps =

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -42,14 +42,6 @@ deps=
 commands=
     python -m pytest tests/cover/ -n2
 
-[testenv:py36]
-basepython=python3.6
-deps=
-    -r../requirements/test.txt
-    -r../requirements/typing.txt
-commands=
-    python -m pytest tests/py3/ -n2
-
 [testenv:unicode]
 basepython=python2.7
 deps =


### PR DESCRIPTION
```python
class AnnotatedNamedTuple(typing.NamedTuple):
    a: str
    i: int
```
is not buildble by `@build(AnnotedNamedTuple)` because they don't have an `__init__` method to introspect and find the argument (field) types. Fixed things so that introspection will happen in this case.