### PR TITLE
Add mechanism to replace wrapped test

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release adds :ref:`an interface <custom-function-execution>`
+which can be used to insert a wrapper between the original test function and
+:func:`@given <hypothesis.given>` (:issue:`1257`).  This will be particularly
+useful for test runner extensions such as :pypi:`pytest-trio`, but is
+not recommended for direct use by other users of Hypothesis.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -3381,7 +3381,7 @@ Bug fixes:
   instead of its contexts. This is obviously silly. It now works with any sequence
   of things convertible to unicode strings.
 * @given will now work on methods whose definitions contains no explicit positional
-  arguments, only varargs (`bug #118 <https://github.com/HypothesisWorks/hypothesis-python/issues/118>`_).
+  arguments, only varargs (:issue:`118`).
   This may have some knock on effects because it means that @given no longer changes the
   argspec of functions other than by adding defaults.
 * Introduction of new @composite feature for more natural definition of strategies you'd
@@ -4019,7 +4019,7 @@ The one tiny bugfix:
 
 Codename: Hygienic macros or bust
 
-* You can now name an argument to @given 'f' and it won't break (issue #38)
+* You can now name an argument to @given 'f' and it won't break (:issue:`38`)
 * strategy_test_suite is now named strategy_test_suite as the documentation claims and not in fact strategy_test_suitee
 * Settings objects can now be used as a context manager to temporarily override the default values inside their context.
 

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -378,6 +378,9 @@ will be passed to the function as normal and not be parametrized over.
 The function returned by given has all the same arguments as the original
 test, minus those that are filled in by :func:`@given <hypothesis.given>`.
 
+
+.. _custom-function-execution:
+
 -------------------------
 Custom function execution
 -------------------------
@@ -444,6 +447,33 @@ and should be rewritten as:
             if callable(result):
                 result = result()
             return result
+
+
+An alternative hook is provided for use by test runner extensions such as
+:pypi:`pytest-trio`, which cannot use the ``execute_example`` method.
+This is **not** recommended for end-users - it is better to write a complete
+test function directly, perhaps by using a decorator to perform the same
+transformation before applying :func:`@given <hypothesis.given>`.
+
+.. code:: python
+
+    @given(x=integers())
+    @pytest.mark.trio
+    async def test(x):
+        ...
+    # Illustrative code, inside the pytest-trio plugin
+    test.hypothesis.inner_test = lambda x: trio.run(test, x)
+
+For authors of test runners however, assigning to the ``inner_test`` attribute
+of the ``hypothesis`` attribute of the test will replace the interior test.
+
+.. note::
+    The new ``inner_test`` must accept and pass through all the ``*args``
+    and ``**kwargs`` expected by the original test.
+
+If the end user has also specified a custom executor using the
+``execute_example`` method, it - and all other execution-time logic - will
+be applied to the *new* inner test assigned by the test runner.
 
 
 -------------------------------

--- a/hypothesis-python/tests/cover/test_modify_inner_test.py
+++ b/hypothesis-python/tests/cover/test_modify_inner_test.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from functools import wraps
+
+import pytest
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+
+def always_passes(*args, **kwargs):
+    """Stand-in for a fixed version of an inner test.
+
+    For example, pytest-trio would take the inner test, wrap it in an
+    async-to-sync converter, and use the new func (not always_passes).
+    """
+    pass
+
+
+@given(st.integers())
+def test_can_replace_inner_test(x):
+    assert False, 'This should be replaced'
+
+
+test_can_replace_inner_test.hypothesis.inner_test = always_passes
+
+
+def decorator(func):
+    """An example of a common decorator pattern."""
+    @wraps(func)
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+    return inner
+
+
+@decorator
+@given(st.integers())
+def test_can_replace_when_decorated(x):
+    assert False, 'This should be replaced'
+
+
+test_can_replace_when_decorated.hypothesis.inner_test = always_passes
+
+
+@pytest.mark.parametrize('x', [1, 2])
+@given(y=st.integers())
+def test_can_replace_when_parametrized(x, y):
+    assert False, 'This should be replaced'
+
+
+test_can_replace_when_parametrized.hypothesis.inner_test = always_passes

--- a/hypothesis-python/tests/numpy/test_sampled_from.py
+++ b/hypothesis-python/tests/numpy/test_sampled_from.py
@@ -17,9 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-import numpy as np
-
-from hypothesis import given, assume
+from hypothesis import given
 from hypothesis.extra import numpy as npst
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import data, sampled_from
@@ -30,12 +28,7 @@ from hypothesis.strategies import data, sampled_from
     shape=npst.array_shapes(max_dims=1)
 ))
 def test_can_sample_1D_numpy_array_without_warning(data, arr):
-    elem = data.draw(sampled_from(arr))
-    try:
-        assume(not np.isnan(elem))
-    except TypeError:
-        pass
-    assert elem in arr
+    data.draw(sampled_from(arr))
 
 
 @checks_deprecated_behaviour


### PR DESCRIPTION
Closes #1257 - see that issue for motivation and discussion, along with python-trio/pytest-trio#42.  
I also have a working patch for pytest-trio (https://github.com/python-trio/pytest-trio/compare/master...Zac-HD:hypothesis-experiment), which enables the following example to work exactly as you'd hope:

```python
from functools import wraps
import pytest
from hypothesis import given, strategies as st

def decorator(f):
    return wraps(f)(lambda *a, **k: f(*a, **k))

@pytest.mark.parametrize('x', [3, 1, 2])
@decorator  # just to be nasty...
@given(n=st.integers())
@pytest.mark.trio
async def test(n, x):
    assert n // x < 50  # fails, obviously, but passes with integers(max_value=49)
```

The patch on our end is quite small, and should be generally applicable to other extensions for asyncio, Curio, Django, Twisted, etc.  I'll open a PR against pytest-trio once this is merged, so that it can check for a sufficiently recent version of Hypothesis and give a useful failure otherwise.

CC @njsmith, @touilleMan, @DRMacIver for general comments and design feedback :rocket: