### PR TITLE
Run lexicographic minimization from the last block backwards

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release changes the order in which Hypothesis chooses parts of the test case
+to shrink. For typical usage this should be a significant performance improvement on
+large examples. It is unlikely to have a major impact on example quality, but where
+it does change the result it should usually be an improvement.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -2011,15 +2011,15 @@ class Shrinker(object):
 
         then in our shrunk example, x = 10 rather than say 97.
         """
-        i = 0
-        while i < len(self.blocks):
+        i = len(self.blocks) - 1
+        while i >= 0:
             u, v = self.blocks[i]
             Lexical.shrink(
                 self.shrink_target.buffer[u:v],
                 lambda b: self.try_shrinking_blocks((i,), b),
                 random=self.random, full=False,
             )
-            i += 1
+            i -= 1
 
     @shrink_pass
     def reorder_blocks(self):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1288,6 +1288,9 @@ def test_buffer_changes_during_pair_shrink_stays_interesting(monkeypatch):
 def test_shrinking_blocks_from_common_offset(monkeypatch):
     monkeypatch.setattr(
         Shrinker, 'shrink', lambda self: (
+            # Run minimize_individual_blocks twice so we have both blocks show
+            # as changed regardless of which order this happens in.
+            self.minimize_individual_blocks(),
             self.minimize_individual_blocks(),
             self.lower_common_block_offset(),
         )
@@ -1302,9 +1305,9 @@ def test_shrinking_blocks_from_common_offset(monkeypatch):
     def x(data):
         m = data.draw_bits(8)
         n = data.draw_bits(8)
-        if abs(m - n) <= 1:
+        if abs(m - n) <= 1 and max(m, n) > 0:
             data.mark_interesting()
-    assert x == hbytes([1, 0])
+    assert sorted(x) == [0, 1]
 
 
 def test_handle_empty_draws(monkeypatch):


### PR DESCRIPTION
In accordance with my recent observation that we should actually prioritise shrinking towards the end rather than the beginning because it's more likely to work, this makes the same change to lexicographic minimization: Shrink later blocks earlier.

This also has the advantage that when there are multiple candidate examples earlier in the test case that an index could be pointing to, this is likely to move them to the earlier one, which can help deletion later.

(There's not much in the way of testing for this as it's just a heuristic change, and I'm not really sure how to test that behaves correctly without overfitting in a way that would just cause the test to break the next time we wanted to change the heuristic)