### PR TITLE
New version of the adaptive deletion pass

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release changes how Hypothesis deletes data when shrinking in order to
+better handle deletion of large numbers of contiguous sequences. Most tests
+should see little change, but this will hopefully provide a significant
+speed up for :doc:`stateful testing <stateful>`.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -50,6 +50,10 @@ class Example(object):
     index = attr.ib()
     start = attr.ib()
     end = attr.ib(default=None)
+
+    # An example is trivial if it contains any non-forced non-zero bytes. All
+    # examples start out as trivial and then get marked non-trivial when we
+    # see such a byte.
     trivial = attr.ib(default=True)
     discarded = attr.ib(default=None)
     children = attr.ib(default=attr.Factory(list))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1484,7 +1484,7 @@ class Shrinker(object):
         return self.__intervals
 
     def zero_example(self, i):
-        """Attempt to replace each a draw call with its minimal possible value.
+        """Attempt to replace a draw call with its minimal possible value.
 
         This is intended as a fast-track to minimize whole sub-examples that
         don't matter as rapidly as possible. For example, suppose we had

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1882,10 +1882,12 @@ class Shrinker(object):
 
         First attempts to replace the example with its minimal possible version
         using zero_example. If the example is trivial (either because of that
-        or because it was anyway). Otherwise, attempts to minimize it by
-        deleting its children.
+        or because it was anyway) then we assume there's nothing we can
+        usefully do here and return early. Otherwise, we attempt to minimize it
+        by deleting its children.
 
-        If that fails, then recurses into the children.
+        If we do not make any successful changes, we recurse to the example's
+        children and attempt the same there.
         """
         self.zero_example(example_index)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1269,6 +1269,8 @@ class Shrinker(object):
         self.update_shrink_target(initial)
         self.shrinks = 0
 
+        self.current_pass_depth = 0
+
         self.run_expensive_shrinks = False
 
     @property
@@ -1342,8 +1344,10 @@ class Shrinker(object):
         initial_shrinks = self.shrinks
         initial_calls = self.calls
         try:
+            self.current_pass_depth += 1
             yield
         finally:
+            self.current_pass_depth -= 1
             calls = self.calls - initial_calls
             shrinks = self.shrinks - initial_shrinks
             self.debug((
@@ -1353,7 +1357,7 @@ class Shrinker(object):
                 calls, 's' if calls != 1 else '',
                 shrinks, 's' if shrinks != 1 else '',
             ))
-        if not self.discarding_failed:
+        if not self.discarding_failed and self.current_pass_depth == 0:
             self.remove_discarded()
 
     def shrink(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/__init__.py
@@ -15,9 +15,10 @@
 #
 # END HEADER
 
+from hypothesis.internal.conjecture.shrinking.length import Length
 from hypothesis.internal.conjecture.shrinking.integer import Integer
 from hypothesis.internal.conjecture.shrinking.lexical import Lexical
 
 __all__ = [
-    'Lexical', 'Integer',
+    'Lexical', 'Length', 'Integer',
 ]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -22,6 +22,44 @@ from __future__ import division, print_function, absolute_import
 """
 
 
+def find_integer(f):
+    """Finds a (hopefully large) integer such that f(n) is True and f(n + 1) is
+    False.
+
+    f(0) is assumed to be True and will not be checked.
+    """
+    # We first do a linear scan over the small numbers and only start to do
+    # anything intelligent if f(4) is true. This is because it's very hard to
+    # win big when the result is small. If the result is 0 and we try 2 first
+    # then we've done twice as much work as we needed to!
+    for i in range(1, 5):
+        if not f(i):
+            return i - 1
+
+    # We now know that f(4) is true. We want to find some number for which
+    # f(n) is *not* true.
+    # lo is the largest number for which we know that f(lo) is true.
+    lo = 4
+
+    # Exponential probe upwards until we find some value hi such that f(hi)
+    # is not true. Subsequently we maintain the invariant that hi is the
+    # smallest number for which we know that f(hi) is not true.
+    hi = 5
+    while f(hi):
+        lo = hi
+        hi *= 2
+
+    # Now binary search until lo + 1 = hi. At that point we have f(lo) and not
+    # f(lo + 1), as desired..
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        if f(mid):
+            lo = mid
+        else:
+            hi = mid
+    return lo
+
+
 class Shrinker(object):
     """A Shrinker object manages a single value and a predicate it should
     satisfy, and attempts to improve it in some direction, making it smaller

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -139,8 +139,11 @@ class Shrinker(object):
 
     def check_invariants(self, value):
         """Make appropriate assertions about the value to ensure that it is
