### PR TITLE
Return early if there are no files to format

### DIFF
--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -186,6 +186,9 @@ def format():
 
     files_to_format = [f for f in sorted(files) if should_format_file(f)]
 
+    if not files_to_format:
+        return
+
     for f in files_to_format:
         print(f)
         lines = []


### PR DESCRIPTION
This fixes a trivial issue where `build.sh format` would fail if there weren't actually any files to format (because it would call `pyformat` with an empty list of files).