### PR TITLE
Add a project-specific parse_release_file for Python + Ruby

### DIFF
--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 
 import hypothesistooling as tools
+import hypothesistooling.releasemanagement as rm
 from hypothesistooling import git
 from hypothesistooling.releasemanagement import bump_version_info, \
     parse_release_file, replace_assignment, release_date_string
@@ -58,6 +59,10 @@ assert __version_info__ is not None
 
 def has_release():
     return os.path.exists(RELEASE_FILE)
+
+
+def parse_release_file():
+    return rm.parse_release_file(RELEASE_FILE)
 
 
 def has_source_changes():

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -27,7 +27,7 @@ import hypothesistooling as tools
 import hypothesistooling.releasemanagement as rm
 from hypothesistooling import git
 from hypothesistooling.releasemanagement import bump_version_info, \
-    parse_release_file, replace_assignment, release_date_string
+    replace_assignment, release_date_string
 
 PACKAGE_NAME = 'hypothesis-python'
 
@@ -91,7 +91,7 @@ def update_changelog_and_version():
             assert '\n'.join((beginning, rest)) == contents
             break
 
-    release_type, release_contents = parse_release_file(RELEASE_FILE)
+    release_type, release_contents = parse_release_file()
 
     new_version_string, new_version_info = bump_version_info(
         __version_info__, release_type)

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -48,6 +48,10 @@ def has_release():
     return os.path.exists(RELEASE_FILE)
 
 
+def parse_release_file():
+    return rm.parse_release_file(RELEASE_FILE)
+
+
 def update_changelog_and_version():
     """Update the changelog and version based on the current release file."""
     release_type, release_contents = rm.parse_release_file(RELEASE_FILE)

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -54,7 +54,7 @@ def parse_release_file():
 
 def update_changelog_and_version():
     """Update the changelog and version based on the current release file."""
-    release_type, release_contents = rm.parse_release_file(RELEASE_FILE)
+    release_type, release_contents = parse_release_file()
     version = current_version()
     version_info = rm.parse_version(version)
 


### PR DESCRIPTION
This is causing failing tests in branches, e.g. https://travis-ci.org/HypothesisWorks/hypothesis/jobs/395525489

```
_______________ test_release_file_exists_and_is_valid[project0] ________________
Traceback (most recent call last):
  File "/home/travis/build/HypothesisWorks/hypothesis/whole-repo-tests/test_release_files.py", line 31, in test_release_file_exists_and_is_valid
    project.parse_release_file()
TypeError: parse_release_file() missing 1 required positional argument: 'filename'
========================== slowest 20 test durations ===========================
```