### PR TITLE
Fix internal error in recursive()

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch substantially improves the distribution of data generated
+with :func:`~hypothesis.strategies.recursive`, and fixes a rare internal
+error (:issue:`1502`).

--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -178,29 +178,15 @@ returns a new strategy for it. So for example:
 
     >>> from string import printable; from pprint import pprint
     >>> json = recursive(none() | booleans() | floats() | text(printable),
-    ... lambda children: lists(children) | dictionaries(text(printable), children))
+    ... lambda children: lists(children, 1) | dictionaries(text(printable), children, min_size=1))
     >>> pprint(json.example())
-    ['dy',
-     [None, True, 6.297399055778002e+16, False],
-     {'a{h\\:694K~{mY>a1yA:#CmDYb': None},
-     '\\kP!4',
-     {'#1J1': '',
-      'cx.': None,
-      "jv'A?qyp_sB\n$62g": [],
-      'qgnP': [False, -inf, 'la)']},
-     [],
-     {}]
+    [[1.175494351e-38, ']', 1.9, True, False, '.M}Xl', ''], True]
     >>> pprint(json.example())
-    {'': None,
-     '(Rt)': 1.192092896e-07,
-     ',': [],
-     '6': 2.2250738585072014e-308,
-     'HA=/': [],
-     'YU]gy8': inf,
-     'l': None,
-     'nK': False}
-    >>> pprint(json.example())
-    []
+    {'de(l': None,
+     'nK': {'(Rt)': None,
+            '+hoZh1YU]gy8': True,
+            '8z]EIFA06^l`i^': 'LFE{Q',
+            '9,': 'l{cA=/'}}
 
 That is, we start with our leaf data and then we augment it by allowing lists and dictionaries of anything we can generate as JSON data.
 
@@ -212,11 +198,9 @@ we wanted to only generate really small JSON we could do this as:
 
     >>> small_lists = recursive(booleans(), lists, max_leaves=5)
     >>> small_lists.example()
-    [False]
-    >>> small_lists.example()
     True
     >>> small_lists.example()
-    []
+    [False]
 
 .. _composite-strategies:
 
@@ -261,12 +245,12 @@ accept all the others in the expected order. Defaults are preserved.
     >>> list_and_index()
     list_and_index()
     >>> list_and_index().example()
-    ([-21904], 0)
+    ([15949, -35, 21764, 8167, 1607867656, -41, 104, 19, -90, 520116744169390387, 7107438879249457973], 0)
 
     >>> list_and_index(booleans())
     list_and_index(elements=booleans())
     >>> list_and_index(booleans()).example()
-    ([True], 0)
+    ([True, False], 0)
 
 Note that the repr will work exactly like it does for all the built-in
 strategies: it will be a function that you can call to get the strategy in

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -199,9 +199,7 @@ specific tests.
 
 .. doctest::
 
-    >>> with settings.get_profile("ci"):
-    ...     print(settings().max_examples)
-    ...
+    >>> settings.get_profile("ci").max_examples
     1000
 
 Optionally, you may define the environment variable to load a profile for you.

--- a/hypothesis-python/tests/cover/test_recursive.py
+++ b/hypothesis-python/tests/cover/test_recursive.py
@@ -53,3 +53,8 @@ def test_recursive_call_validates_base_is_strategy():
     x = st.recursive(1, lambda x: st.none())
     with pytest.raises(InvalidArgument):
         x.example()
+
+
+@given(st.recursive(st.none(), lambda x: st.one_of(x, x)))
+def test_issue_1502_regression(s):
+    pass


### PR DESCRIPTION
I tracked this down to a bug in OneOfStrategy, where if `bias is not None` the sampler might be operating off the pre-flattened list of strategies.  In the case where two strategies are identical, this can be shortened by flattening and thus trigger an IndexError.  The fix is simply to calculate the biased sampler values *after* flattening the strategies list, if we're using it at all.  Closes #1502.