### PR TITLE
Fix attrs tests on Python <3.6; run Py3 tests in all Py3 jobs, run tests if test scripts change

### DIFF
--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -29,6 +29,11 @@ pip install ".[pytz, dateutil]"
 $PYTEST tests/datetime/
 pip uninstall -y pytz python-dateutil
 
+if [ "$(python -c 'import sys; print(sys.version_info[0] == 2)')" = "True" ] ; then
+  $PYTEST "tests/py2"
+else
+  $PYTEST "tests/py3"
+fi
 
 if [ "$DARWIN" = true ]; then
   exit 0

--- a/hypothesis-python/tests/py3/test_annotations.py
+++ b/hypothesis-python/tests/py3/test_annotations.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
+
 import attr
 import pytest
 
@@ -133,11 +135,15 @@ class Inferrables(object):
     annot_converter = attr.ib(converter=a_converter)
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 5),
+                    reason="Too-old typing module can't get return value hint")
 @given(st.builds(Inferrables))
 def test_attrs_inference_builds(c):
     pass
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 5),
+                    reason="Too-old typing module can't get return value hint")
 @given(st.from_type(Inferrables))
 def test_attrs_inference_from_type(c):
     pass

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -352,7 +352,11 @@ for n in [PY27, PY34, PY35, PY36]:
     ALIASES[n] = 'python%s.%s' % (major, minor)
 
 
-python_tests = task(if_changed=(hp.PYTHON_SRC, hp.PYTHON_TESTS))
+python_tests = task(if_changed=(
+    hp.PYTHON_SRC,
+    hp.PYTHON_TESTS,
+    os.path.join(hp.HYPOTHESIS_PYTHON, 'scripts'),
+))
 
 
 @python_tests


### PR DESCRIPTION
Fixes #1366 (cc @jochym), fixes #1367, closes #1368 by including a1c124ef99f63938294c047f8bc6cb8980b8dbee.

The "solution" here is to note that inferring strategies from types is always best-effort, and skipping those tests because the Python 3.5 `typing` module is not up for the task :sob: