### PR TITLE
Remove vestigial zero-extension from tree lookup in cached_test_function

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This change fixes a small bug in how the core engine consults its cache
+of previously-tried inputs. There is unlikely to be any user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -939,11 +939,11 @@ class ConjectureRunner(object):
 
     def cached_test_function(self, buffer):
         node_index = 0
-        for i in hrange(len(buffer)):
+        for c in buffer:
             try:
                 c = self.forced[node_index]
             except KeyError:
-                c = buffer[i]
+                pass
             try:
                 node_index = self.tree[node_index][c]
             except KeyError:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -939,14 +939,11 @@ class ConjectureRunner(object):
 
     def cached_test_function(self, buffer):
         node_index = 0
-        for i in hrange(self.settings.buffer_size):
+        for i in hrange(len(buffer)):
             try:
                 c = self.forced[node_index]
             except KeyError:
-                if i < len(buffer):
-                    c = buffer[i]
-                else:
-                    c = 0
+                c = buffer[i]
             try:
                 node_index = self.tree[node_index][c]
             except KeyError:


### PR DESCRIPTION
Logic for zero-extending input buffers was added in #996, but then removed in favour of having callers add any necessary zeros manually. However, this zero-extension step in the tree traversal was left behind.

In cases where the input buffer would overflow, but a zero-extended copy of that buffer has already been tested and cached, this code would result in one of two small problems:

- The tree traversal continues longer than necessary.
- The cache returns a (non-overflow) result that isn't accurate for the input buffer.