### PR TITLE
Fix release dates for rubygems

### DIFF
--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release updates the release date to the correct date, as part of fixing a
+but which caused the last couple of releases (0.0.11, 0.0.12, and 0.0.13) to
+have an incorrect date.

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
 This release updates the release date to the correct date, as part of fixing a
-but which caused the last couple of releases (0.0.11, 0.0.12, and 0.0.13) to
+bug which caused the last couple of releases (0.0.11, 0.0.12, and 0.0.13) to
 have an incorrect date.

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -63,6 +63,9 @@ def update_changelog_and_version():
     version, version_info = rm.bump_version_info(version_info, release_type)
 
     rm.replace_assignment(GEMSPEC_FILE, 's.version', repr(version))
+    rm.replace_assignment(
+        GEMSPEC_FILE, 's.date', repr(rm.release_date_string())
+    )
 
     rm.update_markdown_changelog(
         CHANGELOG_FILE,


### PR DESCRIPTION
Apparently I'd forgotten (and missed when porting the code over from Ruby) that we need to manually set a release date in the gemspec rather than it being calculated on upload. This fixes that.