### PR TITLE
Make tests pass under pytest 3.7.0

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch is for downstream packagers - our tests now pass under
+:pypi:`pytest` 3.7.0 (released 2018-07-30).  There are no changes
+to the source of Hypothesis itself.

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -77,5 +77,5 @@ def test_can_inject_mock_via_fixture(mock_fixture, xs):
 
 @given(integers())
 def test_can_inject_autospecced_mock_via_fixture(spec_fixture, xs):
-    spec_fixture.bar.return_value = infinity()
+    spec_fixture.bar.return_value = float('inf')
     assert xs <= spec_fixture.bar()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,5 +16,5 @@ pluggy==0.7.1             # via pytest
 py==1.5.4                 # via pytest
 pytest-forked==0.2        # via pytest-xdist
 pytest-xdist==1.22.5
-pytest==3.6.4
+pytest==3.7.0
 six==1.11.0               # via mock, more-itertools, pytest, pytest-xdist

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -54,7 +54,7 @@ pygithub==1.40            # via pyupio
 pygments==2.2.0           # via ipython, sphinx
 pyjwt==1.6.4              # via pygithub
 pyparsing==2.2.0          # via packaging
-pytest==3.6.4
+pytest==3.7.0
 python-dateutil==2.7.3
 python-gitlab==1.5.1      # via pyupio
 pytz==2018.5              # via babel, django


### PR DESCRIPTION
Closes #1448, with a version bump so @jochym has a target to build.