### PR TITLE
Fix builds() argument inference for typing.NamedTuple

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes inference in the :func:`~hypothesis.strategies.builds`
+strategy with subtypes of :class:`python:typing.NamedTuple`, where the
+``__init__`` method is not useful for introspection.  We now use the
+field types instead - thanks to James Uther for identifying this bug.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -25,6 +25,7 @@ import math
 import time
 import array
 import codecs
+import inspect
 import platform
 import importlib
 from base64 import b64encode
@@ -277,7 +278,6 @@ if PY2:
                              'kwonlyargs, kwonlydefaults, annotations')
 
     def getfullargspec(func):
-        import inspect
         args, varargs, varkw, defaults = inspect.getargspec(func)
         return FullArgSpec(args, varargs, varkw, defaults, [], None,
                            getattr(func, '__annotations__', {}))
@@ -296,9 +296,10 @@ if sys.version_info[:2] < (3, 6):
         except TypeError:
             return {}
 else:
+    import typing
+
     def get_type_hints(thing):
         try:
-            import typing
             return typing.get_type_hints(thing)
         except TypeError:
             return {}

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -367,6 +367,24 @@ def test_required_args(target, args, kwargs):
               **{k: st.just(v) for k, v in kwargs.items()}).example()
 
 
+AnnotatedNamedTuple = typing.NamedTuple('AnnotatedNamedTuple', [('a', str)])
+
+
+@given(st.builds(AnnotatedNamedTuple))
+def test_infers_args_for_namedtuple_builds(thing):
+    assert isinstance(thing.a, str)
+
+
+@given(st.from_type(AnnotatedNamedTuple))
+def test_infers_args_for_namedtuple_from_type(thing):
+    assert isinstance(thing.a, str)
+
+
+@given(st.builds(AnnotatedNamedTuple, a=st.none()))
+def test_override_args_for_namedtuple(thing):
+    assert thing.a is None
+
+
 @pytest.mark.parametrize('thing', [
     typing.Optional, typing.List, getattr(typing, 'Type', typing.Set)
 ])  # check Type if it's available, otherwise Set is redundant but harmless


### PR DESCRIPTION
@jbu reported that `builds()` did not infer arguments to NamedTuple instances and, noticing that the `__init__` method is a wrapper of `object.__init__`, started work on a patch.  Unfortunately his workaround did not resolve the issue.

This PR uses a different workaround for the `__init__` problem which is specific to `typing.NamedTuple`, adds a similar workaround to correctly calculate their required arguments, and (now that `builds()` works) removes the special case in `from_type()` in favor of the general fallback.

Closes #1309.