### PR TITLE
Improve Numpy strategies with small dtypes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.extra.numpy.arrays` now checks that integer and float
+values drawn from ``elements`` and ``fill`` strategies can be safely cast
+to the dtype of the array, and emits a warning otherwise (:issue:`1385`).
+
+Elements in the resulting array could previously violate constraints on
+the elements strategy due to floating-point overflow or truncation of
+integers to fit smaller types.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -53,7 +53,7 @@ if you are running Python 3.5 or earlier.
 3.66.33 - 2018-08-10
 --------------------
 
-This release fixes a bug in :func:`~hypotheses.strategies.floats`, where
+This release fixes a bug in :func:`~hypothesis.strategies.floats`, where
 setting ``allow_infinity=False`` and exactly one of ``min_value`` and
 ``max_value`` would allow infinite values to be generated.
 

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -20,6 +20,7 @@ shapes and generate all kinds of fixed-size or compound dtypes.
 
 .. automodule:: hypothesis.extra.numpy
    :members:
+   :exclude-members: ArrayStrategy
 
 .. _hypothesis-pandas:
 
@@ -46,7 +47,7 @@ Supported Versions
 There is quite a lot of variation between pandas versions. We only
 commit to supporting the latest version of pandas, but older minor versions are
 supported on a "best effort" basis.  Hypothesis is currently tested against
-and confirmed working with Pandas 0.19, 0.20, 0.21, and 0.22.
+and confirmed working with Pandas 0.19, 0.20, 0.21, 0.22, and 0.23.
 
 Releases that are not the latest patch release of their minor version are not
 tested or officially supported, but will probably also work unless you hit a


### PR DESCRIPTION
Closes #1385.  `npst.arrays` now checks whether generated array elements will overflow when placed in the output array, and issues a warning if they would.

The patch to *generate* single- and half-precision floats has been expanded and moved to #1432.  ~~Merge the other pull before this one, or we'll be giving users a new error without a ready solution.~~ Update: done.