### PR TITLE
Stateful async POC

### DIFF
--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -242,21 +242,25 @@ class StateMachineRunner(object):
             average_size=self.n_steps,
         )
 
-        try:
-            if print_steps:
-                state_machine.print_start()
-            state_machine.check_invariants()
-
-            while should_continue.more():
-                value = self.data.draw(state_machine.steps())
+        def _default_runner(data, print_steps, should_continue):
+            try:
                 if print_steps:
-                    state_machine.print_step(value)
-                state_machine.execute_step(value)
+                    state_machine.print_start()
                 state_machine.check_invariants()
-        finally:
-            if print_steps:
-                state_machine.print_end()
-            state_machine.teardown()
+
+                while should_continue.more():
+                    value = data.draw(state_machine.steps())
+                    if print_steps:
+                        state_machine.print_step(value)
+                    state_machine.execute_step(value)
+                    state_machine.check_invariants()
+            finally:
+                if print_steps:
+                    state_machine.print_end()
+                state_machine.teardown()
+
+        runner = getattr(state_machine, '_custom_runner', _default_runner)
+        runner(self.data, print_steps, should_continue)
 
 
 class StateMachineSearchStrategy(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/stateful_async.py
+++ b/hypothesis-python/src/hypothesis/stateful_async.py
@@ -1,0 +1,156 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""This module provides support for a stateful style of testing, where tests
+attempt to find a sequence of operations that cause a breakage rather than just
+a single value.
+
+Notably, the set of steps available at any point may depend on the
+execution to date.
+"""
+
+
+
+from __future__ import division, print_function, absolute_import
+
+import inspect
+import traceback
+from copy import copy
+from unittest import TestCase
+
+import attr
+
+import hypothesis.internal.conjecture.utils as cu
+from hypothesis.core import find
+from hypothesis.errors import Flaky, NoSuchExample, InvalidDefinition, \
+    HypothesisException
+from hypothesis.control import BuildContext
+from hypothesis._settings import Verbosity
+from hypothesis._settings import settings as Settings
+from hypothesis.reporting import report, verbose_report, current_verbosity
+from hypothesis.strategies import just, one_of, runner, tuples, \
+    fixed_dictionaries
+from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
+from hypothesis.internal.reflection import proxies, nicerepr
+from hypothesis.internal.conjecture.data import StopTest
+from hypothesis.internal.conjecture.utils import integer_range, \
+    calc_label_from_name
+from hypothesis.searchstrategy.strategies import SearchStrategy
+from hypothesis.stateful import GenericStateMachine, StateMachineRunner, StateMachineSearchStrategy, TestCaseProperty, RuleBasedStateMachine, VarReference
+import trio
+from trio.testing import trio_test
+
+
+class TrioGenericAsyncStateMachine(GenericStateMachine):
+    """A GenericStateMachine is the basic entry point into Hypothesis's
+    approach to stateful testing.
+
+    The intent is for it to be subclassed to provide state machine descriptions
+
+    The way this is used is that Hypothesis will repeatedly execute something
+    that looks something like::
+
+        x = MyStatemachineSubclass()
+        x.check_invariants()
+        try:
+            for _ in range(n_steps):
+                x.execute_step(x.steps().example())
+                x.check_invariants()
+        finally:
+            x.teardown()
+
+    And if this ever produces an error it will shrink it down to a small
+    sequence of example choices demonstrating that.
+    """
+
+    def get_root_nursery(self):
+        return getattr(self, '_nursery', None)
+
+    def _custom_runner(self, data, print_steps, should_continue):
+
+        async def _run():
+            async with trio.open_nursery() as self._nursery:
+                try:
+                    if print_steps:
+                        self.print_start()
+                    await self.check_invariants()
+
+                    while should_continue.more():
+                        value = data.draw(self.steps())
+                        if print_steps:
+                            self.print_step(value)
+                        await self.execute_step(value)
+                        await self.check_invariants()
+                finally:
+                    if print_steps:
+                        self.print_end()
+                    await self.teardown()
+                    self._nursery.cancel_scope.cancel()
+
+        trio_test(_run)()
+
+    async def execute_step(self, step):
+        """Execute a step that has been previously drawn from self.steps()"""
+        raise NotImplementedError(u'%r.execute_step()' % (self,))
+
+    async def teardown(self):
+        """Called after a run has finished executing to clean up any necessary
+        state.
+
+        Does nothing by default.
+        """
+        pass
+
+    async def check_invariants(self):
+        """Called after initializing and after executing each step."""
+        pass
+
+
+class TrioRuleBasedAsyncStateMachine(TrioGenericAsyncStateMachine, RuleBasedStateMachine):
+    """A RuleBasedStateMachine gives you a more structured way to define state
+    machines.
+
+    The idea is that a state machine carries a bunch of types of data
+    divided into Bundles, and has a set of rules which may read data
+    from bundles (or just from normal strategies) and push data onto
+    bundles. At any given point a random applicable rule will be
+    executed.
+    """
+
+    async def execute_step(self, step):
+        rule, data = step
+        data = dict(data)
+        for k, v in list(data.items()):
+            if isinstance(v, VarReference):
+                data[k] = self.names_to_values[v.name]
+        result = await rule.function(self, **data)
+        if rule.targets:
+            name = self.new_name()
+            self.names_to_values[name] = result
+            self.__printer.singleton_pprinters.setdefault(
+                id(result), lambda obj, p, cycle: p.text(name)
+            )
+            for target in rule.targets:
+                self.bundle(target).append(VarReference(name))
+        if self._initialize_rules_to_run:
+            self._initialize_rules_to_run.remove(rule)
+
+    async def check_invariants(self):
+        for invar in self.invariants():
+            if invar.precondition and not invar.precondition(self):
+                continue
+            await invar.function(self)

--- a/hypothesis-python/tests/cover/test_async_stateful.py
+++ b/hypothesis-python/tests/cover/test_async_stateful.py
@@ -1,0 +1,125 @@
+from collections import namedtuple
+import trio
+
+from hypothesis.stateful_async import TrioGenericAsyncStateMachine, TrioRuleBasedAsyncStateMachine
+from hypothesis.stateful import initialize, rule, Bundle, invariant, run_state_machine_as_test
+from hypothesis.strategies import just, integers, lists, tuples
+
+
+def test_triggers():
+    class LogEventsStateMachine(TrioGenericAsyncStateMachine):
+        events = []
+
+        async def teardown(self):
+            await trio.sleep(0)
+            self.events.append('teardown')
+
+        def steps(self):
+            return just(42)
+
+        async def execute_step(self, step):
+            await trio.sleep(0)
+            assert step is 42
+            self.events.append('execute_step')
+
+        async def check_invariants(self):
+            await trio.sleep(0)
+            self.events.append('check_invariants')
+
+    run_state_machine_as_test(LogEventsStateMachine)
+
+    per_run_events = []
+    current_run_events = []
+    for event in LogEventsStateMachine.events:
+        current_run_events.append(event)
+        if event == 'teardown':
+            per_run_events.append(current_run_events)
+            current_run_events = []
+
+    for run_events in per_run_events:
+        expected_events = ['check_invariants']
+        expected_events += ['execute_step', 'check_invariants'] * ((len(run_events) - 2) // 2)
+        expected_events.append('teardown')
+        assert run_events == expected_events
+
+
+def test_rule_based():
+
+    class LogEventsRuleBasedStateMachine(TrioRuleBasedAsyncStateMachine):
+        events = []
+
+        @initialize()
+        async def initialize(self):
+            await trio.sleep(0)
+            self.events.append('initialize')
+
+        @invariant()
+        async def invariant(self):
+            await trio.sleep(0)
+            self.events.append('invariant')
+
+        @rule()
+        async def rule(self):
+            await trio.sleep(0)
+            self.events.append('rule')
+
+    run_state_machine_as_test(LogEventsRuleBasedStateMachine)
+
+    per_run_events = []
+    current_run_events = []
+    for event in LogEventsRuleBasedStateMachine.events:
+        current_run_events.append(event)
+        if event == 'teardown':
+            per_run_events.append(current_run_events)
+            current_run_events = []
+
+    for run_events in per_run_events:
+        expected_events = ['init', 'check_invariants']
+        expected_events += ['execute_step', 'check_invariants'] * ((len(run_events) - 3) // 2)
+        expected_events.append('teardown')
+        assert run_events == expected_events
+
+
+def test_trio_style():
+    async def _consumer(in_queue, out_queue, *, task_status=trio.TASK_STATUS_IGNORED):
+        with trio.open_cancel_scope() as cancel_scope:
+            task_status.started(cancel_scope)
+            while True:
+                x, y = await in_queue.get()
+                await trio.sleep(0)
+                result = x + y
+                await out_queue.put('%s + %s = %s' % (x, y, result))
+
+    async def _producer(out_queue):
+        for i in range(10):
+            await out_queue.put(i)
+
+    class TrioStyleStateMachine(TrioRuleBasedAsyncStateMachine):
+
+        @initialize()
+        async def initialize(self):
+            self.job_queue = trio.Queue(100)
+            self.result_queue = trio.Queue(100)
+            self.consumer_cancel_scope = await self.get_root_nursery().start(_consumer, self.job_queue, self.result_queue)
+
+        @rule(work=lists(tuples(integers(), integers())))
+        async def generate_work(self, work):
+            await trio.sleep(0)
+            for x, y in work:
+                await self.job_queue.put((x, y))
+
+        @rule()
+        async def restart_consumer(self):
+            self.consumer_cancel_scope.cancel()
+            self.consumer_cancel_scope = await self.get_root_nursery().start(_consumer, self.job_queue, self.result_queue)
+
+        @invariant()
+        async def check_results(self):
+            while True:
+                try:
+                    job = self.result_queue.get_nowait()
+                    assert isinstance(job, str)
+                except (trio.WouldBlock, AttributeError):
+                    break
+
+    run_state_machine_as_test(TrioStyleStateMachine)


### PR DESCRIPTION
This is a simple proof of concept implementing async support to stateful testing.
The main idea is to allow `GenericStateMachine` sub-classes to define a `_custom_runner` method that `StateMachineRunner` will call when a run need to be done.

This allow different framework to implement they own custom runner (just like what has been done with #1343). For instance trio's `_custom_runner` create a nursery and allow step rules to access it through a special `get_root_nursery` method.

This is currently super rough stuff, so feedback greatly wanted ;-)