### PR TITLE
Fix a rare IndexError in shrink_offset_pairs

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare bug that would cause a particular shrinker pass to
+raise an IndexError, if a shrink improvement changed the underlying data
+in an unexpected way.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1904,7 +1904,8 @@ class Shrinker(object):
             self.clear_change_tracking()
 
     def shrink_offset_pairs(self):
-        """Lower any two blocks offset from each other the same ammount.
+        """Lowers pairs of blocks that need to maintain a constant difference
+        between their respective values.
 
         Before this shrink pass, two blocks explicitly offset from each
         other would not get minimized properly:
@@ -1914,7 +1915,7 @@ class Shrinker(object):
 
         This expensive (O(n^2)) pass goes through every pair of non-zero
         blocks in the current shrink target and sees if the shrink
-        target can be improved by applying an offset to both of them.
+        target can be improved by applying a negative offset to both of them.
         """
 
         def int_from_block(i):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1916,10 +1916,11 @@ class Shrinker(object):
         blocks in the current shrink target and sees if the shrink
         target can be improved by applying an offset to both of them.
         """
-        current = [self.shrink_target.buffer[u:v] for u, v in self.blocks]
 
         def int_from_block(i):
-            return int_from_bytes(current[i])
+            u, v = self.blocks[i]
+            block_bytes = self.shrink_target.buffer[u:v]
+            return int_from_bytes(block_bytes)
 
         def block_len(i):
             u, v = self.blocks[i]
@@ -1951,16 +1952,13 @@ class Shrinker(object):
         while i < len(self.blocks):
             if self.is_payload_block(i) and int_from_block(i) > 0:
                 j = i + 1
-                while j < len(self.shrink_target.blocks):
+                while j < len(self.blocks):
                     block_val = int_from_block(j)
                     i_block_val = int_from_block(i)
                     if self.is_payload_block(j) \
                        and block_val > 0 and i_block_val > 0:
                         offset = min(int_from_block(i),
                                      int_from_block(j))
-                        # Save current before shrinking
-                        current = [self.shrink_target.buffer[u:v]
-                                   for u, v in self.blocks]
                         Integer.shrink(
                             offset, lambda o: reoffset_pair((i, j), o),
                             random=self.random

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -57,6 +57,34 @@ def run_to_buffer(f):
         return hbytes(last_data.buffer)
 
 
+def shrink_to_data(buffer):
+    """Decorator that takes a test function and an interesting input buffer,
+    and runs the shrinker on that buffer."""
+
+    def decorator(f):
+        runner = ConjectureRunner(
+            f,
+            random=Random(0),
+            settings=settings(
+                phases=[Phase.shrink],
+                database=None,
+            ),
+        )
+
+        # Explicitly test the given buffer, so that the shrinker has
+        # a starting point.
+        data = ConjectureData.for_buffer(buffer)
+        runner.test_function(data)
+        assert data.status == Status.INTERESTING, \
+            'Initial buffer was not interesting'
+
+        runner.run()
+
+        return runner.interesting_examples[data.interesting_origin]
+
+    return decorator
+
+
 def test_can_index_results():
     @run_to_buffer
     def f(data):

--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -124,6 +124,17 @@ def test_lists_of_lower_bounded_length(n):
 
 
 def test_can_find_unique_lists_of_non_set_order():
+    # This test checks that our strategy for unique lists doesn't accidentally
+    # depend on the iteration order of sets.
+    #
+    # Unfortunately, that means that *this* test has to rely on set iteration
+    # order. That makes it tricky to debug on CPython, because set iteration
+    # order changes every time the process is launched.
+    #
+    # To get around this, define the PYTHONHASHSEED environment variable to
+    # a consistent value. This could be 0, or it could be the PYTHONHASHSEED
+    # value listed in a failure log from CI.
+
     ls = minimal(
         lists(text(), unique=True),
         lambda x: list(set(reversed(x))) != x


### PR DESCRIPTION
(Fixes #1299, fixes #1581.)

This PR adds a regression test for the existing bug (together with a handy new test helper), and then fixes the bug by dropping `current` entirely, and reading block information directly from `self.shrink_target` instead.

While I was in the neighbourhood, I also tweaked the docstring for the affected shrink pass. And I added a note to the suspicious-looking test that sent me chasing after #1581 in the first place.