### PR TITLE
Make automatic discarding less automatic

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release removes some minor functionality from the shrinker that had only
+modest benefit and made its behaviour much harder to reason about.
+
+This is unlikely to have much user visible effect, but it is possible that in
+some cases shrinking may get slightly slower.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,8 @@
 RELEASE_TYPE: patch
 
-This release removes some minor functionality from the shrinker that had only
+This release weakens some minor functionality in the shrinker that had only
 modest benefit and made its behaviour much harder to reason about.
 
 This is unlikely to have much user visible effect, but it is possible that in
-some cases shrinking may get slightly slower.
+some cases shrinking may get slightly slower. It is primarily to make it easier
+to work on the shrinker and pave the way for future work.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1218,6 +1218,7 @@ def shrink_pass(fn):
                 calls, 's' if calls != 1 else '',
                 shrinks, 's' if shrinks != 1 else '',
             ))
+            self.remove_discarded()
     return run
 
 
@@ -1819,7 +1820,6 @@ class Shrinker(object):
 
         return False
 
-    @shrink_pass
     def remove_discarded(self):
         """Try removing all bytes marked as discarded.
 
@@ -1850,7 +1850,11 @@ class Shrinker(object):
         for u, v in reversed(discarded):
             del attempt[u:v]
 
-        self.incorporate_new_buffer(attempt)
+        previous_length = len(self.shrink_target.buffer)
+        if self.incorporate_new_buffer(attempt):
+            lost = previous_length - len(self.shrink_target.buffer)
+            self.debug('Discarded %d byte%s' % (
+                lost, '' if lost == 1 else 's'))
 
     @shrink_pass
     def adaptive_example_deletion(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1247,7 +1247,6 @@ class Shrinker(object):
         """
         self.__engine = engine
         self.__predicate = predicate
-        self.__discarding_failed = False
         self.__shrinking_prefixes = set()
 
         # We keep track of the current best example on the shrink_target
@@ -1290,8 +1289,6 @@ class Shrinker(object):
         ):
             self.update_shrink_target(data)
             self.__shrinking_block_cache = {}
-            if data.has_discards and not self.__discarding_failed:
-                self.remove_discarded()
             return True
         return False
 
@@ -1853,14 +1850,7 @@ class Shrinker(object):
         for u, v in reversed(discarded):
             del attempt[u:v]
 
-        # We track whether discarding works because as long as it does we will
-        # always want to run it whenever the option is available - whenever a
-        # shrink ends up introducing new discarded data we can attempt to
-        # delete it immediately. However if some discarded data looks essential
-        # in some way then that would be wasteful, so we turn off the automatic
-        # discarding if this ever fails. When this next runs explicitly, it
-        # will reset the flag if the status changes.
-        self.__discarding_failed = not self.incorporate_new_buffer(attempt)
+        self.incorporate_new_buffer(attempt)
 
     @shrink_pass
     def adaptive_example_deletion(self):


### PR DESCRIPTION
We have this neat trick in the shrinker where it looks out for areas of the byte stream that have been marked as discarded and automatically prunes it for you when doing other things.

This trick is so neat in fact that it resembles time travel!

A really helpful property for reasoning about the behaviour of the shrinker is that the example you are working on remains mostly stable up to the point where you're working - changes made to the byte stream can only affect things that happen after those bytes have already been read. This is true, but if you have automatic discarding it often looks like it's not! The problem is that if you make a change to an example that causes it to be discarded, the example you're working on can disappear out from under you.

This PR makes automatic discarding slightly less automatic. It now runs after each shrink pass rather than  after each successful shrink.