### PR TITLE
Add new block oriented deletion pass

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release adds an additional shrink pass that is able to reduce the size of
+examples in some cases where the transformation is non-obvious. In particular
+this will improve the quality of some examples which would have regressed in
+`3.66.12 <3.66.12>`.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1991,11 +1991,11 @@ class Shrinker(object):
         while i < len(self.shrink_target.blocks):
             j = min(i + 4, len(self.shrink_target.blocks) - 2)
             while j >= i:
-                u, v = self.shrink_target.blocks[i]
-                r, s = self.shrink_target.blocks[j]
+                u, _ = self.shrink_target.blocks[i]
+                _, v = self.shrink_target.blocks[j]
                 if self.incorporate_new_buffer(
-                    self.shrink_target.buffer[:i] +
-                    self.shrink_target.buffer[j:]
+                    self.shrink_target.buffer[:u] +
+                    self.shrink_target.buffer[v:]
                 ):
                     break
                 j -= 1

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -430,7 +430,7 @@ class ConjectureRunner(object):
 
         self.debug(u'%d bytes %s -> %s, %s' % (
             data.index,
-            repr(data.buffer),
+            u''.join(buffer_parts),
             status,
             data.output,
         ))

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -21,6 +21,7 @@ import sys
 
 from hypothesis import find, given, assume, reject
 from hypothesis import settings as Settings
+from hypothesis import unlimited
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from tests.common.utils import no_shrink
 
@@ -38,7 +39,7 @@ def minimal(
     settings = Settings(
         settings,
         max_examples=50000,
-        database=None,
+        database=None, timeout=unlimited,
     )
 
     runtime = []

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -37,9 +37,7 @@ def minimal(
         settings=None, timeout_after=10, random=None
 ):
     settings = Settings(
-        settings,
-        max_examples=50000,
-        database=None, timeout=unlimited,
+        settings, max_examples=50000, database=None, timeout=unlimited,
     )
 
     runtime = []

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -21,7 +21,7 @@ import os
 from tempfile import mkdtemp
 from warnings import filterwarnings
 
-from hypothesis import settings, unlimited
+from hypothesis import Verbosity, settings, unlimited
 from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
@@ -79,5 +79,7 @@ def run():
         'speedy', settings(
             max_examples=5,
         ))
+
+    settings.register_profile('debug', settings(verbosity=Verbosity.debug))
 
     settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'default'))


### PR DESCRIPTION
This adds a new deletion pass that should reliably shrink that flaky test we've been seeing, which I'm pretty sure is the result of 3.66.12 - the two blocks that were being deleted were no longer showing up as adjacent to the shrinker.

It also makes some minor improvements to the test suite.