### PR TITLE
Move slower tasks over to Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
          keys:
            - v1-runtimes-
       - run: ./build.sh install-core
+      - run: ./build.sh check-coverage
+      - run: ./build.sh check-pure-tracer
       - run: ./build.sh check-py27
       - run: ./build.sh check-py36
       - save_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,7 @@ jobs:
     # pass whenever the above do but are still
     # worth testing.
     - stage: extras
-      env: TASK=check-coverage
     - env: TASK=check-unicode
-    - env: TASK=check-pure-tracer
     - env: TASK=check-py27-typing
     - env: TASK=check-py34
     - env: TASK=check-py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
     # pass whenever the above do but are still
     # worth testing.
     - stage: extras
-    - env: TASK=check-unicode
+      env: TASK=check-unicode
     - env: TASK=check-py27-typing
     - env: TASK=check-py34
     - env: TASK=check-py35


### PR DESCRIPTION
We have two tasks in the extras build stage in our Travis config that take *vastly* longer than everything else. Meanwhile CircleCI's machines seem to generically be much faster, and we're running less on them. This moves those tasks over there. Hopefully this should make our builds significantly faster and more reliable.

One minor downside of this is that our Travis deploy does not currently check if *other* CIs have passed before deploying. I think this is OK. These are only the extras jobs, and they had to pass in order to get a merge. In many ways I'd be more worried about the status quo (what we could in theory introduce a windows or OSX bug and have it missed this way) than that these are missing from the deploy pre-checks.