### PR TITLE
Add type hints to @example and @seed

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release adds type hints to the `example` and `seed` decorators.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -77,8 +77,8 @@ except ImportError:  # pragma: no cover
 
 if False:
     from typing import (  # noqa
-        Any, Dict, Callable, Hashable, Optional, Union, TypeVar,  # noqa
-    )  # noqa
+        Any, Dict, Callable, Hashable, Optional, Union, TypeVar,
+    )
     from hypothesis.utils.conventions import InferType  # noqa
 
     T = TypeVar('T')

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,8 +76,9 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict, Callable, Hashable, Optional, \  # noqa
-        Union, TypeVar  # noqa
+    from typing import (  # noqa
+        Any, Dict, Callable, Hashable, Optional, Union, TypeVar,  # noqa
+    )  # noqa
     from hypothesis.utils.conventions import InferType  # noqa
 
     T = TypeVar('T')

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,8 +76,11 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict, Callable, Optional, Union  # noqa
+    from typing import Any, Dict, Callable, Hashable, Optional, Union, \
+        TypeVar  # noqa
     from hypothesis.utils.conventions import InferType  # noqa
+
+    T = TypeVar('T')
 
 
 running_under_pytest = False
@@ -95,6 +98,7 @@ class Example(object):
 
 
 def example(*args, **kwargs):
+    # type: (*Any, **Any) -> Callable[[T], T]
     """A decorator which ensures a specific example is always tested."""
     if args and kwargs:
         raise InvalidArgument(
@@ -114,6 +118,7 @@ def example(*args, **kwargs):
 
 
 def seed(seed):
+    # type: (Hashable) -> Callable[[T], T]
     """seed: Start the test execution from a specific seed.
 
     May be any hashable object. No exact meaning for seed is provided

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,8 +76,8 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict, Callable, Hashable, Optional, Union, \
-        TypeVar  # noqa
+    from typing import Any, Dict, Callable, Hashable, Optional, \  # noqa
+        Union, TypeVar  # noqa
     from hypothesis.utils.conventions import InferType  # noqa
 
     T = TypeVar('T')


### PR DESCRIPTION
Add type hints for the `@example` and `@seed` decorators in `hypothesis.core`