### PR TITLE
Check that the Cargo.toml and Gemfile.lock files have matching helix versions

### DIFF
--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -19,3 +19,4 @@ numpy
 IPython
 mock
 flaky
+toml

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -73,6 +73,7 @@ snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx-rtd-theme==0.4.1
 sphinx==1.7.7
 sphinxcontrib-websupport==1.1.0  # via sphinx
+toml==0.9.4
 tox==3.2.1
 tqdm==4.25.0              # via pyupio, twine
 traitlets==4.3.2          # via ipython

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -39,6 +39,7 @@ RELEASE_FILE = os.path.join(BASE_DIR, 'RELEASE.md')
 CHANGELOG_FILE = os.path.join(BASE_DIR, 'CHANGELOG.md')
 GEMSPEC_FILE = os.path.join(BASE_DIR, 'hypothesis-specs.gemspec')
 CARGO_FILE = os.path.join(BASE_DIR, 'Cargo.toml')
+GEMFILE_LOCK_FILE = os.path.join(BASE_DIR, 'Gemfile.lock')
 CONJECTURE_CARGO_FILE = cr.CARGO_FILE
 
 RUST_SRC = os.path.join(BASE_DIR, 'src')

--- a/whole-repo-tests/test_version_sync.py
+++ b/whole-repo-tests/test_version_sync.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import toml
+
+from hypothesistooling.projects.hypothesisruby import CARGO_FILE, \
+    GEMFILE_LOCK_FILE
+
+
+def test_helix_version_sync():
+    cargo = toml.load(CARGO_FILE)
+    helix_version = cargo['dependencies']['helix']
+    gem_lock = open(GEMFILE_LOCK_FILE).read()
+    assert 'helix_runtime (%s)' % (helix_version,) in gem_lock, \
+        'helix version must be the same in %s and %s' % \
+        (CARGO_FILE, GEMFILE_LOCK_FILE)


### PR DESCRIPTION
Uses the toml library to parse the Cargo.toml file properly, then just uses a string compare to check that the corresponding string exists in the Gemfile.lock file.  Closes #1337.