### PR TITLE
Fix clash between attribute and pytest mark

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes a conflict between the built-in Hypothesis plugin for Pytest,
+and the new :ref:`test customisation interface <custom-function-execution>`
+that caused errors if Hypothesis tests had other pytest markers applied
+(:issue:`1362`).  Thanks to Matt Bullock for reporting this.

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -462,10 +462,11 @@ transformation before applying :func:`@given <hypothesis.given>`.
     async def test(x):
         ...
     # Illustrative code, inside the pytest-trio plugin
-    test.hypothesis.inner_test = lambda x: trio.run(test, x)
+    test.hypothesis_attributes.inner_test = lambda x: trio.run(test, x)
 
 For authors of test runners however, assigning to the ``inner_test`` attribute
-of the ``hypothesis`` attribute of the test will replace the interior test.
+of the ``hypothesis_attributes`` attribute of the test will replace the
+interior test.
 
 .. note::
     The new ``inner_test`` must accept and pass through all the ``*args``

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -958,7 +958,7 @@ def given(
             # Tell pytest to omit the body of this function from tracebacks
             __tracebackhide__ = True
 
-            test = wrapped_test.hypothesis.inner_test
+            test = wrapped_test.hypothesis_attributes.inner_test
 
             if getattr(test, 'is_hypothesis_test', False):
                 note_deprecation(
@@ -1101,7 +1101,7 @@ def given(
         wrapped_test._hypothesis_internal_use_reproduce_failure = getattr(
             test, '_hypothesis_internal_use_reproduce_failure', None
         )
-        wrapped_test.hypothesis = HypothesisHandle(test)
+        wrapped_test.hypothesis_attributes = HypothesisHandle(test)
         return wrapped_test
     return run_test_with_generator
 

--- a/hypothesis-python/tests/cover/test_modify_inner_test.py
+++ b/hypothesis-python/tests/cover/test_modify_inner_test.py
@@ -25,7 +25,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 
-def always_passes(*args, **kwargs):
+def passes(*args, **kwargs):
     """Stand-in for a fixed version of an inner test.
 
     For example, pytest-trio would take the inner test, wrap it in an
@@ -39,7 +39,7 @@ def test_can_replace_inner_test(x):
     assert False, 'This should be replaced'
 
 
-test_can_replace_inner_test.hypothesis.inner_test = always_passes
+test_can_replace_inner_test.hypothesis_attributes.inner_test = passes
 
 
 def decorator(func):
@@ -56,7 +56,7 @@ def test_can_replace_when_decorated(x):
     assert False, 'This should be replaced'
 
 
-test_can_replace_when_decorated.hypothesis.inner_test = always_passes
+test_can_replace_when_decorated.hypothesis_attributes.inner_test = passes
 
 
 @pytest.mark.parametrize('x', [1, 2])
@@ -65,4 +65,4 @@ def test_can_replace_when_parametrized(x, y):
     assert False, 'This should be replaced'
 
 
-test_can_replace_when_parametrized.hypothesis.inner_test = always_passes
+test_can_replace_when_parametrized.hypothesis_attributes.inner_test = passes

--- a/hypothesis-python/tests/pytest/test_mark.py
+++ b/hypothesis-python/tests/pytest/test_mark.py
@@ -62,3 +62,22 @@ def test_can_select_mark_on_unittest(testdir):
                                'hypothesis')
     out = '\n'.join(result.stdout.lines)
     assert '1 passed, 1 deselected' in out
+
+
+MARKER_TESTSUITE = """
+import pytest
+from hypothesis import given
+from hypothesis.strategies import integers
+
+@pytest.mark.hypothesis
+@given(integers())
+def test_foo(x):
+    pass
+"""
+
+
+def test_mark_does_not_clash_with_attribute(testdir):
+    # Regression test for issue #1362, clash between marker and attribute
+    script = testdir.makepyfile(MARKER_TESTSUITE)
+    result = testdir.runpytest(script, '--verbose', '--strict')
+    assert result.ret == 0


### PR DESCRIPTION
Closes #1362.  I'm planning to add a general mitigation to pytest, but this solves out specific problem.