### PR TITLE
Use a more stable strategy for selecting rules

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch modifies how which rule to run is selected during 
+:doc:`rule based stateful testing <stateful>`. This should result in a slight
+performance increase during generation and a significant performance and
+quality improvement when shrinking.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -4,3 +4,6 @@ This patch modifies how which rule to run is selected during
 :doc:`rule based stateful testing <stateful>`. This should result in a slight
 performance increase during generation and a significant performance and
 quality improvement when shrinking.
+
+As a result of this change, some state machines which would previously have
+thrown an ``InvalidDefinition`` are no longer detected as invalid.

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -296,7 +296,12 @@ class BundleReferenceStrategy(SearchStrategy):
         bundle = machine.bundle(self.name)
         if not bundle:
             data.mark_invalid()
-        return bundle[integer_range(data, 0, len(bundle) - 1)]
+        # Shrink towards the right rather than the left. This makes it easier
+        # to delete data generated earlier, as when the error is towards the
+        # end there can be a lot of hard to remove padding.
+        return bundle[
+            integer_range(data, 0, len(bundle) - 1, center=len(bundle))
+        ]
 
 
 class Bundle(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -515,7 +515,19 @@ class RuleStrategy(SearchStrategy):
     def __init__(self, machine):
         SearchStrategy.__init__(self)
         self.machine = machine
-        self.rules = machine.rules()
+        self.rules = list(machine.rules())
+
+        # The order is a bit arbitrary. Primarily we're trying to group rules
+        # that write to the same location together, and to put rules with no
+        # target first as they have less effect on the structure. We order from
+        # fewer to more arguments on grounds that it will plausibly need less
+        # data. This probably won't work especially well and we could be
+        # smarter about it, but it's better than just doing it in definition
+        # order.
+        self.rules.sort(key=lambda rule: (
+            sorted(rule.targets), len(rule.arguments),
+            rule.function.__name__,
+        ))
 
     def do_draw(self, data):
         # This strategy is slightly strange in its implementation.

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -42,7 +42,7 @@ from hypothesis._settings import Verbosity
 from hypothesis._settings import settings as Settings
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.strategies import just, one_of, runner, tuples, \
-    sampled_from, fixed_dictionaries
+    fixed_dictionaries
 from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
 from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.reflection import proxies, nicerepr

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -562,7 +562,7 @@ class RuleStrategy(SearchStrategy):
                 j for j, r in enumerate(self.rules) if self.is_valid(r)
             ]
             if not valid_rules:
-                raise RuntimeError(
+                raise InvalidDefinition(
                     u'No progress can be made from state %r' % (self.machine,)
                 )
             i = valid_rules[cu.integer_range(data, 0, len(valid_rules) - 1)]

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -562,7 +562,7 @@ class RuleStrategy(SearchStrategy):
                 j for j, r in enumerate(self.rules) if self.is_valid(r)
             ]
             if not valid_rules:
