### PR TITLE
Fix building of rubygems

### DIFF
--- a/tooling/scripts/ensure-rustup.sh
+++ b/tooling/scripts/ensure-rustup.sh
@@ -7,8 +7,10 @@ if ! which rustup > /dev/null ; then
   curl https://sh.rustup.rs -sSf | sh -s -- -y
 fi
 
-if ! rustup show | grep nightly > /dev/null ; then
-  rustup install nightly
+if ! rustup show | grep stable > /dev/null ; then
+  rustup install stable
 fi
+
+rustup default stable
 
 rustup update

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -470,9 +470,16 @@ if __name__ == '__main__':
         )
         sys.exit(1)
 
-    task_to_run = os.environ.get('TASK')
-    if task_to_run is None:
+    if len(sys.argv) > 1:
         task_to_run = sys.argv[1]
+    else:
+        task_to_run = os.environ.get('TASK')
+
+    if task_to_run is None:
+        print(
+            'No task specified. Either pass the task to run as an '
+            'argument or as an environment variable TASK.')
+        sys.exit(1)
 
     if task_to_run == 'python':
         os.execv(sys.executable, [sys.executable] + sys.argv[2:])

--- a/tooling/src/hypothesistooling/junkdrawer.py
+++ b/tooling/src/hypothesistooling/junkdrawer.py
@@ -45,3 +45,10 @@ def once(fn):
     accept.has_been_called = False
     accept.__name__ = fn.__name__
     return accept
+
+
+def unlink_if_present(path):
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -25,7 +25,7 @@ import hypothesistooling as tools
 import hypothesistooling.installers as install
 import hypothesistooling.releasemanagement as rm
 from hypothesistooling import git
-from hypothesistooling.junkdrawer import once, in_dir
+from hypothesistooling.junkdrawer import once, in_dir, unlink_if_present
 
 PACKAGE_NAME = 'hypothesis-ruby'
 
@@ -141,7 +141,7 @@ def upload_distribution():
 
     # Yes, rubygems really will only look in this file. Yes this is terrible.
     # This only runs on Travis, so we may be assumed to own it, but still.
-    os.path.unlink(RUBYGEMS_CREDENTIALS)
+    unlink_if_present(RUBYGEMS_CREDENTIALS)
 
     # symlink so that the actual secret credentials can't be leaked via the
     # cache.


### PR DESCRIPTION
~Two~ Three problems were occurring:

1. Silly error on my part where I wrote `os.path.unlink` instead of `os.link`. @alexwlchan based on your suggestion in #1339 I've ended up extracting a function to the junk drawer for safe unlinking as part of this.
2. Due to hilarious comedy, the change I made in #1332 for more robust checking for an install of the build environment meant that (on Travis only) we reran all failing jobs, because the `TASK` environment variable was overriding the `check-installed` command we were explicitly passing.
3. Our build was depending on rust nightly and thus hitting https://github.com/rust-lang/rust/issues/51699. I'm not sure why I went with nightly rather than stable (the library is definitely meant to work on stable!) so I've just switched this over to stable.