### PR TITLE
 Use flake8-alfred to forbid use of bytes()

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,7 @@ exclude =
     hypothesis-python/tests/py2/*,
     test_lambda_formatting.py
 ignore = F811,D1,D205,D209,D213,D400,D401,D999,D202
+
+# Use flake8-alfred to forbid builtins that require compatibility wrappers.
+warn-symbols=
+    bytes=Instead of bytes(), use hbytes() or binary_type

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch makes some small internal changes to comply with a new lint setting
+in the build. There should be no user-visible change.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -50,8 +50,8 @@ from hypothesis.executors import new_style_executor
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.internal.compat import ceil, hbytes, qualname, \
-    str_to_bytes, benchmark_time, get_type_hints, getfullargspec, \
-    int_from_bytes, bad_django_TestCase
+    binary_type, str_to_bytes, benchmark_time, get_type_hints, \
+    getfullargspec, int_from_bytes, bad_django_TestCase
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.escalation import \
@@ -149,7 +149,9 @@ def reproduce_failure(version, blob):
 
 
 def encode_failure(buffer):
-    buffer = bytes(buffer)
+    # This needs to be a real bytes() instance, so we use binary_type()
+    # instead of hbytes() here.
+    buffer = binary_type(buffer)
     compressed = zlib.compress(buffer)
     if len(compressed) < len(buffer):
         buffer = b'\1' + compressed

--- a/hypothesis-python/src/hypothesis/extra/fakefactory.py
+++ b/hypothesis-python/src/hypothesis/extra/fakefactory.py
@@ -79,8 +79,8 @@ class FakeFactoryStrategy(SearchStrategy):
         self.factories = {}
 
     def do_draw(self, data):
-        seed = data.draw_bytes(4)
-        random = Random(bytes(seed))
+        seed = data.draw_bits(32)
+        random = Random(seed)
         return self.gen_example(random)
 
     def factory_for(self, locale):

--- a/hypothesis-python/src/hypothesis/reporting.py
+++ b/hypothesis-python/src/hypothesis/reporting.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, absolute_import
 import inspect
 
 from hypothesis._settings import Verbosity, settings
-from hypothesis.internal.compat import print_unicode, \
+from hypothesis.internal.compat import binary_type, print_unicode, \
     escape_unicode_characters
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
@@ -54,7 +54,7 @@ def current_verbosity():
 def to_text(textish):
     if inspect.isfunction(textish):
         textish = textish()
-    if isinstance(textish, bytes):
+    if isinstance(textish, binary_type):
         textish = textish.decode('utf-8')
     return textish
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -28,7 +28,7 @@ import collections
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.compat import PY2, ForwardRef, abc, text_type, \
-    typing_root_type
+    binary_type, typing_root_type
 
 
 def type_sorting_key(t):
@@ -133,7 +133,7 @@ _global_type_lookup = {
     fractions.Fraction: st.fractions(),
     decimal.Decimal: st.decimals(),
     text_type: st.text(),
-    bytes: st.binary(),
+    binary_type: st.binary(),
     datetime.datetime: st.datetimes(),
     datetime.date: st.dates(),
     datetime.time: st.times(),

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -72,7 +72,7 @@ def test_notes_repr():
 
 
 def test_can_mark_interesting():
-    x = ConjectureData.for_buffer(bytes())
+    x = ConjectureData.for_buffer(hbytes())
     with pytest.raises(StopTest):
         x.mark_interesting()
     assert x.frozen
@@ -80,12 +80,12 @@ def test_can_mark_interesting():
 
 
 def test_drawing_zero_bits_is_free():
-    x = ConjectureData.for_buffer(bytes())
+    x = ConjectureData.for_buffer(hbytes())
     assert x.draw_bits(0) == 0
 
 
 def test_can_mark_invalid():
-    x = ConjectureData.for_buffer(bytes())
+    x = ConjectureData.for_buffer(hbytes())
     with pytest.raises(StopTest):
         x.mark_invalid()
     assert x.frozen

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -262,8 +262,8 @@ def test_may_not_fill_with_non_nan_when_unique_is_set():
 
 def test_may_not_fill_with_non_nan_when_unique_is_set_and_type_is_not_number():
     @given(nps.arrays(
-        dtype=bytes, shape=10,
-        unique=True, fill=st.just(b'')))
+        dtype='U', shape=10,
+        unique=True, fill=st.just(u'')))
     def test(arr):
         pass
 

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -4,6 +4,7 @@ coverage
 django
 dpcontracts
 flake8
+flake8-alfred
 flake8-docstrings
 flaky
 ipython

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -26,6 +26,7 @@ docformatter==1.0         # via pyformat
 docutils==0.14            # via readme-renderer, restructuredtext-lint, sphinx
 dparse==0.4.1             # via pyupio, safety
 dpcontracts==0.6.0
+flake8-alfred==1.1.1
 flake8-docstrings==1.3.0
 flake8-polyfill==1.0.2    # via flake8-docstrings
 flake8==3.5.0


### PR DESCRIPTION
Inspired by #1491, this adds a lint pass that detects uses of `bytes`, and suggests using our compatibility wrappers `hbytes` or `binary_type` instead.

~~There are a few existing places that appear to truly need the real `bytes` (on Python 2.7), which are now marked with `# noqa: B1`.~~

Some caveats:

- This kind of change to the build infrastructure is new territory for me.
- I have no idea if `flake8-alfred` is any good; it's simply the first plugin I found that detects this sort of thing.
- ~~The locations marked with `# noqa: B1` could use some inspection to double-check that `bytes` is truly necessary.~~
- ~~It's possible that some of those ignored locations could be fixed by switching to a *different* compatibility wrapper instead.~~
- If this works well, there are a few other builtins that might also be worth forbidding.