### PR TITLE
New given-based backend for stateful tests

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = attr, click, dateutil, django, faker, flaky, numpy, pandas, pytz, pytest, scipy, unicodenazi
+known_third_party = attr, click, dateutil, django, faker, flaky, numpy, pandas, pytz, pytest, pyup, scipy, unicodenazi
 known_first_party = hypothesis
 add_imports = from __future__ import absolute_import, from __future__ import print_function, from __future__ import division
 multi_line_output = 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ jobs:
       env: TASK=check-unicode
     - env: TASK=check-py27-typing
     - env: TASK=check-nose
-    - env: TASK=check-pytest30
+    # https://github.com/HypothesisWorks/hypothesis/issues/1702
+    # - env: TASK=check-pytest30
     - env: TASK=check-faker070
     - env: TASK=check-faker-latest
     - env: TASK=check-django21

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This release changes the stateful testing backend from
+:func:`~hypothesis.find` to use :func:`@given <hypothesis.given>`
+(:issue:`1300`).  This doesn't change how you create stateful tests,
+but does make them run more like other Hypothesis tests.
+
+:func:`@reproduce_failure <hypothesis.reproduce_failure>` and
+:func:`@seed <hypothesis.seed>` now work for stateful tests.
+
+Stateful tests now respect the :attr:`~hypothesis.settings.deadline`
+and :attr:`~hypothesis.settings.suppress_health_check` settings,
+though they are disabled by default.  You can enable them by using
+:func:`@settings(...) <hypothesis.settings>` as a class decorator
+with whatever arguments you prefer.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -71,7 +71,6 @@ from hypothesis.internal.compat import (
     hbytes,
     int_from_bytes,
     qualname,
-    str_to_bytes,
 )
 from hypothesis.internal.conjecture.data import ConjectureData, StopTest
 from hypothesis.internal.conjecture.engine import ConjectureRunner, ExitReason, sort_key
@@ -85,7 +84,6 @@ from hypothesis.internal.reflection import (
     arg_string,
     convert_positional_arguments,
     define_function_signature,
-    fully_qualified_name,
     function_digest,
     get_pretty_function_description,
     impersonate,
@@ -639,7 +637,7 @@ class StateForActualGivenExecution(object):
         # Tell pytest to omit the body of this function from tracebacks
         __tracebackhide__ = True
         if global_force_seed is None:
-            database_key = str_to_bytes(fully_qualified_name(self.test))
+            database_key = function_digest(self.test)
         else:
             database_key = None
         self.start_time = benchmark_time()

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -93,6 +93,10 @@ def function_digest(function):
         hasher.update(str_to_bytes(repr(getfullargspec(function))))
     except TypeError:
         pass
+    try:
+        hasher.update(function._hypothesis_internal_add_digest)
+    except AttributeError:
+        pass
     return hasher.digest()
 
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -121,6 +121,11 @@ def run_state_machine_as_test(state_machine_factory, settings=None):
                 machine.print_end()
             machine.teardown()
 
+    # Use a machine digest to identify stateful tests in the example database
+    run_state_machine.hypothesis.inner_test._hypothesis_internal_add_digest = function_digest(
+        state_machine_factory
+    )
+
     run_state_machine(state_machine_factory)
 
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -125,6 +125,13 @@ def run_state_machine_as_test(state_machine_factory, settings=None):
     run_state_machine.hypothesis.inner_test._hypothesis_internal_add_digest = function_digest(
         state_machine_factory
     )
+    # Copy some attributes so @seed and @reproduce_failure "just work"
+    run_state_machine._hypothesis_internal_use_seed = getattr(
+        state_machine_factory, "_hypothesis_internal_use_seed", None
+    )
+    run_state_machine._hypothesis_internal_use_reproduce_failure = getattr(
+        state_machine_factory, "_hypothesis_internal_use_reproduce_failure", None
+    )
 
     run_state_machine(state_machine_factory)
 

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -2184,13 +2184,13 @@ def runner(default=not_set):
 class DataObject(object):
     def __init__(self, data):
         self.count = 0
-        self.data = data
+        self.conjecture_data = data
 
     def __repr__(self):
         return "data(...)"
 
     def draw(self, strategy, label=None):
-        result = self.data.draw(strategy)
+        result = self.conjecture_data.draw(strategy)
         self.count += 1
         if label is not None:
             note("Draw %d (%s): %r" % (self.count, label, result))


### PR DESCRIPTION
Which allows more settings to apply to stateful tests, including deadlines and healthchecks.  `@seed` and `@reproduce_failure` are now supported for stateful tests.  `pytest.fail()` is now supported for all tests with `@given` (previously special-cased for stateful tests; see #1372).

Closes #164, closes #1213, closes #1300.

The basic logic is obvious - just use `@given` and `st.data()` to drive the state machine - and after that it's just a matter of bookkeeping to ensure that all the auxiliary features work as expected.

After merging, I'll open an issue to deprecate `find()` and `GenericStateMachine`.