### PR TITLE
Factor out iteration over pairs of blocks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch factors out some common code in the shrinker for iterating
+over pairs of data blocks. There should be no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -61,7 +61,7 @@ class Example(object):
         return self.end - self.start
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, frozen=True)
 class Block(object):
     start = attr.ib()
     end = attr.ib()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -144,8 +144,8 @@ class ConjectureData(object):
     def index(self):
         return len(self.buffer)
 
-    def each_block_bounds(self):
-        return (block.bounds for block in self.blocks)
+    def all_block_bounds(self):
+        return [block.bounds for block in self.blocks]
 
     def note(self, value):
         self.__assert_not_frozen('note')

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -61,6 +61,28 @@ class Example(object):
         return self.end - self.start
 
 
+@attr.s(slots=True)
+class Block(object):
+    start = attr.ib()
+    end = attr.ib()
+    index = attr.ib()
+
+    forced = attr.ib()
+    all_zero = attr.ib()
+
+    @property
+    def bounds(self):
+        return (self.start, self.end)
+
+    @property
+    def length(self):
+        return self.end - self.start
+
+    @property
+    def trivial(self):
+        return self.forced or self.all_zero
+
+
 global_test_counter = 0
 
 
@@ -95,7 +117,6 @@ class ConjectureData(object):
         self.start_time = benchmark_time()
         self.events = set()
         self.forced_indices = set()
-        self.forced_blocks = set()
         self.masked_indices = {}
         self.interesting_origin = None
         self.draw_times = []
@@ -122,6 +143,9 @@ class ConjectureData(object):
     @property
     def index(self):
         return len(self.buffer)
+
+    def each_block_bounds(self):
+        return (block.bounds for block in self.blocks)
 
     def note(self, value):
         self.__assert_not_frozen('note')
@@ -264,7 +288,6 @@ class ConjectureData(object):
         original = self.index
         self.__write(string, forced=True)
         self.forced_indices.update(hrange(original, self.index))
-        self.forced_blocks.add(len(self.blocks) - 1)
         return string
 
     def __check_capacity(self, n):
@@ -276,11 +299,21 @@ class ConjectureData(object):
 
     def __write(self, result, forced=False):
         ex = self.start_example(DRAW_BYTES_LABEL)
-        ex.trivial = forced or not any(result)
         initial = self.index
         n = len(result)
-        self.block_starts.setdefault(n, []).append(initial)
-        self.blocks.append((initial, initial + n))
+
+        block = Block(
+            start=initial,
+            end=initial + n,
+            index=len(self.blocks),
+            forced=forced,
+            all_zero=not any(result),
+        )
+        ex.trivial = block.trivial
+
+        self.block_starts.setdefault(n, []).append(block.start)
+        self.blocks.append(block)
+        assert self.blocks[block.index] is block
         assert len(result) == n
         assert self.index == initial
         self.buffer.extend(result)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -260,7 +260,7 @@ class ConjectureRunner(object):
                 break
 
         # At each node that begins a block, record the size of that block.
-        for u, v in data.each_block_bounds():
+        for u, v in data.all_block_bounds():
             # This can happen if we hit a dead node when walking the buffer.
             # In that case we already have this section of the tree mapped.
             if u >= len(indices):
@@ -1771,8 +1771,8 @@ class Shrinker(object):
     def blocks(self):
         return self.shrink_target.blocks
 
