### PR TITLE
Add a test that an error thrown when caching `charmap()` isn't shown to the user

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch improves the testing of some internal caching.  It should have
+no user-visible effect.

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -82,7 +82,7 @@ def charmap():
                     pickle.dump(sorted(_charmap.items()), o,
                                 pickle.HIGHEST_PROTOCOL)
                 os.rename(tmpfile, f)
-            except Exception:  # pragma: no cover
+            except Exception:
                 pass
     assert _charmap is not None
     return _charmap

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -179,8 +179,6 @@ def test_error_writing_charmap_file_is_suppressed(monkeypatch):
     monkeypatch.setattr(tempfile, 'mkstemp', broken_mkstemp)
 
     cm._charmap = None
-
-    file_loc = cm.charmap_file()
-    os.unlink(file_loc)
+    os.unlink(cm.charmap_file())
 
     cm.charmap()

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -178,7 +178,13 @@ def test_error_writing_charmap_file_is_suppressed(monkeypatch):
 
     monkeypatch.setattr(tempfile, 'mkstemp', broken_mkstemp)
 
-    cm._charmap = None
-    os.unlink(cm.charmap_file())
+    try:
+        # Cache the charmap to avoid a performance hit the next time
+        # somebody tries to use it.
+        saved = cm._charmap
+        cm._charmap = None
+        os.unlink(cm.charmap_file())
 
-    cm.charmap()
+        cm.charmap()
+    finally:
+        cm._charmap = saved

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -19,6 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import os
 import sys
+import tempfile
 import unicodedata
 
 import hypothesis.strategies as st
@@ -169,3 +170,17 @@ def test_regenerate_broken_charmap_file():
 
 def test_exclude_characters_are_included_in_key():
     assert cm.query() != cm.query(exclude_characters='0')
+
+
+def test_error_writing_charmap_file_is_suppressed(monkeypatch):
+    def broken_mkstemp(dir):
+        raise RuntimeError()
+
+    monkeypatch.setattr(tempfile, 'mkstemp', broken_mkstemp)
+
+    cm._charmap = None
+
+    file_loc = cm.charmap_file()
+    os.unlink(file_loc)
+
+    cm.charmap()


### PR DESCRIPTION
While reviewing #1522, I noticed some low-hanging coverage fruit. This adds a test for that branch.