### PR TITLE
Factor out Python specific build components

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ TOOL_HASH=$("$PYTHON" "$SCRIPTS/tool-hash.py" < "$TOOL_REQUIREMENTS")
 TOOL_VIRTUALENV="$VIRTUALENVS/build-$TOOL_HASH"
 TOOL_PYTHON="$TOOL_VIRTUALENV/bin/python"
 
-if [ ! -e "$TOOL_PYTHON" ] ; then
+if ! "$TOOL_PYTHON" -m hypothesistooling check-installed ; then
   rm -rf "$TOOL_VIRTUALENV"
   "$PYTHON" -m pip install --upgrade virtualenv
   "$PYTHON" -m virtualenv "$TOOL_VIRTUALENV"

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is a no-op release to take into account some changes to the release
+process. It should have no user visible effect.

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -119,7 +119,7 @@ def assert_can_release():
 
 
 def has_travis_secrets():
-    return os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true'
+    return os.environ.get('TRAVIS_SECURE_ENV_VARS', None) == 'true'
 
 
 def build_jobs():

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -104,12 +104,22 @@ def create_tag(tagname):
 
 
 def push_tag(tagname):
+    assert_can_release()
     subprocess.check_call([
         'ssh-agent', 'sh', '-c',
         'ssh-add %s && ' % (shlex.quote(DEPLOY_KEY),) +
         'git push ssh-origin HEAD:master &&' +
         'git push ssh-origin %s' % (shlex.quote(tagname),)
     ])
+
+
+def assert_can_release():
+    assert not IS_PULL_REQUEST, 'Cannot release from pull requests'
+    assert has_travis_secrets(), 'Cannot release without travis secure vars'
+
+
+def has_travis_secrets():
+    return os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true'
 
 
 def build_jobs():

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -18,11 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import os
-import re
-import sys
 import shlex
 import subprocess
-from datetime import datetime, timedelta
 
 
 def current_branch():
@@ -43,52 +40,11 @@ ROOT = subprocess.check_output([
     'git', '-C', os.path.dirname(__file__), 'rev-parse', '--show-toplevel',
 ]).decode('ascii').strip()
 
-HYPOTHESIS_PYTHON = os.path.join(ROOT, 'hypothesis-python')
 HYPOTHESIS_RUBY = os.path.join(ROOT, 'hypothesis-ruby')
-
-PYTHON_SRC = os.path.join(HYPOTHESIS_PYTHON, 'src')
-PYTHON_TESTS = os.path.join(HYPOTHESIS_PYTHON, 'tests')
 
 REPO_TESTS = os.path.join(ROOT, 'whole-repo-tests')
 
 PYUP_FILE = os.path.join(ROOT, '.pyup.yml')
-
-
-assert os.path.exists(PYTHON_SRC)
-
-
-__version__ = None
-__version_info__ = None
-
-VERSION_FILE = os.path.join(PYTHON_SRC, 'hypothesis/version.py')
-
-with open(VERSION_FILE) as o:
-    exec(o.read())
-
-assert __version__ is not None
-assert __version_info__ is not None
-
-
-PYTHON_TAG_PREFIX = 'hypothesis-python-'
-
-
-def latest_version():
-    versions = []
-
-    for t in tags():
-        if t.startswith(PYTHON_TAG_PREFIX):
-            t = t[len(PYTHON_TAG_PREFIX):]
-        else:
-            continue
-        assert t == t.strip()
-        parts = t.split('.')
-        assert len(parts) == 3
-        v = tuple(map(int, parts))
-        versions.append((v, t))
-
-    _, latest = max(versions)
-
-    return latest
 
 
 def hash_for_name(name):
@@ -103,14 +59,6 @@ def is_ancestor(a, b):
     ])
     assert 0 <= check <= 1
     return check == 0
-
-
-CHANGELOG_FILE = os.path.join(HYPOTHESIS_PYTHON, 'docs', 'changes.rst')
-
-
-def changelog():
-    with open(CHANGELOG_FILE) as i:
-        return i.read()
 
 
 def merge_base(a, b):
