### PR TITLE
Fix trailing whitespace in changelog

### DIFF
--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -28,11 +28,11 @@ information to the contrary.
 -------------------
 
 This patch handles passing an empty :class:`python:enum.Enum` to
-:func:`~hypothesis.strategies.from_type` returns 
-:func:`~hypothesis.strategies.nothing`, instead of raising an 
+:func:`~hypothesis.strategies.from_type` returns
+:func:`~hypothesis.strategies.nothing`, instead of raising an
 internal :class:`python:AssertionError`.
 
-Thanks to Paul Amazona (@whatevergeek) for writing this patch at the 
+Thanks to Paul Amazona (@whatevergeek) for writing this patch at the
 PyCon Australia sprints!
 
 .. _v3.69.2:

--- a/hypothesis-python/docs/extras.rst
+++ b/hypothesis-python/docs/extras.rst
@@ -53,7 +53,7 @@ hypothesis[fakefactory]
     Hypothesis strategies, which are more effective at both finding and
     shrinking failing examples for your tests.
 
-    The :func:`~hypothesis.strategies.from_regex`,
+    The :func:`~hypothesis.strategies.from_regex`, :func:`~hypothesis.strategies.emails`,
     :func:`~hypothesis.strategies.text` (with some specific alphabet), and
     :func:`~hypothesis.strategies.sampled_from` strategies may be particularly
     useful.


### PR DESCRIPTION
which is making all the builds fail.  See #1515 for source; forthcoming issue for underlying problem.