### PR TITLE
Add test that reliably triggers dtype from elements detection

### DIFF
--- a/hypothesis-python/tests/pandas/test_indexes.py
+++ b/hypothesis-python/tests/pandas/test_indexes.py
@@ -34,7 +34,7 @@ def test_gets_right_dtype_for_empty_indices(ix):
     assert ix.dtype == np.dtype('int64')
 
 
-@given(pdst.indexes(elements=st.integers(0, 2**63-1), max_size=0))
+@given(pdst.indexes(elements=st.integers(0, 2**63 - 1), max_size=0))
 def test_gets_right_dtype_for_empty_indices_with_elements(ix):
     assert ix.dtype == np.dtype('int64')
 

--- a/hypothesis-python/tests/pandas/test_indexes.py
+++ b/hypothesis-python/tests/pandas/test_indexes.py
@@ -34,6 +34,11 @@ def test_gets_right_dtype_for_empty_indices(ix):
     assert ix.dtype == np.dtype('int64')
 
 
+@given(pdst.indexes(elements=st.integers(0, 2**63-1), max_size=0))
+def test_gets_right_dtype_for_empty_indices_with_elements(ix):
+    assert ix.dtype == np.dtype('int64')
+
+
 def test_does_not_generate_impossible_conditions():
     with pytest.raises(NoExamples):
         pdst.indexes(


### PR DESCRIPTION
As part of the entropy-pocalypse from #1295 we now have flaky coverage - line 60 in impl.py isn't being reliably hit. This adds a test that reliably hits it.