### PR TITLE
Make assigning attributes of the settings class an error

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release makes setting attributes of the :class:`hypothesis.settings`
+class an explicit error.  This has never had any effect, but could mislead
+users who confused it with the current settings *instance*
+``hypothesis.settings.default`` (which is also immutable).  You can change
+the global settings with :ref:` settings profiles<settings_profiles>`.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -110,12 +110,23 @@ class settingsMeta(type):
             assert default_variable.value is not None
         return default_variable.value
 
-    @default.setter
-    def default(self, value):
-        raise AttributeError('Cannot assign settings.default')
-
     def _assign_default_internal(self, value):
         default_variable.value = value
+
+    def __setattr__(self, name, value):
+        if name == 'default':
+            raise AttributeError(
+                'Cannot assign to the property settings.default - '
+                'consider using settings.load_profile instead.'
+            )
+        elif not (isinstance(value, settingsProperty) or name.startswith('_')):
+            raise AttributeError(
+                'Cannot assign hypothesis.settings.%s=%r - the settings '
+                'class is immutable.  You can change the global default '
+                'settings with settings.load_profile, or use @settings(...) '
+                'to decorate your test instead.' % (name, value)
+            )
+        return type.__setattr__(self, name, value)
 
 
 class settings(

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -394,3 +394,10 @@ def test_setting_use_coverage_is_deprecated(value):
 def test_settings_apply_for_explicit_examples(x):
     # Regression test for #1521
     assert settings.default.verbosity == Verbosity.verbose
+
+
+def test_setattr_on_settings_singleton_is_error():
+    # https://github.com/pandas-dev/pandas/pull/22679#issuecomment-420750921
+    # Should be setting attributes on settings.default, not settings!
+    with pytest.raises(AttributeError):
+        settings.max_examples = 10


### PR DESCRIPTION
I've now seen a couple of places have to debug timeout or healthcheck (etc) problems where their settings were having no effect... because they were assigning them on the *class* `hypothesis.settings`, and thus missing the explicit error from trying to mutate a settings *instance*.  Since [errors should never pass silently](https://www.python.org/dev/peps/pep-0020/#the-zen-of-python), trying this now raises an `AttributeError` too.