### PR TITLE
Group example around whole loop iteration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ jobs:
     - env: TASK=documentation
     - env: TASK=lint
     - env: TASK=lint-ruby
-    - env: TASK=doctest
     - env: TASK=check-format
     - env: TASK=check-requirements
     - env: TASK=check-rust-tests

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release changes how we group data together for shrinking. It should result
+in improved shrinker performance, especially in stateful testing.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -387,6 +387,8 @@ class many(object):
         self.drawn = True
         self.rejected = False
 
+        self.data.start_example(ONE_FROM_MANY_LABEL)
+
         if self.min_size == self.max_size:
             should_continue = self.count < self.min_size
         elif self.force_stop:
@@ -401,10 +403,10 @@ class many(object):
             should_continue = biased_coin(self.data, p_continue)
 
         if should_continue:
-            self.data.start_example(ONE_FROM_MANY_LABEL)
             self.count += 1
             return True
         else:
+            self.data.stop_example()
             return False
 
     def reject(self):


### PR DESCRIPTION
This changes how we group together values using the `many` helper from conjecture utils. The main effect of this is that now every step in stateful testing will show up as one example rather than two, which means that they are much easier to delete.