### PR TITLE
Deprecate the use of '.example()' when running outside an interactive REPL

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This release deprecates the use of ``.example()`` on a strategy when running
+outside an interactive REPL.
+
+This method is only for interactive exploration of the API, not for serious
+testing.  In particular, the distribution of examples doesn't match that
+provided by ``@given``, and deliberately omits some examples.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -538,7 +538,7 @@ def proxies(target):
     return accept
 
 
-def guess_if_running_in_repl():
+def is_running_in_repl():
     """Tries to guess if Hypothesis is running from inside an interactive
     REPL or inside a script."""
     # The last frame in this list is the outermost call on the stack.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -536,3 +536,14 @@ def proxies(target):
         return impersonate(target)(wraps(target)(define_function_signature(
             target.__name__, target.__doc__, getfullargspec(target))(proxy)))
     return accept
+
+
+def guess_if_running_in_repl():
+    """Tries to guess if Hypothesis is running from inside an interactive
+    REPL or inside a script."""
+    # The last frame in this list is the outermost call on the stack.
+    # In this case, the filename will be '<stdin>' if we're running inside
+    # the REPL.
+    stack = inspect.stack()
+    outermost_call = stack[-1]
+    return outermost_call.filename == '<stdin>'

--- a/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
@@ -280,6 +280,16 @@ class SearchStrategy(Generic[Ex]):
                     '#drawing-interactively-in-tests for more details.'
                 )
 
+        from hypothesis.internal.reflection import is_running_in_repl
+
+        if not is_running_in_repl():
+            note_deprecation(
+                'Using example() outside the interactive REPL is a bad idea. '
+                "It doesn't give a representative sample of outputs -- it's "
+                'meant for interactive exploration of the API, not for '
+                'proper testing.'
+            )
+
         from hypothesis import find, settings, Verbosity
 
         # Conjecture will always try the zero example first. This would result

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -77,6 +77,21 @@ def consistently_increment_time(monkeypatch):
     monkeypatch.setattr(time_module, 'freeze', freeze, raising=False)
 
 
+@pytest.fixture(scope=u'function', autouse=True)
+def disable_warnings_on_example(request, monkeypatch):
+    """The .example() method on strategies emits a warning if used outside
+    an interactive REPL.
+
+    We use it for convenience in some tests -- this stops it from emitting
+    a warning throughout our test suite.
+    """
+    if 'no_disable_warnings_on_example' in request.keywords:
+        return
+
+    import hypothesis.internal.reflection as reflection_module
+    monkeypatch.setattr(reflection_module, 'is_running_in_repl', lambda: True)
+
+
 if not IN_COVERAGE_TESTS:
     @pytest.fixture(scope=u'function', autouse=True)
     def validate_lack_of_trace_function():

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -115,6 +115,24 @@ def external_script(tmpdir):
     return runner
 
 
