### PR TITLE
patch for issue 1317 - improve error for from_type(an_empty_Enum)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -196,6 +196,7 @@ their individual contributions.
 * `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (maxim.kulkin@gmail.com)
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
+* `Paul Lorett Amazona <https://github.com/whatevergeek>`_
 * `Peadar Coyle <http://www.github.com/springcoil>`_ (peadarcoyle@gmail.com)
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
 * `Sam Hames <https://www.github.com/SamHames>`_

--- a/hypothesis-python/release.rst
+++ b/hypothesis-python/release.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This change ensures that the correct error (InvalidArgument) is raised when
+we attempt to call :func:`~hypothesis.strategies.from_type` on an empty 
+:class:`python:enum.Enum`.
+
+Thanks to Paul Amazona (@whatevergeek) for writing this patch at the PyCon Australia sprints! - @Zac-HD 

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1298,7 +1298,6 @@ def from_type(thing):
     # If we don't have a strategy registered for this type or any subtype, we
     # may be able to fall back on type annotations.
     if issubclass(thing, enum.Enum):
-        assert len(thing), repr(thing) + ' has no members to sample'
         return sampled_from(thing)
     # If we know that builds(thing) will fail, give a better error message
     required = required_args(thing)

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import enum
+
 import pytest
 
 import hypothesis.strategies as st
@@ -149,3 +151,11 @@ def test_given_can_infer_on_py2():
         pass
     inner.__annotations__ = {'a': int}
     given(a=infer)(inner)()
+
+
+class EmptyEnum(enum.Enum): 
+    pass
+
+
+def test_error_if_enum_is_empty():
+    assert st.from_type(EmptyEnum).is_empty


### PR DESCRIPTION
This change ensures that the correct error (InvalidArgument) is raised when
we attempt to call :func:`~hypothesis.strategies.from_type` on an empty 
:class:`python:enum.Enum`.

Done during PyCon Australia sprints!