### PR TITLE
[Urgent - failed release] Fix Sphinx cross-reference

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
 This patch allows :func:`~hypothesis.strategies.from_type` to handle the
-empty tuple type, :class:`typing.Tuple[()] <python:typing.Tuple>`.
+empty tuple type, :obj:`typing.Tuple[()] <python:typing.Tuple>`.


### PR DESCRIPTION
Turns out that the new nitpicky mode from #1575 had not yet been merged when #1584 had its most recent build, so when the latter was merged to master the tests failed.  Fixing this cross-reference will therefore finish the stalled release process that is currently blocking any other PRs from building.

CC @Zalathar, @HypothesisWorks/hypothesis-python-contributors with my apologies :disappointed_relieved: 