### PR TITLE
Improve Hypothesis's ability to shrink sums

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,23 @@
+RELEASE_TYPE: patch
+
+This release improves the shrinker's ability to handle situations where there
+is an additive constraint between two values.
+
+For example, consider the following test:
+
+
+.. code-block:: python
+
+    import hypothesis.strategies as st
+    from hypothesis import given
+
+    @given(st.integers(), st.integers())
+    def test_does_not_exceed_100(m, n):
+        assert m + n <= 100
+
+Previously this could have failed with almost any pair ``(m, n)`` with
+``0 <= m <= n`` and ``m + n == 100``. Now it should almost always fail with
+``m=0, n=100``.
+
+This is a relatively niche specialisation, but can be useful in situations
+where e.g. a bug is triggered by an integer overflow.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -2325,7 +2325,7 @@ class Shrinker(object):
                             except OverflowError:
                                 return False
                             return self.incorporate_new_buffer(attempt)
-                        if trial(m - 1, n + 1):
+                        if trial(m - 1, n + 1) and m > 1:
                             m = int_from_bytes(self.shrink_target.buffer[u:v])
                             n = int_from_bytes(self.shrink_target.buffer[r:s])
 


### PR DESCRIPTION
This improves Hypothesis's ability to shrink examples which depend on the sum of two values.

The motivating example for this is the following:

```python
import numpy as np
import hypothesis.strategies as st
import hypothesis.extra.numpy as nps
from hypothesis import given

int16s = nps.from_dtype(np.dtype('int16'))

bounded_lists = st.lists(int16s, max_size=1).filter(lambda x: sum(x) < 256)

problems = st.tuples(
    bounded_lists,
    bounded_lists,
    bounded_lists,
    bounded_lists,
    bounded_lists,
)

@given(problems)
def test_sum_does_not_overflow(p):
    assert sum([x for sub in p for x in sub], np.int16(0)) < 5 * 256
```

This fails because you can get an overflow if the sum is large and negative. The ideal minimum example for it in Hypothesis's ordering is `([], [], [], [-1], [-32768])`, but previously we rarely found that.

This comes from [the SmartCheck paper](https://www.cs.indiana.edu/~lepike/pubs/smartcheck.pdf) and I'm running some evaluations in part based on that paper and it annoyed me that Hypothesis didn't normalize example. This PR is part one of two in fixing that.