### PR TITLE
Elide internal frames from tracebacks, to focus on user code

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This patch shortens tracebacks from Hypothesis, so you can see exactly
+happened in your code without having to skip over irrelevant details
+about our internals (:issue:`848`).
+
+In the example test (see :pull:`1582`), this reduces tracebacks from
+nine frames to just three - and for a test with multiple errors, from
+seven frames per error to just one!
+
+If you *do* want to see the internal details, you can disable frame
+elision by setting :obj:`~hypothesis.settings.verbosity` to ``debug``.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -22,7 +22,6 @@ from __future__ import division, print_function, absolute_import
 
 import os
 import ast
-import sys
 import zlib
 import base64
 import random as rnd_module
@@ -49,12 +48,12 @@ from hypothesis._settings import local_settings, note_deprecation
 from hypothesis.executors import new_style_executor
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
-from hypothesis.internal.compat import ceil, hbytes, qualname, \
+from hypothesis.internal.compat import PY2, ceil, hbytes, qualname, \
     binary_type, str_to_bytes, benchmark_time, get_type_hints, \
     getfullargspec, int_from_bytes, bad_django_TestCase
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.utils.conventions import infer, not_set
-from hypothesis.internal.escalation import \
+from hypothesis.internal.escalation import get_trimmed_traceback, \
     escalate_hypothesis_internal_error
 from hypothesis.internal.reflection import is_mock, proxies, nicerepr, \
     arg_string, impersonate, function_digest, fully_qualified_name, \
@@ -570,16 +569,17 @@ class StateForActualGivenExecution(object):
             raise
         except Exception as e:
             escalate_hypothesis_internal_error()
-            data.__expected_traceback = traceback.format_exc()
+            tb = get_trimmed_traceback()
+            data.__expected_traceback = ''.join(
+                traceback.format_exception(type(e), e, tb)
+            )
             data.__expected_exception = e
             verbose_report(data.__expected_traceback)
-
-            error_class, _, tb = sys.exc_info()
 
             origin = traceback.extract_tb(tb)[-1]
             filename = origin[0]
             lineno = origin[1]
-            data.mark_interesting((error_class, filename, lineno))
+            data.mark_interesting((type(e), filename, lineno))
 
     def run(self):
         # Tell pytest to omit the body of this function from tracebacks
@@ -671,10 +671,11 @@ class StateForActualGivenExecution(object):
                     'Unreliable assumption: An example which satisfied '
                     'assumptions on the first run now fails it.'
                 )
-            except BaseException:
+            except BaseException as e:
                 if len(self.falsifying_examples) <= 1:
                     raise
-                report(traceback.format_exc())
+                tb = get_trimmed_traceback()
+                report(''.join(traceback.format_exception(type(e), e, tb)))
             finally:  # pragma: no cover
                 # This section is in fact entirely covered by the tests in
                 # test_reproduce_failure, but it seems to trigger a lovely set
