### PR TITLE
The really quick CI patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
       - run: brew install readline xz ncurses
       - restore_cache:
          keys:
-           - v1-runtimes-
+           - v2-runtimes-
       - run: ./build.sh install-core
       - run: ./build.sh check-py27
       - run: ./build.sh check-py36
       - save_cache:
-          key: v1-runtimes-{{ epoch }}
+          key: v2-runtimes-{{ epoch }}
           paths:
             - ~/.cache/hypothesis-build-runtimes
             - ~/.cache/pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ install:
   - "%CMD_IN_ENV% python setup.py bdist_wheel --dist-dir dist"
 
 deploy_script:
-  - ps: "if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { python -m twine upload dist/* }"
+  - ps: 'if (($env:APPVEYOR_REPO_TAG -eq $TRUE) -and ($env:PYTHON_ARCH -eq "32")) { python -m twine upload dist/* }'
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
This patch has two parts:

1. Bumping the CircleCI cache key, which is the only way to clear a broken cache.  I'm leaving #1507 open as it would be nice to have a systematic fix at some point, but we need to unblock everything else so this is OK for now.
2. Improving the wheel upload condition fixes #1508, which was showing up as test failures for every release when no tests are failing.  This annoys me because our build *should* be green :fire: 

Merging this will allow CI to pass for all of @Zalathar's PRs, and set us up for the PyCon AU sprints this weekend.