### PR TITLE
Fix failure when shrinking tests with duplicates in hypothesis-ruby tests

### DIFF
--- a/conjecture-rust/RELEASE.md
+++ b/conjecture-rust/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes an occasional assertion failure that could occur
+when shrinking a failing test.

--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -408,15 +408,20 @@ where
     fn minimize_duplicated_blocks(&mut self) -> StepResult {
         let mut i = 0;
         let mut targets = self.calc_duplicates();
+
         while i < targets.len() {
             let target = mem::replace(&mut targets[i], Vec::new());
+            let max_target = *target.iter().max().unwrap();
+
             i += 1;
             assert!(target.len() > 0);
             let v = self.shrink_target.record[target[0]];
-            let base = self.shrink_target.record.clone();
 
             let w = minimize_integer(v, |t| {
-                let mut attempt = base.clone();
+                if max_target >= self.shrink_target.record.len() {
+                  return Ok(false);
+                }
+                let mut attempt = self.shrink_target.record.clone();
                 for i in &target {
                     attempt[*i] = t
                 }

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes an occasional `RuntimeError` that could occur
+when shrinking a failing test.


### PR DESCRIPTION
Fixes #1352.