### PR TITLE
Partially order a test case

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This adds support for partially sorting examples which cannot be fully sorted.
+For example, [5, 4, 3, 2, 1, 0] with a constraint that the first element needs
+to be larger than the last becomes [1, 2, 3, 4, 5, 0].
+
+Thanks to Luke for contributing.

--- a/hypothesis-python/tests/cover/test_conjecture_minimizer.py
+++ b/hypothesis-python/tests/cover/test_conjecture_minimizer.py
@@ -18,6 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 from random import Random
+from collections import Counter
 
 from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.minimizer import minimize
@@ -44,3 +45,30 @@ def test_can_sort_bytes_by_reordering():
     start = hbytes([5, 4, 3, 2, 1, 0])
     finish = minimize(start, lambda x: set(x) == set(start), random=Random(0))
     assert finish == hbytes([0, 1, 2, 3, 4, 5])
+
+
+def test_can_sort_bytes_by_reordering_partially():
+    start = hbytes([5, 4, 3, 2, 1, 0])
+    finish = minimize(
+        start, lambda x: set(x) == set(start) and x[0] > x[-1],
+        random=Random(0),
+    )
+    assert finish == hbytes([1, 2, 3, 4, 5, 0])
+
+
+def test_can_sort_bytes_by_reordering_partially2():
+    start = hbytes([5, 4, 3, 2, 1, 0])
+    finish = minimize(
+        start, lambda x: Counter(x) == Counter(start) and x[0] > x[2],
+        random=Random(0),
+    )
+    assert finish <= hbytes([1, 2, 0, 3, 4, 5])
+
+
+def test_can_sort_bytes_by_reordering_partially_not_cross_stationary_element():
+    start = hbytes([5, 3, 0, 2, 1, 4])
+    finish = minimize(
+        start, lambda x: set(x) == set(start) and x[3] == 2,
+        random=Random(0),
+    )
+    assert finish <= hbytes([0, 3, 5, 2, 1, 4])


### PR DESCRIPTION
When a test case is generated and cannot be fully ordered, attempt to
still impose some order within it.

This is step 2 of https://github.com/HypothesisWorks/hypothesis/issues/1096