### PR TITLE
Report multiple failures in Hypothesis for Ruby

### DIFF
--- a/conjecture-rust/RELEASE.md
+++ b/conjecture-rust/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds support for annotating interesting examples
+to indicate that they are logically distinct. When multiple distinct
+reasons for being interesting are found, Conjecture will attempt to
+shrink all of them.

--- a/conjecture-rust/src/data.rs
+++ b/conjecture-rust/src/data.rs
@@ -3,6 +3,7 @@
 
 use rand::{ChaChaRng, Rng};
 use std::collections::HashSet;
+use std::cmp::Ordering;
 
 pub type DataStream = Vec<u64>;
 
@@ -182,3 +183,25 @@ pub struct TestResult {
     pub sizes: Vec<u64>,
     pub written_indices: HashSet<usize>,
 }
+
+
+impl Ord for TestResult {
+    fn cmp(&self, other: &TestResult) -> Ordering {
+      self.record.len().cmp(&other.record.len()).
+      then(self.record.cmp(&other.record))
+    }
+}
+
+impl PartialOrd for TestResult {
+    fn partial_cmp(&self, other: &TestResult) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for TestResult {
+    fn eq(&self, other: &TestResult) -> bool {
+        self.record == other.record
+    }
+}
+
+impl Eq for TestResult { }

--- a/conjecture-rust/src/data.rs
+++ b/conjecture-rust/src/data.rs
@@ -167,7 +167,7 @@ pub enum Status {
 
     // This was an interesting test execution! (Usually this
     // means failing, but for things like find it may not).
-    Interesting,
+    Interesting(u64),
 }
 
 // Once a data source is finished it "decays" to a

--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -63,6 +63,20 @@ impl MainGenerationLoop {
     fn loop_body(&mut self) -> StepResult {
         self.generate_examples()?;
 
+        // At the start of this loop we can only have example in
+        // self.minimized_examples, but as we shrink we may find other ones.
+        // The reason why we loop is twofold:
+        // a) This allows us to include newly discovered examples. Labels that
+        //    are not found in self.minimized_examples at the beginning of the
+        //    loop will be added for the next iteration around.
+        // b) If we've previously marked a label as finished it can become
+        //    unfinished again if when shrinking another label, as when trying
+        //    to shrink one label we might accidentally find an improved shrink
+        //    for another.
+        // 
+        // In principle this might cause us to loop for a very long time before
+        // eventually settling on a fixed point, but when that happens we
+        // should hit limits on shrinking (which we haven't implemented yet).
         while self.minimized_examples.len() > self.fully_minimized.len() {
           let keys: Vec<u64> = self.minimized_examples.keys().map(|i| *i).collect();
           for label in keys.iter() {

--- a/hypothesis-ruby/.rubocop.yml
+++ b/hypothesis-ruby/.rubocop.yml
@@ -26,3 +26,5 @@ Metrics/BlockLength:
   Enabled: false
 Lint/HandleExceptions:
   Enabled: false
+Style/GuardClause:
+  Enabled: false

--- a/hypothesis-ruby/Gemfile.lock
+++ b/hypothesis-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hypothesis-specs (0.0.14)
+    hypothesis-specs (0.0.15)
       helix_runtime (~> 0.7.0)
       rake (>= 10.0, < 13.0)
 

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release adds support for reporting multiple exceptions when Hypothesis
+finds more than one way for the test to fail. 

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'hypothesis/junkdrawer'
 require 'hypothesis/errors'
 require 'hypothesis/possible'
 require 'hypothesis/testcase'

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -56,6 +56,7 @@ module Hypothesis
       else
         exceptions = []
         (0...@core_engine.count_failing_examples).each do |example|
+          core = @core_engine.failing_example(example)
           @current_source = TestCase.new(core, print_draws: true)
 
           begin

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -23,7 +23,7 @@ module Hypothesis
         begin
           result = yield(@current_source)
           if is_find && result
-            @core_engine.finish_interesting(core)
+            @core_engine.finish_interesting(core, 0)
           else
             @core_engine.finish_valid(core)
           end
@@ -33,7 +33,7 @@ module Hypothesis
           @core_engine.finish_overflow(core)
         rescue Exception
           raise if is_find
-          @core_engine.finish_interesting(core)
+          @core_engine.finish_interesting(core, 0)
         end
       end
       @current_source = nil

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -2,9 +2,13 @@
 
 require 'helix_runtime'
 require 'hypothesis-ruby/native'
+require 'rspec/expectations'
+
 
 module Hypothesis
   class Engine
+    include RSpec::Matchers
+
     attr_reader :current_source
     attr_accessor :is_find
 
@@ -13,6 +17,8 @@ module Hypothesis
       @core_engine = HypothesisCoreEngine.new(
         seed, options.fetch(:max_examples)
       )
+
+      @exceptions_to_tags = Hash.new{|h, k| h[k] = h.size }
     end
 
     def run
@@ -31,53 +37,61 @@ module Hypothesis
           @core_engine.finish_invalid(core)
         rescue DataOverflow
           @core_engine.finish_overflow(core)
-        rescue Exception
+        rescue Exception => e
           raise if is_find
-          @core_engine.finish_interesting(core, 0)
+          key = [e.class, e.backtrace[0]] 
+          @core_engine.finish_interesting(core, @exceptions_to_tags[key])
         end
       end
-      @current_source = nil
-      core = @core_engine.failing_example
-      if core.nil?
+      if @core_engine.count_failing_examples == 0
         raise Unsatisfiable if @core_engine.was_unsatisfiable
+        @current_source = nil
         return
       end
 
       if is_find
+        core = @core_engine.failing_example(0)
         @current_source = TestCase.new(core, record_draws: true)
         yield @current_source
       else
-        @current_source = TestCase.new(core, print_draws: true)
+        exceptions = []
+        (0...@core_engine.count_failing_examples).each do |example|
+          @current_source = TestCase.new(core, print_draws: true)
 
-        begin
-          yield @current_source
-        rescue Exception => e
-          givens = @current_source.print_log
-          given_str = givens.each_with_index.map do |(name, s), i|
-            name = "##{i + 1}" if name.nil?
-            "Given #{name}: #{s}"
-          end.to_a
+          begin
+            yield @current_source
+          rescue Exception => e
+            givens = @current_source.print_log
+            given_str = givens.each_with_index.map do |(name, s), i|
+              name = "##{i + 1}" if name.nil?
+              "Given #{name}: #{s}"
+            end.to_a
 
-          if e.respond_to? :hypothesis_data
-            e.hypothesis_data[0] = given_str
-          else
-            original_to_s = e.to_s
-            original_inspect = e.inspect
+            if e.respond_to? :hypothesis_data
+              e.hypothesis_data[0] = given_str
+            else
+              original_to_s = e.to_s
+              original_inspect = e.inspect
 
-            class <<e
-              attr_accessor :hypothesis_data
+              class <<e
+                attr_accessor :hypothesis_data
 
-              def to_s
-                ['', hypothesis_data[0], '', hypothesis_data[1]].join("\n")
+                def to_s
+                  ['', hypothesis_data[0], '', hypothesis_data[1]].join("\n")
+                end
+
+                def inspect
+                  ['', hypothesis_data[0], '', hypothesis_data[2]].join("\n")
+                end
               end
-
-              def inspect
-                ['', hypothesis_data[0], '', hypothesis_data[2]].join("\n")
-              end
+              e.hypothesis_data = [given_str, original_to_s, original_inspect]
             end
-            e.hypothesis_data = [given_str, original_to_s, original_inspect]
+            if @core_engine.count_failing_examples == 1
+              raise e
+            else
+              exceptions.push(e)
+            end
           end
-          raise e
         end
       end
     end

--- a/hypothesis-ruby/lib/hypothesis/errors.rb
+++ b/hypothesis-ruby/lib/hypothesis/errors.rb
@@ -25,4 +25,37 @@ module Hypothesis
   # @!visibility private
   class DataOverflow < HypothesisError
   end
+
+  if defined?(RSpec::Core::MultipleExceptionError)
+    MultipleExceptionErrorParent = RSpec::Core::MultipleExceptionError
+  # :nocov:
+  else
+    class MultipleExceptionErrorParent < StandardError
+      def initialize(*exceptions)
+        super()
+
+        @all_exceptions = exceptions.to_a
+      end
+
+      attr_reader :all_exceptions
+    end
+  end
+
+  class MultipleExceptionError < MultipleExceptionErrorParent
+    def message
+      jd = HypothesisJunkDrawer
+      "Test raised #{all_exceptions.length} distinct errors:\n\n" +
+        all_exceptions.map do |e|
+          location = jd.find_first_relevant_line(e.backtrace).sub(/:in.+$/, '')
+          backtrace = jd.prune_backtrace(e.backtrace)
+          "#{e.class} at #{location}:\n" \
+            "#{e.message}\n#{backtrace.map { |s| '  ' + s }
+              .join("\n")}"
+        end.join("\n\n")
+    end
+
+    def backtrace
+      []
+    end
+  end
 end

--- a/hypothesis-ruby/lib/hypothesis/junkdrawer.rb
+++ b/hypothesis-ruby/lib/hypothesis/junkdrawer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Hypothesis
+  # @!visibility private
+  module HypothesisJunkDrawer
+    HYPOTHESIS_ROOT = File.absolute_path(File.dirname(__FILE__))
+
+    def self.prune_backtrace(backtrace)
+      result = []
+      seen_hypothesis = false
+      backtrace.each do |b|
+        if b.start_with?(HYPOTHESIS_ROOT)
+          seen_hypothesis = true
+        else
+          result.push(b)
+          break if seen_hypothesis
+        end
+      end
+      result
+    end
+
+    def self.find_first_relevant_line(backtrace)
+      backtrace.each do |b|
+        next if b.include?('minitest/assertions.rb')
+        next if b.start_with?(HYPOTHESIS_ROOT)
+        return b
+      end
+      nil
+    end
+  end
+end

--- a/hypothesis-ruby/minitests/test_multiple_failures.rb
+++ b/hypothesis-ruby/minitests/test_multiple_failures.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'hypothesis'
+
+class TestMultipleFailures < Minitest::Test
+  include Hypothesis
+  include Hypothesis::Possibilities
+
+  def test_multiple_failures
+    assert_raises(Hypothesis::MultipleExceptionError) do
+      @initial = nil
+
+      hypothesis do
+        x = any integers
+        if @initial.nil?
+          if x >= 1000
+            @initial = x
+          else
+            next
+          end
+        end
+
+        assert(x != @initial)
+        raise 'Nope'
+      end
+    end
+  end
+end

--- a/hypothesis-ruby/spec/backtrace_spec.rb
+++ b/hypothesis-ruby/spec/backtrace_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe 'backtrace manipulation' do
+  JD = Hypothesis::HypothesisJunkDrawer
+
+  it 'identifies the test file as relevant' do
+    JD.find_first_relevant_line(caller).include?('backtrace_spec.rb')
+  end
+
+  it 'prunes out hypothesis and rspec related lines' do
+    hypothesis do
+      relevant = JD.prune_backtrace(caller)
+      relevant.each do |e|
+        expect(e).to_not include(JD::HYPOTHESIS_ROOT)
+        expect(e).to_not include('/rspec-core/')
+      end
+      expect(relevant.grep(/backtrace_spec.rb/)).to_not be_empty
+    end
+  end
+end

--- a/hypothesis-ruby/spec/multiple_failures_spec.rb
+++ b/hypothesis-ruby/spec/multiple_failures_spec.rb
@@ -16,10 +16,27 @@ RSpec.describe 'tests with multiple failures' do
         end
 
         expect(x).to_not eq(@initial)
-        raise "Nope"
+        raise 'Nope'
       end
-    end.to raise_exception(RSpec::Expectations::MultipleExpectationsNotMetError){|e|
+    end.to raise_exception(Hypothesis::MultipleExceptionError) { |e|
       expect(e.all_exceptions.length).to eq(2)
     }
+  end
+end
+
+RSpec.describe Hypothesis::MultipleExceptionError do
+  it 'includes the message from each exception' do
+    exceptions = []
+    %w[hello world].each do |m|
+      begin
+        raise m
+      rescue Exception => e
+        exceptions.append(e)
+      end
+    end
+
+    e = Hypothesis::MultipleExceptionError.new(*exceptions)
+    expect(e.message).to include('hello')
+    expect(e.message).to include('world')
   end
 end

--- a/hypothesis-ruby/spec/multiple_failures_spec.rb
+++ b/hypothesis-ruby/spec/multiple_failures_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe 'tests with multiple failures' do
+  they 'show multiple failures' do
+    expect do
+      @initial = nil
+
+      hypothesis do
+        x = any integers
+        if @initial.nil?
+          if x >= 1000
+            @initial = x
+          else
+            next
+          end
+        end
+
+        expect(x).to_not eq(@initial)
+        raise "Nope"
+      end
+    end.to raise_exception(RSpec::Expectations::MultipleExpectationsNotMetError){|e|
+      expect(e.all_exceptions.length).to eq(2)
+    }
+  end
+end

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -2,6 +2,47 @@
 
 require 'simplecov'
 SimpleCov.minimum_coverage 100
+
+class PrintingFormatter
+  # Takes a SimpleCov::Result and generates a string out of it
+  def format(result)
+    bad = []
+    result.files.each do |file|
+      bad.push file if file.covered_percent < 100.0
+    end
+
+    unless bad.empty?
+      puts "Files with missing coverage!"
+      bad.each do |file|
+        lines = file.source_lines.select{|l| l.coverage == 0}.map{|l| l.line_number}.sort
+        s = lines[0]
+        groups = [[s, s]]
+        lines.each do |i|
+          if i <= groups[-1][-1] + 1
+            groups[-1][-1] = i
+          else
+            groups.push([i, i])
+          end
+        end
+        markers = []
+        groups.each do |g|
+          if g[0] == g[1]
+            markers.push(g[0].to_s)
+          else
+            markers.push(g.join("-"))
+          end
+        end
+        puts "#{file.filename}: #{markers.join(", ")}"
+      end
+    end
+  end
+end
+
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  PrintingFormatter,
+])
+
 SimpleCov.start do
   add_filter do |source_file|
     name = source_file.filename

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -46,7 +46,7 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
 SimpleCov.start do
   add_filter do |source_file|
     name = source_file.filename
-    !(name.include?('/hypothesis/') || name.end_with?('hypothesis.rb'))
+    !(name.include?('/hypothesis-ruby/lib/') || name.end_with?('hypothesis.rb'))
   end
 end
 

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -12,9 +12,10 @@ class PrintingFormatter
     end
 
     unless bad.empty?
-      puts "Files with missing coverage!"
+      puts 'Files with missing coverage!'
       bad.each do |file|
-        lines = file.source_lines.select{|l| l.coverage == 0}.map{|l| l.line_number}.sort
+        lines = file.source_lines.select { |l| l.coverage == 0 }
+                    .map(&:line_number).sort
         s = lines[0]
         groups = [[s, s]]
         lines.each do |i|
@@ -29,19 +30,18 @@ class PrintingFormatter
           if g[0] == g[1]
             markers.push(g[0].to_s)
           else
-            markers.push(g.join("-"))
+            markers.push(g.join('-'))
           end
         end
-        puts "#{file.filename}: #{markers.join(", ")}"
+        puts "#{file.filename}: #{markers.join(', ')}"
       end
     end
   end
 end
 
-SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  PrintingFormatter,
-])
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [SimpleCov::Formatter::HTMLFormatter, PrintingFormatter]
+)
 
 SimpleCov.start do
   add_filter do |source_file|

