### PR TITLE
Correct the way that django models are instantiated

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -200,6 +200,7 @@ their individual contributions.
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (s.shanabrook@gmail.com)
 * `Sushobhit <https://github.com/sushobhit27>`_ (sushobhitsolanki@gmail.com)
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
+* `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)
 * `Zac Hatfield-Dodds <https://www.github.com/Zac-HD>`_ (zac.hatfield.dodds@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+Fixed a bug in generating an instance of a Django model from a
+strategy where the primary key is generated as part of the
+strategy. See :ref:`details here <django-generating-primary-key>`.
+
+Thanks to Tim Martin for this contribution.

--- a/hypothesis-python/docs/django.rst
+++ b/hypothesis-python/docs/django.rst
@@ -163,3 +163,19 @@ instead of generating one by passing ``fieldname=default_value`` to
     >>> x = models(DefaultCustomish, customish=default_value).example()
     >>> x.customish
     'b'
+
+.. _django-generating-primary-key:
+
+Generating primary key values
+=============================
+
+If your model includes a custom primary key that you want to generate
+using a strategy (rather than a default auto-increment primary key)
+then Hypothesis has to deal with the possibility of a duplicate
+primary key.
+
+If a model strategy generates a value for the primary key field,
+Hypothesis will create the model instance with
+:meth:`~django:django.db.models.query.QuerySet.update_or_create`,
+overwriting any existing instance in the database for this test case
+with the same primary key.

--- a/hypothesis-python/tests/django/toystore/models.py
+++ b/hypothesis-python/tests/django/toystore/models.py
@@ -141,3 +141,21 @@ class RestrictedFields(models.Model):
         validators=[validate_even]
     )
     non_blank_text_field = models.TextField(blank=False)
+
+
+class SelfModifyingField(models.IntegerField):
+    def pre_save(self, model_instance, add):
+        value = getattr(model_instance, self.attname)
+        value += 1
+        setattr(model_instance, self.attname, value)
+        return value
+
+
+class CompanyExtension(models.Model):
+    company = models.OneToOneField(
+        Company,
+        primary_key=True,
+        on_delete=models.CASCADE
+    )
+
+    self_modifying = SelfModifyingField()


### PR DESCRIPTION
If the primary key value is specified as part of the strategy, then
using get_or_create() doesn't do the right thing, since it will not
match existing rows that have the same primary key field but different
values in other fields.

This fixes #1307 