### PR TITLE
Change ensure-rustup.sh to only update rustup stable rather than all versions

### DIFF
--- a/tooling/scripts/ensure-rustup.sh
+++ b/tooling/scripts/ensure-rustup.sh
@@ -13,4 +13,4 @@ fi
 
 rustup default stable
 
-rustup update
+rustup update stable


### PR DESCRIPTION
This doesn't matter much for our CI, but it's annoying when running locally if you have nightly installed in your toolchain as well.