### PR TITLE
Add a sort pass to the minimizer

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -184,6 +184,7 @@ their individual contributions.
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)
 * `Lee Begg <https://www.github.com/llnz2>`_
 * `Louis Taylor <https://github.com/kragniz>`_
+* `Luke Barone-Adesi <https://github.com/baluke>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (marius@gedmin.as)
 * `Markus Unterwaditzer <http://github.com/untitaker/>`_ (markus@unterwaditzer.net)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This improves the shrinker. It can now reorder examples: 3 1 2 becomes 1 2 3.
+
+Thanks to Luke for contributing.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py
@@ -211,6 +211,9 @@ class Minimizer(object):
             lambda c: c == self.current_int or self.incorporate_int(c)
         )
 
+    def sort(self):
+        self.incorporate(hbytes(sorted(self.current)))
+
     def run(self):
         if not any(self.current):
             return
@@ -268,6 +271,7 @@ class Minimizer(object):
             first = False
             change_counter = self.changes
 
+            self.sort()
             self.float_hack()
             self.shift()
             self.shrink_indices()

--- a/hypothesis-python/tests/cover/test_conjecture_minimizer.py
+++ b/hypothesis-python/tests/cover/test_conjecture_minimizer.py
@@ -38,3 +38,9 @@ def test_float_hack_fails():
     assert minimize(
         hbytes([255] * 8), lambda x: x[0] >> 7, random=Random(0),
     ) == hbytes([128] + [0] * 7)
+
+
+def test_can_sort_bytes_by_reordering():
+    start = hbytes([5, 4, 3, 2, 1, 0])
+    finish = minimize(start, lambda x: set(x) == set(start), random=Random(0))
+    assert finish == hbytes([0, 1, 2, 3, 4, 5])


### PR DESCRIPTION
Re-order input bytes without otherwise changing the input, from lowest to highest.

This is step 1 of https://github.com/HypothesisWorks/hypothesis/issues/1096 , which is also the source of the new test.