### PR TITLE
Extract greedy shrink loop body into its own method

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release is a very small internal refactoring which should have no user
+visible impact.


### PR DESCRIPTION
This is a teeny tiny refactoring that exists mostly in support of the evaluations I'll be running (but I think it's a net improvement in its own right), where it's useful to be able to run the greedy shrink loop body on its own.