### PR TITLE
Prescreen capped bytes by masking, not by saturating

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This change fixes a small bug in how the core engine caches the results of
+previously-tried inputs. The effect is unlikely to be noticeable, but it might
+avoid unnecesary work in some cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -927,7 +927,7 @@ class ConjectureRunner(object):
             except KeyError:
                 pass
             try:
-                b = min(b, self.capped[node_index])
+                b = b & self.capped[node_index]
             except KeyError:
                 pass
             try:

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -151,3 +151,23 @@ def test_regression_1():
     assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
 
     assert int_from_bytes(x[-2:]) in (254, 512)
+
+
+@given(st.integers(0, 255), st.integers(0, 255))
+def test_prescreen_with_capped_byte_agrees_with_results(byte_a, byte_b):
+    def f(data):
+        data.draw_bits(2)
+
+    runner = ConjectureRunner(f)
+
+    data_a = ConjectureData.for_buffer(hbytes([byte_a]))
+    data_b = ConjectureData.for_buffer(hbytes([byte_b]))
+
+    runner.test_function(data_a)
+    prescreen_b = runner.prescreen_buffer(hbytes([byte_b]))
+    # Always test buffer B, to check whether the prescreen was correct.
+    runner.test_function(data_b)
+
+    # If the prescreen passed, then the buffers should be different.
+    # If it failed, then the buffers should be the same.
+    assert prescreen_b == (data_a.buffer != data_b.buffer)


### PR DESCRIPTION
I was reading through the tree traversal in `prescreen_buffer`, and made some observations:

- When we encounter a forced node, we pretend the buffer has that value, because that's what the test would end up doing.
- When we encounter a capped node, we pretend the buffer's value is saturated, because that's what the test would end up doing ...

... except that the latter isn't true! In reality, `draw_bits` will mask its raw byte value, not saturate it.

This results in situations where the prescreen rejects a novel buffer, or accepts a buffer that's equivalent to a past one.

----

I'm fairly confident this is a real bug, but not entirely. So a second opinion would be very welcome.

Also note that the first patch in the PR is a test that fails on master, followed by a patch that fixes it. That seems reasonable to me, but if it's a problem I can reorder them.