### PR TITLE
Fix a latent Python 2.7 test bug: bytes(5) should be hbytes(5)

### DIFF
--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -57,7 +57,7 @@ def test_can_draw_zero_bytes():
 
 
 def test_draw_past_end_sets_overflow():
-    x = ConjectureData.for_buffer(bytes(5))
+    x = ConjectureData.for_buffer(hbytes(5))
     with pytest.raises(StopTest) as e:
         x.draw_bytes(6)
     assert e.value.testcounter == x.testcounter


### PR DESCRIPTION
In Python 2.7, `bytes(5)` is the string `'5'`, rather than five 0 bytes.

In this particular test, that doesn't matter much, because the draw still overflows as intended. But it shouldn't be testing subtly different things across Python versions.

(I ran into this in #1488, because I copied the `bytes` call into a new test where the difference actually mattered, so my test failed on 2.7.)