### PR TITLE
Lots of small documentation improvements

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,19 +1,19 @@
-Please use one of the following samples to cite the hypothesis version (change
-x.y) from this installation
+Please use one of the following samples to cite the hypothesis version
+(change x.y to the version you are using) from this installation.
 
 Text:
 
-[Hypothesis]  Hypothesis x.y, 2016
-David R. MacIver, https://github.com/HypothesisWorks/hypothesis-python
+[Hypothesis]  Hypothesis x.y, 2018
+David R. MacIver, https://github.com/HypothesisWorks/hypothesis
 
 BibTeX:
 
 @misc{Hypothesisx.y,
-  title =            {{H}ypothesis x.y},
-  author =     {David R. MacIver},
-  year =             {2016},
-  howpublished = {\href{https://github.com/HypothesisWorks/hypothesis-python}{\texttt{https://github.com/HypothesisWorks/hypothesis-python}}},
+  title = {{H}ypothesis x.y},
+  author = {David R. MacIver},
+  year = {2018},
+  howpublished = {\href{https://github.com/HypothesisWorks/hypothesis}{\texttt{https://github.com/HypothesisWorks/hypothesis}}},
 }
 
-If you are unsure about which version of hypothesis you are using run: `pip show
-hypothesis`.
+If you are unsure about which version of Hypothesis you are using run:
+`pip show hypothesis` for the Python version.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -46,7 +46,7 @@ triggered while shrinking a failing test.
 3.64.1 - 2018-06-27
 -------------------
 
-This patch fixes type-checking errors in our vendored prety-printer,
+This patch fixes type-checking errors in our vendored pretty-printer,
 which were ignored by our mypy config but visible for anyone else
 (whoops).  Thanks to Pi Delport for reporting :issue:`1359` so promptly.
 

--- a/hypothesis-python/docs/community.rst
+++ b/hypothesis-python/docs/community.rst
@@ -18,3 +18,17 @@ applies in all Hypothesis community spaces.
 
 If you would like to cite Hypothesis, please consider `our sugested citation
 <https://github.com/HypothesisWorks/hypothesis/blob/master/CITATION>`_.
+
+If you like repo badges, we suggest the following badge, which you can add
+with restructuredtext or markdown, respectively:
+
+.. image:: https://img.shields.io/badge/hypothesis-tested-brightgreen.svg
+
+.. code:: restructuredtext
+
+    .. image:: https://img.shields.io/badge/hypothesis-tested-brightgreen.svg
+       :target: https://hypothesis.readthedocs.io
+
+.. code:: md
+
+    [![](https://img.shields.io/badge/hypothesis-tested-brightgreen.svg)](https://hypothesis.readthedocs.io/)

--- a/hypothesis-python/docs/community.rst
+++ b/hypothesis-python/docs/community.rst
@@ -13,5 +13,8 @@ The two major places for community discussion are:
 Feel free to use these to ask for help, provide feedback, or discuss anything remotely
 Hypothesis related at all.
 
-Please note that `the Hypothesis code of conduct <https://github.com/HypothesisWorks/hypothesis-python/blob/master/CODE_OF_CONDUCT.rst>`_
+Please note that `the Hypothesis code of conduct <https://github.com/HypothesisWorks/hypothesis/blob/master/CODE_OF_CONDUCT.rst>`_
 applies in all Hypothesis community spaces.
+
+If you would like to cite Hypothesis, please consider `our sugested citation
+<https://github.com/HypothesisWorks/hypothesis/blob/master/CITATION>`_.

--- a/hypothesis-python/docs/community.rst
+++ b/hypothesis-python/docs/community.rst
@@ -20,15 +20,16 @@ If you would like to cite Hypothesis, please consider `our sugested citation
 <https://github.com/HypothesisWorks/hypothesis/blob/master/CITATION>`_.
 
 If you like repo badges, we suggest the following badge, which you can add
-with restructuredtext or markdown, respectively:
+with reStructuredText or Markdown, respectively:
 
 .. image:: https://img.shields.io/badge/hypothesis-tested-brightgreen.svg
 
 .. code:: restructuredtext
 
     .. image:: https://img.shields.io/badge/hypothesis-tested-brightgreen.svg
+       :alt: Tested with Hypothesis
        :target: https://hypothesis.readthedocs.io
 
 .. code:: md
 
-    [![](https://img.shields.io/badge/hypothesis-tested-brightgreen.svg)](https://hypothesis.readthedocs.io/)
+    [![Tested with Hypothesis](https://img.shields.io/badge/hypothesis-tested-brightgreen.svg)](https://hypothesis.readthedocs.io/)

--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -224,13 +224,24 @@ we wanted to only generate really small JSON we could do this as:
 Composite strategies
 ~~~~~~~~~~~~~~~~~~~~
 
-The :func:`@composite <hypothesis.strategies.composite>` decorator lets you combine other strategies in more or less
+The :func:`@composite <hypothesis.strategies.composite>` decorator lets
+you combine other strategies in more or less
 arbitrary ways. It's probably the main thing you'll want to use for
 complicated custom strategies.
 
-The composite decorator works by giving you a function as the first argument
-that you can use to draw examples from other strategies. For example, the
-following gives you a list and an index into it:
+The composite decorator works by converting a function that returns one
+example into a function that returns a strategy that produces such
+examples - which you can pass to :func:`@given <hypothesis.given>`, modify
+with ``.map`` or ``.filter``, and generally use like any other strategy.
+
+It does this by giving you a special function ``draw`` as the first
+argument, which can be used just like the corresponding method of the
+:func:`~hypothesis.strategies.data` strategy within a test.  In fact,
+the implementation is almost the same - but defining a strategy with
+:func:`@composite <hypothesis.strategies.composite>` makes code reuse
+easier, and usually improves the display of failing examples.
+
+For example, the following gives you a list and an index into it:
 
 .. doctest::
 

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -637,13 +637,13 @@ it creates.  For example:
 .. _pytest-plugin:
 
 ----------------------------
-The Hypothesis Pytest Plugin
+The Hypothesis pytest Plugin
 ----------------------------
 
 Hypothesis includes a tiny plugin to improve integration with :pypi:`pytest`,
 which is activated by default (but does not affect other test runners).
 It aims to improve the integration between Hypothesis and Pytest by
-providing extra information and a convenient access to config options.
+providing extra information and convenient access to config options.
 
 - ``pytest --hypothesis-show-statistics`` can be used to
   :ref:`display test and data generation statistics <statistics>`.

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -632,3 +632,30 @@ it creates.  For example:
     use it in any way outside of type hints.  The only supported way to
     construct objects of this type is to use the functions provided by the
     :mod:`hypothesis.strategies` module!
+
+
+.. _pytest-plugin:
+
+----------------------------
+The Hypothesis Pytest Plugin
+----------------------------
+
+Hypothesis includes a tiny plugin to improve integration with :pypi:`pytest`,
+which is activated by default (but does not affect other test runners).
+It aims to improve the integration between Hypothesis and Pytest by
+providing extra information and a convenient access to config options.
+
+- ``pytest --hypothesis-show-statistics`` can be used to
+  :ref:`display test and data generation statistics <statistics>`.
+- ``pytest --hypothesis-profile=<profile name>`` can be used to
+  :ref:`load a settings profile <settings_profiles>`.
+- ``pytest --hypothesis-seed=<an int>`` can be used to
+  :ref:`reproduce a failure with a particular seed <reproducing-with-seed>`.
+
+Finally, all tests that are defined with Hypothesis automatically have
+``@pytest.mark.hypothesis`` applied to them.  See :ref:`here for information
+on working with markers <pytest:mark examples>`.
+
+.. note::
+    Pytest will load the plugin automatically if Hypothesis is installed.
+    You don't need to do anything at all to use it.

--- a/hypothesis-python/docs/reproducing.rst
+++ b/hypothesis-python/docs/reproducing.rst
@@ -60,6 +60,8 @@ Either are fine, and you can use one in one example and the other in another
 example if for some reason you really want to, but a single example must be
 consistent.
 
+.. _reproducing-with-seed:
+
 -------------------------------------
 Reproducing a test run with ``@seed``
 -------------------------------------

--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -179,7 +179,7 @@ on a function.
 Note that RuleBasedStateMachine must have at least one rule defined and that
 a single function cannot be used to define multiple rules (this to avoid having
 multiple rules doing the same things).
-Due to the stateful execution method, rules are generally cannot take arguments
+Due to the stateful execution method, rules generally cannot take arguments
 from other sources such as fixtures or ``pytest.mark.parametrize`` - consider
 providing them via a strategy such as :func:`~hypothesis.strategies.sampled_from`
 instead.

--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -179,6 +179,10 @@ on a function.
 Note that RuleBasedStateMachine must have at least one rule defined and that
 a single function cannot be used to define multiple rules (this to avoid having
 multiple rules doing the same things).
+Due to the stateful execution method, rules are generally cannot take arguments
+from other sources such as fixtures or ``pytest.mark.parametrize`` - consider
+providing them via a strategy such as :func:`~hypothesis.strategies.sampled_from`
+instead.
 
 .. autofunction:: hypothesis.stateful.rule
 


### PR DESCRIPTION
- Closes #1315 by suggesting [![](https://img.shields.io/badge/hypothesis-tested-brightgreen.svg)](http://hypothesis.readthedocs.io/) for those who like badges.
- Closes #1338 by clarifing the documentation for `@composite` - including explicit comparison to `st.data()`.
- Closes #1356 by linking to our CITATION file.  We'll update again if or when we have a formal publication in e.g. [JOSS](https://joss.theoj.org/).
- Adds note suggested by @lennax on #1300 that `@rule` and `@pytest.mark.parametrize` do not work well together.
- Handles documentation portion of #1238, leaving the implementation of a verbosity option.