@@ -921,11 +922,11 @@ def given(
                         setattr(runner, 'subTest', subTest)
                 else:
                     state.run()
-            except BaseException:
+            except BaseException as e:
                 generated_seed = \
                     wrapped_test._hypothesis_internal_use_generated_seed
-                if generated_seed is not None and not state.failed_normally:
-                    with local_settings(settings):
+                with local_settings(settings):
+                    if not (state.failed_normally or generated_seed is None):
                         if running_under_pytest:
                             report(
                                 'You can add @seed(%(seed)d) to this test or '
@@ -936,7 +937,25 @@ def given(
                             report(
                                 'You can add @seed(%d) to this test to '
                                 'reproduce this failure.' % (generated_seed,))
-                raise
+                    # The dance here is to avoid showing users long tracebacks
+                    # full of Hypothesis internals they don't care about.
+                    # We have to do this inline, to avoid adding another
+                    # internal stack frame just when we've removed the rest.
+                    if PY2:
+                        # Python 2 doesn't have Exception.with_traceback(...);
+                        # instead it has a three-argument form of the `raise`
+                        # statement.  Which is a SyntaxError on Python 3.
+                        exec(
+                            'raise type(e), e, get_trimmed_traceback()',
+                            globals(), locals()
+                        )
+                    # On Python 3, we swap out the real traceback for our
+                    # trimmed version.  Using a variable ensures that the line
+                    # which will actually appear in trackbacks is as clear as
+                    # possible - "raise the_error_hypothesis_found".
+                    the_error_hypothesis_found = \
+                        e.with_traceback(get_trimmed_traceback())
+                    raise the_error_hypothesis_found
 
         for attrib in dir(test):
             if not (attrib.startswith('_') or hasattr(wrapped_test, attrib)):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -561,7 +561,6 @@ class StateForActualGivenExecution(object):
                     'Tests run under @given should return None, but '
                     '%s returned %r instead.'
                 ) % (self.test.__name__, result), HealthCheck.return_value)
-            return False
         except UnsatisfiedAssumption:
             data.mark_invalid()
         except (

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -166,7 +166,7 @@ class ConjectureRunner(object):
         except StopTest as e:
             if e.testcounter != data.testcounter:
                 self.save_buffer(data.buffer)
-                raise e
+                raise
         except BaseException:
             self.save_buffer(data.buffer)
             raise

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -544,6 +544,7 @@ def impersonate(target):
         f.__name__ = target.__name__
         f.__module__ = target.__module__
         f.__doc__ = target.__doc__
+        f.__globals__['__hypothesistracebackhide__'] = True
         return f
     return accept
 


### PR DESCRIPTION
Closes #848, with [an approach adapted from `trio`](https://vorpus.org/blog/beautiful-tracebacks-in-trio-v070/).

Basically we just strip frames off the traceback until we reach one that did not come from a Hypothesis file, attach the shortened traceback to the exception, and raise it.  Then our `@proxies` decorator overwrites the frame location so it doesn't look like a Hypothesis file... so there's a cute trick where we inject an entry into the frame globals and check for that too when unwinding.

<details><summary> comparison of old and new output from pytest</summary>

Here's a very simple test suite:

```python
from hypothesis import given
from hypothesis.strategies import integers

@given(integers())
def test_simple(x):
    assert x

@given(integers())
def test_multiple_failures(x):
    if x > 100:
        raise ValueError("This number is too big!")
    elif x < -100:
        raise RuntimeError("This number is too small!")
```

After this change, here's the output from pytest:

```python-traceback
================================== FAILURES ===================================
_________________________________ test_simple _________________________________
Traceback (most recent call last):
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 5, in test_simple
    def test_simple(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 958, in wrapped_test
    raise the_error_hypothesis_found
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 6, in test_simple
    assert x
AssertionError: assert 0
--------------------------------- Hypothesis ----------------------------------
Falsifying example: test_simple(x=0)
___________________________ test_multiple_failures ____________________________
Traceback (most recent call last):
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 9, in test_multiple_failures
    def test_multiple_failures(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 958, in wrapped_test
    raise the_error_hypothesis_found
hypothesis.errors.MultipleFailures: Hypothesis found 2 distinct failures.
--------------------------------- Hypothesis ----------------------------------
Falsifying example: test_multiple_failures(x=-101)
Traceback (most recent call last):
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 13, in test_multiple_failures
    raise RuntimeError("This number is too small!")
RuntimeError: This number is too small!

Falsifying example: test_multiple_failures(x=101)
Traceback (most recent call last):
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 11, in test_multiple_failures
    raise ValueError("This number is too big!")
ValueError: This number is too big!
```

While here's what it looked like before:

```python-traceback
================================== FAILURES ===================================
_________________________________ test_simple _________________________________
Traceback (most recent call last):
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 5, in test_simple
    def test_simple(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 924, in wrapped_test
    state.run()
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 666, in run
    falsifying_example.__expected_traceback,
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 525, in execute
    result = self.test_runner(data, run)
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\executors.py", line 58, in default_new_style_executor
    return function(data)
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 523, in run
    return test(*args, **kwargs)
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 5, in test_simple
    def test_simple(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 470, in test
    result = self.test(*args, **kwargs)
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 6, in test_simple
    assert x
AssertionError: assert 0
--------------------------------- Hypothesis ----------------------------------
Falsifying example: test_simple(x=0)
___________________________ test_multiple_failures ____________________________
Traceback (most recent call last):
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 9, in test_multiple_failures
    def test_multiple_failures(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 924, in wrapped_test
    state.run()
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 723, in run
    len(self.falsifying_examples,)))
hypothesis.errors.MultipleFailures: Hypothesis found 2 distinct failures.
--------------------------------- Hypothesis ----------------------------------
Falsifying example: test_multiple_failures(x=-101)
Traceback (most recent call last):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 666, in run
    falsifying_example.__expected_traceback,
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 525, in execute
    result = self.test_runner(data, run)
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\executors.py", line 58, in default_new_style_executor
    return function(data)
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 523, in run
    return test(*args, **kwargs)
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 9, in test_multiple_failures
    def test_multiple_failures(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 470, in test
    result = self.test(*args, **kwargs)
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 13, in test_multiple_failures
    raise RuntimeError("This number is too small!")
RuntimeError: This number is too small!

Falsifying example: test_multiple_failures(x=101)
Traceback (most recent call last):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 666, in run
    falsifying_example.__expected_traceback,
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 525, in execute
    result = self.test_runner(data, run)
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\executors.py", line 58, in default_new_style_executor
    return function(data)
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 523, in run
    return test(*args, **kwargs)
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 9, in test_multiple_failures
    def test_multiple_failures(x):
  File "c:\users\zac\documents\github\hypothesis\hypothesis-python\src\hypothesis\core.py", line 470, in test
    result = self.test(*args, **kwargs)
  File "C:\Users\Zac\Documents\GitHub\hypothesis\test.py", line 11, in test_multiple_failures
    raise ValueError("This number is too big!")
ValueError: This number is too big!
```

</details>