@@ -130,10 +78,6 @@ def has_changes(files):
     ]) != 0
 
 
-def has_python_source_changes():
-    return has_changes([PYTHON_SRC])
-
-
 def has_uncommitted_changes(filename):
     return subprocess.call([
         'git', 'diff', '--exit-code', filename
@@ -144,8 +88,7 @@ def git(*args):
     subprocess.check_call(('git',) + args)
 
 
-def create_tag_and_push():
-    assert __version__ not in tags()
+def configure_git():
     git('config', 'user.name', 'Travis CI on behalf of David R. MacIver')
     git('config', 'user.email', 'david@drmaciver.com')
     git('config', 'core.sshCommand', 'ssh -i deploy_key')
@@ -153,13 +96,19 @@ def create_tag_and_push():
         'remote', 'add', 'ssh-origin',
         'git@github.com:HypothesisWorks/hypothesis.git'
     )
-    git('tag', PYTHON_TAG_PREFIX + __version__)
 
+
+def create_tag(tagname):
+    assert tagname not in tags()
+    git('tag', tagname)
+
+
+def push_tag(tagname):
     subprocess.check_call([
         'ssh-agent', 'sh', '-c',
         'ssh-add %s && ' % (shlex.quote(DEPLOY_KEY),) +
-        'git push ssh-origin HEAD:master &&'
-        'git push ssh-origin --tags'
+        'git push ssh-origin HEAD:master &&' +
+        'git push ssh-origin %s' % (shlex.quote(tagname),)
     ])
 
 
@@ -215,135 +164,6 @@ def all_files():
     ]
 
 
-RELEASE_FILE = os.path.join(HYPOTHESIS_PYTHON, 'RELEASE.rst')
-
-
-def has_release():
-    return os.path.exists(RELEASE_FILE)
-
-
-CHANGELOG_ANCHOR = re.compile(r"^\.\. _v\d+\.\d+\.\d+:$")
-CHANGELOG_BORDER = re.compile(r"^-+$")
-CHANGELOG_HEADER = re.compile(r"^\d+\.\d+\.\d+ - \d\d\d\d-\d\d-\d\d$")
-RELEASE_TYPE = re.compile(r"^RELEASE_TYPE: +(major|minor|patch)")
-
-
-MAJOR = 'major'
-MINOR = 'minor'
-PATCH = 'patch'
-
-VALID_RELEASE_TYPES = (MAJOR, MINOR, PATCH)
-
-
-def parse_release_file():
-    with open(RELEASE_FILE) as i:
-        release_contents = i.read()
-
-    release_lines = release_contents.split('\n')
-
-    m = RELEASE_TYPE.match(release_lines[0])
-    if m is not None:
-        release_type = m.group(1)
-        if release_type not in VALID_RELEASE_TYPES:
-            print('Unrecognised release type %r' % (release_type,))
-            sys.exit(1)
-        del release_lines[0]
-        release_contents = '\n'.join(release_lines).strip()
-    else:
-        print(
-            'RELEASE.rst does not start by specifying release type. The first '
-            'line of the file should be RELEASE_TYPE: followed by one of '
-            'major, minor, or patch, to specify the type of release that '
-            'this is (i.e. which version number to increment). Instead the '
-            'first line was %r' % (release_lines[0],)
-        )
-        sys.exit(1)
-
-    return release_type, release_contents
-
-
-def update_changelog_and_version():
-    global __version_info__
-    global __version__
-
-    with open(CHANGELOG_FILE) as i:
-        contents = i.read()
-    assert '\r' not in contents
-    lines = contents.split('\n')
-    assert contents == '\n'.join(lines)
-    for i, l in enumerate(lines):
-        if CHANGELOG_ANCHOR.match(l):
-            assert CHANGELOG_BORDER.match(lines[i + 2]), repr(lines[i + 2])
-            assert CHANGELOG_HEADER.match(lines[i + 3]), repr(lines[i + 3])
-            assert CHANGELOG_BORDER.match(lines[i + 4]), repr(lines[i + 4])
-            beginning = '\n'.join(lines[:i])
-            rest = '\n'.join(lines[i:])
-            assert '\n'.join((beginning, rest)) == contents
-            break
-
-    release_type, release_contents = parse_release_file()
-
-    new_version = list(__version_info__)
-    bump = VALID_RELEASE_TYPES.index(release_type)
-    new_version[bump] += 1
-    for i in range(bump + 1, len(new_version)):
-        new_version[i] = 0
-    new_version = tuple(new_version)
-    new_version_string = '.'.join(map(str, new_version))
-
-    __version_info__ = new_version
-    __version__ = new_version_string
-
-    with open(VERSION_FILE) as i:
-        version_lines = i.read().split('\n')
-
-    for i, l in enumerate(version_lines):
-        if 'version_info' in l:
-            version_lines[i] = '__version_info__ = %r' % (new_version,)
-            break
-
-    with open(VERSION_FILE, 'w') as o:
-        o.write('\n'.join(version_lines))
-
-    now = datetime.utcnow()
-
-    date = max([
-        d.strftime('%Y-%m-%d') for d in (now, now + timedelta(hours=1))
-    ])
-
-    heading_for_new_version = ' - '.join((new_version_string, date))
-    border_for_new_version = '-' * len(heading_for_new_version)
-
-    new_changelog_parts = [
-        beginning.strip(),
-        '',
-        '.. _v%s:' % (new_version_string),
-        '',
-        border_for_new_version,
-        heading_for_new_version,
-        border_for_new_version,
-        '',
-        release_contents,
-        '',
-        rest
-    ]
-
-    with open(CHANGELOG_FILE, 'w') as o:
-        o.write('\n'.join(new_changelog_parts))
-
-
-def update_for_pending_release():
-    update_changelog_and_version()
-
-    git('rm', RELEASE_FILE)
-    git('add', CHANGELOG_FILE, VERSION_FILE)
-
-    git(
-        'commit', '-m',
-        'Bump version to %s and update changelog\n\n[skip ci]' % (__version__,)
-    )
-
-
 def changed_files_from_master():
     """Returns a list of files which have changed between a branch and
     master."""
