### PR TITLE
Add npst.from_dtype to public API

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch documents the :func:`~hypothesis.extra.numpy.from_dtype` function,
+which infers a strategy for :class:`numpy:numpy.dtype`s.  This is used in
+:func:`~hypothesis.extra.numpy.arrays`, but can also be used directly when
+creating e.g. Pandas objects.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -31,6 +31,7 @@ from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.internal.compat import hrange, text_type
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
+from hypothesis.internal.validation import check_type
 
 if False:
     from typing import Any, Union, Sequence, Tuple  # noqa
@@ -42,6 +43,8 @@ TIME_RESOLUTIONS = tuple('Y  M  D  h  m  s  ms  us  ns  ps  fs  as'.split())
 @st.defines_strategy_with_reusable_values
 def from_dtype(dtype):
     # type: (np.dtype) -> st.SearchStrategy[Any]
+    """Creates a strategy which can generate any value of the given dtype."""
+    check_type(np.dtype, dtype, 'dtype')
     # Compound datatypes, eg 'f4,f4,f4'
     if dtype.names is not None:
         # mapping np.void.type over a strategy is nonsense, so return now.

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -17,6 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import numpy
 import pytest
 
 import hypothesis.strategies as st
@@ -53,6 +54,10 @@ def e(a, **kwargs):
         e(nps.unsigned_integer_dtypes, endianness=3),
         e(nps.unsigned_integer_dtypes, sizes=()),
         e(nps.unsigned_integer_dtypes, sizes=(3,)),
+        e(nps.from_dtype, dtype='float64'),
+        e(nps.from_dtype, dtype=float),
+        e(nps.from_dtype, dtype=numpy.int8),
+        e(nps.from_dtype, dtype=1),
     ]
 )
 def test_raise_invalid_argument(function, kwargs):


### PR DESCRIPTION
I actually thought this was already public API - and mentioned it at conferences - but apparently not!  I've therefore added a brief docstring and some validation so it can be used downstream, by e.g. Pandas when they're generating data with related dtypes.  Closes #1485.