### PR TITLE
Add temporary cache buster to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - restore_cache:
          keys:
            - v1-runtimes-
+      - run: rm -rf ~/.cache/hypothesis-build-runtimes
       - run: ./build.sh install-core
       - run: ./build.sh check-py27
       - run: ./build.sh check-py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,7 @@ jobs:
       - restore_cache:
          keys:
            - v1-runtimes-
-      - run: rm -rf ~/.cache/hypothesis-build-runtimes
-      - run: ./build.sh install-core
-      - run: ./build.sh check-py27
-      - run: ./build.sh check-py36
+      - run: rm -rf ~/.cache/hypothesis-build-runtimes/
       - save_cache:
           key: v1-runtimes-{{ epoch }}
           paths:


### PR DESCRIPTION
Apparently the way to delete your CircleCI project cache is to contact support. Ain't nobody got time for that. Thanks @alexwlchan for the alternate suggestion.

I don't *think* this even needs to be merged. I think the cache is shared. I'll rebuild master once CircleCI has built this PR and see if it had a cache.