### PR TITLE
min_size arguments default to 0

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -222,6 +222,7 @@ their individual contributions.
 * `kbara <https://www.github.com/kbara>`_
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)
 * `Lee Begg <https://www.github.com/llnz2>`_
+* `Lisa Goeller <https://www.github.com/lgoeller>`_
 * `Louis Taylor <https://github.com/kragniz>`_
 * `Luke Barone-Adesi <https://github.com/baluke>`_
 * `marekventur <https://www.github.com/marekventur>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release deprecates  the use of ``min_size=None``, setting the default
+``min_size`` to 0 (:issue: `1618`).

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -125,7 +125,7 @@ def _get_strategy_for_field(f):
         strategy = st.sampled_from(choices)
     elif type(f) == dm.SlugField:
         strategy = st.text(alphabet=string.ascii_letters + string.digits,
-                           min_size=(None if f.blank else 1),
+                           min_size=(0 if f.blank else 1),
                            max_size=f.max_length)
     elif type(f) == dm.GenericIPAddressField:
         lookup = {'both': ip4_addr_strings() | ip6_addr_strings(),
@@ -135,7 +135,7 @@ def _get_strategy_for_field(f):
         strategy = st.text(
             alphabet=st.characters(blacklist_characters=u'\x00',
                                    blacklist_categories=('Cs',)),
-            min_size=(None if f.blank else 1),
+            min_size=(0 if f.blank else 1),
             max_size=f.max_length,
         )
         # We can infer a vastly more precise strategy by considering the

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -110,8 +110,7 @@ def check_valid_size(value, name):
         if name == 'min_size':
             from hypothesis._settings import note_deprecation
             note_deprecation(
-                'You should set your settings to min_size=0, as min_size=None'
-                'is deprecated and no longer has an affect.' 
+               'min_size=None is deprecated; use min_size=0 instead.'
             )
         return
     check_type(integer_types + (float,), value)

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -107,6 +107,12 @@ def check_valid_size(value, name):
     Otherwise raises InvalidArgument.
     """
     if value is None:
+        if name == 'min_size':
+            from hypothesis._settings import note_deprecation
+            note_deprecation(
+                'You should set your settings to min_size=0, as min_size=None'
+                'is deprecated and no longer has an affect.' 
+            )
         return
     check_type(integer_types + (float,), value)
     if value < 0:

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -110,7 +110,7 @@ def check_valid_size(value, name):
         if name == 'min_size':
             from hypothesis._settings import note_deprecation
             note_deprecation(
-               'min_size=None is deprecated; use min_size=0 instead.'
+                'min_size=None is deprecated; use min_size=0 instead.'
             )
         return
     check_type(integer_types + (float,), value)

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -601,7 +601,7 @@ def sampled_from(elements):
 @defines_strategy
 def lists(
     elements=None,  # type: SearchStrategy[Ex]
-    min_size=None,  # type: int
+    min_size=0,  # type: int
     average_size=None,  # type: int
     max_size=None,  # type: int
     unique_by=None,  # type: Callable[..., Any]
@@ -671,7 +671,7 @@ def lists(
 @defines_strategy
 def sets(
     elements=None,  # type: SearchStrategy[Ex]
-    min_size=None,   # type: int
+    min_size=0,   # type: int
     average_size=None,  # type: int
     max_size=None,  # type: int
 ):
@@ -701,7 +701,7 @@ def sets(
 @defines_strategy
 def frozensets(
     elements=None,  # type: SearchStrategy[Ex]
-    min_size=None,   # type: int
+    min_size=0,   # type: int
     average_size=None,  # type: int
     max_size=None,  # type: int
 ):
@@ -738,7 +738,7 @@ class PrettyIter(object):
 
 
 @defines_strategy
-def iterables(elements=None, min_size=None, average_size=None, max_size=None,
+def iterables(elements=None, min_size=0, average_size=None, max_size=None,
               unique_by=None, unique=False):
     """This has the same behaviour as lists, but returns iterables instead.
 
@@ -788,7 +788,7 @@ def dictionaries(
     keys,  # type: SearchStrategy[Ex]
     values,  # type: SearchStrategy[T]
     dict_class=dict,  # type: type
-    min_size=None,  # type: int
+    min_size=0,  # type: int
     average_size=None,  # type: int
     max_size=None,  # type: int
 ):
@@ -936,7 +936,7 @@ def characters(
 @defines_strategy_with_reusable_values
 def text(
     alphabet=None,  # type: Union[Sequence[Text], SearchStrategy[Text]]
-    min_size=None,   # type: int
+    min_size=0,   # type: int
     average_size=None,   # type: int
     max_size=None  # type: int
 ):
@@ -1041,7 +1041,7 @@ def from_regex(regex, fullmatch=False):
 @cacheable
 @defines_strategy_with_reusable_values
 def binary(
-    min_size=None, average_size=None, max_size=None
+    min_size=0, average_size=None, max_size=None
 ):
     # type: (int, int, int) -> SearchStrategy[bytes]
     """Generates the appropriate binary type (str in python 2, bytes in python

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -21,10 +21,13 @@ import pytest
 
 from hypothesis import find, given
 from hypothesis.errors import InvalidArgument
-from tests.common.utils import fails_with
+from tests.common.utils import fails_with, checks_deprecated_behaviour
 from hypothesis.strategies import sets, lists, floats, booleans, \
     integers, recursive, frozensets
 
+@checks_deprecated_behaviour
+def test_min_size_none_behavior(): 
+    lists(integers(), min_size=None).example()
 
 def test_errors_when_given_varargs():
     @given(integers())

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -25,9 +25,11 @@ from tests.common.utils import fails_with, checks_deprecated_behaviour
 from hypothesis.strategies import sets, lists, floats, booleans, \
     integers, recursive, frozensets
 
+
 @checks_deprecated_behaviour
-def test_min_size_none_behavior(): 
+def test_min_size_none_behavior():
     lists(integers(), min_size=None).example()
+
 
 def test_errors_when_given_varargs():
     @given(integers())

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -54,7 +54,7 @@ def builds_ignoring_invalid(target, *args, **kwargs):
 
 
 size_strategies = dict(
-    min_size=st.integers(min_value=0, max_value=100) | st.none(),
+    min_size=st.integers(min_value=0, max_value=100),
     max_size=st.integers(min_value=0, max_value=100) | st.none(),
 )
 


### PR DESCRIPTION
Sets default `min_size=0` instead of `min_size=None`.

Closes #1618.