### PR TITLE
Find multiple bugs during example generation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch allows Hypothesis to try a few more examples after finding the
+first bug, in hopes of reporting multiple distinct bugs.  The heuristics
+described in :issue:`847` ensure that we avoid wasting time on fruitless
+searches, while still surfacing each bug as soon as possible.
+For tests that don't find any bugs, there is no change at all.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -95,7 +95,6 @@ class ConjectureRunner(object):
         self.target_selector = TargetSelector(self.random)
 
         self.interesting_examples = {}
-        self.covering_examples = {}
 
         self.shrunk_examples = set()
 
@@ -825,8 +824,6 @@ class ConjectureRunner(object):
                     result = uniform(self.random, n)
                 return self.__zero_bound(data, result)
 
-            targets_found = len(self.covering_examples)
-
             last_data = ConjectureData(
                 max_length=self.settings.buffer_size,
                 draw_bytes=draw_bytes
@@ -883,22 +880,15 @@ class ConjectureRunner(object):
             else:
                 origin = self.target_selector.select()
                 mutations += 1
-                targets_found = len(self.covering_examples)
                 data = ConjectureData(
                     draw_bytes=mutator(origin),
                     max_length=self.settings.buffer_size
                 )
                 self.test_function(data)
                 data.freeze()
-                if (
-                    data.status > origin.status or
-                    len(self.covering_examples) > targets_found
-                ):
+                if data.status > origin.status:
                     mutations = 0
-                elif (
-                    data.status < origin.status or
-                    mutations >= 10
-                ):
+                elif data.status < origin.status or mutations >= 10:
                     # Cap the variations of a single example and move on to
                     # an entirely fresh start.  Ten is an entirely arbitrary
                     # constant, but it's been working well for years.


### PR DESCRIPTION
Instead of giving up on generating new examples immediately after finding a bug, we continue until one of the following conditions is met:

1. We would stop if we had not found a bug
2. More than ten seconds have elapsed since finding the *first* bug
3. We have tried as many valid examples since finding the *last unique bug* (by exception type and location) as valid examples before that bug

And then proceed to shrinking as before.  This does not actually change the semantics of our API, it just makes us more likely to find and report multiple bugs per run!

Closes #847.  We should probably merge #1582 first, since I'd expect users to see many more MultipleFailures errors now!