### PR TITLE
Improve shrinking of integers() with one bound

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes the internals for :func:`~hypothesis.strategies.integers`
+with one bound.  Values from this strategy now always shrink towards zero
+instead of towards the bound, and should shrink much more efficiently too.
+On Python 2, providing a bound incorrectly excluded ``long`` integers,
+which can now be generated.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -109,10 +109,6 @@ def integer_range(data, lower, upper, center=None):
     return int(result)
 
 
-def centered_integer_range(data, lower, upper, center):
-    return integer_range(data, lower, upper, center=center)
-
-
 try:
     from numpy import ndarray
 except ImportError:  # pragma: no cover

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 import enum
 import hashlib
 import heapq
-import math
 from collections import OrderedDict
 from fractions import Fraction
 
@@ -58,7 +57,6 @@ def combine_labels(*labels):
 
 
 INTEGER_RANGE_DRAW_LABEL = calc_label_from_name("another draw in integer_range()")
-GEOMETRIC_LABEL = calc_label_from_name("geometric()")
 BIASED_COIN_LABEL = calc_label_from_name("biased_coin()")
 SAMPLE_IN_SAMPLER_LABLE = calc_label_from_name("a sample() in Sampler")
 ONE_FROM_MANY_LABEL = calc_label_from_name("one more from many()")
@@ -163,18 +161,6 @@ FULL_FLOAT = int_to_float(FLOAT_PREFIX | ((2 << 53) - 1)) - 1
 
 def fractional_float(data):
     return (int_to_float(FLOAT_PREFIX | getrandbits(data, 52)) - 1) / FULL_FLOAT
-
-
-def geometric(data, p):
-    denom = math.log1p(-p)
-    data.start_example(GEOMETRIC_LABEL)
-    while True:
-        probe = fractional_float(data)
-        if probe < 1.0:
-            result = int(math.log1p(-probe) / denom)
-            assert result >= 0, (probe, p, result)
-            data.stop_example()
-            return result
 
 
 def boolean(data):

--- a/hypothesis-python/src/hypothesis/searchstrategy/datetime.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/datetime.py
@@ -51,7 +51,7 @@ class DatetimeStrategy(SearchStrategy):
             low = getattr(self.min_dt if cap_low else dt.datetime.min, name)
             high = getattr(self.max_dt if cap_high else dt.datetime.max, name)
             if name == "year":
-                val = utils.centered_integer_range(data, low, high, 2000)
+                val = utils.integer_range(data, low, high, 2000)
             else:
                 val = utils.integer_range(data, low, high)
             result[name] = val
@@ -89,11 +89,8 @@ class DateStrategy(SearchStrategy):
         self.center = (dt.date(2000, 1, 1) - min_value).days
 
     def do_draw(self, data):
-        return self.min_value + dt.timedelta(
-            days=utils.centered_integer_range(
-                data, 0, self.days_apart, center=self.center
-            )
-        )
+        days = utils.integer_range(data, 0, self.days_apart, center=self.center)
+        return self.min_value + dt.timedelta(days=days)
 
 
 class TimedeltaStrategy(SearchStrategy):
@@ -111,7 +108,7 @@ class TimedeltaStrategy(SearchStrategy):
         for name in ("days", "seconds", "microseconds"):
             low = getattr(self.min_value if low_bound else dt.timedelta.min, name)
             high = getattr(self.max_value if high_bound else dt.timedelta.max, name)
-            val = utils.centered_integer_range(data, low, high, 0)
+            val = utils.integer_range(data, low, high, 0)
             result[name] = val
             low_bound = low_bound and val == low
             high_bound = high_bound and val == high

--- a/hypothesis-python/src/hypothesis/searchstrategy/numbers.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/numbers.py
@@ -27,19 +27,6 @@ from hypothesis.internal.floats import sign
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
 
