### PR TITLE
Deprecate float sizes (min_size, max_size)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -230,6 +230,7 @@ their individual contributions.
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (marius@gedmin.as)
 * `Markus Unterwaditzer <http://github.com/untitaker/>`_ (markus@unterwaditzer.net)
 * `Matt Bachmann <https://www.github.com/bachmann1234>`_ (bachmann.matt@gmail.com)
+* `Mathieu Paturel <https://github.com/math2001>`_ (mathieu.paturel@gmail.com)
 * `Max Nordlund <https://www.github.com/maxnordlund>`_ (max.nordlund@gmail.com)
 * `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (maxim.kulkin@gmail.com)
 * `mulkieran <https://www.github.com/mulkieran>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release deprecates using floats for ``min_size`` and ``max_size``.

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -106,14 +106,21 @@ def check_valid_size(value, name):
 
     Otherwise raises InvalidArgument.
     """
+    from hypothesis._settings import note_deprecation
     if value is None:
         if name == 'min_size':
-            from hypothesis._settings import note_deprecation
             note_deprecation(
                 'min_size=None is deprecated; use min_size=0 instead.'
             )
         return
-    check_type(integer_types + (float,), value)
+    if isinstance(value, float):
+        note_deprecation(
+            'Float size are deprecated: {} should be an integer, got {}'.format(
+                name, value
+            )
+        )
+    else:
+        check_type(integer_types, value)
     if value < 0:
         raise InvalidArgument(u'Invalid size %s=%r < 0' % (name, value))
     if isinstance(value, float) and math.isnan(value):

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -602,7 +602,7 @@ def sampled_from(elements):
 def lists(
     elements=None,  # type: SearchStrategy[Ex]
     min_size=0,  # type: int
-    average_size=None,  # type: int
+    average_size=None,  # type: None
     max_size=None,  # type: int
     unique_by=None,  # type: Callable[..., Any]
     unique=False,  # type: bool
@@ -672,7 +672,7 @@ def lists(
 def sets(
     elements=None,  # type: SearchStrategy[Ex]
     min_size=0,   # type: int
-    average_size=None,  # type: int
+    average_size=None,  # type: None
     max_size=None,  # type: int
 ):
     # type: (...) -> SearchStrategy[Set[Ex]]
@@ -702,7 +702,7 @@ def sets(
 def frozensets(
     elements=None,  # type: SearchStrategy[Ex]
     min_size=0,   # type: int
-    average_size=None,  # type: int
+    average_size=None,  # type: None
     max_size=None,  # type: int
 ):
     # type: (...) -> SearchStrategy[FrozenSet[Ex]]
@@ -789,7 +789,7 @@ def dictionaries(
     values,  # type: SearchStrategy[T]
     dict_class=dict,  # type: type
     min_size=0,  # type: int
-    average_size=None,  # type: int
+    average_size=None,  # type: None
     max_size=None,  # type: int
 ):
     # type: (...) -> SearchStrategy[Dict[Ex, T]]
@@ -937,7 +937,7 @@ def characters(
 def text(
     alphabet=None,  # type: Union[Sequence[Text], SearchStrategy[Text]]
     min_size=0,   # type: int
-    average_size=None,   # type: int
+    average_size=None,   # type: None
     max_size=None  # type: int
 ):
     # type: (...) -> SearchStrategy[Text]

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -30,6 +30,10 @@ from hypothesis.strategies import sets, lists, floats, booleans, \
 def test_min_size_none_behavior():
     lists(integers(), min_size=None).example()
 
+@checks_deprecated_behaviour
+def test_size_float_behaviour():
+    lists(integers(), min_size=5.0).example()
+    lists(integers(), max_size=-7.1).example()
 
 def test_errors_when_given_varargs():
     @given(integers())

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -31,9 +31,14 @@ def test_min_size_none_behavior():
     lists(integers(), min_size=None).example()
 
 @checks_deprecated_behaviour
-def test_size_float_behaviour():
-    lists(integers(), min_size=5.0).example()
-    lists(integers(), max_size=-7.1).example()
+@given(lists(integers(), min_size=5.0))
+def test_min_size_float_behaviour(arr):
+    assert len(arr) >= 5
+
+@checks_deprecated_behaviour
+@given(lists(integers(), max_size=5.0))
+def test_max_size_float_behaviour(arr):
+    assert len(arr) <= 5
 
 def test_errors_when_given_varargs():
     @given(integers())


### PR DESCRIPTION
Will close #1619 

It shows a deprecation warning when `min_size` or `max_size` is a **float**, instead of being an integer.

The tests only target "whole" float number like `5.0`, and not `5.1`.

I tried to find somewhere in the **documentation** where to mention this deprecation, but I didn't find anything... I'm not really sure if it'd be that useful anyway...

It also changes the **type hints** for `average_size` to being `None` instead of `int`.

However, this PR isn't quite finished, I'm not sure about something: **NaN** shouldn't be allowed as a size.

However, a test (in `cover/test_direct_strategies.py`, at `test_validates_keyword_arguments`), checks a bunch of invalid arguments and asserts that they raise `InvalidArgument`.

One of them tests `min_size` as `float('nan')`. And this **breaks** because it raises a warning that it doesn't expect (the warning that this PR adds). Here's the error message

```
Traceback (most recent call last):                                                                                                                                                                
  File "/home/math2001/code/python/hypothesis/hypothesis-python/tests/cover/test_direct_strategies.py", line 158, in test_validates_keyword_arguments                                             
    fn(**kwargs).example()                                                                                                                                                                        
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/searchstrategy/strategies.py", line 304, in example                                                                
    phases=tuple(set(Phase) - {Phase.shrink}),                                                                                                                                                    
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/core.py", line 985, in find                                                                                        
    specifier.validate()                                                                                                                                                                          
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/searchstrategy/strategies.py", line 379, in validate                                                               
    self.do_validate()                                                                                                                                                                            
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/searchstrategy/lazy.py", line 127, in do_validate                                                                  
    w = self.wrapped_strategy                                                                                                                                                                     
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/searchstrategy/lazy.py", line 113, in wrapped_strategy                                                             
    *self.__args, **self.__kwargs                                                                                                                                                                 
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/strategies.py", line 631, in lists                                                                                 
    check_valid_sizes(min_size, average_size, max_size)                                                                                                                                           
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/internal/validation.py", line 156, in check_valid_sizes                                                            
    check_valid_size(min_size, 'min_size')                                                                                                                                                        
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/internal/validation.py", line 119, in check_valid_size                                                             
    name, value                                                                                                                                                                                   
  File "/home/math2001/code/python/hypothesis/hypothesis-python/src/hypothesis/_settings.py", line 873, in note_deprecation                                                                       
    warnings.warn(warning, stacklevel=2)                                                                                                                                                          
hypothesis.errors.HypothesisDeprecationWarning: Float size are deprecated: min_size should be an integer, got nan
```

I'm not sure what should be done in this case. Here are the different options I'm thinking of:

1. remove this particular test row (pretty bad)
2. block all floats except NaN so that the exception alone is raised, and not the warning (pretty bad from a user perspective)
3. Find a way for this test to ignore the warning, without breaking all the other tests in the table.

The last solution is, I think, what should be done, but I'm not quite sure how to do it cleanly.

I've tried to use `@pytest.mark.filterwarnings`, without success...

If you want to try it locally:

```
git remote add mathieu https://github.com/math2001/hypothesis
git fetch mathieu deprecate-float-sizes
git checkout deprecate-float-sizes
pytest "hypothesis-python/tests/cover/test_direct_strategies.py::test_validates_keyword_arguments" 
```