### PR TITLE
Move a bunch of Travis tasks into main to improve throughput

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,14 @@ jobs:
       env: TASK=check-coverage
     - env: TASK=check-pypy
     - env: TASK=check-py36
+    - env: TASK=check-py27
     - env: TASK=check-ruby-tests
+    - env: TASK=check-quality
+    - env: TASK=check-py34
+    - env: TASK=check-py35
+    - env: TASK=check-py37
+      sudo: required
+      dist: xenial
 
     # Less important tests that will probably
     # pass whenever the above do but are still
@@ -54,14 +61,7 @@ jobs:
     - stage: extras
       env: TASK=check-unicode
       env: TASK=check-pure-tracer
-    - env: TASK=check-py27
-    - env: TASK=check-quality
     - env: TASK=check-py27-typing
-    - env: TASK=check-py34
-    - env: TASK=check-py35
-    - env: TASK=check-py37
-      sudo: required
-      dist: xenial
     - env: TASK=check-nose
     - env: TASK=check-pytest30
     - env: TASK=check-faker070


### PR DESCRIPTION
Currently we have only four tasks in main. We have five builders, so this means we're not getting full parallelism.

More than that though, the coverage task takes twice as long as all of the other python ones (and the ruby tests are very fast), which means that once builders finish they end up starved of work.

This moves one large task and a bunch of medium sized tasks back into main to attempt to fix that and improve our throughput when the build is green. The downside is of course we'll do a bit more work when one of these tasks fail, but c'est la vie.