### PR TITLE
Update type hints for `example`, `seed` and `register_type_strategy`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -180,6 +180,7 @@ their individual contributions.
 * `Jeremy Thurgood <https://github.com/jerith>`_
 * `J.J. Green <http://soliton.vm.bytemark.co.uk/pub/jjg/>`_
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)
+* `Joey Tuong <https://github.com/tetrapus>`_
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)
 * `jwg4 <https://www.github.com/jwg4>`_
 * `kbara <https://www.github.com/kbara>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes the type hint on `register_type_strategy`. The second
+argument to `register_type_strategy` must either be a `SearchStrategy`,
+or a callable which takes a `type` and returns a `SearchStrategy`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,8 @@
 RELEASE_TYPE: patch
 
-This release fixes the type hint on `register_type_strategy`. The second
-argument to `register_type_strategy` must either be a `SearchStrategy`,
-or a callable which takes a `type` and returns a `SearchStrategy`.
+This release adds type hints to the :func:`~hypothesis.example` and
+:func:`~hypothesis.seed` decorators, and fixes the type hint on
+:func:`~hypothesis.strategies.register_type_strategy`. The second argument to
+:func:`~hypothesis.strategies.register_type_strategy` must either be a
+``SearchStrategy``, or a callable which takes a ``type`` and returns a
+``SearchStrategy``.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,8 +76,12 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict, Callable, Optional, Union  # noqa
+    from typing import (  # noqa
+        Any, Dict, Callable, Hashable, Optional, Union, TypeVar,
+    )
     from hypothesis.utils.conventions import InferType  # noqa
+
+    TestFunc = TypeVar('TestFunc', bound=Callable)
 
 
 running_under_pytest = False
@@ -95,6 +99,7 @@ class Example(object):
 
 
 def example(*args, **kwargs):
+    # type: (*Any, **Any) -> Callable[[TestFunc], TestFunc]
     """A decorator which ensures a specific example is always tested."""
     if args and kwargs:
         raise InvalidArgument(
@@ -114,6 +119,7 @@ def example(*args, **kwargs):
 
 
 def seed(seed):
+    # type: (Hashable) -> Callable[[TestFunc], TestFunc]
     """seed: Start the test execution from a specific seed.
 
     May be any hashable object. No exact meaning for seed is provided

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -2054,8 +2054,11 @@ def data():
     return DataStrategy()
 
 
-def register_type_strategy(custom_type, strategy):
-    # type: (type, Union[SearchStrategy, Callable[[type], SearchStrategy]]) -> None
+def register_type_strategy(
+    custom_type,  # type: type
+    strategy,  # type: Union[SearchStrategy, Callable[[type], SearchStrategy]]
+):
+    # type: (...) -> None
     """Add an entry to the global type-to-strategy lookup.
 
     This lookup is used in :func:`~hypothesis.strategies.builds` and

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -2055,7 +2055,7 @@ def data():
 
 
 def register_type_strategy(custom_type, strategy):
-    # type: (type, Union[type, Callable[[type], SearchStrategy]]) -> None
+    # type: (type, Union[SearchStrategy, Callable[[type], SearchStrategy]]) -> None
     """Add an entry to the global type-to-strategy lookup.
 
     This lookup is used in :func:`~hypothesis.strategies.builds` and


### PR DESCRIPTION
The second argument of `register_type_strategy` should accept either a strategy, or a callable which returns a strategy.