### PR TITLE
Add caching to appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,13 @@ environment:
       PYTHON_VERSION: "3.6.5"
       PYTHON_ARCH: "64"
 
+cache:
+  - "C:\\Python27"
+  - "C:\\Python27-x64"
+  - "C:\\Python36"
+  - "C:\\Python36-x64"
+  - "%LOCALAPPDATA%\pip\Cache"
+
 # Appveyor "helpfully" ignores skip directives in the commit message body
 # https://www.appveyor.com/docs/how-to/filtering-commits/#commit-message
 skip_commits:


### PR DESCRIPTION
Hey you know what's cool? Caching!

You know what's bad? Slow builds!

Guess which of these two things we have on our Windows builds. 🤔🤔🤔

Unfortunately this cannot easily be tested as working correctly until this build is merged, because appveyor doesn't distinguish PRs from forks vs PRs from the main repo, so cache building is either off in all PRs or on in external ones. 😢 