### PR TITLE
Fix failing test, changelog formatting

### DIFF
--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -28,7 +28,9 @@ information to the contrary.
 --------------------
 
 This patch will hide all logging messages produced by test cases before the
-final test.
+final, minimal, failing test case (:issue:`356`).
+
+Thanks to Gary Donovan for writing this patch at the PyCon Australia sprints!
 
 .. _v3.69.10:
 
@@ -52,7 +54,7 @@ This patch improves the packaging of the Python package by adding
 supported versions of :pypi:`pytz` and :pypi:`dateutil <python-dateutil>`
 (:issue:`1383`), and adds keywords to the metadata (:issue:`1520`).
 
-Thanks to Graham Williamson (@00willo) for writing this patch at the PyCon
+Thanks to Graham Williamson for writing this patch at the PyCon
 Australia sprints!
 
 .. _v3.69.8:
@@ -64,8 +66,7 @@ Australia sprints!
 This is an internal change which replaces pickle with json to prevent possible
 security issues.
 
-Thanks to Vidya Rani D G (@vidyarani-dg) for writing this patch at the
-PyCon Australia sprints!
+Thanks to Vidya Rani D G for writing this patch at the PyCon Australia sprints!
 
 .. _v3.69.7:
 
@@ -73,8 +74,10 @@ PyCon Australia sprints!
 3.69.7 - 2018-08-28
 -------------------
 
-This patch ensures that :func:`~hypothesis.note` prints when verbosity
-is set to ``Verbosity.verbose``
+This patch ensures that :func:`~hypothesis.note` prints the note for every
+test case when the :obj:`~hypothesis.settings.verbosity` setting is
+``Verbosity.verbose``.  At normal verbosity it only prints from the final
+test case.
 
 Thanks to Tom McDermott for writing this patch at
 the PyCon Australia sprints!
@@ -117,7 +120,7 @@ This patch handles passing an empty :class:`python:enum.Enum` to
 :func:`~hypothesis.strategies.nothing`, instead of raising an
 internal :class:`python:AssertionError`.
 
-Thanks to Paul Amazona (@whatevergeek) for writing this patch at the
+Thanks to Paul Amazona for writing this patch at the
 PyCon Australia sprints!
 
 .. _v3.69.2:

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -130,16 +130,14 @@ def test_current_build_context_is_current():
 
 def test_prints_all_notes_in_verbose_mode():
     # slightly roundabout because @example messes with verbosity - see #1521
-    generated_integers = []
+    messages = set()
 
-    def notefmt(x):
-        return 'x -> %d' % (x,)
-
-    @settings(verbosity=Verbosity.debug)
+    @settings(verbosity=Verbosity.debug, database=None)
     @given(integers(1, 10))
     def test(x):
-        generated_integers.append(x)
-        note(notefmt(x))
+        msg = 'x -> %d' % (x,)
+        note(msg)
+        messages.add(msg)
         assert x < 5
 
     with capture_out() as out:
@@ -147,5 +145,5 @@ def test_prints_all_notes_in_verbose_mode():
             with pytest.raises(AssertionError):
                 test()
     v = out.getvalue()
-    for x in generated_integers:
-        assert notefmt(x) in v
+    for x in sorted(messages):
+        assert x in v


### PR DESCRIPTION
Closes #1543, where a test added in #1535 needed to run without the database.