### PR TITLE
Fix code example error in stateful docs

### DIFF
--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -164,7 +164,7 @@ fewer examples with larger programs you could change the settings to:
 
 .. code:: python
 
-  DatabaseComparison.settings = settings(max_examples=50, stateful_step_count=100)
+  DatabaseComparison.TestCase.settings = settings(max_examples=50, stateful_step_count=100)
 
 Which doubles the number of steps each program runs and halves the number of
 test cases that will be run.


### PR DESCRIPTION
Hello again! I noticed this small mistake in the stateful docs: the docs suggest `settings` can be set at `FiniteStateMachine.settings` when it is actually at `FiniteStateMachine.TestCase.settings`.

I realize that this is a pretty light PR. If that is a problem, I'd be happy to flesh this PR out with additional doc improvements. I could add some notes on using `@settings(...)` with state machines (... which I probably should have done in my last PR). I'm open to other suggestions too :smile: 