### PR TITLE
Correct required version of pytest, actually test it, and bump version-related docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       sudo: required
       dist: xenial
     - env: TASK=check-nose
-    - env: TASK=check-pytest28
+    - env: TASK=check-pytest30
     - env: TASK=check-faker070
     - env: TASK=check-faker-latest
     - env: TASK=check-django20

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch includes some minor fixes in the documentation, and updates
+the minimum version of :pypi:`pytest` to 3.0 (released August 2016).

--- a/hypothesis-python/docs/packaging.rst
+++ b/hypothesis-python/docs/packaging.rst
@@ -37,6 +37,7 @@ Hypothesis is designed to work with a range of Python versions. Currently suppor
 * CPython 3.4.x
 * CPython 3.5.x
 * CPython 3.6.x
+* CPython 3.7.x
 
 If you feel the need to have separate Python 3 and Python 2 packages you can, but Hypothesis works unmodified
 on either.
@@ -57,8 +58,8 @@ Hypothesis has *optional* dependencies on the following libraries:
 * :pypi:`Faker`, version 0.7 or later
 * `Django <https://www.djangoproject.com>`_, all supported versions
 * :pypi:`numpy`, 1.10 or later (earlier versions will probably work fine)
-* :pypi:`pandas`, 1.8 or later
-* :pypi:`py.test <pytest>` (2.8.0 or greater). This is a mandatory dependency for testing Hypothesis itself but optional for users.
+* :pypi:`pandas`, 1.19 or later
+* :pypi:`pytest` (3.0 or greater). This is a mandatory dependency for testing Hypothesis itself but optional for users.
 
 The way this works when installing Hypothesis normally is that these features become available if the relevant
 library is installed.

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -45,6 +45,13 @@ run an entire test suite to check that the implementation matches the spec.
 The command-line version can test apps written in any language, simply by
 passing the file or URL path to the schema to check!
 
+`Trio <https://trio.readthedocs.io/>`_ is an async framework with "an obsessive
+focus on usability and correctness", so naturally it works with Hypothesis!
+:pypi:`pytest-trio` includes :ref:`a custom hook <custom-function-execution>`
+that allows ``@given(...)`` to work with Trio-style async test functions, and
+:pypi:`hypothesis-trio` includes stateful testing extensions to support
+concurrent programs.
+
 :pypi:`libarchimedes` makes it easy to use Hypothesis in
 `the Hy language <https://github.com/hylang/hy>`_, a Lisp embedded in Python.
 

--- a/hypothesis-python/docs/supported.rst
+++ b/hypothesis-python/docs/supported.rst
@@ -15,7 +15,7 @@ Hypothesis is supported and tested on CPython 2.7 and CPython 3.4+.
 
 Hypothesis also supports PyPy2, and will support PyPy3 when there is a stable
 release supporting Python 3.4+.  Hypothesis does not currently work on Jython,
-though could feasibly be made to do so. IronPython might work but hasn't been
+though it probably could (:issue:`174`). IronPython might work but hasn't been
 tested.  32-bit and narrow builds should work, though this is currently only
 tested on Windows.
 
@@ -48,7 +48,8 @@ If your testing relies on doing something other than calling a function and seei
 if it raises an exception then it probably *won't* work out of the box. In particular
 things like tests which return generators and expect you to do something with them
 (e.g. nose's yield based tests) will not work. Use a decorator or similar to wrap the
-test to take this form.
+test to take this form, or ask the framework maintainer to support our
+:ref:`hooks for inserting such a wrapper later <custom-function-execution>`.
 
 In terms of what's actually *known* to work:
 
@@ -56,7 +57,7 @@ In terms of what's actually *known* to work:
     and this is verified as part of the CI.
     Note however that :func:`@given <hypothesis.given>` should only be used on
     tests, not :class:`python:unittest.TestCase` setup or teardown methods.
-  * py.test fixtures work in the usual way for tests that have been decorated
+  * :pypi:`pytest` fixtures work in the usual way for tests that have been decorated
     with :func:`@given <hypothesis.given>` - just avoid passing a strategy for
     each argument that will be supplied by a fixture.  However, each fixture
     will run once for the whole function, not once per example.  Decorating a

--- a/hypothesis-python/docs/usage.rst
+++ b/hypothesis-python/docs/usage.rst
@@ -8,7 +8,8 @@ The only inclusion criterion right now is that if it's a Python library
 then it should be available on pypi.
 
 You can find hundreds more from `the Hypothesis page at libraries.io
-<https://libraries.io/pypi/hypothesis>`_.
+<https://libraries.io/pypi/hypothesis>`_, and over a thousand
+`on GitHub <https://github.com/HypothesisWorks/hypothesis/network/dependents>`_.
 
 * `aur <https://github.com/cdown/aur>`_
 * `argon2_cffi <https://github.com/hynek/argon2_cffi>`_

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -110,6 +110,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -58,7 +58,7 @@ extras = {
     'dateutil': ['python-dateutil'],
     'fakefactory': ['Faker>=0.7'],
     'numpy': ['numpy>=1.9.0'],
-    'pytest': ['pytest>=2.8.0'],
+    'pytest': ['pytest>=3.0'],
     # We only support Django versions with upstream support - see
     # https://www.djangoproject.com/download/#supported-versions
     'django': ['pytz', 'django>=1.11'],

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -64,7 +64,7 @@ def test_prints_statistics_given_option(testdir):
     assert 'Hypothesis Statistics' in out
     assert 'timeout=0.2' in out
     assert 'max_examples=100' in out
-    assert 'HypothesisDeprecationWarning' in out
+    assert '< 10% of examples satisfied assumptions' in out
 
 
 UNITTEST_TESTSUITE = """

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -126,12 +126,7 @@ commands=
 deps =
     -r../requirements/test.txt
 commands=
-    python -m pytest tests/pytest tests/cover/test_testdecorators.py
-
-[testenv:pytest28]
-deps =
-    -r../requirements/test.txt
-commands=
+    pip install pytest==3.0
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -405,7 +405,7 @@ def standard_tox_task(name):
 
 
 standard_tox_task('nose')
-standard_tox_task('pytest28')
+standard_tox_task('pytest30')
 standard_tox_task('faker070')
 standard_tox_task('faker-latest')
 standard_tox_task('django20')


### PR DESCRIPTION
Closes #863, which was getting positively *venerable* for such a small fix.  It turns out that we haven't been compatible with Pytest 2.8 for some time (though with no complaints apparently this hasn't been a problem), so I've bumped the version and we should actually run the test now.

Also updated various small version-related things in the docs as I spotted them.