### PR TITLE
Extract out a common shrinking interface

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release makes some internal changes to how shrinking is structure. It is
+mostly a pure refactoring, but you may see some minor changes in the final
+shrunk examples.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-This release makes some internal changes to how shrinking is structure. It is
-mostly a pure refactoring, but you may see some minor changes in the final
-shrunk examples.
+This release makes some internal changes to enable further improvements to the
+shrinker. You may see some changes in the final shrunk examples, but they are
+unlikely to be significant.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -38,8 +38,7 @@ from hypothesis.internal.reflection import proxies
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     StopTest, ConjectureData
-from hypothesis.internal.conjecture.shrinking import Lexical
-from hypothesis.internal.conjecture.shrinking.lexical import minimize_int
+from hypothesis.internal.conjecture.shrinking import Integer, Lexical
 
 # Tell pytest to omit the body of this module from tracebacks
 # http://doc.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
@@ -1663,7 +1662,7 @@ class Shrinker(object):
                 new_blocks[i] = int_to_bytes(v + o, len(blocked[i]))
             return self.incorporate_new_buffer(hbytes().join(new_blocks))
 
-        minimize_int(offset, reoffset)
+        Integer.shrink(offset, reoffset, random=self.random)
 
     @shrink_pass
     def shrink_offset_pairs(self):
@@ -1724,8 +1723,10 @@ class Shrinker(object):
                         # Save current before shrinking
                         current = [self.shrink_target.buffer[u:v]
                                    for u, v in self.blocks]
-                        minimize_int(
-                            offset, lambda o: reoffset_pair((i, j), o))
+                        Integer.shrink(
+                            offset, lambda o: reoffset_pair((i, j), o),
+                            random=self.random
+                        )
                     j += 1
             i += 1
 
@@ -2414,8 +2415,9 @@ class Shrinker(object):
                             n = int_from_bytes(self.shrink_target.buffer[r:s])
 
                             tot = m + n
