### PR TITLE
Explain how Length.run_step works

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds more internal comments to the core engine's sequence-length
+shrinker. There should be no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
@@ -53,13 +53,13 @@ class Length(Shrinker):
         return len(left) < len(right)
 
     def run_step(self):
-        j = 0
-        while j < len(self.current):
-            i = len(self.current) - 1 - j
+        skipped = 0
+        while skipped < len(self.current):
+            candidates = len(self.current) - skipped
             start = self.current
             find_integer(
-                lambda k: k <= i + 1 and self.consider(
-                    start[:i + 1 - k] + start[i + 1:]
+                lambda k: k <= candidates and self.consider(
+                    start[:candidates - k] + start[candidates:]
                 )
             )
-            j += 1
+            skipped += 1


### PR DESCRIPTION
This PR (hopefully) makes it easier to understand how `Length.run_step` works.

First it replaces `j` and `i + 1` with more meaningful variable names, based on my interpretation of what's happening.

Then it adds an overall description of the shrinking process, step-by-step comments, and a diagram to put each variable and slice into context.

----

This is a stand-alone change that doesn't fix or change any behaviour, so there's no particular hurry to get it merged.

I recommend looking the variable-renaming commit on its own, because the combined diff makes it a bit harder to see that the new version is equivalent.