@@ -394,3 +214,8 @@ IS_CIRCLE_PULL_REQUEST = (
 
 
 IS_PULL_REQUEST = IS_TRAVIS_PULL_REQUEST or IS_CIRCLE_PULL_REQUEST
+
+
+def all_projects():
+    import hypothesistooling.projects.hypothesispython as hp
+    return [hp]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -19,13 +19,13 @@ from __future__ import division, print_function, absolute_import
 
 import os
 import sys
-import shutil
 import subprocess
 from glob import glob
 from datetime import datetime
 
 import hypothesistooling as tools
 import hypothesistooling.installers as install
+import hypothesistooling.projects.hypothesispython as hp
 from hypothesistooling import fix_doctests as fd
 from hypothesistooling.scripts import pip_tool
 
@@ -65,74 +65,59 @@ def lint():
     )
 
 
-@task(if_changed=tools.PYTHON_SRC)
+@task(if_changed=hp.PYTHON_SRC)
 def check_type_hints():
-    pip_tool('mypy', tools.PYTHON_SRC)
+    pip_tool('mypy', hp.PYTHON_SRC)
 
 
-DIST = os.path.join(tools.HYPOTHESIS_PYTHON, 'dist')
-PENDING_STATUS = ('started', 'created')
+HEAD = tools.hash_for_name('HEAD')
+MASTER = tools.hash_for_name('origin/master')
+
+
+def do_release(package):
+    if not package.has_release():
+        print('No release for %s' % (package.__name__,))
+        return
+
+    os.chdir(package.BASE_DIR)
+
+    print('Updating changelog and version')
+    package.update_for_pending_release()
+    package.build_distribution()
+
+    print('Looks good to release!')
+
+    tag_name = package.tag_name()
+
+    print('Creating tag %s' % (tag_name,))
+
+    tools.create_tag(tag_name)
+
+    print('Uploading distribution')
+    package.upload_distribution()
+
+    print('Pushing tag')
+    tools.push_tag(tag_name)
 
 
 @task()
 def deploy():
