### PR TITLE
Fix pip-tools version

### DIFF
--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -53,7 +53,7 @@ parso==0.3.1              # via jedi
 pbr==4.2.0                # via mock, stevedore
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==3.0.0
+pip-tools==3.1.0
 pkginfo==1.4.2            # via twine
 pluggy==0.7.1             # via pytest, tox
 prompt-toolkit==2.0.5     # via ipython


### PR DESCRIPTION
3.0 was incompatible with pip 18.1, which has been making our `check-requirements` test fail.  So this is a tiny patch to get the fixes from jazzband/pip-tools#689

CC @HypothesisWorks/hypothesis-python-contributors - every build will fail until we merge this!