### PR TITLE
Only run the deploy stage in a 'push' job (i.e. not PRs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,13 @@ script:
 matrix:
     fast_finish: true
 
+stages:
+    - precheck
+    - main
+    - extras
+    - name: deploy
+      if: type = push
+
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Given the recent stack of pull requests, this makes a small change to our Travis config to run one less job in PR builds.