### PR TITLE
Validate strategy before starting the draw timer

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`1153`, where time spent reifying a strategy was
+also counted in the time spent generating the first example.  Strategies
+are now fully constructed and validated before the timer is started.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -177,14 +177,16 @@ class ConjectureData(object):
             if not at_top_level:
                 return strategy.do_draw(self)
             else:
-                start_time = benchmark_time()
                 try:
-                    return strategy.do_draw(self)
+                    strategy.validate()
+                    start_time = benchmark_time()
+                    try:
+                        return strategy.do_draw(self)
+                    finally:
+                        self.draw_times.append(benchmark_time() - start_time)
                 except BaseException as e:
                     mark_for_escalation(e)
                     raise
-                finally:
-                    self.draw_times.append(benchmark_time() - start_time)
         finally:
             self.stop_example()
 


### PR DESCRIPTION
...because otherwise, time spend reifying the strategy is also counted towards the first draw call, which is just plain wrong.  Aside from producing incorrect statistics, it can also trigger the `too_slow` health check!

Fixes #1153.  Sadly there is no regression test, because every attempt I tried was flaky due to some horrible combination of caches and timing issues.