### PR TITLE
Handle block losses in try_shrinking_blocks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug that could cause an ``IndexError`` to be raised from
+inside Hypothesis during shrinking. It is likely that it was impossible to
+trigger this bug in practice - it was only made visible by some currently
+unreleased work.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1785,10 +1785,11 @@ class Shrinker(object):
         block to be lowered.
         """
         initial_attempt = bytearray(self.shrink_target.buffer)
-        for i in blocks:
-            if i >= len(self.blocks):
+        for i, block in enumerate(blocks):
+            if block >= len(self.blocks):
+                blocks = blocks[:i]
                 break
-            u, v = self.blocks[i]
+            u, v = self.blocks[block]
             n = min(v - u, len(b))
             initial_attempt[v - n:v] = b[-n:]
 

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1437,3 +1437,29 @@ def test_block_deletion_can_delete_short_ranges(monkeypatch):
                 data.mark_interesting()
 
     assert list(x) == [0, 4] * 5
+
+
+def test_try_shrinking_blocks_ignores_overrun_blocks(monkeypatch):
+    monkeypatch.setattr(
+        ConjectureRunner, 'generate_new_examples',
+        lambda runner: runner.test_function(
+            ConjectureData.for_buffer([3, 3, 0, 1])))
+
+    monkeypatch.setattr(
+        Shrinker, 'shrink',
+        lambda self: self.try_shrinking_blocks(
+            (0, 1, 5), hbytes([2])
+        ),
+    )
+
+    @run_to_buffer
+    def x(data):
+        n1 = data.draw_bits(8)
+        data.draw_bits(8)
+        if n1 == 3:
+            data.draw_bits(8)
+        k = data.draw_bits(8)
+        if k == 1:
+            data.mark_interesting()
+
+    assert list(x) == [2, 2, 1]


### PR DESCRIPTION
In the course of working on #1423 I managed to trigger a weird error inside the shrinker during about 1 in 20 runs of the quality tests.

```python-traceback
Traceback (most recent call last):
  File "/home/david/hypothesis/hypothesis-python/tests/quality/test_shrink_quality.py", line 156, in test_dictionary
    lambda t: len(t) >= 3)
  File "/home/david/hypothesis/hypothesis-python/tests/common/debug.py", line 66, in minimal
    random=random,
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/core.py", line 1194, in find
    runner.run()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 444, in run
    self._run()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 790, in _run
    self.shrink_interesting_examples()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 832, in shrink_interesting_examples
    self.shrink(example, predicate)
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 868, in shrink
    s.shrink()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1316, in shrink
    self.greedy_shrink()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1339, in greedy_shrink
    self.minimize_duplicated_blocks()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1953, in minimize_duplicated_blocks
    def minimize_duplicated_blocks(self):
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1209, in run
    return fn(self, *args, **kwargs)
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 2001, in minimize_duplicated_blocks
    random=self.random, full=False
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 307, in minimize
    m.run()                                                                                                                                                          File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 240, in run
    self.minimize_as_integer()
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 211, in minimize_as_integer
    lambda c: c == self.current_int or self.incorporate_int(c)
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 348, in minimize_int
    if f(c - 1):
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 211, in <lambda>
    lambda c: c == self.current_int or self.incorporate_int(c)
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 132, in incorporate_int
    return self.incorporate(int_to_bytes(i, self.size))
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/minimizer.py", line 71, in incorporate
    if buffer != self.current and self.condition(buffer):
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 2000, in <lambda>
    lambda b: self.try_shrinking_blocks(targets, b),
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1808, in try_shrinking_blocks
    self.mark_shrinking(blocks)
  File "/home/david/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1659, in mark_shrinking
    prefix = t.buffer[:t.blocks[i][0]]
IndexError: list index out of range
```

It turns out that we've had a latent bug in the duplicate example minimization for a very long time, but have for some reason never been able to trigger it. I *still* can't reliably trigger it from a more high level test, so the test I've added for this is very low level and unit testy, but I think that's OK.