-    os.chdir(tools.HYPOTHESIS_PYTHON)
-
-    last_release = tools.latest_version()
-
-    print('Current version: %s. Latest released version: %s' % (
-        tools.__version__, last_release
-    ))
-
-    HEAD = tools.hash_for_name('HEAD')
-    MASTER = tools.hash_for_name('origin/master')
     print('Current head:', HEAD)
     print('Current master:', MASTER)
 
-    on_master = tools.is_ancestor(HEAD, MASTER)
-    has_release = tools.has_release()
-
-    if has_release:
-        print('Updating changelog and version')
-        tools.update_for_pending_release()
-
-    print('Building an sdist...')
-
-    if os.path.exists(DIST):
-        shutil.rmtree(DIST)
-
-    subprocess.check_output([
-        sys.executable, 'setup.py', 'sdist', '--dist-dir', DIST,
-    ])
-
-    if not on_master:
+    if not tools.is_ancestor(HEAD, MASTER):
         print('Not deploying due to not being on master')
         sys.exit(0)
 
-    if not has_release:
-        print('Not deploying due to no release')
-        sys.exit(0)
-
-    print('Looks good to release!')
-
     if os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true':
-        print("But we don't have the keys to do it")
+        print('Running without access to secure variables, so no deployment')
         sys.exit(0)
 
     print('Decrypting secrets')
     tools.decrypt_secrets()
+    tools.configure_git()
 
-    print('Release seems good. Pushing to github now.')
-
-    tools.create_tag_and_push()
-
-    print('Now uploading to pypi.')
-
-    subprocess.check_call([
-        sys.executable, '-m', 'twine', 'upload',
-        '--config-file', tools.PYPIRC,
-        os.path.join(DIST, '*'),
-    ])
+    do_release(hp)
 
     sys.exit(0)
 
@@ -283,23 +268,12 @@ def check_requirements():
     check_not_changed()
 
 
-def update_changelog_for_docs():
-    if not tools.has_release():
-        return
-    if tools.has_uncommitted_changes(tools.CHANGELOG_FILE):
-        print(
-            'Cannot build documentation with uncommitted changes to '
-            'changelog and a pending release. Please commit your changes or '
-            'delete your release file.')
-        sys.exit(1)
-    tools.update_changelog_and_version()
-
-
-@task(if_changed=tools.HYPOTHESIS_PYTHON)
+@task(if_changed=hp.HYPOTHESIS_PYTHON)
 def documentation():
-    os.chdir(tools.HYPOTHESIS_PYTHON)
+    os.chdir(hp.HYPOTHESIS_PYTHON)
     try:
-        update_changelog_for_docs()
+        if hp.has_release():
+            hp.update_changelog_and_version()
         pip_tool(
             'sphinx-build', '-W', '-b', 'html', '-d', 'docs/_build/doctrees',
             'docs', 'docs/_build/html'
@@ -310,9 +284,9 @@ def documentation():
         ])
 
 
-@task(if_changed=tools.HYPOTHESIS_PYTHON)
+@task(if_changed=hp.HYPOTHESIS_PYTHON)
 def doctest():
-    os.chdir(tools.HYPOTHESIS_PYTHON)
+    os.chdir(hp.HYPOTHESIS_PYTHON)
     env = dict(os.environ)
     env['PYTHONPATH'] = 'src'
 
@@ -333,7 +307,7 @@ def run_tox(task, version):
     except FileExistsError:
         pass
 
-    os.chdir(tools.HYPOTHESIS_PYTHON)
+    os.chdir(hp.HYPOTHESIS_PYTHON)
     env = dict(os.environ)
     python = install.python_executable(version)
 
@@ -365,7 +339,7 @@ for n in [PY27, PY34, PY35, PY36]:
     ALIASES[n] = 'python%s.%s' % (major, minor)
 
 
-python_tests = task(if_changed=(tools.PYTHON_SRC, tools.PYTHON_TESTS))
+python_tests = task(if_changed=(hp.PYTHON_SRC, hp.PYTHON_TESTS))
 
 
 @python_tests
