### PR TITLE
Do less stuff in each build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ jobs:
          keys:
            - v1-runtimes-
       - run: ./build.sh install-core
-      - run: ./build.sh check-coverage
-      - run: ./build.sh check-pure-tracer
       - run: ./build.sh check-py27
       - run: ./build.sh check-py36
       - save_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,9 @@ jobs:
     - env: TASK=check-rust-tests
 
     - stage: main
-      env: TASK=check-pypy
-    - env: TASK=check-py27
+      env: TASK=check-coverage
+    - env: TASK=check-pypy
     - env: TASK=check-py36
-    - env: TASK=check-quality
     - env: TASK=check-ruby-tests
 
     # Less important tests that will probably
@@ -54,6 +53,9 @@ jobs:
     # worth testing.
     - stage: extras
       env: TASK=check-unicode
+      env: TASK=check-pure-tracer
+    - env: TASK=check-py27
+    - env: TASK=check-quality
     - env: TASK=check-py27-typing
     - env: TASK=check-py34
     - env: TASK=check-py35

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -150,7 +150,7 @@ deps =
 setenv=
     HYPOTHESIS_FORCE_PURE_TRACER=true
 commands =
-    python -m pytest tests/cover tests/nocover/test_coverage.py -n 0 {posargs}
+    python -m pytest tests/cover/test_testdecorators.py tests/nocover/test_coverage.py -n 0 {posargs}
 
 
 [testenv:pypy-with-tracer]


### PR DESCRIPTION
I noticed that our CircleCI build times had gone sky high. I think a lot of the problem is that although it is faster, it's sequential, and we'd moved two very expensive jobs over there.

This PR does a couple of things:

* It moves `check-coverage` and `check-pure-tracer` back to Travis
* It significantly reduces the size of `check-pure-tracer` because they're not very useful tests and they were taking 15 (!) minutes to run.
* It moves a bunch of tasks out of main and into extra so that they don't run needlessly.

Hopefully that should help our slightly monstrous build queue.