### PR TITLE
Rename 'capped' to 'masks' in ConjectureRunner and ConjectureData

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This change performs a small rename and refactoring in the core engine.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -115,7 +115,7 @@ class ConjectureData(object):
         self.events = set()
         self.forced_indices = set()
         self.forced_blocks = set()
-        self.capped_indices = {}
+        self.masked_indices = {}
         self.interesting_origin = None
         self.tags = set()
         self.draw_times = []
@@ -282,7 +282,7 @@ class ConjectureData(object):
             assert len(buf) == n_bytes
             mask = (1 << (n % 8)) - 1
             buf[0] &= mask
-            self.capped_indices[self.index] = mask
+            self.masked_indices[self.index] = mask
             buf = hbytes(buf)
             self.__write(buf)
             result = int_from_bytes(buf)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -116,10 +116,10 @@ class ConjectureRunner(object):
         # point. Corresponds to data.write() calls.
         self.forced = {}
 
-        # Maps tree indices to the maximum byte that is valid at that point.
-        # Currently this is only used inside draw_bits, but it potentially
+        # Maps tree indices to a mask that restricts bytes at that point.
+        # Currently this is only updated by draw_bits, but it potentially
         # could get used elsewhere.
-        self.capped = {}
+        self.masks = {}
 
         # Where a tree node consists of the beginning of a block we track the
         # size of said block. This allows us to tell when an example is too
@@ -196,7 +196,7 @@ class ConjectureRunner(object):
             if i in data.forced_indices:
                 self.forced[node_index] = b
             try:
-                self.capped[node_index] = data.capped_indices[i]
+                self.masks[node_index] = data.masked_indices[i]
             except KeyError:
                 pass
             try:
@@ -223,7 +223,7 @@ class ConjectureRunner(object):
             self.tree[node_index] = data
 
             for j in reversed(indices):
-                mask = self.capped.get(j, 0xff)
+                mask = self.masks.get(j, 0xff)
                 assert _is_simple_mask(mask)
                 max_size = mask + 1
 
@@ -298,7 +298,7 @@ class ConjectureRunner(object):
             assert len(prefix) < self.cap
             assert node not in self.dead
 
-            mask = self.capped.get(node, 0xff)
+            mask = self.masks.get(node, 0xff)
             assert _is_simple_mask(mask)
             upper_bound = mask + 1
 
@@ -935,7 +935,7 @@ class ConjectureRunner(object):
             except KeyError:
                 pass
             try:
-                b = b & self.capped[node_index]
+                b = b & self.masks[node_index]
             except KeyError:
                 pass
             try:
@@ -953,7 +953,7 @@ class ConjectureRunner(object):
             except KeyError:
                 pass
             try:
-                c = c & self.capped[node_index]
+                c = c & self.masks[node_index]
             except KeyError:
                 pass
             try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -223,8 +223,12 @@ class ConjectureRunner(object):
             self.tree[node_index] = data
 
             for j in reversed(indices):
+                mask = self.capped.get(j, 0xff)
+                assert _is_simple_mask(mask)
+                max_size = mask + 1
+
                 if (
-                    len(self.tree[j]) < self.capped.get(j, 255) + 1 and
+                    len(self.tree[j]) < max_size and
                     j not in self.forced
                 ):
                     break
@@ -293,7 +297,11 @@ class ConjectureRunner(object):
         while True:
             assert len(prefix) < self.cap
             assert node not in self.dead
-            upper_bound = self.capped.get(node, 255) + 1
+
+            mask = self.capped.get(node, 0xff)
+            assert _is_simple_mask(mask)
+            upper_bound = mask + 1
+
             try:
                 c = self.forced[node]
                 prefix.append(c)
@@ -969,6 +977,16 @@ class ConjectureRunner(object):
         result = str(event)
         self.events_to_strings[event] = result
         return result
+
+
+def _is_simple_mask(mask):
+    """A simple mask is ``(2 ** n - 1)`` for some ``n``, so it has the effect
+    of keeping the lowest ``n`` bits and discarding the rest.
+
+    A mask in this form can produce any integer between 0 and the mask itself
+    (inclusive), and the total number of these values is ``(mask + 1)``.
+    """
+    return (mask & (mask + 1)) == 0
 
 
 def _draw_predecessor(rnd, xs):

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -154,7 +154,7 @@ def test_regression_1():
 
 
 @given(st.integers(0, 255), st.integers(0, 255))
-def test_prescreen_with_capped_byte_agrees_with_results(byte_a, byte_b):
+def test_prescreen_with_masked_byte_agrees_with_results(byte_a, byte_b):
     def f(data):
         data.draw_bits(2)
 
@@ -174,7 +174,7 @@ def test_prescreen_with_capped_byte_agrees_with_results(byte_a, byte_b):
 
 
 @given(st.integers(0, 255), st.integers(0, 255))
-def test_cached_with_capped_byte_agrees_with_results(byte_a, byte_b):
+def test_cached_with_masked_byte_agrees_with_results(byte_a, byte_b):
     def f(data):
         data.draw_bits(2)
 


### PR DESCRIPTION
~~(Depends on #1505; don't merge this until that has been merged and this has been rebased.)~~

This is a follow-up to the observation in https://github.com/HypothesisWorks/hypothesis/pull/1494#discussion_r211069136 that “capped” isn't a very accurate description of these values, which are primarily byte masks.

This PR first adds assertions in the places where we use a mask as something other than a mask. Then it renames `capped` to `masks`, and `capped_indices` to `masked_indices`.