### PR TITLE
Track example depth implicitly, via the length of the example stack

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -200,6 +200,7 @@ their individual contributions.
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
 * `Sam Hames <https://www.github.com/SamHames>`_
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (s.shanabrook@gmail.com)
+* `Stuart Cook <https://www.github.com/Zalathar>`_
 * `Sushobhit <https://github.com/sushobhit27>`_ (sushobhitsolanki@gmail.com)
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
 * `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release contains a tiny refactoring of the internals.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -102,7 +102,6 @@ class ConjectureData(object):
         self.is_find = False
         self._draw_bytes = draw_bytes
         self.overdraw = 0
-        self.level = 0
         self.block_starts = {}
         self.blocks = []
         self.buffer = bytearray()
@@ -142,7 +141,7 @@ class ConjectureData(object):
     def depth(self):
         # We always have a single example wrapping everything. We want to treat
         # that as depth 0 rather than depth 1.
-        return self.level - 1
+        return len(self.example_stack) - 1
 
     @property
     def index(self):
@@ -199,11 +198,12 @@ class ConjectureData(object):
 
     def start_example(self, label):
         self.__assert_not_frozen('start_example')
-        self.level += 1
+
         i = len(self.examples)
+        new_depth = self.depth + 1
         ex = Example(
             index=i,
-            depth=self.depth, label=label, start=self.index,
+            depth=new_depth, label=label, start=self.index,
         )
         self.examples.append(ex)
         if self.example_stack:
@@ -216,7 +216,6 @@ class ConjectureData(object):
     def stop_example(self, discard=False):
         if self.frozen:
             return
-        self.level -= 1
 
         k = self.example_stack.pop()
         ex = self.examples[k]

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -147,3 +147,21 @@ def test_triviality():
     assert not eg(0, 1).trivial
     assert eg(1, 2).trivial
     assert eg(2, 3).trivial
+
+
+def test_example_depth_marking():
+    d = ConjectureData.for_buffer(hbytes(24))
+
+    # These draw sizes are chosen so that each example has a unique length.
+    d.draw_bytes(2)
+    d.start_example('inner')
+    d.draw_bytes(3)
+    d.draw_bytes(6)
+    d.stop_example()
+    d.draw_bytes(12)
+    d.freeze()
+
+    depths = set((ex.length, ex.depth) for ex in d.examples)
+    assert depths == set([
+        (2, 1), (3, 2), (6, 2), (9, 1), (12, 1), (23, 0)
+    ])


### PR DESCRIPTION
I was poking around in Conjecture, and noticed that `self.level` is manually maintaining a value that is always equal to the length of the example stack.

Since the depth is always read through a property accessor anyway, getting rid of the explicit level field seems like a net improvement.