-        valid for this shrinker."""
-        raise NotImplementedError()
+        valid for this shrinker.
+
+        Does nothing by default.
+        """
+        pass
 
     def short_circuit(self):
         """Possibly attempt to do some shrinking.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis.internal.conjecture.shrinking.common import Shrinker, \
+    find_integer
+
+
+"""
+This module implements a length minimizer for sequences.
+
+That is, given some sequence of elements satisfying some predicate, it tries to
+find a strictly shorter one satisfying the same predicate.
+
+Doing so perfectly is provably exponential. This only implements a linear time
+worst case algorithm which guarantees certain minimality properties of the
+fixed point.
+"""
+
+
+class Length(Shrinker):
+    """Attempts to find a smaller sequence satisfying f. Will only perform
+    linearly many evaluations, and does not loop to a fixed point.
+
+    Guarantees made at a fixed point:
+
+        1. No individual element may be deleted.
+        2. No *adjacent* pair of elements may be deleted.
+    """
+
+    def make_immutable(self, value):
+        return tuple(value)
+
+    def short_circuit(self):
+        return self.consider(()) or len(self.current) <= 1
+
+    def left_is_better(self, left, right):
+        return len(left) < len(right)
+
+    def run_step(self):
+        j = 0
+        while j < len(self.current):
+            i = len(self.current) - 1 - j
+            start = self.current
+            find_integer(
+                lambda k: k <= i and self.consider(
+                    start[:i + 1 - k] + start[i + 1:]
+                )
+            )
+            j += 1

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1033,7 +1033,9 @@ def test_can_zero_subintervals(monkeypatch):
             hbytes([3, 0, 0, 0, 1]) * 10
         ))
 
-    monkeypatch.setattr(Shrinker, 'shrink', fixate(Shrinker.zero_draws))
+    monkeypatch.setattr(
+        Shrinker, 'shrink', fixate(Shrinker.adaptive_example_deletion)
+    )
 
     @run_to_buffer
     def x(data):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -24,6 +24,7 @@ from random import seed as seed_random
 
 import pytest
 
+from mock import MagicMock
 from hypothesis import Phase, Verbosity, HealthCheck, settings, unlimited
 from hypothesis.errors import FailedHealthCheck
 from tests.common.utils import no_shrink, all_values, \
@@ -1447,3 +1448,39 @@ def test_try_shrinking_blocks_ignores_overrun_blocks(monkeypatch):
             data.mark_interesting()
 
     assert list(x) == [2, 2, 1]
+
+
+def test_only_calls_discard_at_top_level_pass():
+    def tree(data):
+        data.start_example('tree')
+        result = 1
+        if data.draw_bits(1):
+            result += max(tree(data), tree(data))
+        data.stop_example()
+        return result
+
+    def f(data):
+        if tree(data) == 3:
+            data.mark_interesting()
+
+    runner = ConjectureRunner(f, settings=settings(
+        max_examples=1, buffer_size=1024,
+        database=None, suppress_health_check=HealthCheck.all(),
+    ))
+
+    runner.test_function(ConjectureData.for_buffer([
+        1, 0, 1, 0, 0,
+    ]))
+
+    assert runner.interesting_examples
+    last_data, = runner.interesting_examples.values()
+
+    shrinker = runner.new_shrinker(
+        last_data, lambda d: d.status == Status.INTERESTING
+    )
+
+    shrinker.remove_discarded = MagicMock(return_value=None)
+
+    shrinker.adaptive_example_deletion()
+
+    assert shrinker.remove_discarded.call_count == 1


### PR DESCRIPTION
This updates our "adaptive delete" pass to be better at adapting to large tests, especially stateful testing.

It mostly does this by bringing it closer to [the adaptive algorithm as I originally proposed it](https://www.drmaciver.com/2017/06/adaptive-delta-debugging/). The version we were using is a bit weird and strange. This basically does hierarchical debugging, applying the algorithm to the children of each draw call.

One slightly interesting point which is something I only discovered in the course of the current work is that this now goes from the right rather than the left.

* The reason for this is basically that a) Deleting on the right is more likely to work because less depends on stuff on the right
* If we can delete either A or B but B is to the right of A, we want to delete B, because if we delete A we now are stuck with B and potentially have a large amount of dead space sitting in front of it that we may struggle to delete.