-class IntegersFromStrategy(SearchStrategy):
-    def __init__(self, lower_bound, average_size=100000.0):
-        super(IntegersFromStrategy, self).__init__()
-        self.lower_bound = lower_bound
-        self.average_size = average_size
-
-    def __repr__(self):
-        return "IntegersFromStrategy(%d)" % (self.lower_bound,)
-
-    def do_draw(self, data):
-        return int(self.lower_bound + d.geometric(data, 1.0 / self.average_size))
-
-
 class WideRangeIntStrategy(SearchStrategy):
 
     distribution = d.Sampler([4.0, 8.0, 1.0, 1.0, 0.5])

--- a/hypothesis-python/src/hypothesis/searchstrategy/numbers.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/numbers.py
@@ -27,14 +27,6 @@ from hypothesis.internal.floats import sign
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
 
-class IntStrategy(SearchStrategy):
-    """A generic strategy for integer types that provides the basic methods
-    other than produce.
-
-    Subclasses should provide the produce method.
-    """
-
-
 class IntegersFromStrategy(SearchStrategy):
     def __init__(self, lower_bound, average_size=100000.0):
         super(IntegersFromStrategy, self).__init__()
@@ -48,7 +40,7 @@ class IntegersFromStrategy(SearchStrategy):
         return int(self.lower_bound + d.geometric(data, 1.0 / self.average_size))
 
 
-class WideRangeIntStrategy(IntStrategy):
+class WideRangeIntStrategy(SearchStrategy):
 
     distribution = d.Sampler([4.0, 8.0, 1.0, 1.0, 0.5])
 

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -436,9 +436,13 @@ def integers(min_value=None, max_value=None):
         if max_int_value is None:
             return WideRangeIntStrategy()
         else:
+            if max_int_value > 0:
+                return WideRangeIntStrategy().filter(lambda x: x <= max_int_value)
             return WideRangeIntStrategy().map(lambda x: max_int_value - abs(x))
     else:
         if max_int_value is None:
+            if min_int_value < 0:
+                return WideRangeIntStrategy().filter(lambda x: x >= min_int_value)
             return WideRangeIntStrategy().map(lambda x: min_int_value + abs(x))
         else:
             assert min_int_value <= max_int_value

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -105,7 +105,6 @@ from hypothesis.searchstrategy.numbers import (
     BoundedIntStrategy,
     FixedBoundedFloatStrategy,
     FloatStrategy,
-    IntegersFromStrategy,
     WideRangeIntStrategy,
 )
 from hypothesis.searchstrategy.recursive import RecursiveStrategy
@@ -437,10 +436,10 @@ def integers(min_value=None, max_value=None):
         if max_int_value is None:
             return WideRangeIntStrategy()
         else:
-            return IntegersFromStrategy(0).map(lambda x: max_int_value - x)
+            return WideRangeIntStrategy().map(lambda x: max_int_value - abs(x))
     else:
         if max_int_value is None:
-            return IntegersFromStrategy(min_int_value)
+            return WideRangeIntStrategy().map(lambda x: min_int_value + abs(x))
         else:
             assert min_int_value <= max_int_value
             if min_int_value == max_int_value:

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -47,12 +47,6 @@ def test_uniform_float_can_draw_1():
     assert len(d.buffer) == 7
 
 
-def test_geometric_can_handle_bad_first_draw():
-    assert (
-        cu.geometric(ConjectureData.for_buffer(hbytes([255] * 7 + [0] * 7)), 0.5) == 0
-    )
-
-
 def test_coin_biased_towards_truth():
     p = 1 - 1.0 / 500
 

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -164,7 +164,7 @@ def test_shrinks_both_failures():
     second_target = [None]
 
     @settings(database=None)
-    @given(st.integers(min_value=0))
+    @given(st.integers(min_value=0).map(int))
     def test(i):
         if i >= 10000:
             first_has_failed[0] = True


### PR DESCRIPTION
> The root of the [many test timeouts] is the `geometric` helper in conjecture utils, which ends up mapping quite complicated values to quite simple integers. We should change that format, and generally avoid things that look like the `geometric` helper.

This patch removes the `geometric` helper, which was only ever used for `integers()` with one bound, and thus closes #1452.

It also ensures that such integers shrink to `0` as documented rather than shrinking to the bound, and cleans up some minor dead code related to integer generation.