-    def each_block_bounds(self):
-        return self.shrink_target.each_block_bounds()
+    def all_block_bounds(self):
+        return self.shrink_target.all_block_bounds()
 
     def each_pair_of_blocks(self, accept_first, accept_second):
         """Yield each pair of blocks ``(a, b)``, such that ``a.index <
@@ -1902,7 +1902,7 @@ class Shrinker(object):
 
         current = self.shrink_target
 
-        blocked = [current.buffer[u:v] for u, v in current.each_block_bounds()]
+        blocked = [current.buffer[u:v] for u, v in current.all_block_bounds()]
 
         changed = [
             i for i in sorted(self.__changed_blocks)
@@ -1967,7 +1967,7 @@ class Shrinker(object):
             m = min([int_from_block(p) for p in valid_pair])
 
             new_blocks = [self.shrink_target.buffer[u:v]
-                          for u, v in self.shrink_target.each_block_bounds()]
+                          for u, v in self.shrink_target.all_block_bounds()]
             for i in valid_pair:
                 new_blocks[i] = int_to_bytes(
                     int_from_block(i) + o - m, block_len(i))
@@ -2019,13 +2019,13 @@ class Shrinker(object):
             self.shrinks += 1
             if (
                 len(new_target.blocks) != len(self.shrink_target.blocks) or
-                list(new_target.each_block_bounds()) !=
-                    list(self.shrink_target.each_block_bounds())
+                new_target.all_block_bounds() !=
+                    self.shrink_target.all_block_bounds()
             ):
                 self.clear_change_tracking()
             else:
                 for i, (u, v) in enumerate(
-                    self.shrink_target.each_block_bounds()
+                    self.shrink_target.all_block_bounds()
                 ):
                     if (
                         i not in self.__changed_blocks and
@@ -2312,7 +2312,7 @@ class Shrinker(object):
 
         counts = Counter(
             canon(self.shrink_target.buffer[u:v])
-            for u, v in self.each_block_bounds()
+            for u, v in self.all_block_bounds()
         )
         counts.pop(hbytes(), None)
         blocks = [buffer for buffer, count in counts.items() if count > 1]
@@ -2321,7 +2321,7 @@ class Shrinker(object):
         blocks.sort(key=lambda b: counts[b] * len(b), reverse=True)
         for block in blocks:
             targets = [
-                i for i, (u, v) in enumerate(self.each_block_bounds())
+                i for i, (u, v) in enumerate(self.all_block_bounds())
                 if canon(self.shrink_target.buffer[u:v]) == block
             ]
             # This can happen if some blocks have been lost in the previous

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -583,7 +583,7 @@ class RuleStrategy(SearchStrategy):
         # Easy, right?
         n = len(self.rules)
         i = cu.integer_range(data, 0, n - 1)
-        u, v = data.blocks[-1]
+        u, v = data.blocks[-1].bounds
         block_length = v - u
         rule = self.rules[i]
         if not self.is_valid(rule):

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -26,7 +26,8 @@ from hypothesis import strategies as st
 from tests.common.utils import no_shrink, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
-from tests.cover.test_conjecture_engine import shrink, run_to_buffer
+from tests.cover.test_conjecture_engine import shrink, run_to_buffer, \
+    shrinking_from
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import RunIsComplete, \
     ConjectureRunner
@@ -233,3 +234,76 @@ def test_cached_with_masked_byte_agrees_with_results(byte_a, byte_b):
     # If the cache found an old result, then it should match the real result.
     # If it did not, then it must be because A and B were different.
     assert (cached_a is cached_b) == (cached_a.buffer == data_b.buffer)
+
+
+def test_each_pair_of_blocks():
+    initial = hbytes([1, 1, 1])
+
+    @shrinking_from(initial)
+    def shrinker(data):
+        data.draw_bits(1)
+        data.draw_bits(1)
+        data.draw_bits(1)
+        data.mark_interesting()
+
+    bounds = [
+        (a.bounds, b.bounds) for a, b in shrinker.each_pair_of_blocks(
+            lambda block: True,
+            lambda block: True,
+        )
+    ]
+
+    assert bounds == [
+        ((0, 1), (1, 2)),
+        ((0, 1), (2, 3)),
+        ((1, 2), (2, 3)),
+    ]
+
+
+def test_each_pair_of_blocks_with_filters():
+    initial = hbytes(5)
+
+    @shrinking_from(initial)
+    def shrinker(data):
+        for x in range(5):
+            data.draw_bits(1)
+        data.mark_interesting()
+
+    blocks = [
+        (a.index, b.index) for a, b in shrinker.each_pair_of_blocks(
+            lambda block: block.index != 1,
+            lambda block: block.index != 3,
+        )
+    ]
+
+    assert blocks == [
+        (0, 1), (0, 2), (0, 4),
+        (2, 4),
+        (3, 4),
+    ]
+
+
+def test_each_pair_of_blocks_handles_change():
+    initial = hbytes([9] + [0] * 10)
+
+    @shrinking_from(initial)
+    def shrinker(data):
+        x = data.draw_bits(8)
+        for y in range(x):
+            data.draw_bits(1)
+        data.mark_interesting()
+
+    blocks = []
+    for a, b in shrinker.each_pair_of_blocks(
+        lambda block: True,
+        lambda block: True,
+    ):
+        if a.index == 0 and b.index == 6:
+            shrinker.incorporate_new_buffer(hbytes([3] + [0] * 10))
+        blocks.append((a.index, b.index))
+
+    assert blocks == [
+        (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6),
+        (1, 2), (1, 3),
+        (2, 3),
+    ]

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -182,6 +182,21 @@ def test_shrink_offset_pairs_handles_block_structure_change():
     assert f == [10, 0, 0, 30]
 
 
+def test_retaining_sum_considers_zero_destination_blocks():
+    """Explicitly test that this shrink pass will try to move data into blocks
+    that are currently all-zero."""
+    @shrink([100, 0, 0], 'minimize_block_pairs_retaining_sum')
+    def f(data):
+        x = data.draw_bytes(1)[0]
+        data.draw_bytes(1)
+        y = data.draw_bytes(1)[0]
+
+        if x >= 10 and (x + y) == 100:
+            data.mark_interesting()
+
+    assert f == [10, 0, 90]
+
+
 @given(st.integers(0, 255), st.integers(0, 255))
 def test_prescreen_with_masked_byte_agrees_with_results(byte_a, byte_b):
     def f(data):


### PR DESCRIPTION
This change introduces `Shrinker.for_each_pair_of_blocks`, and updates shrinker passes `shrink_offset_pairs` and `minimize_block_pairs_retaining_sum` to use it instead of manually iterating over block pairs.

Along the way it introduces a `Block` class that `ConjectureData` now uses to record its block information, instead of keeping a list of `(start, end)` pairs.