### PR TITLE
Add comments to all tree traversals in ConjectureRunner

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds internal comments to some tree traversals in the core engine.
+There is no user-visible change.


### PR DESCRIPTION
These are my notes from reading through the tree traversals in `engine.py`.

I've tried pretty hard to make sure they are actually accurate, but there is still potential for error.