### PR TITLE
Tests no longer fail with a DeprecationWarning for users of pluggy<0.6.

### DIFF
--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -33,6 +33,9 @@ def run():
     filterwarnings('ignore', category=ImportWarning)
     filterwarnings('ignore', category=FutureWarning, module='pandas._version')
 
+    # Fixed in recent versions but allowed by pytest=3.0.0; see #1630
+    filterwarnings('ignore', category=DeprecationWarning, module='pluggy')
+
     # See https://github.com/numpy/numpy/pull/432
     filterwarnings('ignore', message='numpy.dtype size changed')
     filterwarnings('ignore', message='numpy.ufunc size changed')


### PR DESCRIPTION
I basically copied the code by @Zac-HD in #1630 with a slight change of the module argument.
Closes #1630