### PR TITLE
Check for capped bytes in cached_test_function

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This change improves the core engine's ability to avoid unnecessary work,
+by consulting its cache of previously-tried inputs in more cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -945,6 +945,10 @@ class ConjectureRunner(object):
             except KeyError:
                 pass
             try:
+                c = c & self.capped[node_index]
+            except KeyError:
+                pass
+            try:
                 node_index = self.tree[node_index][c]
             except KeyError:
                 break

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -171,3 +171,21 @@ def test_prescreen_with_capped_byte_agrees_with_results(byte_a, byte_b):
     # If the prescreen passed, then the buffers should be different.
     # If it failed, then the buffers should be the same.
     assert prescreen_b == (data_a.buffer != data_b.buffer)
+
+
+@given(st.integers(0, 255), st.integers(0, 255))
+def test_cached_with_capped_byte_agrees_with_results(byte_a, byte_b):
+    def f(data):
+        data.draw_bits(2)
+
+    runner = ConjectureRunner(f)
+
+    cached_a = runner.cached_test_function(hbytes([byte_a]))
+    cached_b = runner.cached_test_function(hbytes([byte_b]))
+
+    data_b = ConjectureData.for_buffer(hbytes([byte_b]))
+    runner.test_function(data_b)
+
+    # If the cache found an old result, then it should match the real result.
+    # If it did not, then it must be because A and B were different.
+    assert (cached_a is cached_b) == (cached_a.buffer == data_b.buffer)


### PR DESCRIPTION
This adds support for `self.capped` to `cached_test_function`, to bring it in line with `prescreen_buffer`.