### PR TITLE
Add fullmatch flag to strategies.from_regex

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -179,6 +179,7 @@ their individual contributions.
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
+* `Jakub Nabaglo <https://github.com/nbgl>`_ (j@nab.gl)
 * `Jeremy Thurgood <https://github.com/jerith>`_
 * `J.J. Green <http://soliton.vm.bytemark.co.uk/pub/jjg/>`_
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release adds a ``fullmatch`` argument to
+:func:`~hypothesis.strategies.from_regex`.  When ``fullmatch=True``, the
+whole example will match the regex pattern as for :func:`python:re.fullmatch`.
+
+Thanks to Jakub Nabaglo for writing this patch at the PyCon Australia sprints!

--- a/hypothesis-python/src/hypothesis/searchstrategy/regex.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/regex.py
@@ -235,7 +235,7 @@ def base_regex_strategy(regex, parsed=None):
     ))
 
 
-def regex_strategy(regex):
+def regex_strategy(regex, fullmatch):
     if not hasattr(regex, 'pattern'):
         regex = re.compile(regex)
 
@@ -261,7 +261,9 @@ def regex_strategy(regex):
     right_pad = base_padding_strategy
     left_pad = base_padding_strategy
 
-    if parsed[-1][0] == sre.AT:
+    if fullmatch:
+        right_pad = empty
+    elif parsed[-1][0] == sre.AT:
         if parsed[-1][1] == sre.AT_END_STRING:
             right_pad = empty
         elif parsed[-1][1] == sre.AT_END:
@@ -272,7 +274,9 @@ def regex_strategy(regex):
                 )
             else:
                 right_pad = st.one_of(empty, newline)
-    if parsed[0][0] == sre.AT:
+    if fullmatch:
+        left_pad = empty
+    elif parsed[0][0] == sre.AT:
         if parsed[0][1] == sre.AT_BEGINNING_STRING:
             left_pad = empty
         elif parsed[0][1] == sre.AT_BEGINNING:

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1002,8 +1002,8 @@ def text(
 
 @cacheable
 @defines_strategy
-def from_regex(regex):
-    # type: (Union[AnyStr, Pattern[AnyStr]]) -> SearchStrategy[AnyStr]
+def from_regex(regex, fullmatch=False):
+    # type: (Union[AnyStr, Pattern[AnyStr]], bool) -> SearchStrategy[AnyStr]
     """Generates strings that contain a match for the given regex (i.e. ones
     for which :func:`re.search` will return a non-None result).
 
@@ -1025,14 +1025,17 @@ def from_regex(regex):
     boundary markers. So e.g. ``r"\\A.\\Z"`` will return a single character
     string, while ``"."`` will return any string, and ``r"\\A.$"`` will return
     a single character optionally followed by a ``"\\n"``.
+    Alternatively, passing ``fullmatch=True`` will ensure that the whole
+    string is a match, as if you had used the ``\\A`` and ``\\Z`` markers.
 
     Examples from this strategy shrink towards shorter strings and lower
-    character values.
+    character values, with exact behaviour that may depend on the pattern.
     """
+    check_type(bool, fullmatch, 'fullmatch')
     # TODO: We would like to move this to the top level, but pending some major
     # refactoring it's hard to do without creating circular imports.
     from hypothesis.searchstrategy.regex import regex_strategy
-    return regex_strategy(regex)
+    return regex_strategy(regex, fullmatch)
 
 
 @cacheable

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -29,6 +29,7 @@ from hypothesis.database import InMemoryExampleDatabase
 def test_raises_multiple_failures_with_varying_type():
     target = [None]
 
+    @settings(database=None)
     @given(st.integers())
     def test(i):
         if abs(i) < 1000:
@@ -162,7 +163,8 @@ def test_shrinks_both_failures():
     duds = set()
     second_target = [None]
 
-    @given(st.integers())
+    @settings(database=None)
+    @given(st.integers(min_value=0))
     def test(i):
         if i >= 10000:
             first_has_failed[0] = True


### PR DESCRIPTION
This release adds a `fullmatch` flag to `hypothesis.strategies.from_regex`. When set, the whole generated example will match the regular expression pattern. This mirrors the functionality of Python's `python:re.fullmatch`. Fixes #840.