### PR TITLE
Push the tag immediately rather than after upload

### DIFF
--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -101,12 +101,10 @@ def do_release(package):
     print('Creating tag %s' % (tag_name,))
 
     tools.create_tag(tag_name)
+    tools.push_tag(tag_name)
 
     print('Uploading distribution')
     package.upload_distribution()
-
-    print('Pushing tag')
-    tools.push_tag(tag_name)
 
 
 @task()


### PR DESCRIPTION
We just found ourselves in a state where we'd uploaded to pypi but lost the tag because it happened after the upload and had to recreate the release. This was non-ideal.

This changes it so we always try to push the tag first, leading to the less bad failure mode of having a tag with no release if something goes wrong.

Something else fishy is going on here which merits investigation, but I'm not sure exactly what and this fix at least seems a uniform improvement regardless.