### PR TITLE
Make shellcheck happy about our rustup check

### DIFF
--- a/tooling/scripts/ensure-rustup.sh
+++ b/tooling/scripts/ensure-rustup.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-if ! which rustup > /dev/null ; then 
+if ! command -v rustup > /dev/null ; then
   curl https://sh.rustup.rs -sSf | sh -s -- -y
 fi
 


### PR DESCRIPTION
Apparently more recent versions of shellcheck don't like the use of `which`. This replaces our one use of it with its suggested replacement of `command -v`