### PR TITLE
Remove the new shrinking test helper, and use the existing one instead

### DIFF
--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -57,34 +57,6 @@ def run_to_buffer(f):
         return hbytes(last_data.buffer)
 
 
-def shrink_to_data(buffer):
-    """Decorator that takes a test function and an interesting input buffer,
-    and runs the shrinker on that buffer."""
-
-    def decorator(f):
-        runner = ConjectureRunner(
-            f,
-            random=Random(0),
-            settings=settings(
-                phases=[Phase.shrink],
-                database=None,
-            ),
-        )
-
-        # Explicitly test the given buffer, so that the shrinker has
-        # a starting point.
-        data = ConjectureData.for_buffer(buffer)
-        runner.test_function(data)
-        assert data.status == Status.INTERESTING, \
-            'Initial buffer was not interesting'
-
-        runner.run()
-
-        return runner.interesting_examples[data.interesting_origin]
-
-    return decorator
-
-
 def test_can_index_results():
     @run_to_buffer
     def f(data):

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -26,8 +26,7 @@ from hypothesis import strategies as st
 from tests.common.utils import no_shrink, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
-from tests.cover.test_conjecture_engine import run_to_buffer, \
-    shrink_to_data
+from tests.cover.test_conjecture_engine import shrink, run_to_buffer
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import RunIsComplete, \
     ConjectureRunner
@@ -161,7 +160,7 @@ def test_shrink_offset_pairs_handles_block_structure_change():
     shrinker.
     """
 
-    @shrink_to_data(buffer=[235, 0, 0, 255])
+    @shrink([235, 0, 0, 255], 'shrink_offset_pairs')
     def f(data):
         x = data.draw_bytes(1)[0]
 
@@ -180,7 +179,7 @@ def test_shrink_offset_pairs_handles_block_structure_change():
         if x >= 10 and y - x == 20:
             data.mark_interesting()
 
-    assert f.buffer == hbytes([10, 0, 0, 30])
+    assert f == [10, 0, 0, 30]
 
 
 @given(st.integers(0, 255), st.integers(0, 255))


### PR DESCRIPTION
It turns out that my new shrinking test helper in #1585 was such a great idea that it already existed (via #1470 and #1478).

So I removed my "new" helper, and changed my test to use the existing `@shrink` helper instead.