### PR TITLE
Handle assertion error by making it not an error

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug where difficult to shrink tests could sometimes
+trigger an internal assertion error inside the shrinker.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1233,6 +1233,13 @@ class Shrinker(object):
 
     def incorporate_new_buffer(self, buffer):
         buffer = hbytes(buffer[:self.shrink_target.index])
+
+        # Sometimes an attempt at lexicographic minimization will do the wrong
+        # thing because the buffer has changed under it (e.g. something has
+        # turned into a write, the bit size has changed). The result would be
+        # an invalid string, but it's better for us to just ignore it here as
+        # it turns out to involve quite a lot of tricky book-keeping to get
+        # this right and it's better to just handle it in one place.
         if sort_key(buffer) >= sort_key(self.shrink_target.buffer):
             return False
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1233,7 +1233,8 @@ class Shrinker(object):
 
     def incorporate_new_buffer(self, buffer):
         buffer = hbytes(buffer[:self.shrink_target.index])
-        assert sort_key(buffer) < sort_key(self.shrink_target.buffer)
+        if sort_key(buffer) >= sort_key(self.shrink_target.buffer):
+            return False
 
         if self.shrink_target.buffer.startswith(buffer):
             return False

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1396,3 +1396,22 @@ def test_can_reorder_examples(monkeypatch):
             data.mark_interesting()
 
     assert list(x) == [0, 0, 0, 1, 0, 1, 1, 0, 1]
+
+
+def test_permits_but_ignores_raising_order(monkeypatch):
+    monkeypatch.setattr(
+        ConjectureRunner, 'generate_new_examples',
+        lambda runner: runner.test_function(
+            ConjectureData.for_buffer([1])))
+
+    monkeypatch.setattr(
+        Shrinker, 'shrink',
+        lambda self: self.incorporate_new_buffer(hbytes([2]))
+    )
+
+    @run_to_buffer
+    def x(data):
+        data.draw_bits(2)
+        data.mark_interesting()
+
+    assert list(x) == [1]


### PR DESCRIPTION
We're still seeing an AssertionError every now and then in shrinking - it seems to happen pretty reliably on hard to shrink tests, but I've yet to get a good reproducible test case for its current incarnation.

In the interests of a) Not spending time tracking this down and b) Making the shrinker easier to work on, I figured why not just relax the condition: Instead of erroring when given a non-shrink, why not just reject it?

So, that's what this PR does. It creates the possibility of silently ignoring slightly silly things, but I think we've demonstrated that this sort of incredibly hard to trigger condition around subtle invariants in the shrinker is a recipe for pain, so this seems like a good trade-off.