### PR TITLE
Fix description of when an Example is "trivial"

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes a small mistake in an internal comment.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -51,9 +51,9 @@ class Example(object):
     start = attr.ib()
     end = attr.ib(default=None)
 
-    # An example is trivial if it contains any non-forced non-zero bytes. All
-    # examples start out as trivial and then get marked non-trivial when we
-    # see such a byte.
+    # An example is "trivial" if it only contains forced bytes and zero bytes.
+    # All examples start out as trivial, and then get marked non-trivial when
+    # we see a byte that is neither forced nor zero.
     trivial = attr.ib(default=True)
     discarded = attr.ib(default=None)
     children = attr.ib(default=attr.Factory(list))


### PR DESCRIPTION
The original comment started by trying to describe a trivial example, but then listed the characteristics of a non-trivial example.