### PR TITLE
Don't bother running quality tests on 2.7

### DIFF
--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import sys
 from random import Random
 from fractions import Fraction
 from functools import reduce

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -32,7 +32,7 @@ from tests.common.debug import minimal
 from hypothesis.strategies import just, none, sets, text, lists, builds, \
     tuples, booleans, integers, fractions, frozensets, dictionaries, \
     sampled_from, fixed_dictionaries
-from hypothesis.internal.compat import PY3, OrderedDict, hrange
+from hypothesis.internal.compat import OrderedDict, hrange
 
 
 def test_integers_from_minimizes_leftwards():
@@ -192,12 +192,6 @@ def test_minimize_multiple_elements_in_silly_large_int_range_min_is_not_dupe():
         timeout_after=60,
     )
     assert x == target
-
-
-@pytest.mark.skipif(PY3, reason=u'Python 3 has better integers')
-def test_minimize_long():
-    assert minimal(
-        integers(), lambda x: type(x).__name__ == u'long') == sys.maxint + 1
 
 
 def test_find_large_union_list():

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -420,7 +420,6 @@ standard_tox_task('pure-tracer')
 @task()
 def check_quality():
     run_tox('quality', PY36)
-    run_tox('quality2', PY27)
 
 
 examples_task = task(if_changed=(hp.PYTHON_SRC, os.path.join(


### PR DESCRIPTION
A new battle in the ongoing war on build times.

TLDR: There should be no material differences between these tests on different Python versions. Where there are that's a bug we should find with other tests (and also due to the gradual decline of how much we care about Python 2, meh if there are).