### PR TITLE
Increase variation in Unicode character generation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+This release substantially increases the variety of examples from the
+:func:`~hypothesis.strategies.characters` strategy.
+
+Unicode characters used to be selected by codepoint alone, which made
+generation of some rare character types highly unlikely (:issue:`1401`).
+Character generation now selects a Unicode category - preferring letters
+to numbers to whitespace, and so on - then a code point within that category.

--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -177,16 +177,26 @@ returns a new strategy for it. So for example:
 .. doctest::
 
     >>> from string import printable; from pprint import pprint
-    >>> json = recursive(none() | booleans() | floats() | text(printable),
-    ... lambda children: lists(children, 1) | dictionaries(text(printable), children, min_size=1))
+    >>> nice_text = text(printable, max_size=3)
+    >>> json = recursive(none() | booleans() | floats() | nice_text,
+    ... lambda children: lists(children, 1) | dictionaries(nice_text, children, min_size=1))
     >>> pprint(json.example())
-    [[1.175494351e-38, ']', 1.9, True, False, '.M}Xl', ''], True]
+    {'^-$': {'': -4.4078854352852856e+16,
+             '3': None,
+             '_': False,
+             '`': '$',
+             '{': None}}
     >>> pprint(json.example())
-    {'de(l': None,
-     'nK': {'(Rt)': None,
-            '+hoZh1YU]gy8': True,
-            '8z]EIFA06^l`i^': 'LFE{Q',
-            '9,': 'l{cA=/'}}
+    {'': {'': -2.00001},
+     ' )\n': '',
+     '-': ['', True, None, True, nan, ''],
+     '-\x0c': {'': None, '`': None, 'h': True, '}O]': '^_['},
+     '9': {'': '',
+           ' \\': -1.192092896e-07,
+           '+$!': True,
+           '-': False,
+           '<}': -1.1,
+           '_': None}}
 
 That is, we start with our leaf data and then we augment it by allowing lists and dictionaries of anything we can generate as JSON data.
 

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -129,11 +129,6 @@ def test_can_set_max_size_large(s):
 
 
 @checks_deprecated_behaviour
-def test_alphabet_is_not_a_sequence():
-    text(alphabet=set('abc')).example()
-
-
-@checks_deprecated_behaviour
 def test_alphabet_breaking_size_limit():
     text(['a', 'c', 'ed', 'b', 'abc']).example()
 

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -17,13 +17,14 @@
 
 from __future__ import division, print_function, absolute_import
 
+import unicodedata
 from random import Random
 
 import pytest
 
 from hypothesis import given
 from tests.common.debug import minimal
-from tests.common.utils import checks_deprecated_behaviour
+from tests.common.utils import fails, checks_deprecated_behaviour
 from hypothesis.strategies import text, binary, tuples, characters
 
 
@@ -141,3 +142,15 @@ def test_explicit_alphabet_None_is_deprecated():
 @checks_deprecated_behaviour
 def test_alphabet_non_string():
     text([1, 2, 3]).example()
+
+
+@fails
+@given(text(min_size=2))
+def test_can_find_non_NFC_normalised_strings_issue_341(s):
+    assert s == unicodedata.normalize('NFC', s)
+
+
+@fails
+@given(text(min_size=1))
+def test_can_find_non_NFD_normalised_strings_issue_341(s):
+    assert s == unicodedata.normalize('NFD', s)


### PR DESCRIPTION
This patch substantially increases the variety of examples from the `characters()` strategy.  Instead of generating directly from codepoint, `characters()` now selects a Unicode category and then a code point within that category.  However the shrink target is unchanged, as the choice of category 'shrinks open' to allow codepoint-wise minimisation during shrinking.

I've extracted the unrelated cleanups and refactoring as #1660 - it would be great if that can be reviewed and merged soon, so I can rebase on it.

Closes #1401 and closes #341.