### PR TITLE
Timeout is also deprecated in find

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release expands the deprecation of timeout from `3.16.0 <_v3.16.0>` to
+also emit the deprecation warning in ``find`` or `stateful testing <stateful>`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-This release expands the deprecation of timeout from `3.16.0 <_v3.16.0>` to
-also emit the deprecation warning in ``find`` or `stateful testing <stateful>`.
+This release expands the deprecation of timeout from :ref:`3.16.0 <v3.16.0>` to
+also emit the deprecation warning in ``find`` or :doc:`stateful testing <stateful>`.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -30,7 +30,7 @@ information to the contrary.
 This release adds an additional shrink pass that is able to reduce the size of
 examples in some cases where the transformation is non-obvious. In particular
 this will improve the quality of some examples which would have regressed in
-`3.66.12 <3.66.12>`.
+:ref:`3.66.12 <3.66.12>`.
 
 .. _v3.66.12:
 

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -30,7 +30,7 @@ information to the contrary.
 This release adds an additional shrink pass that is able to reduce the size of
 examples in some cases where the transformation is non-obvious. In particular
 this will improve the quality of some examples which would have regressed in
-:ref:`3.66.12 <3.66.12>`.
+:ref:`3.66.12 <v3.66.12>`.
 
 .. _v3.66.12:
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -783,19 +783,6 @@ class StateForActualGivenExecution(object):
                 key=lambda d: sort_key(d.buffer), reverse=True
             )
         else:
-            if timed_out:
-                note_deprecation((
-                    'Your tests are hitting the settings timeout (%.2fs). '
-                    'This functionality will go away in a future release '
-                    'and you should not rely on it. Instead, try setting '
-                    'max_examples to be some value lower than %d (the number '
-                    'of examples your test successfully ran here). Or, if you '
-                    'would prefer your tests to run to completion, regardless '
-                    'of how long they take, you can set the timeout value to '
-                    'hypothesis.unlimited.'
-                ) % (
-                    self.settings.timeout, runner.valid_examples),
-                    self.settings)
             if runner.valid_examples == 0:
                 if timed_out:
                     raise Timeout((

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -27,7 +27,7 @@ import attr
 
 from hypothesis import Phase, Verbosity, HealthCheck
 from hypothesis import settings as Settings
-from hypothesis._settings import local_settings
+from hypothesis._settings import local_settings, note_deprecation
 from hypothesis.reporting import debug_report
 from hypothesis.internal.compat import Counter, ceil, hbytes, hrange, \
     int_to_text, int_to_bytes, benchmark_time, int_from_bytes, \
@@ -257,6 +257,18 @@ class ConjectureRunner(object):
             self.settings.timeout > 0 and
             benchmark_time() >= self.start_time + self.settings.timeout
         ):
+            note_deprecation((
+                'Your tests are hitting the settings timeout (%.2fs). '
+                'This functionality will go away in a future release '
+                'and you should not rely on it. Instead, try setting '
+                'max_examples to be some value lower than %d (the number '
+                'of examples your test successfully ran here). Or, if you '
+                'would prefer your tests to run to completion, regardless '
+                'of how long they take, you can set the timeout value to '
+                'hypothesis.unlimited.'
+            ) % (
+                self.settings.timeout, self.valid_examples),
+                self.settings)
             self.exit_with(ExitReason.timeout)
 
         if not self.interesting_examples:

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -72,6 +72,10 @@ def fails_with(e):
 fails = fails_with(AssertionError)
 
 
+class NotDeprecated(Exception):
+    pass
+
+
 @contextlib.contextmanager
 def validate_deprecation():
     import warnings
@@ -80,12 +84,14 @@ def validate_deprecation():
         warnings.simplefilter('always', HypothesisDeprecationWarning)
         with warnings.catch_warnings(record=True) as w:
             yield
-            assert any(
-                e.category == HypothesisDeprecationWarning for e in w
-            ), 'Expected to get a deprecation warning but got %r' % (
-                [e.category for e in w],)
     finally:
         warnings.simplefilter('error', HypothesisDeprecationWarning)
+        if not any(
+            e.category == HypothesisDeprecationWarning for e in w
+        ):
+            raise NotDeprecated(
+                'Expected to get a deprecation warning but got %r' % (
+                    [e.category for e in w],))
 
 
 def checks_deprecated_behaviour(func):


### PR DESCRIPTION
It turns out that aw hole bunch of mysterious shrink failures I've been seeing are because we never deprecated timeout in find, and the tests were triggering the timeout if they executed more than 1000 function calls. Argh.

This expands the deprecation by moving it into the engine.

~This is WIP because I expect a tonne of tests to fail as a result of it~. I forgot the obvious solution: Just turn timeouts off in `minimal`!