+@pytest.fixture
+def repl_session():
+    """Returns a helper that runs a single line of code in the Python REPL,
+    and returns a (stdout, stderr) tuple.
+    """
+    def runner(code):
+        proc = subprocess.Popen(
+            ['python'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        return proc.communicate(code)
+
+    return runner
+
+
 if not IN_COVERAGE_TESTS:
     @pytest.fixture(scope=u'function', autouse=True)
     def validate_lack_of_trace_function():

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 import gc
 import sys
 import time as time_module
+import subprocess
 
 import pytest
 
@@ -90,6 +91,28 @@ def disable_warnings_on_example(request, monkeypatch):
 
     import hypothesis.internal.reflection as reflection_module
     monkeypatch.setattr(reflection_module, 'is_running_in_repl', lambda: True)
+
+
+@pytest.fixture
+def external_script(tmpdir):
+    """Returns a helper that saves code to an external Python script,
+    runs the code, and returns an (exit_code, stdout, stderr) tuple.
+    """
+    def runner(code):
+        script = tmpdir.join('example_script.py')
+        with open(script, 'wb') as outfile:
+            outfile.write(code)
+
+        proc = subprocess.Popen(
+            ['python', script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        stdout, stderr = proc.communicate()
+        return (proc.returncode, stdout, stderr)
+
+    return runner
 
 
 if not IN_COVERAGE_TESTS:

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -83,26 +83,17 @@ def test_example_inside_strategy():
     st.booleans().map(lambda x: st.integers().example()).example()
 
 
-def test_using_example_outside_repl_is_error(tmpdir):
-    script = tmpdir.join('example_script.py')
-    with open(script, 'wb') as outfile:
-        outfile.write(
-            b'from hypothesis.strategies import integers\n'
-            b'print(integers().example())\n'
-        )
-
-    proc = subprocess.Popen(
-        ['python', script],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+def test_using_example_outside_repl_is_error(external_script):
+    returncode, stdout, stderr = external_script(
+        b'from hypothesis.strategies import integers\n'
+        b'print(integers().example())\n'
     )
 
-    stdout, stderr = proc.communicate()
+    assert returncode == 0
+    assert b'HypothesisDeprecationWarning' in stderr
 
     # We're looking for strings like b'45\n' or b'-30894\n'.
     assert re.match(rb'^\-?\d+\n$', stdout)
-
-    assert b'HypothesisDeprecationWarning' in stderr
 
 
 def test_using_example_inside_repl_is_no_warning():

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -97,7 +97,8 @@ def test_using_example_inside_repl_is_no_warning():
     )
 
     stdout, stderr = proc.communicate(
-        b'from hypothesis.strategies import integers; integers().example()\n'
+        b'from hypothesis.strategies import integers; '
+        b'print(integers().example())\n'
     )
 
     # We're looking for strings like b'45\n' or b'-30894\n'.

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -18,7 +18,6 @@
 from __future__ import division, print_function, absolute_import
 
 import re
-import subprocess
 from random import Random
 from decimal import Decimal
 
@@ -96,15 +95,8 @@ def test_using_example_outside_repl_is_error(external_script):
     assert re.match(rb'^\-?\d+\n$', stdout)
 
 
-def test_using_example_inside_repl_is_no_warning():
-    proc = subprocess.Popen(
-        ['python'],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
-
-    stdout, stderr = proc.communicate(
+def test_using_example_inside_repl_is_no_warning(repl_session):
+    stdout, stderr = repl_session(
         b'from hypothesis.strategies import integers; '
         b'print(integers().example())\n'
     )

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -607,8 +607,8 @@ def test_does_not_think_is_inside_repl_from_script(tmpdir):
 
     lines = [
         'import sys',
-        'from hypothesis.internal.reflection import guess_if_running_in_repl',
-        'if guess_if_running_in_repl():',
+        'from hypothesis.internal.reflection import is_running_in_repl',
+        'if is_running_in_repl():',
         '    sys.exit(1)',
         'else:',
         '    sys.exit(0)',
@@ -630,8 +630,8 @@ def test_does_think_is_inside_repl_from_repl():
     )
 
     lines = [
-        b'from hypothesis.internal.reflection import guess_if_running_in_repl',
-        b'print(guess_if_running_in_repl())'
+        b'from hypothesis.internal.reflection import is_running_in_repl',
+        b'print(is_running_in_repl())'
     ]
     command = b'; '.join(lines) + b'\n'
 

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -629,12 +629,8 @@ def test_does_think_is_inside_repl_from_repl():
         stderr=subprocess.PIPE
     )
 
-    lines = [
-        b'from hypothesis.internal.reflection import is_running_in_repl',
-        b'print(is_running_in_repl())'
-    ]
-    command = b'; '.join(lines) + b'\n'
-
-    stdout, stderr = proc.communicate(command)
+    stdout, stderr = proc.communicate(
+        b'from hypothesis.internal.reflection import *; is_running_in_repl()\n'
+    )
     assert stdout == b'True\n'
     assert stderr == b''

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -603,8 +603,22 @@ def test_required_args(target, args, kwargs, expected):
 
 
 def test_does_not_think_is_inside_repl_from_script(tmpdir):
-    from hypothesis.internal.reflection import is_running_in_repl
-    assert not is_running_in_repl()
+    script = tmpdir.join('example_script.py')
+    with open(script, 'wb') as outfile:
+        outfile.write(
+            b'from hypothesis.internal.reflection import is_running_in_repl\n'
+            b'print(is_running_in_repl())\n'
+        )
+
+    proc = subprocess.Popen(
+        ['python', script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    stdout, stderr = proc.communicate()
+    assert stdout == b'False\n'
+    assert stderr == b''
 
 
 def test_does_think_is_inside_repl_from_repl():
@@ -616,7 +630,8 @@ def test_does_think_is_inside_repl_from_repl():
     )
 
     stdout, stderr = proc.communicate(
-        b'from hypothesis.internal.reflection import *; is_running_in_repl()\n'
+        b'from hypothesis.internal.reflection import is_running_in_repl; '
+        b'print(is_running_in_repl())\n'
     )
     assert stdout == b'True\n'
     assert stderr == b''

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -602,21 +602,13 @@ def test_required_args(target, args, kwargs, expected):
     assert required_args(target, args, kwargs) == expected
 
 
-def test_does_not_think_is_inside_repl_from_script(tmpdir):
-    script = tmpdir.join('example_script.py')
-    with open(script, 'wb') as outfile:
-        outfile.write(
-            b'from hypothesis.internal.reflection import is_running_in_repl\n'
-            b'print(is_running_in_repl())\n'
-        )
-
-    proc = subprocess.Popen(
-        ['python', script],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+def test_does_not_think_is_inside_repl_from_script(external_script):
+    returncode, stdout, stderr = external_script(
+        b'from hypothesis.internal.reflection import is_running_in_repl\n'
+        b'print(is_running_in_repl())\n'
     )
 
-    stdout, stderr = proc.communicate()
+    assert returncode == 0
     assert stdout == b'False\n'
     assert stderr == b''
 

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -603,22 +603,8 @@ def test_required_args(target, args, kwargs, expected):
 
 
 def test_does_not_think_is_inside_repl_from_script(tmpdir):
-    script = tmpdir.join('test_script.py')
-
-    lines = [
-        'import sys',
-        'from hypothesis.internal.reflection import is_running_in_repl',
-        'if is_running_in_repl():',
-        '    sys.exit(1)',
-        'else:',
-        '    sys.exit(0)',
-    ]
-
-    with open(script, 'w') as f:
-        f.write('\n'.join(lines))
-
-    result = subprocess.call(['python', script])
-    assert result == 0
+    from hypothesis.internal.reflection import is_running_in_repl
+    assert not is_running_in_repl()
 
 
 def test_does_think_is_inside_repl_from_repl():

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -599,3 +599,23 @@ class Target(object):
 def test_required_args(target, args, kwargs, expected):
     # Mostly checking that `self` (and only self) is correctly excluded
     assert required_args(target, args, kwargs) == expected
+
+
+def test_does_not_think_is_inside_repl_from_script(tmpdir):
+    script = tmpdir.join('test_script.py')
+
+    lines = [
+        'import sys',
+        'from hypothesis.internal.reflection import *',
+        'if guess_if_running_in_repl():',
+        '    sys.exit(1)',
+        'else:',
+        '    sys.exit(0)',
+    ]
+
+    with open(script, 'w') as f:
+        f.write('\n'.join(lines))
+
+    import subprocess
+    result = subprocess.call(['python', script])
+    assert result == 0

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -18,7 +18,6 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-import subprocess
 from copy import deepcopy
 from functools import partial
 
@@ -613,15 +612,8 @@ def test_does_not_think_is_inside_repl_from_script(external_script):
     assert stderr == b''
 
 
-def test_does_think_is_inside_repl_from_repl():
-    proc = subprocess.Popen(
-        ['python'],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
-
-    stdout, stderr = proc.communicate(
+def test_does_think_is_inside_repl_from_repl(repl_session):
+    stdout, stderr = repl_session(
         b'from hypothesis.internal.reflection import is_running_in_repl; '
         b'print(is_running_in_repl())\n'
     )


### PR DESCRIPTION
As discussed on WhatsApp, this prints a warning if you try to use `.example()` outside an interactive REPL.

Notes for reviewers:

* There may be better ways to check if you’re in the REPL. I went with a simple check because I didn't care to spend lots of time on the problem – this isn’t a core API, and I’m less fussed about bugs here.

* This is going to break every test which uses `.example()`. What do we want to do about that? Fix all those tests (expensive) or modify `is_running_inside_repl()` to detect our test suite?

* My lazy impulse is to get rid of and/or deprecate `.example()` entirely.