### PR TITLE
Add SubSequence strategy

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1830,14 +1830,14 @@ def subsequence_of(
 
     def element_mask():
         # type: () -> List[bool]
-        always_size = min_size
-        never_size = len(elements) - max_size
-        maybe_size = len(elements) - always_size - never_size
-        choices = ([True] * always_size + [draw(booleans()) for _ in range(maybe_size)] + [False] * never_size)
+        num_include = draw(integers(min_size, max_size))
+        num_exclude = len(elements) - num_include
+        choices = [True] * num_include + [False] * num_exclude
         assert len(elements) == len(choices)
         return draw(permutations(choices))
 
-    return [element for (element, include) in zip(elements, element_mask()) if include]
+    element_includes = zip(elements, element_mask())
+    return [element for element, include in element_includes if include]
 
 
 @defines_strategy_with_reusable_values

--- a/hypothesis-python/tests/cover/test_subsequence_of.py
+++ b/hypothesis-python/tests/cover/test_subsequence_of.py
@@ -24,7 +24,6 @@ from tests.common.debug import assert_no_examples
 
 def test_subsequence_of_empty():
     sub_seq_strat = st.lists(st.none(), max_size=0)
-    # assert strat.is_empty  # See #1517
     assert_no_examples(sub_seq_strat)
 
 
@@ -67,8 +66,6 @@ def test_subsequence_original_elements_not_over_produced(data, seq):
 
 @given(st.data(), st.lists(st.integers()))
 def test_subsequence_max_size_constraint(data, seq):
-    # Make a maximum length constraint of the subsequence, that's no
-    # longer than the main sequence too.
     max_size_strat = st.integers(min_value=0, max_value=len(seq))
     max_size = data.draw(max_size_strat)
 
@@ -80,8 +77,6 @@ def test_subsequence_max_size_constraint(data, seq):
 
 @given(st.data(), st.lists(st.integers()))
 def test_subsequence_min_size_constraint(data, seq):
-    # Make a maximum length constraint of the subsequence, that's no
-    # longer than the main sequence too.
     min_size_strat = st.integers(min_value=0, max_value=len(seq))
     min_size = data.draw(min_size_strat)
 
@@ -93,8 +88,6 @@ def test_subsequence_min_size_constraint(data, seq):
 
 @given(st.data(), st.lists(st.integers()))
 def test_subsequence_min_max_size_constraint(data, seq):
-    # Make a maximum length constraint of the subsequence, that's no
-    # longer than the main sequence too.
     min_size_strat = st.integers(min_value=0, max_value=len(seq))
     min_size = data.draw(min_size_strat)
 


### PR DESCRIPTION
This implements a new strategy: `subsequence_of`, that will produce
ordered subsequences of a source sequence.

I know there's more to do; such as shrinking, release notes, documentation, and suchlike, but I think it would be good to at least have the strategy itself reviewed.

The current questions I have are:

- Is the name `subsequence_of` suitable?
- Should the `average_size` keyword be included or not? I'm aware it's depreciated, though I am not sure if it should be there or not to preserve the calling conventions with other sequence strategies.
- What's the best way to convert the optional arguments to actual numbers;
- And more generally, should there be more/better validation?