### PR TITLE
Check that the print_blob setting is a PrintSettings value

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+This release checks that the value of the
+:attr:`~hypothesis.settings.print_blob` setting is a
+:class:`~hypothesis.PrintSettings` instance.
+
+Being able to specify a boolean value was not intended, and is now deprecated.
+In addition, specifying ``True`` will now cause the blob to always be printed,
+instead of causing it to be suppressed.
+
+Specifying any value that is not a :class:`~hypothesis.PrintSettings`
+or a boolean is now an error.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -821,6 +821,29 @@ class PrintSettings(Enum):
     ALWAYS = 2
     """Always print a blob on failure."""
 
+    def __repr__(self):
+        return 'PrintSettings.%s' % (self.name,)
+
+
+def _validate_print_blob(value):
+    if isinstance(value, bool):
+        if value:
+            replacement = PrintSettings.ALWAYS
+        else:
+            replacement = PrintSettings.NEVER
+
+        note_deprecation(
+            'Setting print_blob=%r is deprecated and will become an error '
+            'in a future version of Hypothesis. Use print_blob=%r instead.' % (
+                value, replacement,
+            )
+        )
+        return replacement
+
+    # Values that aren't bool or PrintSettings will be turned into hard errors
+    # by the 'options' check.
+    return value
+
 
 settings._define_setting(
     'print_blob',
@@ -831,7 +854,9 @@ failures.
 
 See :ref:`the documentation on @reproduce_failure <reproduce_failure>` for
 more details of this behaviour.
-"""
+""",
+    validator=_validate_print_blob,
+    options=tuple(PrintSettings),
 )
 
 settings.lock_further_definitions()


### PR DESCRIPTION
Specifying a boolean value is now deprecated, and specifying True will now have the expected effect instead of silently suppressing the blob.

Specifying any other value is now an error.

Closes #1612.