-                            minimize_int(
-                                m, lambda x: trial(x, tot - x)
+                            Integer.shrink(
+                                m, lambda x: trial(x, tot - x),
+                                random=self.random
                             )
                     j += 1
             i += 1

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -38,7 +38,8 @@ from hypothesis.internal.reflection import proxies
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     StopTest, ConjectureData
-from hypothesis.internal.conjecture.minimizer import minimize, minimize_int
+from hypothesis.internal.conjecture.shrinking import Lexical
+from hypothesis.internal.conjecture.shrinking.lexical import minimize_int
 
 # Tell pytest to omit the body of this module from tracebacks
 # http://doc.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
@@ -2049,7 +2050,7 @@ class Shrinker(object):
             if len(targets) <= 1:
                 continue
 
-            minimize(
+            Lexical.shrink(
                 block,
                 lambda b: self.try_shrinking_blocks(targets, b),
                 random=self.random, full=False
@@ -2070,7 +2071,7 @@ class Shrinker(object):
         i = 0
         while i < len(self.blocks):
             u, v = self.blocks[i]
-            minimize(
+            Lexical.shrink(
                 self.shrink_target.buffer[u:v],
                 lambda b: self.try_shrinking_blocks((i,), b),
                 random=self.random, full=False,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
@@ -209,7 +209,10 @@ def float_to_lex(f):
     if is_simple(f):
         assert f >= 0
         return int(f)
+    return base_float_to_lex(f)
 
+
+def base_float_to_lex(f):
     i = float_to_int(f)
     i &= ((1 << 63) - 1)
     exponent = i >> 52

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/__init__.py
@@ -15,8 +15,9 @@
 #
 # END HEADER
 
+from hypothesis.internal.conjecture.shrinking.integer import Integer
 from hypothesis.internal.conjecture.shrinking.lexical import Lexical
 
 __all__ = [
-    'Lexical',
+    'Lexical', 'Integer',
 ]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/__init__.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from hypothesis.internal.conjecture.shrinking.lexical import Lexical
+
+__all__ = [
+    'Lexical',
+]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -94,8 +94,10 @@ class Shrinker(object):
         itself.
 
         It is these immutable versions that the shrinker will work on.
+
+        Defaults to just returning the value.
         """
-        raise NotImplementedError()
+        return value
 
     def check_invariants(self, value):
         """Make appropriate assertions about the value to ensure that it is

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+
+"""This module implements various useful common functions for shrinking tasks.
+"""
+
+
+class Shrinker(object):
+    """A Shrinker object manages a single value and a predicate it should
+    satisfy, and attempts to improve it in some direction, making it smaller
+    and simpler."""
+
+    def __init__(self, initial, predicate, random, full):
+        self.current = self.make_immutable(initial)
+        self.random = random
+        self.full = full
+        self.changes = 0
+
+        self.__predicate = predicate
+        self.__seen = set()
+
+    @classmethod
+    def shrink(cls, initial, predicate, random, full=False):
+        """Shrink the value ``initial`` subject to the constraint that it
+        satisfies ``predicate``.
+
+        Returns the shrunk value.
+        """
+        shrinker = cls(initial, predicate, random, full)
+        shrinker.run()
+        return shrinker.current
+
+    def run(self):
+        """Run for an appropriate number of steps to improve the current value.
+
+        If self.full is True, will run until no further improvements can
+        be found.
+        """
+        if self.short_circuit():
+            return
+        if self.full:
+            prev = -1
+            while self.changes != prev:
+                prev = self.changes
+                self.run_step()
+        else:
+            self.run_step()
+
+    def incorporate(self, value):
+        """Try using ``value`` as a possible candidate improvement.
+
+        Return True if it works.
+        """
+        value = self.make_immutable(value)
+        self.check_invariants(value)
+        if not self.left_is_better(value, self.current):
+            return False
+        if value in self.__seen:
+            return False
+        self.__seen.add(value)
+        if self.__predicate(value):
+            self.changes += 1
+            self.current = value
+            return True
+        return False
+
+    def consider(self, value):
+        """Returns True if make_immutable(value) == self.current after calling
+        self.incorporate(value)."""
+        value = self.make_immutable(value)
+        if value == self.current:
+            return True
+        return self.incorporate(value)
+
+    def make_immutable(self, value):
+        """Convert value into an immutable (and hashable) representation of
+        itself.
+
+        It is these immutable versions that the shrinker will work on.
+        """
+        raise NotImplementedError()
+
+    def check_invariants(self, value):
+        """Make appropriate assertions about the value to ensure that it is
+        valid for this shrinker."""
+        raise NotImplementedError()
+
+    def short_circuit(self):
+        """Possibly attempt to do some shrinking.
+
+        If this returns True, the ``run`` method will terminate early
+        without doing any more work.
+        """
+        raise NotImplementedError()
+
+    def left_is_better(self, left, right):
+        """Returns True if the left is strictly simpler than the right
+        according to the standards of this shrinker."""
+        raise NotImplementedError()
+
+    def run_step(self):
+        """Run a single step of the main shrink loop, attempting to improve the
+        current value."""
+        raise NotImplementedError()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/integer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/integer.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis.internal.compat import hrange
+from hypothesis.internal.conjecture.shrinking.common import Shrinker
+
+
+"""
+This module implements a shrinker for non-negative integers.
+"""
+
+
+class Integer(Shrinker):
+    """Attempts to find a smaller sequence satisfying f. Will only perform
+    linearly many evaluations, and does not loop to a fixed point.
+
+    Guarantees made at a fixed point:
+
+        1. No individual element may be deleted.
+        2. No *adjacent* pair of elements may be deleted.
+    """
+
+    def short_circuit(self):
+        for i in hrange(3):
+            if self.consider(i):
+                return True
+        return False
+
+    def check_invariants(self, value):
+        assert value >= 0
+
+    def left_is_better(self, left, right):
+        return left < right
+
+    def run_step(self):
+        assert self.current > 2
+        self.consider(self.current - 2)
+        self.consider(self.current - 1)
+        assert self.current > 2
+        lo = 2
+        while lo + 1 < self.current:
+            mid = (lo + self.current) // 2
+            if not self.consider(mid):
+                lo = mid

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/lexical.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/lexical.py
@@ -24,6 +24,7 @@ from hypothesis.internal.compat import ceil, floor, hbytes, hrange, \
     int_to_bytes, int_from_bytes
 from hypothesis.internal.conjecture.floats import is_simple, \
     float_to_lex, lex_to_float
+from hypothesis.internal.conjecture.shrinking.common import Shrinker
 
 
 """
@@ -45,34 +46,19 @@ to do better in practice:
 """
 
 
-class Minimizer(object):
+class Lexical(Shrinker):
+    def make_immutable(self, value):
+        return hbytes(value)
 
-    def __init__(self, initial, condition, random, full):
-        self.current = hbytes(initial)
-        self.size = len(self.current)
-        self.condition = condition
-        self.random = random
-        self.full = full
-        self.changes = 0
-        self.seen = set()
+    @property
+    def size(self):
+        return len(self.current)
 
-    def incorporate(self, buffer):
-        """Consider this buffer as a possible replacement for the current best
-        buffer.
+    def check_invariants(self, value):
+        assert len(value) == self.size
 
-        Return True if it succeeds as such.
-        """
-        assert isinstance(buffer, hbytes)
-        assert len(buffer) == self.size
-        assert buffer <= self.current
-        if buffer in self.seen:
-            return False
-        self.seen.add(buffer)
-        if buffer != self.current and self.condition(buffer):
-            self.current = buffer
-            self.changes += 1
-            return True
-        return False
+    def left_is_better(self, left, right):
+        return left < right
 
     def shift(self):
         """Attempt to shift individual byte values right as far as they can
@@ -113,7 +99,7 @@ class Minimizer(object):
             minimize_int(
                 self.current[i],
                 lambda c: self.current[i] == c or self.incorporate(
-                    prefix + hbytes([c]) + suffix)
+                    prefix + hbytes([c]) + suffix),
             )
 
     def incorporate_int(self, i):
@@ -193,14 +179,14 @@ class Minimizer(object):
     def current_int(self):
         return int_from_bytes(self.current)
 
-    def minimize_as_integer(self):
+    def minimize_as_integer(self, full=False):
         minimize_int(
             self.current_int,
-            lambda c: c == self.current_int or self.incorporate_int(c)
+            lambda c: c == self.current_int or self.incorporate_int(c),
         )
 
     def sort(self):
-        return self.incorporate(hbytes(sorted(self.current)))
+        return self.consider(hbytes(sorted(self.current)))
 
     # Sometimes data can be sorted, except that some elements need to remain
     # in constant locations to preserve invariants that the minimizer can't be
@@ -221,107 +207,38 @@ class Minimizer(object):
                 j = j - 1
         return any_sorting_done
 
-    def run(self):
-        if not any(self.current):
-            return
-        if len(self.current) == 1:
-            self.minimize_as_integer()
-            return
-
+    def short_circuit(self):
         # Initial checks as to whether the two smallest possible buffers of
         # this length can work. If so there's nothing to do here.
-        if self.incorporate(hbytes(self.size)):
-            return
-
-        if self.incorporate(hbytes([0] * (self.size - 1) + [1])):
-            return
-
-        # Perform a binary search to try to replace a long initial segment with
-        # zero bytes.
-        # Note that because this property isn't monotonic this will not always
-        # find the longest subsequence we can replace with zero, only some
-        # subsequence.
-
-        # Replacing the first nonzero bytes with zero does *not* work
-        nonzero = len(self.current)
-
-        # Replacing the first canzero bytes with zero *does* work.
-        canzero = 0
-        while self.current[canzero] == 0:
-            canzero += 1
-
-        base = self.current
-
-        @binsearch(canzero, nonzero)
-        def zero_prefix(mid):
-            return self.incorporate(
-                hbytes(mid) +
-                base[mid:]
-            )
-
-        base = self.current
-
-        @binsearch(0, self.size)
-        def shift_right(mid):
-            if mid == 0:
+        for c in (0, 1):
+            if self.consider(hbytes([0] * (self.size - 1) + [c])):
                 return True
-            if mid == self.size:
-                return False
-            return self.incorporate(hbytes(mid) + base[:-mid])
 
-        change_counter = -1
-        first = True
-        while (
-            (first or self.full) and
-            change_counter < self.changes
-        ):
-            first = False
-            change_counter = self.changes
-
-            self.sort()
-            self.float_hack()
-            self.shift()
-            self.shrink_indices()
-            self.rotate_suffixes()
-            self.minimize_as_integer()
-            self.partial_sort()
-
-
-def minimize(initial, condition, random, full=True):
-    """Perform a lexicographical minimization of the byte string 'initial' such
-    that the predicate 'condition' returns True, and return the minimized
-    string."""
-    m = Minimizer(initial, condition, random, full)
-    m.run()
-    return m.current
-
-
-def binsearch(_lo, _hi):
-    """Run a binary search to find the point at which a function changes value
-    between two bounds.
-
-    This function is used purely for its side effects and returns
-    nothing.
-    """
-    def accept(f):
-        lo = _lo
-        hi = _hi
-
-        loval = f(lo)
-        hival = f(hi)
-
-        if loval == hival:
-            return
-
+        # Binary search to try to zero as much of the prefix zero as possible.
+        lo = 0
+        hi = self.size - 1
         while lo + 1 < hi:
             mid = (lo + hi) // 2
-            midval = f(mid)
-            if midval == loval:
+            if self.consider(hbytes(mid) + self.current[mid:]):
                 lo = mid
             else:
-                assert hival == midval
                 hi = mid
-    return accept
+
+        # When all but the last bytes are zero then we might as well just
+        # minimize the last byte as if it were an integer and call it done.
+        if not any(self.current[:-1]):
+            self.minimize_as_integer(full=self.full)
+            return True
+        return False
+
+    def run_step(self):
+        self.sort()
+        self.float_hack()
+        self.shift()
+        self.shrink_indices()
+        self.rotate_suffixes()
+        self.minimize_as_integer()
+        self.partial_sort()
 
 
 def minimize_int(c, f):

--- a/hypothesis-python/tests/cover/test_conjecture_float_encoding.py
+++ b/hypothesis-python/tests/cover/test_conjecture_float_encoding.py
@@ -29,7 +29,7 @@ from hypothesis.internal.compat import ceil, floor, hbytes, int_to_bytes, \
     int_from_bytes
 from hypothesis.internal.floats import float_to_int
 from hypothesis.internal.conjecture.data import ConjectureData
-from hypothesis.internal.conjecture.minimizer import minimize
+from hypothesis.internal.conjecture.shrinking import Lexical
 
 EXPONENTS = list(range(0, flt.MAX_EXPONENT + 1))
 assert len(EXPONENTS) == 2 ** 11
@@ -167,7 +167,7 @@ def minimal_from(start, condition):
     def parse_buf(b):
         return flt.lex_to_float(int_from_bytes(b))
 
-    shrunk = minimize(
+    shrunk = Lexical.shrink(
         buf, lambda b: condition(parse_buf(b)),
         full=True, random=Random(0)
     )

--- a/hypothesis-python/tests/cover/test_conjecture_float_encoding.py
+++ b/hypothesis-python/tests/cover/test_conjecture_float_encoding.py
@@ -221,3 +221,19 @@ def test_does_not_shrink_across_one():
     # This test primarily exists to validate that we don't try to subtract one
     # from the starting point and trigger an internal exception.
     assert minimal_from(1.1, lambda x: x == 1.1 or 0 < x < 1) == 1.1
+
+
+@pytest.mark.parametrize('f', [2.0, 10000000.0])
+def test_converts_floats_to_integer_form(f):
+    assert flt.is_simple(f)
+
+    buf = int_to_bytes(flt.base_float_to_lex(f), 8)
+
+    def parse_buf(b):
+        return flt.lex_to_float(int_from_bytes(b))
+
+    shrunk = Lexical.shrink(
+        buf, lambda b: parse_buf(b) == f,
+        full=True, random=Random(0)
+    )
+    assert shrunk < buf

--- a/hypothesis-python/tests/cover/test_conjecture_minimizer.py
+++ b/hypothesis-python/tests/cover/test_conjecture_minimizer.py
@@ -21,35 +21,36 @@ from random import Random
 from collections import Counter
 
 from hypothesis.internal.compat import hbytes
-from hypothesis.internal.conjecture.minimizer import minimize
+from hypothesis.internal.conjecture.shrinking import Lexical
 
 
 def test_shrink_to_zero():
-    assert minimize(
+    assert Lexical.shrink(
         hbytes([255] * 8), lambda x: True, random=Random(0)) == hbytes(8)
 
 
 def test_shrink_to_smallest():
-    assert minimize(
+    assert Lexical.shrink(
         hbytes([255] * 8), lambda x: sum(x) > 10, random=Random(0),
     ) == hbytes([0] * 7 + [11])
 
 
 def test_float_hack_fails():
-    assert minimize(
+    assert Lexical.shrink(
         hbytes([255] * 8), lambda x: x[0] >> 7, random=Random(0),
     ) == hbytes([128] + [0] * 7)
 
 
 def test_can_sort_bytes_by_reordering():
     start = hbytes([5, 4, 3, 2, 1, 0])
-    finish = minimize(start, lambda x: set(x) == set(start), random=Random(0))
+    finish = Lexical.shrink(
+        start, lambda x: set(x) == set(start), random=Random(0))
     assert finish == hbytes([0, 1, 2, 3, 4, 5])
 
 
 def test_can_sort_bytes_by_reordering_partially():
     start = hbytes([5, 4, 3, 2, 1, 0])
-    finish = minimize(
+    finish = Lexical.shrink(
         start, lambda x: set(x) == set(start) and x[0] > x[-1],
         random=Random(0),
     )
@@ -58,7 +59,7 @@ def test_can_sort_bytes_by_reordering_partially():
 
 def test_can_sort_bytes_by_reordering_partially2():
     start = hbytes([5, 4, 3, 2, 1, 0])
-    finish = minimize(
+    finish = Lexical.shrink(
         start, lambda x: Counter(x) == Counter(start) and x[0] > x[2],
         random=Random(0),
     )
@@ -67,7 +68,7 @@ def test_can_sort_bytes_by_reordering_partially2():
 
 def test_can_sort_bytes_by_reordering_partially_not_cross_stationary_element():
     start = hbytes([5, 3, 0, 2, 1, 4])
-    finish = minimize(
+    finish = Lexical.shrink(
         start, lambda x: set(x) == set(start) and x[3] == 2,
         random=Random(0),
     )

--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -241,13 +241,14 @@ def test_can_find_unique_lists_of_non_set_order():
 def test_can_find_sets_unique_by_incomplete_data():
     size = 5
     ls = minimal(
-        lists(lists(integers(min_value=0), min_size=2), unique_by=max),
+        lists(tuples(integers(), integers()), unique_by=max),
         lambda x: len(x) >= size
     )
     assert len(ls) == size
-    assert sorted(list(map(max, ls))) == list(range(size))
-    for v in ls:
-        assert 0 in v
+    values = sorted(list(map(max, ls)))
+    assert values[-1] - values[0] == size - 1
+    for u, v in ls:
+        assert u <= 0
 
 
 def test_can_draw_empty_list_from_unsatisfiable_strategy():


### PR DESCRIPTION
As part of #1423 we're going to start to have other sorts of shrinkers around, not just the lexical minimizer. This creates a common shrinking interface that currently only has one implementation but will very soon have more.

NB. the main shrinker in conjecture is not an implementation of this interface. The reason for that is that while these ones shrink concrete values, the main conjecture shrinker operates on conjecture data objects, which are a bit weirder. This could probably still be made to work, but it's not totally obvious how yet.