### PR TITLE
Make new adaptive deletion pass actually work

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes several bugs that were introduced to the shrinker in
+:ref:`3.16.24 <v3.66.24>` which would have caused it to behave significantly
+less well than advertised. With any luck you should *actually* see the promised
+benefits now.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -296,7 +296,7 @@ class ConjectureData(object):
         self.__check_capacity(len(string))
         assert isinstance(string, hbytes)
         original = self.index
-        self.__write(string)
+        self.__write(string, forced=True)
         self.forced_indices.update(hrange(original, self.index))
         self.forced_blocks.add(len(self.blocks) - 1)
         return string
@@ -310,7 +310,7 @@ class ConjectureData(object):
 
     def __write(self, result, forced=False):
         ex = self.start_example(DRAW_BYTES_LABEL)
-        ex.trivial = not forced and any(result)
+        ex.trivial = forced or not any(result)
         initial = self.index
         n = len(result)
         self.block_starts.setdefault(n, []).append(initial)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
@@ -58,7 +58,7 @@ class Length(Shrinker):
             i = len(self.current) - 1 - j
             start = self.current
             find_integer(
-                lambda k: k <= i and self.consider(
+                lambda k: k <= i + 1 and self.consider(
                     start[:i + 1 - k] + start[i + 1:]
                 )
             )

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -22,6 +22,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.errors import Frozen
+from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.data import Status, StopTest, \
     ConjectureData
 from hypothesis.searchstrategy.strategies import SearchStrategy
@@ -126,3 +127,23 @@ def test_empty_discards_do_not_count():
     x.stop_example(discard=True)
     x.freeze()
     assert not x.has_discards
+
+
+def test_triviality():
+    d = ConjectureData.for_buffer([1, 0, 1])
+
+    d.start_example(1)
+    d.draw_bits(1)
+    d.draw_bits(1)
+    d.stop_example(1)
+
+    d.write(hbytes([2]))
+    d.freeze()
+
+    def eg(u, v):
+        return [ex for ex in d.examples if ex.start == u and ex.end == v][0]
+
+    assert not eg(0, 2).trivial
+    assert not eg(0, 1).trivial
+    assert eg(1, 2).trivial
+    assert eg(2, 3).trivial

--- a/hypothesis-python/tests/nocover/test_conjecture_length_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_length_shrinking.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from random import Random
+
+import hypothesis.strategies as st
+from hypothesis import given, example
+from hypothesis.internal.conjecture.shrinking import Length
+
+sizes = st.integers(0, 100)
+
+
+@example(m=0, n=1)
+@given(sizes, sizes)
+def test_shrinks_down_to_size(m, n):
+    m, n = sorted((m, n))
+    assert Length.shrink(
+        [0] * n + [1], lambda ls: len(ls) >= m + 1 and ls[-1] == 1,
+        random=Random(0)
+    ) == (0,) * m + (1,)

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -95,7 +95,7 @@ TRIAL_SETTINGS = settings(
 ])
 @pytest.mark.parametrize('size', [5, 10, 20])
 @pytest.mark.parametrize('p', [0.01, 0.1])
-@pytest.mark.parametrize('strategy_class', [LinearLists, Matrices])
+@pytest.mark.parametrize('strategy_class', [LinearLists])
 def test_minimal_poisoned_containers(seed, size, p, strategy_class):
     elements = Poisoned(p)
     strategy = strategy_class(elements, size)


### PR DESCRIPTION
Somewhat impressively, the new adaptive deletion pass was literally 100% broken but the tests we had for the pass specifically happened to work given that it now attempted to zero examples, and all of the quality tests the rest of the shrinker was able to pick up the slack.

Um, oops?