### PR TITLE
Fix zero-division, display in draw time stats

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare bug where an incorrect percentage drawtime
+could be displayed for a test, when the system clock was changed during
+a test running under Python 2 (we use :func:`python:time.monotonic`
+where it is available to avoid such problems).  It also fixes a possible
+zero-division error that can occur when the underlying C library
+double-rounds an intermediate value in :func:`python:math.fsum` and
+gets the least significant bit wrong.

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -87,8 +87,15 @@ class Statistics(object):
         total_runtime = math.fsum(engine.all_runtimes)
         total_drawtime = math.fsum(engine.all_drawtimes)
 
-        if total_drawtime == 0.0:
+        if total_drawtime == 0.0 and total_runtime >= 0.0:
             self.draw_time_percentage = '~ 0%'
+        elif total_drawtime < 0.0 or total_runtime <= 0.0:
+            # This weird condition is possible in two ways:
+            # 1.  drawtime and/or runtime are negative, due to clock changes
+            #     on Python 2 or old OSs (we use monotonic() where available)
+            # 2.  floating-point issues *very rarely* cause math.fsum to be
+            #     off by the lowest bit, so drawtime==0 and runtime!=0, eek!
+            self.draw_time_percentage = 'NaN'
         else:
             draw_time_percentage = 100.0 * min(
                 1, total_drawtime / total_runtime)


### PR DESCRIPTION
Closes #1346.  
It wasn't timezones, or system clock resets.  
It was (as far as I can tell) floating-point imprecision flipping the least significant bit of an intermediate value in `math.fsum`, which is in turn thanks to the system C libraries (but only on "some non-Windows platforms using **extended precision** arithmetic" [my emphasis]).  :sob: 

Anyway, it's now handled and has a regression test providing full coverage :sparkles: 