### PR TITLE
Remove unused __intervals attributes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch removes some unnecessary code from the internals.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -119,7 +119,6 @@ class ConjectureData(object):
         self.interesting_origin = None
         self.tags = set()
         self.draw_times = []
-        self.__intervals = None
         self.max_depth = 0
 
         self.examples = []

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -2021,7 +2021,6 @@ class Shrinker(object):
 
         self.shrink_target = new_target
         self.__shrinking_block_cache = {}
-        self.__intervals = None
 
     def try_shrinking_blocks(self, blocks, b):
         """Attempts to replace each block in the blocks list with b. Returns


### PR DESCRIPTION
These appear to have been left behind during the switch from intervals to `Example`.