### PR TITLE
Avoid caching virtualenvs

### DIFF
--- a/tooling/scripts/common.sh
+++ b/tooling/scripts/common.sh
@@ -14,7 +14,11 @@ export BUILD_RUNTIMES=${BUILD_RUNTIMES:-$HOME/.cache/hypothesis-build-runtimes}
 export BASE="$BUILD_RUNTIMES"
 export PYENV="$BASE/pyenv"
 export SNAKEPIT="$BASE/python-versions/"
-export VIRTUALENVS="$BASE/virtualenvs/"
+
+# Note: Deliberately ignoring BUILD_RUNTIMES configuration because we don't
+# want this to go in cache, because it takes up a huge amount of space and
+# slows everything down!
+export VIRTUALENVS="$ROOT/.runtimes/virtualenvs/"
 export RBENV_VERSION="2.5.1"
 export RBENV_ROOT="$BASE/.rbenv"
 export INSTALLED_RUBY_DIR="$RBENV_ROOT/versions/$RBENV_VERSION/"


### PR DESCRIPTION
Have you noticed that a) Our CI caches are > 2GB each and b) CircleCI currently takes 7 minutes to fetch the cache and 15 minutes to upload it?

Yikes, right?

Anyway it turns out that more than two thirds of that is virtualenvs. We're already caching the built Pythons and wheels, so building a virtualenv is *relatively* cheap, as long as disk is faster than network which is sure seems to be on these CI setups.