@@ -427,8 +401,8 @@ def check_quality():
     run_tox('quality2', PY27)
 
 
-examples_task = task(if_changed=(tools.PYTHON_SRC, os.path.join(
-    tools.HYPOTHESIS_PYTHON, 'examples')
+examples_task = task(if_changed=(hp.PYTHON_SRC, os.path.join(
+    hp.HYPOTHESIS_PYTHON, 'examples')
 ))
 
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -128,7 +128,8 @@ def deploy():
     tools.decrypt_secrets()
     tools.configure_git()
 
-    do_release(hp)
+    for project in tools.all_projects():
+        do_release(project)
 
     sys.exit(0)
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -19,11 +19,9 @@ from __future__ import division, print_function, absolute_import
 
 import os
 import sys
-import random
 import shutil
 import subprocess
 from glob import glob
-from time import time, sleep
 from datetime import datetime
 
 import hypothesistooling as tools
@@ -114,59 +112,6 @@ def deploy():
     if not has_release:
         print('Not deploying due to no release')
         sys.exit(0)
-
-    start_time = time()
-
-    prev_pending = None
-
-    # We time out after an hour, which is a stupidly long time and it should
-    # never actually take that long: A full Travis run only takes about 20-30
-    # minutes! This is really just here as a guard in case something goes
-    # wrong and we're not paying attention so as to not be too mean to Travis..
-    while time() <= start_time + 60 * 60:
-        jobs = tools.build_jobs()
-
-        failed_jobs = [
-            (k, v)
-            for k, vs in jobs.items()
-            if k not in PENDING_STATUS + ('passed',)
-            for v in vs
-        ]
-
-        if failed_jobs:
-            print('Failing this due to failure of jobs %s' % (
-                ', '.join('%s(%s)' % (s, j) for j, s in failed_jobs),
-            ))
-            sys.exit(1)
-        else:
-            pending = [j for s in PENDING_STATUS for j in jobs.get(s, ())]
-            try:
-                # This allows us to test the deploy job for a build locally.
-                pending.remove('deploy')
-            except ValueError:
-                pass
-            if pending:
-                still_pending = set(pending)
-                if prev_pending is None:
-                    print('Waiting for the following jobs to complete:')
-                    for p in sorted(still_pending):
-                        print(' * %s' % (p,))
-                    print()
-                else:
-                    completed = prev_pending - still_pending
-                    if completed:
-                        print('%s completed since last check.' % (
-                            ', '.join(sorted(completed)),))
-                prev_pending = still_pending
-                naptime = 10.0 * (2 + random.random())
-                print('Waiting %.2fs for %d more job%s to complete' % (
-                    naptime, len(pending), 's' if len(pending) > 1 else '',))
-                sleep(naptime)
-            else:
-                break
-    else:
-        print("We've been waiting for an hour. That seems bad. Failing now.")
-        sys.exit(1)
 
     print('Looks good to release!')
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -113,7 +113,7 @@ def do_release(package):
 
 @task()
 def deploy():
-    print('Current head:', HEAD)
+    print('Current head:  ', HEAD)
     print('Current master:', MASTER)
 
     if not tools.is_ancestor(HEAD, MASTER):

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -82,7 +82,12 @@ def do_release(package):
     os.chdir(package.BASE_DIR)
 
     print('Updating changelog and version')
-    package.update_for_pending_release()
+    package.update_changelog_and_version()
+
+    print('Committing changes')
+    package.commit_pending_release()
+
+    print('Building distribution')
     package.build_distribution()
 
     print('Looks good to release!')
@@ -109,7 +114,7 @@ def deploy():
         print('Not deploying due to not being on master')
         sys.exit(0)
 
-    if os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true':
+    if not tools.has_travis_secrets():
         print('Running without access to secure variables, so no deployment')
         sys.exit(0)
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -57,6 +57,12 @@ def task(if_changed=()):
 
 
 @task()
+def check_installed():
+    """No-op task that can be used to test for a successful install (so we
+    don't fail to run if a previous install failed midway)."""
+
+
+@task()
 def lint():
     pip_tool(
         'flake8',

--- a/tooling/src/hypothesistooling/projects/__init__.py
+++ b/tooling/src/hypothesistooling/projects/__init__.py
@@ -14,18 +14,3 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 #
 # END HEADER
-
-from __future__ import division, print_function, absolute_import
-
-import pytest
-
-import hypothesistooling as tools
-
-
-@pytest.mark.parametrize('project', tools.all_projects())
-def test_release_file_exists_and_is_valid(project):
-    if project.has_source_changes():
-        assert project.has_release(), \
-            'There are source changes but no RELEASE.rst. Please create ' \
-            'one to describe your changes.'
-        project.parse_release_file()

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -1,0 +1,243 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import re
+import sys
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+
+import hypothesistooling as tools
+from hypothesistooling import git
+
+PACKAGE_NAME = 'hypothesis-python'
+
+HYPOTHESIS_PYTHON = os.path.join(tools.ROOT, PACKAGE_NAME)
+PYTHON_TAG_PREFIX = 'hypothesis-python-'
+
+
+BASE_DIR = HYPOTHESIS_PYTHON
+
+PYTHON_SRC = os.path.join(HYPOTHESIS_PYTHON, 'src')
+PYTHON_TESTS = os.path.join(HYPOTHESIS_PYTHON, 'tests')
+
+RELEASE_FILE = os.path.join(HYPOTHESIS_PYTHON, 'RELEASE.rst')
+
+assert os.path.exists(PYTHON_SRC)
+
+
+__version__ = None
+__version_info__ = None
+
+VERSION_FILE = os.path.join(PYTHON_SRC, 'hypothesis/version.py')
+
+with open(VERSION_FILE) as o:
+    exec(o.read())
+
+
+def has_release():
+    return os.path.exists(RELEASE_FILE)
+
+
+def has_source_changes():
+    return tools.has_changes([PYTHON_SRC])
+
+
+CHANGELOG_ANCHOR = re.compile(r"^\.\. _v\d+\.\d+\.\d+:$")
+CHANGELOG_BORDER = re.compile(r"^-+$")
+CHANGELOG_HEADER = re.compile(r"^\d+\.\d+\.\d+ - \d\d\d\d-\d\d-\d\d$")
+RELEASE_TYPE = re.compile(r"^RELEASE_TYPE: +(major|minor|patch)")
+
+
+MAJOR = 'major'
+MINOR = 'minor'
+PATCH = 'patch'
+
+VALID_RELEASE_TYPES = (MAJOR, MINOR, PATCH)
+
+
+def parse_release_file():
+    with open(RELEASE_FILE) as i:
+        release_contents = i.read()
+
+    release_lines = release_contents.split('\n')
+
+    m = RELEASE_TYPE.match(release_lines[0])
+    if m is not None:
+        release_type = m.group(1)
+        if release_type not in VALID_RELEASE_TYPES:
+            print('Unrecognised release type %r' % (release_type,))
+            sys.exit(1)
+        del release_lines[0]
+        release_contents = '\n'.join(release_lines).strip()
+    else:
+        print(
+            'RELEASE.rst does not start by specifying release type. The first '
+            'line of the file should be RELEASE_TYPE: followed by one of '
+            'major, minor, or patch, to specify the type of release that '
+            'this is (i.e. which version number to increment). Instead the '
+            'first line was %r' % (release_lines[0],)
+        )
+        sys.exit(1)
+
+    return release_type, release_contents
+
+
+def update_changelog_and_version():
+    global __version_info__
+    global __version__
+
+    with open(CHANGELOG_FILE) as i:
+        contents = i.read()
+    assert '\r' not in contents
+    lines = contents.split('\n')
+    assert contents == '\n'.join(lines)
+    for i, l in enumerate(lines):
+        if CHANGELOG_ANCHOR.match(l):
+            assert CHANGELOG_BORDER.match(lines[i + 2]), repr(lines[i + 2])
+            assert CHANGELOG_HEADER.match(lines[i + 3]), repr(lines[i + 3])
+            assert CHANGELOG_BORDER.match(lines[i + 4]), repr(lines[i + 4])
+            beginning = '\n'.join(lines[:i])
+            rest = '\n'.join(lines[i:])
+            assert '\n'.join((beginning, rest)) == contents
+            break
+
+    release_type, release_contents = parse_release_file()
+
+    new_version = list(__version_info__)
+    bump = VALID_RELEASE_TYPES.index(release_type)
+    new_version[bump] += 1
+    for i in range(bump + 1, len(new_version)):
+        new_version[i] = 0
+    new_version = tuple(new_version)
+    new_version_string = '.'.join(map(str, new_version))
+
+    __version_info__ = new_version
+    __version__ = new_version_string
+
+    with open(VERSION_FILE) as i:
+        version_lines = i.read().split('\n')
+
+    for i, l in enumerate(version_lines):
+        if 'version_info' in l:
+            version_lines[i] = '__version_info__ = %r' % (new_version,)
+            break
+
+    with open(VERSION_FILE, 'w') as o:
+        o.write('\n'.join(version_lines))
+
+    now = datetime.utcnow()
+
+    date = max([
+        d.strftime('%Y-%m-%d') for d in (now, now + timedelta(hours=1))
+    ])
+
+    heading_for_new_version = ' - '.join((new_version_string, date))
+    border_for_new_version = '-' * len(heading_for_new_version)
+
+    new_changelog_parts = [
+        beginning.strip(),
+        '',
+        '.. _v%s:' % (new_version_string),
+        '',
+        border_for_new_version,
+        heading_for_new_version,
+        border_for_new_version,
+        '',
+        release_contents,
+        '',
+        rest
+    ]
+
+    with open(CHANGELOG_FILE, 'w') as o:
+        o.write('\n'.join(new_changelog_parts))
+
+
+def update_for_pending_release():
+    update_changelog_and_version()
+
+    git('rm', RELEASE_FILE)
+    git('add', CHANGELOG_FILE, VERSION_FILE)
+
+    git(
+        'commit', '-m',
+        'Bump version to %s and update changelog\n\n[skip ci]' % (__version__,)
+    )
+
+
+def update_changelog_for_docs():
+    if not tools.has_release():
+        return
+    if tools.has_uncommitted_changes(tools.CHANGELOG_FILE):
+        print(
+            'Cannot build documentation with uncommitted changes to '
+            'changelog and a pending release. Please commit your changes or '
+            'delete your release file.')
+        sys.exit(1)
+    tools.update_changelog_and_version()
+
+
+CHANGELOG_FILE = os.path.join(HYPOTHESIS_PYTHON, 'docs', 'changes.rst')
+DIST = os.path.join(HYPOTHESIS_PYTHON, 'dist')
+
+
+def changelog():
+    with open(CHANGELOG_FILE) as i:
+        return i.read()
+
+
+def build_distribution():
+    if os.path.exists(DIST):
+        shutil.rmtree(DIST)
+
+    subprocess.check_output([
+        sys.executable, 'setup.py', 'sdist', '--dist-dir', DIST,
+    ])
+
+
+def upload_distribution():
+    subprocess.check_call([
+        sys.executable, '-m', 'twine', 'upload',
+        '--config-file', tools.PYPIRC,
+        os.path.join(DIST, '*'),
+    ])
+
+
+def latest_version():
+    versions = []
+
+    for t in tools.tags():
+        if t.startswith(PYTHON_TAG_PREFIX):
+            t = t[len(PYTHON_TAG_PREFIX):]
+        else:
+            continue
+        assert t == t.strip()
+        parts = t.split('.')
+        assert len(parts) == 3
+        v = tuple(map(int, parts))
+        versions.append((v, t))
+
+    _, latest = max(versions)
+
+    return latest
+
+
+def tag_name():
+    return PYTHON_TAG_PREFIX + __version__

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -51,6 +51,9 @@ VERSION_FILE = os.path.join(PYTHON_SRC, 'hypothesis/version.py')
 with open(VERSION_FILE) as o:
     exec(o.read())
 
+assert __version__ is not None
+assert __version_info__ is not None
+
 
 def has_release():
     return os.path.exists(RELEASE_FILE)

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -170,9 +170,7 @@ def update_changelog_and_version():
         o.write('\n'.join(new_changelog_parts))
 
 
-def update_for_pending_release():
-    update_changelog_and_version()
-
+def commit_pending_release():
     git('rm', RELEASE_FILE)
     git('add', CHANGELOG_FILE, VERSION_FILE)
 
@@ -213,6 +211,7 @@ def build_distribution():
 
 
 def upload_distribution():
+    tools.assert_can_release()
     subprocess.check_call([
         sys.executable, '-m', 'twine', 'upload',
         '--config-file', tools.PYPIRC,

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -110,7 +110,6 @@ def update_changelog_and_version():
     contents = changelog()
     assert '\r' not in contents
     lines = contents.split('\n')
-    assert contents == '\n'.join(lines)
     for i, l in enumerate(lines):
         if CHANGELOG_ANCHOR.match(l):
             assert CHANGELOG_BORDER.match(lines[i + 2]), repr(lines[i + 2])

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -183,18 +183,6 @@ def commit_pending_release():
     )
 
 
-def update_changelog_for_docs():
-    if not tools.has_release():
-        return
-    if tools.has_uncommitted_changes(tools.CHANGELOG_FILE):
-        print(
-            'Cannot build documentation with uncommitted changes to '
-            'changelog and a pending release. Please commit your changes or '
-            'delete your release file.')
-        sys.exit(1)
-    tools.update_changelog_and_version()
-
-
 CHANGELOG_FILE = os.path.join(HYPOTHESIS_PYTHON, 'docs', 'changes.rst')
 DIST = os.path.join(HYPOTHESIS_PYTHON, 'dist')
 

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -107,8 +107,7 @@ def update_changelog_and_version():
     global __version_info__
     global __version__
 
-    with open(CHANGELOG_FILE) as i:
-        contents = i.read()
+    contents = changelog()
     assert '\r' not in contents
     lines = contents.split('\n')
     assert contents == '\n'.join(lines)

--- a/whole-repo-tests/test_deploy.py
+++ b/whole-repo-tests/test_deploy.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+
+import pytest
+
+import hypothesistooling as tools
+import hypothesistooling.__main__ as main
+
+
+@pytest.mark.parametrize('project', [
+    p for p in tools.all_projects() if p.has_release()
+])
+def test_release_file_exists_and_is_valid(project, monkeypatch):
+    assert not tools.has_uncommitted_changes(project.BASE_DIR)
+
+    monkeypatch.setattr(tools, 'create_tag', lambda *args, **kwargs: None)
+    monkeypatch.setattr(tools, 'push_tag', lambda name: None)
+    monkeypatch.setattr(project, 'upload_distribution', lambda: None)
+    monkeypatch.setattr(project, 'commit_pending_release', lambda: None)
+
+    try:
+        main.do_release(project)
+    finally:
+        tools.git('checkout', project.BASE_DIR)
+        os.chdir(tools.ROOT)

--- a/whole-repo-tests/test_rst_is_valid.py
+++ b/whole-repo-tests/test_rst_is_valid.py
@@ -20,12 +20,13 @@ from __future__ import division, print_function, absolute_import
 import os
 
 import hypothesistooling as tools
+import hypothesistooling.projects.hypothesispython as hp
 from hypothesistooling.scripts import pip_tool
 
 
 def is_sphinx(f):
     f = os.path.abspath(f)
-    return f.startswith(os.path.join(tools.HYPOTHESIS_PYTHON, 'docs'))
+    return f.startswith(os.path.join(hp.HYPOTHESIS_PYTHON, 'docs'))
 
 
 ALL_RST = [


### PR DESCRIPTION
This is a refactoring of some of the build system to move the Python build components out into their own file, as a precursor to making the build multi-language.

The general intended approach here is to have each project we want to build be a module in `hypothesistooling.projects`, with a common interface. It *might* make sense to make these objects rather than modules at some point, but the module approach I think works pretty well as a first pass.

Bonus features:

* We now test our deploy code (kinda).
* Better handling of failed installs of the tooling (which we're getting a lot of right now due to some network flakiness)