### PR TITLE
Move over use of find in tests to standard debug helpers

### DIFF
--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -47,10 +47,11 @@ def minimal(
             return True
 
     def wrapped_condition(x):
-        if runtime:
-            runtime[0] += TIME_INCREMENT
-            if runtime[0] >= timeout_after:
-                raise Timeout()
+        if timeout_after is not None:
+            if runtime:
+                runtime[0] += TIME_INCREMENT
+                if runtime[0] >= timeout_after:
+                    raise Timeout()
         result = condition(x)
         if result and not runtime:
             runtime.append(0.0)

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -74,9 +74,7 @@ def find_any(
 ):
     settings = Settings(
         settings,
-        max_examples=10000,
-        phases=no_shrink,
-        database=None,
+        max_examples=10000, phases=no_shrink, database=None, timeout=unlimited
     )
 
     if condition is None:

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -21,7 +21,7 @@ import pytest
 from flaky import flaky
 
 import hypothesis.strategies as st
-from hypothesis import find, given, assume
+from hypothesis import given, assume
 from hypothesis.errors import InvalidArgument
 from tests.common.debug import minimal
 from hypothesis.internal.compat import hrange
@@ -36,12 +36,12 @@ def badly_draw_lists(draw, m=0):
 
 
 def test_simplify_draws():
-    assert find(badly_draw_lists(), lambda x: len(x) >= 3) == [0] * 3
+    assert minimal(badly_draw_lists(), lambda x: len(x) >= 3) == [0] * 3
 
 
 def test_can_pass_through_arguments():
-    assert find(badly_draw_lists(5), lambda x: True) == [0] * 5
-    assert find(badly_draw_lists(m=6), lambda x: True) == [0] * 6
+    assert minimal(badly_draw_lists(5), lambda x: True) == [0] * 5
+    assert minimal(badly_draw_lists(m=6), lambda x: True) == [0] * 6
 
 
 @st.composite
@@ -88,7 +88,7 @@ def test_can_use_pure_args():
     @st.composite
     def stuff(*args):
         return args[0](st.sampled_from(args[1:]))
-    assert find(stuff(1, 2, 3, 4, 5), lambda x: True) == 1
+    assert minimal(stuff(1, 2, 3, 4, 5), lambda x: True) == 1
 
 
 def test_composite_of_lists():
@@ -96,7 +96,7 @@ def test_composite_of_lists():
     def f(draw):
         return draw(st.integers()) + draw(st.integers())
 
-    assert find(st.lists(f()), lambda x: len(x) >= 10) == [0] * 10
+    assert minimal(st.lists(f()), lambda x: len(x) >= 10) == [0] * 10
 
 
 @flaky(min_passes=3, max_runs=5)

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -26,8 +26,9 @@ from datetime import date, time, datetime, timedelta
 import pytest
 
 import hypothesis.strategies as ds
-from hypothesis import find, given, settings
+from hypothesis import given, settings
 from hypothesis.errors import InvalidArgument
+from tests.common.debug import minimal
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.internal.reflection import nicerepr
 
@@ -325,40 +326,40 @@ def test_decimal_is_in_bounds(x):
 
 
 def test_float_can_find_max_value_inf():
-    assert find(
+    assert minimal(
         ds.floats(max_value=float('inf')), lambda x: math.isinf(x)
     ) == float('inf')
-    assert find(
+    assert minimal(
         ds.floats(min_value=0.0), lambda x: math.isinf(x)) == float('inf')
 
 
 def test_float_can_find_min_value_inf():
-    find(ds.floats(), lambda x: x < 0 and math.isinf(x))
-    find(
+    minimal(ds.floats(), lambda x: x < 0 and math.isinf(x))
+    minimal(
         ds.floats(min_value=float('-inf'), max_value=0.0),
         lambda x: math.isinf(x))
 
 
 def test_can_find_none_list():
-    assert find(ds.lists(ds.none()), lambda x: len(x) >= 3) == [None] * 3
+    assert minimal(ds.lists(ds.none()), lambda x: len(x) >= 3) == [None] * 3
 
 
 def test_fractions():
-    assert find(ds.fractions(), lambda f: f >= 1) == 1
+    assert minimal(ds.fractions(), lambda f: f >= 1) == 1
 
 
 def test_decimals():
-    assert find(ds.decimals(), lambda f: f.is_finite() and f >= 1) == 1
+    assert minimal(ds.decimals(), lambda f: f.is_finite() and f >= 1) == 1
 
 
 def test_non_float_decimal():
-    find(
+    minimal(
         ds.decimals(),
         lambda d: d.is_finite() and decimal.Decimal(float(d)) != d)
 
 
 def test_produces_dictionaries_of_at_least_minimum_size():
-    t = find(
+    t = minimal(
         ds.dictionaries(ds.booleans(), ds.integers(), min_size=2),
         lambda x: True)
     assert t == {False: 0, True: 0}
@@ -399,7 +400,7 @@ def test_iterables_are_exhaustible(it):
 
 
 def test_minimal_iterable():
-    assert list(find(ds.iterables(ds.integers()), lambda x: True)) == []
+    assert list(minimal(ds.iterables(ds.integers()), lambda x: True)) == []
 
 
 @checks_deprecated_behaviour

--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -24,26 +24,27 @@ import pytest
 from hypothesis import find
 from hypothesis import settings as Settings
 from hypothesis.errors import NoSuchExample
+from tests.common.debug import minimal
 from hypothesis.strategies import lists, floats, booleans, integers, \
     dictionaries
 
 
 def test_can_find_an_int():
-    assert find(integers(), lambda x: True) == 0
-    assert find(integers(), lambda x: x >= 13) == 13
+    assert minimal(integers(), lambda x: True) == 0
+    assert minimal(integers(), lambda x: x >= 13) == 13
 
 
 def test_can_find_list():
-    x = find(lists(integers()), lambda x: sum(x) >= 10)
+    x = minimal(lists(integers()), lambda x: sum(x) >= 10)
     assert sum(x) == 10
 
 
 def test_can_find_nan():
-    find(floats(), math.isnan)
+    minimal(floats(), math.isnan)
 
 
 def test_can_find_nans():
-    x = find(lists(floats()), lambda x: math.isnan(sum(x)))
+    x = minimal(lists(floats()), lambda x: math.isnan(sum(x)))
     if len(x) == 1:
         assert math.isnan(x[0])
     else:
@@ -69,6 +70,6 @@ def test_condition_is_name():
 
 
 def test_find_dictionary():
-    assert len(find(
+    assert len(minimal(
         dictionaries(keys=integers(), values=integers()),
         lambda xs: any(kv[0] > kv[1] for kv in xs.items()))) == 1

--- a/hypothesis-python/tests/cover/test_flatmap.py
+++ b/hypothesis-python/tests/cover/test_flatmap.py
@@ -19,7 +19,8 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
-from hypothesis import find, given, assume, settings
+from hypothesis import given, assume, settings
+from tests.common.debug import minimal
 from hypothesis.database import ExampleDatabase
 from hypothesis.strategies import just, text, lists, builds, floats, \
     tuples, booleans, integers
@@ -94,7 +95,7 @@ def test_mixed_list_flatmap():
         c = Counter(type(l) for l in ls)
         return len(c) >= 2 and min(c.values()) >= 3
 
-    result = find(s, criterion)
+    result = minimal(s, criterion)
     assert len(result) == 6
     assert set(result) == set([False, u''])
 
@@ -104,7 +105,7 @@ def test_can_shrink_through_a_binding(n):
     bool_lists = integers(0, 100).flatmap(
         lambda k: lists(booleans(), min_size=k, max_size=k))
 
-    assert find(
+    assert minimal(
         bool_lists, lambda x: len(list(filter(bool, x))) >= n
     ) == [True] * n
 
@@ -114,6 +115,6 @@ def test_can_delete_in_middle_of_a_binding(n):
     bool_lists = integers(1, 100).flatmap(
         lambda k: lists(booleans(), min_size=k, max_size=k))
 
-    assert find(
+    assert minimal(
         bool_lists, lambda x: x[0] and x[-1] and x.count(False) >= n
     ) == [True] + [False] * n + [True]

--- a/hypothesis-python/tests/cover/test_float_nastiness.py
+++ b/hypothesis-python/tests/cover/test_float_nastiness.py
@@ -25,7 +25,7 @@ import pytest
 from flaky import flaky
 
 import hypothesis.strategies as st
-from hypothesis import find, given, assume, settings
+from hypothesis import given, assume, settings
 from hypothesis.errors import InvalidArgument
 from tests.common.debug import minimal, find_any
 from hypothesis.internal.compat import WINDOWS
@@ -84,8 +84,8 @@ def test_does_not_generate_positive_if_right_boundary_is_negative(x):
 @flaky(max_runs=4, min_passes=1)
 def test_can_generate_interval_endpoints(l, r):
     interval = st.floats(l, r)
-    find(interval, lambda x: x == l, settings=settings(max_examples=10000))
-    find(interval, lambda x: x == r, settings=settings(max_examples=10000))
+    minimal(interval, lambda x: x == l, settings=settings(max_examples=10000))
+    minimal(interval, lambda x: x == r, settings=settings(max_examples=10000))
 
 
 @flaky(max_runs=4, min_passes=1)
@@ -140,7 +140,7 @@ def test_can_guard_against_draws_of_nan():
         st.tuples(st.just(1), st.floats(allow_nan=True)),
     )
 
-    tag, f = find(tagged_floats, lambda x: math.isnan(x[1]))
+    tag, f = minimal(tagged_floats, lambda x: math.isnan(x[1]))
     assert tag == 1
 
 

--- a/hypothesis-python/tests/cover/test_integer_ranges.py
+++ b/hypothesis-python/tests/cover/test_integer_ranges.py
@@ -18,7 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
-from hypothesis import find, given, settings, unlimited
+from hypothesis import given, settings, unlimited
+from tests.common.debug import minimal
 from tests.common.utils import no_shrink
 from hypothesis._settings import Phase
 from hypothesis.internal.conjecture.utils import integer_range
@@ -53,8 +54,8 @@ def test_intervals_shrink_to_center(inter, rnd):
     lower, center, upper = inter
     s = interval(lower, upper, center)
     shrink = settings(phases=tuple(Phase))
-    assert find(s, lambda x: True, shrink) == center
+    assert minimal(s, lambda x: True, shrink) == center
     if lower < center:
-        assert find(s, lambda x: x < center, shrink) == center - 1
+        assert minimal(s, lambda x: x < center, shrink) == center - 1
     if center < upper:
-        assert find(s, lambda x: x > center, shrink) == center + 1
+        assert minimal(s, lambda x: x > center, shrink) == center + 1

--- a/hypothesis-python/tests/cover/test_nothing.py
+++ b/hypothesis-python/tests/cover/test_nothing.py
@@ -19,14 +19,14 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
-from hypothesis import find, given
+from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument
-from tests.common.debug import assert_no_examples
+from tests.common.debug import minimal, assert_no_examples
 
 
 def test_resampling():
-    x = find(
+    x = minimal(
         st.lists(st.integers()).flatmap(
             lambda x: st.lists(st.sampled_from(x))),
         lambda x: len(x) >= 10 and len(set(x)) == 1)

--- a/hypothesis-python/tests/cover/test_permutations.py
+++ b/hypothesis-python/tests/cover/test_permutations.py
@@ -17,13 +17,14 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis import find, given
+from hypothesis import given
+from tests.common.debug import minimal
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import data, sets, integers, permutations
 
 
 def test_can_find_non_trivial_permutation():
-    x = find(
+    x = minimal(
         permutations(list(range(5))), lambda x: x[0] != 0
     )
 

--- a/hypothesis-python/tests/cover/test_recursive.py
+++ b/hypothesis-python/tests/cover/test_recursive.py
@@ -20,8 +20,9 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import find, given
+from hypothesis import given
 from hypothesis.errors import InvalidArgument
+from tests.common.debug import minimal
 
 
 @given(st.recursive(st.booleans(), st.lists, max_leaves=10))
@@ -35,7 +36,7 @@ def test_respects_leaf_limit(xs):
 
 
 def test_can_find_nested():
-    x = find(
+    x = minimal(
         st.recursive(st.booleans(), lambda x: st.tuples(x, x)),
         lambda x: isinstance(x, tuple) and isinstance(x[0], tuple)
     )

--- a/hypothesis-python/tests/cover/test_sets.py
+++ b/hypothesis-python/tests/cover/test_sets.py
@@ -17,7 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis import find, given, settings
+from hypothesis import given, settings
+from tests.common.debug import find_any
 from hypothesis.strategies import sets, floats, randoms, integers
 
 
@@ -25,7 +26,7 @@ from hypothesis.strategies import sets, floats, randoms, integers
 @settings(max_examples=5, deadline=None)
 def test_can_draw_sets_of_hard_to_find_elements(rnd):
     rarebool = floats(0, 1).map(lambda x: x <= 0.05)
-    find(
+    find_any(
         sets(rarebool, min_size=2), lambda x: True,
         random=rnd, settings=settings(database=None))
 

--- a/hypothesis-python/tests/cover/test_sharing.py
+++ b/hypothesis-python/tests/cover/test_sharing.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
 from hypothesis import given
-from tests.common.debug import find_any, minimal
+from tests.common.debug import minimal, find_any
 
 x = st.shared(st.integers())
 
@@ -69,7 +69,7 @@ def test_can_simplify_shared_lists():
 
 
 def test_simplify_shared_linked_to_size():
-    xs = find_any(
+    xs = minimal(
         st.lists(st.shared(st.integers())),
         lambda t: sum(t) >= 1000
     )

--- a/hypothesis-python/tests/cover/test_sharing.py
+++ b/hypothesis-python/tests/cover/test_sharing.py
@@ -18,7 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
-from hypothesis import find, given
+from hypothesis import given
+from tests.common.debug import find_any
 
 x = st.shared(st.integers())
 
@@ -35,14 +36,14 @@ def test_different_instances_with_the_same_key_are_shared(a, b):
 
 
 def test_different_instances_are_not_shared():
-    find(
+    find_any(
         st.tuples(st.shared(st.integers()), st.shared(st.integers())),
         lambda x: x[0] != x[1]
     )
 
 
 def test_different_keys_are_not_shared():
-    find(
+    find_any(
         st.tuples(
             st.shared(st.integers(), key=1),
             st.shared(st.integers(), key=2)),
@@ -51,7 +52,7 @@ def test_different_keys_are_not_shared():
 
 
 def test_keys_and_default_are_not_shared():
-    find(
+    find_any(
         st.tuples(
             st.shared(st.integers(), key=1),
             st.shared(st.integers())),
@@ -60,7 +61,7 @@ def test_keys_and_default_are_not_shared():
 
 
 def test_can_simplify_shared_lists():
-    xs = find(
+    xs = find_any(
         st.lists(st.shared(st.integers())),
         lambda x: len(x) >= 10 and x[0] != 0
     )
@@ -68,7 +69,7 @@ def test_can_simplify_shared_lists():
 
 
 def test_simplify_shared_linked_to_size():
-    xs = find(
+    xs = find_any(
         st.lists(st.shared(st.integers())),
         lambda t: sum(t) >= 1000
     )

--- a/hypothesis-python/tests/cover/test_sharing.py
+++ b/hypothesis-python/tests/cover/test_sharing.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
 from hypothesis import given
-from tests.common.debug import find_any
+from tests.common.debug import find_any, minimize
 
 x = st.shared(st.integers())
 
@@ -61,7 +61,7 @@ def test_keys_and_default_are_not_shared():
 
 
 def test_can_simplify_shared_lists():
-    xs = find_any(
+    xs = minimize(
         st.lists(st.shared(st.integers())),
         lambda x: len(x) >= 10 and x[0] != 0
     )

--- a/hypothesis-python/tests/cover/test_sharing.py
+++ b/hypothesis-python/tests/cover/test_sharing.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
 from hypothesis import given
-from tests.common.debug import find_any, minimize
+from tests.common.debug import find_any, minimal
 
 x = st.shared(st.integers())
 
@@ -61,7 +61,7 @@ def test_keys_and_default_are_not_shared():
 
 
 def test_can_simplify_shared_lists():
-    xs = minimize(
+    xs = minimal(
         st.lists(st.shared(st.integers())),
         lambda x: len(x) >= 10 and x[0] != 0
     )

--- a/hypothesis-python/tests/cover/test_simple_characters.py
+++ b/hypothesis-python/tests/cover/test_simple_characters.py
@@ -53,8 +53,8 @@ def test_when_nothing_could_be_produced():
 def test_characters_of_specific_groups():
     st = characters(whitelist_categories=('Lu', 'Nd'))
 
-    minimal(st, lambda c: unicodedata.category(c) == 'Lu')
-    minimal(st, lambda c: unicodedata.category(c) == 'Nd')
+    find_any(st, lambda c: unicodedata.category(c) == 'Lu')
+    find_any(st, lambda c: unicodedata.category(c) == 'Nd')
 
     assert_no_examples(
         st, lambda c: unicodedata.category(c) not in ('Lu', 'Nd'))
@@ -62,8 +62,8 @@ def test_characters_of_specific_groups():
 
 def test_characters_of_major_categories():
     st = characters(whitelist_categories=('L', 'N'))
-    minimal(st, lambda c: unicodedata.category(c).startswith('L'))
-    minimal(st, lambda c: unicodedata.category(c).startswith('N'))
+    find_any(st, lambda c: unicodedata.category(c).startswith('L'))
+    find_any(st, lambda c: unicodedata.category(c).startswith('N'))
     assert_no_examples(
         st, lambda c: unicodedata.category(c)[0] not in ('L', 'N'))
 
@@ -71,16 +71,16 @@ def test_characters_of_major_categories():
 def test_exclude_characters_of_specific_groups():
     st = characters(blacklist_categories=('Lu', 'Nd'))
 
-    minimal(st, lambda c: unicodedata.category(c) != 'Lu')
-    minimal(st, lambda c: unicodedata.category(c) != 'Nd')
+    find_any(st, lambda c: unicodedata.category(c) != 'Lu')
+    find_any(st, lambda c: unicodedata.category(c) != 'Nd')
 
     assert_no_examples(st, lambda c: unicodedata.category(c) in ('Lu', 'Nd'))
 
 
 def test_exclude_characters_of_major_categories():
     st = characters(blacklist_categories=('L', 'N'))
-    minimal(st, lambda c: not unicodedata.category(c).startswith('L'))
-    minimal(st, lambda c: not unicodedata.category(c).startswith('N'))
+    find_any(st, lambda c: not unicodedata.category(c).startswith('L'))
+    find_any(st, lambda c: not unicodedata.category(c).startswith('N'))
     assert_no_examples(st, lambda c: unicodedata.category(c)[0] in ('L', 'N'))
 
 
@@ -93,7 +93,7 @@ def test_find_one():
 def test_find_something_rare():
     st = characters(whitelist_categories=['Zs'], min_codepoint=12288)
 
-    minimal(st, lambda c: unicodedata.category(c) == 'Zs')
+    find_any(st, lambda c: unicodedata.category(c) == 'Zs')
 
     assert_no_examples(st, lambda c: unicodedata.category(c) != 'Zs')
 

--- a/hypothesis-python/tests/cover/test_simple_characters.py
+++ b/hypothesis-python/tests/cover/test_simple_characters.py
@@ -21,9 +21,8 @@ import unicodedata
 
 import pytest
 
-from hypothesis import find
 from hypothesis.errors import InvalidArgument
-from tests.common.debug import find_any, assert_no_examples
+from tests.common.debug import minimal, find_any, assert_no_examples
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import characters
 from hypothesis.internal.compat import text_type
@@ -54,8 +53,8 @@ def test_when_nothing_could_be_produced():
 def test_characters_of_specific_groups():
     st = characters(whitelist_categories=('Lu', 'Nd'))
 
-    find(st, lambda c: unicodedata.category(c) == 'Lu')
-    find(st, lambda c: unicodedata.category(c) == 'Nd')
+    minimal(st, lambda c: unicodedata.category(c) == 'Lu')
+    minimal(st, lambda c: unicodedata.category(c) == 'Nd')
 
     assert_no_examples(
         st, lambda c: unicodedata.category(c) not in ('Lu', 'Nd'))
@@ -63,8 +62,8 @@ def test_characters_of_specific_groups():
 
 def test_characters_of_major_categories():
     st = characters(whitelist_categories=('L', 'N'))
-    find(st, lambda c: unicodedata.category(c).startswith('L'))
-    find(st, lambda c: unicodedata.category(c).startswith('N'))
+    minimal(st, lambda c: unicodedata.category(c).startswith('L'))
+    minimal(st, lambda c: unicodedata.category(c).startswith('N'))
     assert_no_examples(
         st, lambda c: unicodedata.category(c)[0] not in ('L', 'N'))
 
@@ -72,28 +71,29 @@ def test_characters_of_major_categories():
 def test_exclude_characters_of_specific_groups():
     st = characters(blacklist_categories=('Lu', 'Nd'))
 
-    find(st, lambda c: unicodedata.category(c) != 'Lu')
-    find(st, lambda c: unicodedata.category(c) != 'Nd')
+    minimal(st, lambda c: unicodedata.category(c) != 'Lu')
+    minimal(st, lambda c: unicodedata.category(c) != 'Nd')
 
     assert_no_examples(st, lambda c: unicodedata.category(c) in ('Lu', 'Nd'))
 
 
 def test_exclude_characters_of_major_categories():
     st = characters(blacklist_categories=('L', 'N'))
-    find(st, lambda c: not unicodedata.category(c).startswith('L'))
-    find(st, lambda c: not unicodedata.category(c).startswith('N'))
+    minimal(st, lambda c: not unicodedata.category(c).startswith('L'))
+    minimal(st, lambda c: not unicodedata.category(c).startswith('N'))
     assert_no_examples(st, lambda c: unicodedata.category(c)[0] in ('L', 'N'))
 
 
 def test_find_one():
-    char = find(characters(min_codepoint=48, max_codepoint=48), lambda _: True)
+    char = minimal(characters(min_codepoint=48,
+                              max_codepoint=48), lambda _: True)
     assert char == u'0'
 
 
 def test_find_something_rare():
     st = characters(whitelist_categories=['Zs'], min_codepoint=12288)
 
-    find(st, lambda c: unicodedata.category(c) == 'Zs')
+    minimal(st, lambda c: unicodedata.category(c) == 'Zs')
 
     assert_no_examples(st, lambda c: unicodedata.category(c) != 'Zs')
 
@@ -130,7 +130,7 @@ def test_blacklisted_characters():
     st = characters(min_codepoint=ord('0'), max_codepoint=ord('9'),
                     blacklist_characters=bad_chars)
 
-    assert '1' == find(st, lambda c: True)
+    assert '1' == minimal(st, lambda c: True)
 
     assert_no_examples(st, lambda c: c in bad_chars)
 

--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -23,7 +23,7 @@ from collections import namedtuple
 import pytest
 from flaky import flaky
 
-from hypothesis import find, given, settings
+from hypothesis import given, settings
 from tests.common.debug import minimal, find_any
 from hypothesis.strategies import none, sets, text, lists, builds, \
     tuples, booleans, integers, frozensets, dictionaries, \
@@ -39,7 +39,7 @@ from hypothesis.internal.compat import OrderedDict
     ({}, fixed_dictionaries({})),
 ])
 def test_find_empty_collection_gives_empty(col, strat):
-    assert find(strat, lambda x: True) == col
+    assert minimal(strat, lambda x: True) == col
 
 
 @pytest.mark.parametrize((u'coltype', u'strat'), [
@@ -48,7 +48,7 @@ def test_find_empty_collection_gives_empty(col, strat):
     (frozenset, frozensets),
 ])
 def test_find_non_empty_collection_gives_single_zero(coltype, strat):
-    assert find(
+    assert minimal(
         strat(integers()), bool
     ) == coltype((0,))
 
@@ -59,25 +59,25 @@ def test_find_non_empty_collection_gives_single_zero(coltype, strat):
     (frozenset, frozensets),
 ])
 def test_minimizes_to_empty(coltype, strat):
-    assert find(
+    assert minimal(
         strat(integers()), lambda x: True
     ) == coltype()
 
 
 def test_minimizes_list_of_lists():
-    xs = find(lists(lists(booleans())), lambda x: any(x) and not all(x))
+    xs = minimal(lists(lists(booleans())), lambda x: any(x) and not all(x))
     xs.sort()
     assert xs == [[], [False]]
 
 
 def test_minimize_long_list():
-    assert find(
+    assert minimal(
         lists(booleans(), min_size=50), lambda x: len(x) >= 70
     ) == [False] * 70
 
 
 def test_minimize_list_of_longish_lists():
-    xs = find(
+    xs = minimal(
         lists(lists(booleans())),
         lambda x: len([t for t in x if any(t) and len(t) >= 3]) >= 10)
     assert len(xs) == 10
@@ -87,19 +87,19 @@ def test_minimize_list_of_longish_lists():
 
 
 def test_minimize_list_of_fairly_non_unique_ints():
-    xs = find(lists(integers()), lambda x: len(set(x)) < len(x))
+    xs = minimal(lists(integers()), lambda x: len(set(x)) < len(x))
     assert len(xs) == 2
 
 
 def test_list_with_complex_sorting_structure():
-    xs = find(
+    xs = minimal(
         lists(lists(booleans())),
         lambda x: [list(reversed(t)) for t in x] > x and len(x) > 3)
     assert len(xs) == 4
 
 
 def test_list_with_wide_gap():
-    xs = find(lists(integers()), lambda x: x and (max(x) > min(x) + 10 > 0))
+    xs = minimal(lists(integers()), lambda x: x and (max(x) > min(x) + 10 > 0))
     assert len(xs) == 2
     xs.sort()
     assert xs[1] == 11 + xs[0]
@@ -107,14 +107,14 @@ def test_list_with_wide_gap():
 
 def test_minimize_namedtuple():
     T = namedtuple(u'T', (u'a', u'b'))
-    tab = find(
+    tab = minimal(
         builds(T, integers(), integers()),
         lambda x: x.a < x.b)
     assert tab.b == tab.a + 1
 
 
 def test_minimize_dict():
-    tab = find(
+    tab = minimal(
         fixed_dictionaries({u'a': booleans(), u'b': booleans()}),
         lambda x: x[u'a'] or x[u'b']
     )
@@ -122,7 +122,7 @@ def test_minimize_dict():
 
 
 def test_minimize_list_of_sets():
-    assert find(
+    assert minimal(
         lists(sets(booleans())),
         lambda x: len(list(filter(None, x))) >= 3) == (
         [set((False,))] * 3
@@ -130,7 +130,7 @@ def test_minimize_list_of_sets():
 
 
 def test_minimize_list_of_lists():
-    assert find(
+    assert minimal(
         lists(lists(integers())),
         lambda x: len(list(filter(None, x))) >= 3) == (
         [[0]] * 3
@@ -138,27 +138,27 @@ def test_minimize_list_of_lists():
 
 
 def test_minimize_list_of_tuples():
-    xs = find(
+    xs = minimal(
         lists(tuples(integers(), integers())), lambda x: len(x) >= 2)
     assert xs == [(0, 0), (0, 0)]
 
 
 def test_minimize_multi_key_dicts():
-    assert find(
+    assert minimal(
         dictionaries(keys=booleans(), values=booleans()),
         bool
     ) == {False: False}
 
 
 def test_minimize_dicts_with_incompatible_keys():
-    assert find(
+    assert minimal(
         fixed_dictionaries({1: booleans(), u'hi': lists(booleans())}),
         lambda x: True
     ) == {1: False, u'hi': []}
 
 
 def test_multiple_empty_lists_are_independent():
-    x = find(lists(lists(none(), max_size=0)), lambda t: len(t) >= 2)
+    x = minimal(lists(lists(none(), max_size=0)), lambda t: len(t) >= 2)
     u, v = x
     assert u is not v
 
@@ -180,13 +180,13 @@ def test_ordered_dictionaries_preserve_keys():
 
 @pytest.mark.parametrize(u'n', range(10))
 def test_lists_of_fixed_length(n):
-    assert find(
+    assert minimal(
         lists(integers(), min_size=n, max_size=n), lambda x: True) == [0] * n
 
 
 @pytest.mark.parametrize(u'n', range(10))
 def test_sets_of_fixed_length(n):
-    x = find(
+    x = minimal(
         sets(integers(), min_size=n, max_size=n), lambda x: True)
     assert len(x) == n
 
@@ -198,7 +198,7 @@ def test_sets_of_fixed_length(n):
 
 @pytest.mark.parametrize(u'n', range(10))
 def test_dictionaries_of_fixed_length(n):
-    x = set(find(
+    x = set(minimal(
         dictionaries(integers(), booleans(), min_size=n, max_size=n),
         lambda x: True).keys())
 
@@ -210,7 +210,7 @@ def test_dictionaries_of_fixed_length(n):
 
 @pytest.mark.parametrize(u'n', range(10))
 def test_lists_of_lower_bounded_length(n):
-    x = find(
+    x = minimal(
         lists(integers(), min_size=n), lambda x: sum(x) >= 2 * n
     )
     assert n <= len(x) <= 2 * n
@@ -221,7 +221,7 @@ def test_lists_of_lower_bounded_length(n):
 
 @pytest.mark.parametrize(u'n', range(10))
 def test_lists_forced_near_top(n):
-    assert find(
+    assert minimal(
         lists(integers(), min_size=n, max_size=n + 2),
         lambda t: len(t) == n + 2
     ) == [0] * (n + 2)
@@ -238,7 +238,7 @@ def test_can_find_unique_lists_of_non_set_order():
 
 
 def test_can_find_sets_unique_by_incomplete_data():
-    ls = find(
+    ls = minimal(
         lists(lists(integers(min_value=0), min_size=2), unique_by=max),
         lambda x: len(x) >= 10
     )

--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -77,10 +77,11 @@ def test_minimize_long_list():
 
 
 def test_minimize_list_of_longish_lists():
+    size = 5
     xs = minimal(
         lists(lists(booleans())),
-        lambda x: len([t for t in x if any(t) and len(t) >= 3]) >= 10)
-    assert len(xs) == 10
+        lambda x: len([t for t in x if any(t) and len(t) >= 3]) >= size)
+    assert len(xs) == size
     for x in xs:
         assert len(x) == 3
         assert len([t for t in x if t]) == 1
@@ -238,12 +239,13 @@ def test_can_find_unique_lists_of_non_set_order():
 
 
 def test_can_find_sets_unique_by_incomplete_data():
+    size = 5
     ls = minimal(
         lists(lists(integers(min_value=0), min_size=2), unique_by=max),
-        lambda x: len(x) >= 10
+        lambda x: len(x) >= size
     )
-    assert len(ls) == 10
-    assert sorted(list(map(max, ls))) == list(range(10))
+    assert len(ls) == size
+    assert sorted(list(map(max, ls))) == list(range(size))
     for v in ls:
         assert 0 in v
 

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -22,28 +22,29 @@ from random import Random
 
 import pytest
 
-from hypothesis import find, given, settings
+from hypothesis import given, settings
+from tests.common.debug import minimal
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import text, binary, tuples, characters
 
 
 def test_can_minimize_up_to_zero():
-    s = find(text(), lambda x: any(lambda t: t <= u'0' for t in x))
+    s = minimal(text(), lambda x: any(lambda t: t <= u'0' for t in x))
     assert s == u'0'
 
 
 def test_minimizes_towards_ascii_zero():
-    s = find(text(), lambda x: any(t < u'0' for t in x))
+    s = minimal(text(), lambda x: any(t < u'0' for t in x))
     assert s == chr(ord(u'0') - 1)
 
 
 def test_can_handle_large_codepoints():
-    s = find(text(), lambda x: x >= u'☃')
+    s = minimal(text(), lambda x: x >= u'☃')
     assert s == u'☃'
 
 
 def test_can_find_mixed_ascii_and_non_ascii_strings():
-    s = find(
+    s = minimal(
         text(), lambda x: (
             any(t >= u'☃' for t in x) and
             any(ord(t) <= 127 for t in x)))
@@ -52,7 +53,7 @@ def test_can_find_mixed_ascii_and_non_ascii_strings():
 
 
 def test_will_find_ascii_examples_given_the_chance():
-    s = find(
+    s = minimal(
         tuples(text(max_size=1), text(max_size=1)),
         lambda x: x[0] and (x[0] < x[1]))
     assert ord(s[1]) == ord(s[0]) + 1
@@ -60,7 +61,7 @@ def test_will_find_ascii_examples_given_the_chance():
 
 
 def test_finds_single_element_strings():
-    assert find(text(), bool, random=Random(4)) == u'0'
+    assert minimal(text(), bool, random=Random(4)) == u'0'
 
 
 def test_binary_respects_changes_in_size():
@@ -83,9 +84,10 @@ def test_does_not_generate_surrogates(t):
 
 
 def test_does_not_simplify_into_surrogates():
-    f = find(text(), lambda x: x >= u'\udfff')
+    f = minimal(text(), lambda x: x >= u'\udfff')
     assert f == u'\ue000'
-    f = find(text(min_size=10), lambda x: sum(t >= u'\udfff' for t in x) >= 10)
+    f = minimal(
+        text(min_size=10), lambda x: sum(t >= u'\udfff' for t in x) >= 10)
     assert f == u'\ue000' * 10
 
 

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -86,9 +86,12 @@ def test_does_not_generate_surrogates(t):
 def test_does_not_simplify_into_surrogates():
     f = minimal(text(), lambda x: x >= u'\udfff')
     assert f == u'\ue000'
+
+    size = 5
+
     f = minimal(
-        text(min_size=10), lambda x: sum(t >= u'\udfff' for t in x) >= 10)
-    assert f == u'\ue000' * 10
+        text(min_size=size), lambda x: sum(t >= u'\udfff' for t in x) >= size)
+    assert f == u'\ue000' * size
 
 
 @given(text(alphabet=[u'a', u'b']))

--- a/hypothesis-python/tests/datetime/test_datetime.py
+++ b/hypothesis-python/tests/datetime/test_datetime.py
@@ -23,7 +23,7 @@ import pytz
 import pytest
 from flaky import flaky
 
-from hypothesis import find, given, assume, settings, unlimited
+from hypothesis import given, assume, settings, unlimited
 from hypothesis.errors import InvalidArgument
 from tests.common.debug import minimal, find_any
 from tests.common.utils import checks_deprecated_behaviour
@@ -146,7 +146,7 @@ def test_needs_permission_for_no_timezones():
 @checks_deprecated_behaviour
 @flaky(max_runs=3, min_passes=1)
 def test_bordering_on_a_leap_year():
-    x = find(
+    x = minimal(
         datetimes(min_year=2002, max_year=2005),
         lambda x: x.month == 2 and x.day == 29,
         settings=settings(

--- a/hypothesis-python/tests/nocover/test_boundary_exploration.py
+++ b/hypothesis-python/tests/nocover/test_boundary_exploration.py
@@ -20,9 +20,9 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import Verbosity, HealthCheck, find, given, reject, \
-    settings
+from hypothesis import Verbosity, HealthCheck, given, reject, settings
 from hypothesis.errors import NoSuchExample
+from tests.common.debug import minimal
 from tests.common.utils import no_shrink
 
 
@@ -42,7 +42,7 @@ def test_explore_arbitrary_function(strat, data):
             return cache.setdefault(x, data.draw(st.booleans(), label=repr(x)))
 
     try:
-        find(
+        minimal(
             strat, predicate,
             settings=settings(database=None, verbosity=Verbosity.quiet)
         )

--- a/hypothesis-python/tests/nocover/test_collective_minimization.py
+++ b/hypothesis-python/tests/nocover/test_collective_minimization.py
@@ -20,9 +20,10 @@ from __future__ import division, print_function, absolute_import
 import pytest
 from flaky import flaky
 
-from hypothesis import find, settings
+from hypothesis import settings
 from tests.common import standard_types
 from hypothesis.errors import NoSuchExample
+from tests.common.debug import minimal
 from hypothesis.strategies import lists
 
 
@@ -44,7 +45,7 @@ def test_can_collectively_minimize(spec):
         return False
 
     try:
-        xs = find(
+        xs = minimal(
             lists(spec, min_size=n, max_size=n),
             distinct_reprs,
             settings=settings(max_examples=2000))

--- a/hypothesis-python/tests/nocover/test_deferred_strategies.py
+++ b/hypothesis-python/tests/nocover/test_deferred_strategies.py
@@ -17,9 +17,10 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis import Verbosity, find, note, given, settings
+from hypothesis import Verbosity, note, given, settings
 from hypothesis import strategies as st
 from hypothesis.errors import NoSuchExample, Unsatisfiable
+from tests.common.debug import minimal
 from tests.common.utils import no_shrink
 from hypothesis.internal.compat import hrange
 
@@ -64,7 +65,7 @@ def test_arbitrary_recursion(strategies):
             s.validate()
 
             try:
-                find(s, lambda x: True, settings=settings(
+                minimal(s, lambda x: True, settings=settings(
                     phases=no_shrink, database=None, verbosity=Verbosity.quiet,
                     max_examples=1,
                 ))

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -125,9 +125,11 @@ def test_can_use_recursive_data_in_sets(rnd):
 
 @flaky(max_runs=2, min_passes=1)
 def test_can_form_sets_of_recursive_data():
+    size = 3
+
     trees = st.sets(st.recursive(
         st.booleans(),
-        lambda x: st.lists(x, min_size=5).map(tuple),
+        lambda x: st.lists(x, min_size=size).map(tuple),
         max_leaves=20))
-    xs = minimal(trees, lambda x: len(x) >= 5)
-    assert len(xs) == 5
+    xs = minimal(trees, lambda x: len(x) >= size, timeout_after=None)
+    assert len(xs) == size

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -20,8 +20,8 @@ from __future__ import division, print_function, absolute_import
 from flaky import flaky
 
 import hypothesis.strategies as st
-from hypothesis import HealthCheck, find, given, settings
-from tests.common.debug import find_any
+from hypothesis import HealthCheck, given, settings
+from tests.common.debug import minimal, find_any
 from tests.common.utils import no_shrink
 
 
@@ -32,7 +32,7 @@ def test_can_generate_with_large_branching():
         else:
             return [x]
 
-    xs = find(
+    xs = minimal(
         st.recursive(
             st.integers(), lambda x: st.lists(x, min_size=25),
             max_leaves=100),
@@ -47,7 +47,7 @@ def test_can_generate_some_depth_with_large_branching():
             return 1 + max(map(depth, x))
         else:
             return 1
-    xs = find(
+    xs = minimal(
         st.recursive(st.integers(), st.lists),
         lambda x: depth(x) > 1
     )
@@ -61,7 +61,7 @@ def test_can_find_quite_broad_lists():
         else:
             return 1
 
-    broad = find(
+    broad = minimal(
         st.recursive(st.booleans(), lambda x: st.lists(x, max_size=10)),
         lambda x: breadth(x) >= 20,
         settings=settings(max_examples=10000)
@@ -70,7 +70,7 @@ def test_can_find_quite_broad_lists():
 
 
 def test_drawing_many_near_boundary():
-    ls = find(
+    ls = minimal(
         st.lists(st.recursive(
             st.booleans(),
             lambda x: st.lists(x, min_size=8, max_size=10).map(tuple),
@@ -101,7 +101,7 @@ def test_can_use_recursive_data_in_sets(rnd):
                     break
             return result
     assert rnd is not None
-    x = find(
+    x = minimal(
         nested_sets, lambda x: len(flatten(x)) == 2, random=rnd,
         settings=settings(database=None, max_examples=1000))
     assert x in (
@@ -117,7 +117,7 @@ def test_can_form_sets_of_recursive_data():
         st.booleans(),
         lambda x: st.lists(x, min_size=5).map(tuple),
         max_leaves=20))
-    xs = find(trees, lambda x: len(x) >= 5, settings=settings(
+    xs = minimal(trees, lambda x: len(x) >= 5, settings=settings(
         database=None, max_examples=1000
     ))
     assert len(xs) == 5

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -26,8 +26,9 @@ import collections
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import HealthCheck, find, given, infer, assume, settings
+from hypothesis import HealthCheck, given, infer, assume, settings
 from hypothesis.errors import NoExamples, InvalidArgument, ResolutionFailed
+from tests.common.debug import minimal
 from hypothesis.strategies import from_type
 from hypothesis.searchstrategy import types
 from hypothesis.internal.compat import ForwardRef, integer_types, \
@@ -158,7 +159,7 @@ def test_ItemsView():
 
 
 def test_Optional_minimises_to_None():
-    assert find(from_type(typing.Optional[int]), lambda ex: True) is None
+    assert minimal(from_type(typing.Optional[int]), lambda ex: True) is None
 
 
 @pytest.mark.parametrize('n', range(10))
@@ -268,10 +269,10 @@ def test_can_get_type_hints(thing):
 
 def test_force_builds_to_infer_strategies_for_default_args():
     # By default, leaves args with defaults and minimises to 2+4=6
-    assert find(st.builds(annotated_func), lambda ex: True) == 6
+    assert minimal(st.builds(annotated_func), lambda ex: True) == 6
     # Inferring integers() for args makes it minimise to zero
-    assert find(st.builds(annotated_func, b=infer, d=infer),
-                lambda ex: True) == 0
+    assert minimal(st.builds(annotated_func, b=infer, d=infer),
+                   lambda ex: True) == 0
 
 
 def non_annotated_func(a, b=2, *, c, d=4):

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -25,7 +25,7 @@ from functools import reduce
 import pytest
 from flaky import flaky
 
-from hypothesis import find, assume, settings
+from hypothesis import assume, settings
 from tests.common import parametrize
 from tests.common.debug import minimal
 from hypothesis.strategies import just, sets, text, lists, tuples, \
@@ -137,7 +137,7 @@ def test_flatmap_rectangles():
     def lists_of_length(n):
         return lists(sampled_from('ab'), min_size=n, max_size=n)
 
-    xs = find(lengths.flatmap(
+    xs = minimal(lengths.flatmap(
         lambda w: lists(lists_of_length(w))), lambda x: ['a', 'b'] in x,
         settings=settings(database=None, max_examples=2000)
     )


### PR DESCRIPTION
We have a bunch of slightly flaky tests that use find. I'm 80% sure this is them hitting the timeout and us not having merged #1428 yet (at which point they'll become flaky in a different way). 

This PR moves almost (there are some that are tests of e.g error behaviour rather than the generated example) all tests using find over to one of `minimal` or `find_any`. It also updates `find_any` to also set `timeout=unlimited` so that that actually helps.

Methodology for most of this: `grep` for `find(` in our tests and manually inspect and fix the files to determine what the test was doing. Fix all the tests that CI complained about. This was as boring as it sounds.