### PR TITLE
Efficient path for unique collections

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds an internal performance optimisation for lists of distinct
+elements from a :func:`~hypothesis.strategies.sampled_from` strategy.

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -347,3 +347,13 @@ def test_lists_forced_near_top(n):
         lists(integers(), min_size=n, max_size=n + 2),
         lambda t: len(t) == n + 2
     ) == [0] * (n + 2)
+
+
+@pytest.mark.parametrize('m, n', [
+    (m, n) for n in range(2, 10)
+    for m in range(n)
+])
+def test_shrink_for_inclusion(m, n):
+    assert minimal(
+        lists(sampled_from(range(n)), unique=True), lambda ls: m in ls
+    ) == [m]


### PR DESCRIPTION
This special-cases `lists(sampled_from(...), unique_by=...)` with an algorithm adapted from `permutations()`.  Using a shuffle instead of rejection sampling means each element can be considered once; in turn this means that the size of the collection is not capped by our inability to find any remaining elements.

Closes #1617.