### PR TITLE
Fix off-by-one error and add lots of tests to conjecture engine

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,9 @@
 RELEASE_TYPE: patch
 
-This release improves how Hypothesis handles reducing the size of integers'
-representation yet further, by covering a corner case that was missing in
-:ref:`3.66.28 <v3.66.28>`.
+This release fixes two very minor bugs in the core engine:
+
+* it fixes a corner case that was missing in :ref:`3.66.28 <v3.66.28>`, which
+  should cause shrinking to work slightly better.
+* it fixes some logic for how shrinking interacts with the database that was
+  causing Hypothesis to be insufficiently aggressive about clearing out old
+  keys.


### PR DESCRIPTION
This started out as an attempt to get the conjecture engine unit tests to 100% branch coverage because the release of 3.66.28 was held up by a flaky coverage of one line, but then some tests I was writing failed to cover the line I expected them to. I stared a bit at the code we were about to release and about 30 seconds after the release went out realised that it had a (very minor) bug. :sad:

So here's a patch to fix that bug and add lots of tests.