### PR TITLE
Ignore *.pyo files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # python
 
 *.pyc
+*.pyo
 venv*
 .cache
 .pytest_cache


### PR DESCRIPTION
Now that #1541 has made some tests run with `PYTHONOPTIMIZE=2`, we should tell Git to ignore the `.pyo` files that can be produced by a test run.