### PR TITLE
Fix a flaky test for HealthCheck.data_too_large

### DIFF
--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -119,7 +119,7 @@ def test_filtering_most_things_fails_a_health_check():
 
 
 def test_large_data_will_fail_a_health_check():
-    @given(st.lists(st.binary(min_size=1024)))
+    @given(st.none() | st.binary(min_size=1024))
     @settings(database=None, buffer_size=1000)
     def test(x):
         pass


### PR DESCRIPTION
This test could occasionally fail, because it would manage to generate 10 valid examples (the empty list) before generating 20 overflowing examples.

The engine's tree cache was unable to prevent these redundant valid examples, because its mechanism for encouraging diversity interacts poorly with `biased_coin`.

Fixes #1492.