### PR TITLE
Improve our CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,4 @@ jobs:
           paths:
             - ~/.cache/hypothesis-build-runtimes
             - ~/.cache/pip
+            - /usr/local/Homebrew

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,3 +17,4 @@ jobs:
           key: v1-runtimes-{{ epoch }}
           paths:
             - ~/.cache/hypothesis-build-runtimes
+            - ~/.cache/pip


### PR DESCRIPTION
Having just slimmed down our CircleCI caches, this fattens them up again!

Specifically, I noticed that a) We weren't caching pip's downloaded and built wheels, which is unfortunate given that we're no longer caching our virtualenvs and b) We weren't caching homebrew, which takes a considerable time to update. This fixes both of those things.