### PR TITLE
Remove random backtracking

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This release removes some functionality from the shrinker that was taking a
+considerable amount of time and does not appear to be useful any more due to
+a number of quality improvements in the shrinker.
+
+You may see some degradation in shrink quality as a result of this, but mostly
+shrinking should just get much faster.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1342,7 +1342,6 @@ class Shrinker(object):
             return
 
         self.greedy_shrink()
-        self.escape_local_minimum()
 
     def greedy_shrink(self):
         """Run a full set of greedy shrinks (that is, ones that will only ever
@@ -1731,71 +1730,6 @@ class Shrinker(object):
         self.shrink_target = new_target
         self.__shrinking_block_cache = {}
         self.__intervals = None
-
-    def escape_local_minimum(self):
-        """Attempt to restart the shrink process from a larger initial value in
-        a way that allows us to escape a local minimum that the main greedy
-        shrink process will get stuck in.
-
-        The idea is that when we've completed the shrink process, we try
-        starting it again from something reasonably near to the shrunk example
-        that is likely to exhibit the same behaviour.
-
-        We search for an example that is selected randomly among ones that are
-        "structurally similar" to the original. If we don't find one we bail
-        out fairly quickly as this will usually not work. If we do, we restart
-        the shrink process from there. If this results in us finding a better
-        final example, we do this again until it stops working.
-
-        This is especially useful for things where the tendency to move
-        complexity to the right works against us - often a generic instance of
-        the problem is easy to shrink, but trying to reduce the size of a
-        minimized example further is hard. For example suppose we had something
-        like:
-
-        x = data.draw(lists(integers()))
-        y = data.draw(lists(integers(), min_size=len(x), max_size=len(x)))
-        assert not (any(x) and any(y))
-
-        Then this could shrink to something like [0, 1], [0, 1].
-
-        Attempting to shrink this further by deleting an element of x would
-        result in losing the last element of y, and the test would start
-        passing. But if we were to replace this with [a, b], [c, d] with c != 0
-        then deleting a or b would work.
-        """
-        count = 0
-        while count < 10:
-            count += 1
-            self.debug('Retrying from random restart')
-            attempt_buf = bytearray(self.shrink_target.buffer)
-
-            # We use the shrinking information to identify the
-            # structural locations in the byte stream - if lowering
-            # the block would result in changing the size of the
-            # example, changing it here is too likely to break whatever
-            # it was caused the behaviour we're trying to shrink.
-            # Everything non-structural, we redraw uniformly at random.
-            for i, (u, v) in enumerate(self.blocks):
-                if self.is_payload_block(i):
-                    attempt_buf[u:v] = uniform(self.random, v - u)
-            attempt = self.cached_test_function(attempt_buf)
-            if self.__predicate(attempt):
-                prev = self.shrink_target
-                self.update_shrink_target(attempt)
-                self.__shrinking_block_cache = {}
-                self.greedy_shrink()
-                if (
-                    sort_key(self.shrink_target.buffer) <
-                    sort_key(prev.buffer)
-                ):
-                    # We have successfully shrunk the example past where
-                    # we started from. Now we begin the whole process
-                    # again from the new, smaller, example.
-                    count = 0
-                else:
-                    self.update_shrink_target(prev)
-                    self.__shrinking_block_cache = {}
 
     def try_shrinking_blocks(self, blocks, b):
         """Attempts to replace each block in the blocks list with b. Returns

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1713,8 +1713,8 @@ class Shrinker(object):
         if self.shrink_target is not None:
             current = self.shrink_target.buffer
             new = new_target.buffer
-            if sort_key(new) < sort_key(current):
-                self.shrinks += 1
+            assert sort_key(new) < sort_key(current)
+            self.shrinks += 1
             if new_target.blocks != self.shrink_target.blocks:
                 self.__changed_blocks = set()
             else:

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -929,24 +929,6 @@ def test_automatic_discarding_is_turned_off_if_it_does_not_work(monkeypatch):
     assert calls[0] == 1
 
 
-def test_can_redraw_to_prevent_getting_stuck(monkeypatch):
-    monkeypatch.setattr(
-        ConjectureRunner, 'generate_new_examples',
-        lambda runner: runner.cached_test_function(
-            [10] + ([0] * 9 + [1]) * 2
-        ))
-
-    @run_to_buffer
-    def x(data):
-        n = data.draw_bits(8)
-        x = data.draw_bytes(n)
-        y = data.draw_bytes(n)
-        if any(x) and any(y):
-            data.mark_interesting()
-
-    assert x == hbytes([1, 1, 1])
-
-
 @pytest.mark.parametrize('bits', [3, 9])
 @pytest.mark.parametrize('prefix', [b'', b'\0'])
 @pytest.mark.parametrize('seed', [0])


### PR DESCRIPTION
In tracking down some tests that had become flaky as a result of the move over to `minimal` (where they would now error instead of silently timing out) I found the culprit was the random backtracking code, which basically meant they were doing triple the work they needed to.

So I wondered... is that code actually doing anything for us any more? The shrinker has improved a lot since it was introduced, and it was never very good in the first place.

Based on some sampling of the tests it was originally designed to support, it looks like the answer is no. CI will tell us if I'm missing anything I guess.