### PR TITLE
Replace pickle with json in charmap.py

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -206,6 +206,7 @@ their individual contributions.
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
 * `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Tom McDermott <https://www.github.com/sponster-au>`_ (sponster@gmail.com)
+* `Vidya Rani <https://www.github.com/vidyarani-dg>`_ (vidyarani.d.g@gmail.com)
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)
 * `Zac Hatfield-Dodds <https://www.github.com/Zac-HD>`_ (zac.hatfield.dodds@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This is an internal change which replaces pickle with json to prevent possible
+security issues.
+
+Thanks to Vidya Rani D G (@vidyarani-dg) for writing this patch at the
+PyCon Australia sprints!

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -84,8 +84,7 @@ def charmap():
             except Exception:
                 pass
 
-        # This line converting to tuples needs to be moved down from
-        # line 73 now, to below the json.load, i.e. just before the assertions.
+        # convert between lists and tuples
         _charmap = {k: tuple(tuple(pair) for pair in pairs)
                     for k, pairs in tmp_charmap.items()}
         # each value is a tuple of 2-tuples (that is, tuples of length 2)

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import sys
 import gzip
-import pickle
+import json
 import tempfile
 import unicodedata
 
@@ -37,7 +37,7 @@ if False:
 def charmap_file():
     return os.path.join(
         storage_directory('unicodedata', unicodedata.unidata_version),
-        'charmap.pickle.gz'
+        'charmap.json.gz'
     )
 
 
@@ -59,7 +59,7 @@ def charmap():
         f = charmap_file()
         try:
             with gzip.GzipFile(f, 'rb') as i:
-                _charmap = dict(pickle.load(i))
+                _charmap = dict(json.loads(i))
 
         except Exception:
             tmp_charmap = {}
@@ -79,12 +79,20 @@ def charmap():
                 os.close(fd)
                 # Explicitly set the mtime to get reproducible output
                 with gzip.GzipFile(tmpfile, 'wb', mtime=1) as o:
-                    pickle.dump(sorted(_charmap.items()), o,
-                                pickle.HIGHEST_PROTOCOL)
+                    result = json.dumps(sorted(_charmap.items()))
+                    o.write(result.encode())
+
                 os.rename(tmpfile, f)
             except Exception:
                 pass
     assert _charmap is not None
+
+    # each value is a tuple of 2-tuples (that is, tuples of length 2)
+    # and that both elements of that tuple are integers.
+    for vs in _charmap.values():
+        for tup in vs:
+            assert len(tup) == 2
+            assert all([isinstance(elem, int) for elem in tup])
     return _charmap
 
 


### PR DESCRIPTION
 This PR replaces pickle with json and tuple in charmap.py - closes #1512 

Issue addressed during PyCon AU 2018 sprints.  