### PR TITLE
Avoid caching internal strategy that has a reference to the test class

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch avoids caching a trivial case, fixing :issue:`493`.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -65,6 +65,7 @@ from hypothesis.internal.conjecture.data import StopTest, ConjectureData
 from hypothesis.searchstrategy.strategies import SearchStrategy
 from hypothesis.internal.conjecture.engine import ExitReason, \
     ConjectureRunner, sort_key
+from hypothesis.searchstrategy.collections import TupleStrategy
 
 if False:
     from typing import (  # noqa
@@ -339,12 +340,15 @@ def process_arguments_to_given(
 
     arguments = tuple(arguments)
 
-    search_strategy = st.tuples(
+    # We use TupleStrategy over tuples() here to avoid polluting
+    # st.STRATEGY_CACHE with references (see #493), and because this is
+    # trivial anyway if the fixed_dictionaries strategy is cacheable.
+    search_strategy = TupleStrategy((
         st.just(arguments),
         st.fixed_dictionaries(generator_kwargs).map(
             lambda args: dict(args, **kwargs)
         )
-    )
+    ))
 
     if selfy is not None:
         search_strategy = WithRunner(search_strategy, selfy)


### PR DESCRIPTION
For equivalent effect but better behaviour around memory use and garbage collection.  Fixes #493.