### PR TITLE
Better debug information for profiling shrink passes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the debugging information that the shrinker emits about
+the operations it performs, giving better summary statistics about which
+passes resulted in test executions and whether they were successful.

--- a/hypothesis-python/tests/cover/test_debug_information.py
+++ b/hypothesis-python/tests/cover/test_debug_information.py
@@ -30,7 +30,7 @@ def test_reports_passes():
     @given(st.integers())
     @settings(verbosity=Verbosity.debug)
     def test(i):
-        assert i < 10000
+        assert i < 10
 
     with capture_out() as out:
         with pytest.raises(AssertionError):
@@ -42,11 +42,11 @@ def test_reports_passes():
     assert 'calls' in value
     assert 'shrinks' in value
 
-    shrinks_info = re.compile(r"call(s?) and ([0-9]+) shrink(s?)")
+    shrinks_info = re.compile(r"call(s?) of which ([0-9]+) shrank")
 
     for l in value.splitlines():
         m = shrinks_info.search(l)
         if m is not None and int(m.group(2)) != 0:
             break
     else:
-        assert False, 'No reports of successful shrinks!'
+        assert False, value


### PR DESCRIPTION
This adds a useful debug report at the end of shrinking to help people (in this case me) debug WTF is going on and what bits of the shrinker cost a lot / don't work that well.

Example output:

```
---------------------
Shrink pass profiling
---------------------

Shrinking made a total of 254 calls of which 37 shrank.

Individual breakdown:

  * adaptive_example_deletion made 85 calls of which 8 shrank.
  * minimize_individual_blocks made 44 calls of which 15 shrank.
  * interval_deletion_with_block_lowering made 39 calls of which 0 shrank.
  * adaptive_zero made 35 calls of which 12 shrank.
  * reorder_examples made 14 calls of which 0 shrank.
  * block_deletion made 12 calls of which 0 shrank.
  * pass_to_descendant made 9 calls of which 0 shrank.
  * minimize_block_pairs_retaining_sum made 8 calls of which 0 shrank.
  * lower_dependent_block_pairs made 4 calls of which 1 shrank.
  * bulk_block_zero made 2 calls of which 0 shrank.
  * remove_discarded made 1 call of which 1 shrank.
  * shrink_offset_pairs made 1 call of which 0 shrank.
```