-                raise InvalidDefinition(
+                raise RuntimeError(
                     u'No progress can be made from state %r' % (self.machine,)
                 )
             i = valid_rules[cu.integer_range(data, 0, len(valid_rules) - 1)]

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -33,7 +33,6 @@ from unittest import TestCase
 
 import attr
 
-from hypothesis.internal.compat import int_to_bytes
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.core import EXCEPTIONS_TO_FAIL, find
 from hypothesis.errors import Flaky, NoSuchExample, InvalidDefinition, \
@@ -45,6 +44,7 @@ from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.strategies import just, one_of, runner, tuples, \
     sampled_from, fixed_dictionaries
 from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
+from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.reflection import proxies, nicerepr
 from hypothesis.internal.conjecture.data import StopTest
 from hypothesis.internal.conjecture.utils import integer_range, \
@@ -508,7 +508,7 @@ def invariant():
     return accept
 
 
-LOOP_LABEL = cu.calc_label_from_name("RuleStrategy loop iteration")
+LOOP_LABEL = cu.calc_label_from_name('RuleStrategy loop iteration')
 
 
 class RuleStrategy(SearchStrategy):
@@ -529,7 +529,7 @@ class RuleStrategy(SearchStrategy):
         #
         #   1. We first draw a rule unconditionally, and check if it's valid.
         #      If it is, great. Nothing more to do, that's our rule.
-        #   2. If it is invalid, we now calculate the list of valid rules and 
+        #   2. If it is invalid, we now calculate the list of valid rules and
         #      draw from that list (if there are none, that's an error in the
         #      definition of the machine and we complain to the user about it).
         #   3. Once we've drawn a valid rule, we write that back to the byte
@@ -566,7 +566,6 @@ class RuleStrategy(SearchStrategy):
             if not bundle:
                 return False
         return True
-
 
 
 class RuleBasedStateMachine(GenericStateMachine):

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -975,20 +975,3 @@ def test_steps_not_printed_with_pytest_skip(capsys):
         run_state_machine_as_test(RaisesProblem)
     out, _ = capsys.readouterr()
     assert '' == out
-
-
-def test_raises_InvalidDefinition_when_out_of_transitions(capsys):
-    class RunsOutOfTransitions(RuleBasedStateMachine):
-
-        @precondition(lambda self: not hasattr(self, 'marker'))
-        @rule()
-        def test_works_once_then_invalid(self):
-            self.marker = True
-
-    with pytest.raises(RuntimeError):
-        run_state_machine_as_test(RunsOutOfTransitions)
-    out, _ = capsys.readouterr()
-    assert out == """state = RunsOutOfTransitions()
-state.test_works_once_then_invalid()
-state.teardown()
-"""

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -975,3 +975,20 @@ def test_steps_not_printed_with_pytest_skip(capsys):
         run_state_machine_as_test(RaisesProblem)
     out, _ = capsys.readouterr()
     assert '' == out
+
+
+def test_raises_InvalidDefinition_when_out_of_transitions(capsys):
+    class RunsOutOfTransitions(RuleBasedStateMachine):
+
+        @precondition(lambda self: not hasattr(self, 'marker'))
+        @rule()
+        def test_works_once_then_invalid(self):
+            self.marker = True
+
+    with pytest.raises(RuntimeError):
+        run_state_machine_as_test(RunsOutOfTransitions)
+    out, _ = capsys.readouterr()
+    assert out == """state = RunsOutOfTransitions()
+state.test_works_once_then_invalid()
+state.teardown()
+"""

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -338,6 +338,17 @@ def test_empty_machine_is_invalid():
         EmptyMachine.TestCase().runTest()
 
 
+def test_machine_with_no_terminals_is_invalid():
+    class NonTerminalMachine(RuleBasedStateMachine):
+
+        @rule(value=Bundle(u'hi'))
+        def bye(self, hi):
+            pass
+
+    with raises(InvalidDefinition):
+        NonTerminalMachine.TestCase().runTest()
+
+
 class DynamicMachine(RuleBasedStateMachine):
 
     @rule(value=Bundle(u'hi'))

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -215,9 +215,23 @@ class NotTheLastMachine(RuleBasedStateMachine):
         self.bye_called = True
 
 
+class PopulateMultipleTargets(RuleBasedStateMachine):
+    b1 = Bundle('b1')
+    b2 = Bundle('b2')
+
+    @rule(targets=(b1, b2))
+    def populate(self):
+        return 1
+
+    @rule(x=b1, y=b2)
+    def fail(self, x, y):
+        assert False
+
+
 bad_machines = (
     OrderedStateMachine, SetStateMachine, BalancedTrees,
     DepthMachine, RoseTreeStateMachine, NotTheLastMachine,
+    PopulateMultipleTargets,
 )
 
 for m in bad_machines:

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -338,17 +338,6 @@ def test_empty_machine_is_invalid():
         EmptyMachine.TestCase().runTest()
 
 
-def test_machine_with_no_terminals_is_invalid():
-    class NonTerminalMachine(RuleBasedStateMachine):
-
-        @rule(value=Bundle(u'hi'))
-        def bye(self, hi):
-            pass
-
-    with raises(InvalidDefinition):
-        NonTerminalMachine.TestCase().runTest()
-
-
 class DynamicMachine(RuleBasedStateMachine):
 
     @rule(value=Bundle(u'hi'))


### PR DESCRIPTION
The way that we were selecting rules in `RuleBasedStateMachine` was almost pessimal for the shrinker. The problem was that unrelated changes to the structure could completely change the interpretation of subsequent rules - if an earlier rule is useless but puts something into a bundle, you've now changed the number of rules that can be run, which means that everything that comes afterwards has its interpretation changed if you try to remove that!

Solution: Don't do that then. This changes the way we handle bundles and preconditions to just filter for validity. As a bonus that means we can construct the strategy up front and it should be faster during generation as well.