--- a/hypothesis-ruby/src/lib.rs
+++ b/hypothesis-ruby/src/lib.rs
@@ -91,8 +91,8 @@ ruby! {
       mark_child_status(&mut self.engine, child, Status::Invalid);
     }
 
-    def finish_interesting(&mut self, child: &mut HypothesisCoreDataSource){
-      mark_child_status(&mut self.engine, child, Status::Interesting);
+    def finish_interesting(&mut self, child: &mut HypothesisCoreDataSource, label: u64){
+      mark_child_status(&mut self.engine, child, Status::Interesting(label));
     }
 
     def finish_valid(&mut self, child: &mut HypothesisCoreDataSource){

--- a/hypothesis-ruby/src/lib.rs
+++ b/hypothesis-ruby/src/lib.rs
@@ -15,7 +15,7 @@ extern crate conjecture;
 
 use std::mem;
 
-use conjecture::data::{DataSource, Status};
+use conjecture::data::{DataSource, Status, TestResult};
 use conjecture::distributions::Repeat;
 use conjecture::distributions;
 use conjecture::engine::Engine;
@@ -49,6 +49,7 @@ ruby! {
     struct {
       engine: Engine,
       pending: Option<DataSource>,
+      interesting_examples: Vec<TestResult>,
     }
 
     def initialize(helix, seed: u64, max_examples: u64){
@@ -57,12 +58,16 @@ ruby! {
         helix,
         engine: Engine::new(max_examples, &xs),
         pending: None,
+        interesting_examples: Vec::new(),
       }
     }
 
     def new_source(&mut self) -> Option<HypothesisCoreDataSource> {
       match self.engine.next_source() {
-        None => None,
+        None => {
+          self.interesting_examples = self.engine.list_minimized_examples();
+          None
+        },
         Some(source) => {
           self.pending = Some(source);
           Some(HypothesisCoreDataSource::new(self))
@@ -70,13 +75,15 @@ ruby! {
       }
     }
 
-    def failing_example(&mut self) -> Option<HypothesisCoreDataSource> {
-      if let Some(source) = self.engine.best_source() {
-        self.pending = Some(source);
-        return Some(HypothesisCoreDataSource::new(self));
-      } else {
-        return None;
-      }
+    def count_failing_examples(&self) -> usize {
+      self.interesting_examples.len()
+    }
+
+    def failing_example(&mut self, i: usize) -> HypothesisCoreDataSource {
+      self.pending = Some(
+        DataSource::from_vec(self.interesting_examples[i].record.clone())
+      );
+      HypothesisCoreDataSource::new(self)
     }
 
     def was_unsatisfiable(&mut self) -> bool {


### PR DESCRIPTION
This adds the feature (already found in Hypothesis for Python) that when there are multiple exceptions triggered during shrinking, Hypothesis will report them all.

Notable oddities: 

* This involved some somewhat interesting shenanigans with the exception reporting. We use RSpec's native support for this if running on RSpec and create an exception with a custom message for use when running anywhere else.
* We have to do some exception backtrace mangling ourself because unlike in python land, assert is a function and so the backtrace always starts somewhere boring.

Otherwise, fairly straightforward port of the logic from Python land.