### PR TITLE
Minor refactorings for composite and permutations strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Tracebacks involving :func:`@composite <hypothesis.strategies.composite>`
+are now slightly shorter due to some internal refactoring.

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1758,13 +1758,7 @@ class CompositeStrategy(SearchStrategy):
         self.kwargs = kwargs
 
     def do_draw(self, data):
-        first_draw = [True]
-
-        def draw(strategy):
-            first_draw[0] = False
-            return data.draw(strategy)
-
-        return self.definition(draw, *self.args, **self.kwargs)
+        return self.definition(data.draw, *self.args, **self.kwargs)
 
     def calc_label(self):
         return self.__label

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1574,11 +1574,11 @@ class PermutationStrategy(SearchStrategy):
         self.values = values
 
     def do_draw(self, data):
-        # Reversed Fisher-Yates shuffle. Reverse order so that it shrinks
-        # propertly: This way we prefer things that are lexicographically
-        # closer to the identity.
+        # Reversed Fisher-Yates shuffle: swap each element with itself or with
+        # a later element.  This shrinks i==j for each element, i.e. to no
+        # change.  We don't consider the last element as it's always a no-op.
         result = list(self.values)
-        for i in hrange(len(result)):
+        for i in hrange(len(result) - 1):
             j = integer_range(data, i, len(result) - 1)
             result[i], result[j] = result[j], result[i]
         return result


### PR DESCRIPTION
The extra `draw` function for composite strategies has been a no-op since `data.mark_bind()` was removed a few years ago.  Removing it has slight performance gains, but mostly it shortens the stack - good for avoiding overflows, and user happiness (even if #1582 means that will only apply in debug mode).

I also noticed (while fixing a typo in a comment) that the shuffle for `permutations` would always finish with a no-op, so I cut that out too.