### PR TITLE
Make sure we always pass around the allow_infinite parameter

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug in :func:`~hypotheses.strategies.floats`, where
+setting ``allow_infinity=False`` and only one of ``min_value`` and
+``max_value`` would allow infinite values to be generated.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
 This release fixes a bug in :func:`~hypotheses.strategies.floats`, where
-setting ``allow_infinity=False`` and only one of ``min_value`` and
+setting ``allow_infinity=False`` and exactly one of ``min_value`` and
 ``max_value`` would allow infinite values to be generated.

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -466,7 +466,7 @@ def floats(
     elif min_value is not None:
         if min_value < 0:
             result = floats(
-                min_value=0.0
+                min_value=0.0, allow_infinity=allow_infinity
             ) | floats(min_value=min_value, max_value=-0.0)
         else:
             result = (
@@ -483,7 +483,7 @@ def floats(
             result = floats(
                 min_value=0.0,
                 max_value=max_value,
-            ) | floats(max_value=-0.0)
+            ) | floats(max_value=-0.0, allow_infinity=allow_infinity)
         else:
             result = (
                 floats(allow_infinity=allow_infinity, allow_nan=False).map(

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -437,3 +437,17 @@ def test_no_infinity_for_min_max_values(value, parameter_name):
         assert not math.isinf(xs)
 
     test_not_infinite()
+
+@pytest.mark.parametrize('parameter_name', ['min_value', 'max_value'])
+@pytest.mark.parametrize('value', [-1, 0, 1])
+def test_no_nan_for_min_max_values(value, parameter_name):
+    kwargs = {
+        'allow_nan': False,
+        parameter_name: value,
+    }
+
+    @given(ds.floats(**kwargs))
+    def test_not_nan(xs):
+        assert not math.isnan(xs)
+
+    test_not_nan()

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -422,3 +422,18 @@ def test_empty_elements_with_max_size_is_deprecated():
 @checks_deprecated_behaviour
 def test_average_size_is_deprecated():
     ds.lists(ds.integers(), average_size=1).example()
+
+
+@pytest.mark.parametrize('parameter_name', ['min_value', 'max_value'])
+@pytest.mark.parametrize('value', [-1, 0, 1])
+def test_no_infinity_for_min_max_values(value, parameter_name):
+    kwargs = {
+        'allow_infinity': False,
+        parameter_name: value,
+    }
+
+    @given(ds.floats(**kwargs))
+    def test_not_infinite(xs):
+        assert not math.isinf(xs)
+
+    test_not_infinite()

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -438,6 +438,7 @@ def test_no_infinity_for_min_max_values(value, parameter_name):
 
     test_not_infinite()
 
+
 @pytest.mark.parametrize('parameter_name', ['min_value', 'max_value'])
 @pytest.mark.parametrize('value', [-1, 0, 1])
 def test_no_nan_for_min_max_values(value, parameter_name):


### PR DESCRIPTION
Resolves #1476. Turns out when we recursively call `floats()`, we weren't always passing it in correctly.

The NaN test isn't fixing a bug; I just couldn't convince myself we were doing the right thing without writing a test first, and once I'd written it I figured it would be a useful counterpart.