### PR TITLE
Add example database functionality to Hypothesis for Ruby

### DIFF
--- a/conjecture-rust/Cargo.toml
+++ b/conjecture-rust/Cargo.toml
@@ -15,6 +15,7 @@ license = "MPL-2.0"
 
 rand = '0.3'
 crypto-hash = '0.3.1'
+byteorder = '1.2'
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/conjecture-rust/Cargo.toml
+++ b/conjecture-rust/Cargo.toml
@@ -14,4 +14,7 @@ license = "MPL-2.0"
 [dependencies]
 
 rand = '0.3'
-conjecture = '0.1.0'
+crypto-hash = '0.3.1'
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/conjecture-rust/RELEASE.md
+++ b/conjecture-rust/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release extends Conjecture for Rust with support for saving examples it discovers on disk in an example database,
+in line with Hypothesis for Python's existing functionality for this.

--- a/conjecture-rust/src/database.rs
+++ b/conjecture-rust/src/database.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 pub type Key = str;
 
 
-pub trait Database: Debug {
+pub trait Database: Debug + Send {
     fn save(&mut self, key: &Key, value: &[u8]) -> ();
     fn delete(&mut self, key: &Key, value: &[u8]) -> ();
     fn fetch(&mut self, key: &Key) -> Vec<Vec<u8>>;

--- a/conjecture-rust/src/database.rs
+++ b/conjecture-rust/src/database.rs
@@ -1,0 +1,137 @@
+use crypto_hash::{hex_digest, Algorithm};
+use std::fs;
+use std::io;
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+
+pub type Key = str;
+
+pub trait Database {
+    fn save(&mut self, key: &Key, value: &[u8]) -> ();
+    fn delete(&mut self, key: &Key, value: &[u8]) -> ();
+    fn fetch(&mut self, key: &Key) -> Vec<Vec<u8>>;
+}
+
+pub struct NoDatabase();
+
+impl Database for NoDatabase {
+    fn save(&mut self, _key: &Key, _value: &[u8]) -> () {}
+    fn delete(&mut self, _key: &Key, _value: &[u8]) -> () {}
+    fn fetch(&mut self, _key: &Key) -> Vec<Vec<u8>> {
+        vec![]
+    }
+}
+
+pub struct DirectoryDatabase {
+    path: PathBuf,
+}
+
+fn expect_io_error(expected: io::ErrorKind, result: io::Result<()>) {
+    match result {
+        Ok(()) => (),
+        Err(error) => {
+            if error.kind() != expected {
+                panic!("IO Error: {:?}", error.kind());
+            }
+        }
+    }
+}
+
+impl DirectoryDatabase {
+    pub fn new<P: AsRef<Path>>(path: P) -> DirectoryDatabase {
+        let mut result = DirectoryDatabase {
+            path: PathBuf::new(),
+        };
+        result.path.push(path);
+        result
+    }
+
+    fn path_for_key(&self, key: &Key) -> PathBuf {
+        let hashed_key = hex_digest(Algorithm::SHA1, key.as_bytes());
+        let mut result = PathBuf::new();
+        result.push(&self.path);
+        result.push(&hashed_key[0..7]);
+        expect_io_error(io::ErrorKind::AlreadyExists, fs::create_dir(&result));
+        result
+    }
+
+    fn path_for_entry(&self, key: &Key, value: &[u8]) -> PathBuf {
+        let mut result = self.path_for_key(key);
+        result.push(&hex_digest(Algorithm::SHA1, value)[0..7]);
+        result
+    }
+}
+
+impl Database for DirectoryDatabase {
+    fn save(&mut self, key: &Key, value: &[u8]) -> () {
+        let mut target = fs::File::create(self.path_for_entry(key, &value)).unwrap();
+        target.write_all(value).unwrap();
+        target.sync_all().unwrap();
+    }
+
+    fn delete(&mut self, key: &Key, value: &[u8]) -> () {
+        let target = self.path_for_entry(key, &value);
+        expect_io_error(io::ErrorKind::NotFound, fs::remove_file(target));
+    }
+
+    fn fetch(&mut self, key: &Key) -> Vec<Vec<u8>> {
+        let mut results = Vec::new();
+        for entry_result in fs::read_dir(self.path_for_key(key)).unwrap() {
+            let path = entry_result.unwrap().path();
+            let file = fs::File::open(path).unwrap();
+            let mut buf_reader = io::BufReader::new(file);
+            let mut contents = Vec::new();
+            buf_reader.read_to_end(&mut contents).unwrap();
+            results.push(contents);
+        }
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempdir::TempDir;
+
+    struct TestDatabase {
+        _temp: TempDir,
+        db: DirectoryDatabase,
+    }
+
+    impl TestDatabase {
+        pub fn new() -> TestDatabase {
+            let dir = TempDir::new("test-db").unwrap();
+            let db = DirectoryDatabase::new(dir.path());
+            TestDatabase { _temp: dir, db: db }
+        }
+    }
+
+    impl Database for TestDatabase {
+        fn save(&mut self, key: &Key, value: &[u8]) -> () {
+            self.db.save(key, value)
+        }
+
+        fn delete(&mut self, key: &Key, value: &[u8]) -> () {
+            self.db.delete(key, value)
+        }
+
+        fn fetch(&mut self, key: &Key) -> Vec<Vec<u8>> {
+            self.db.fetch(key)
+        }
+    }
+
+    #[test]
+    fn can_delete_non_existing_key() {
+        let mut db = TestDatabase::new();
+        db.delete("foo", b"bar");
+    }
+
+    #[test]
+    fn appears_in_listing_after_saving() {
+        let mut db = TestDatabase::new();
+        db.save("foo", b"bar");
+        let results = db.fetch("foo");
+        assert!(results.len() == 1);
+        assert!(results[0].as_slice() == b"bar");
+    }
+}

--- a/conjecture-rust/src/database.rs
+++ b/conjecture-rust/src/database.rs
@@ -141,4 +141,13 @@ mod tests {
         assert!(results.len() == 1);
         assert!(results[0].as_slice() == b"bar");
     }
+
+    #[test]
+    fn can_delete_key() {
+        let mut db = TestDatabase::new();
+        db.save("foo", b"bar");
+        db.delete("foo", b"bar");
+        let results = db.fetch("foo");
+        assert!(results.len() == 0);
+    }
 }

--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -2,12 +2,14 @@
 // the API that can be used to get test data from it.
 
 use rand::{ChaChaRng, Rng, SeedableRng};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::thread;
+use std::io;
 
 use data::{DataSource, DataStream, Status, TestResult};
 use database::BoxedDatabase;
@@ -28,6 +30,8 @@ enum LoopCommand {
 
 #[derive(Debug)]
 struct MainGenerationLoop {
+    name: String,
+    database: BoxedDatabase,
     receiver: Receiver<TestResult>,
     sender: SyncSender<LoopCommand>,
     max_examples: u64,
@@ -61,11 +65,25 @@ impl MainGenerationLoop {
         }
     }
 
-    fn loop_body(&mut self) -> StepResult {
-        self.generate_examples()?;
+    fn run_previous_examples(&mut self) -> Result<(), LoopExitReason>{
+        for v in self.database.fetch(&self.name) {
+            self.execute(DataSource::from_vec(bytes_to_u64s(&v)))?;
+        }
+        Ok(())
+    }
 
-        // At the start of this loop we can only have example in
+    fn loop_body(&mut self) -> StepResult {
+        self.run_previous_examples()?;
+
+        if self.interesting_examples == 0 {
+            self.generate_examples()?;
+        }
+
+        // At the start of this loop we usually only have one example in
         // self.minimized_examples, but as we shrink we may find other ones.
+        // Additionally, we may have multiple different failing examples from
+        // a previous run.
+        //
         // The reason why we loop is twofold:
         // a) This allows us to include newly discovered examples. Labels that
         //    are not found in self.minimized_examples at the beginning of the
@@ -125,10 +143,15 @@ impl MainGenerationLoop {
             Status::Interesting(n) => {
                 self.best_example = Some(result.clone());
                 let mut changed = false;
-                self.minimized_examples.entry(n).or_insert_with(|| {result.clone()}); 
-                self.minimized_examples.entry(n).and_modify(|e| {
+                let mut minimized_examples = &mut self.minimized_examples;
+                let mut database = &mut self.database;
+                let name = &self.name;
+
+                minimized_examples.entry(n).or_insert_with(|| {result.clone()}); 
+                minimized_examples.entry(n).and_modify(|e| {
                   if result < *e {
                     changed = true;
+                    database.delete(name, &u64s_to_bytes(&(*e.record)));
                     *e = result.clone()
                   }; 
                 });
@@ -136,6 +159,7 @@ impl MainGenerationLoop {
                   self.fully_minimized.remove(&n);
                 }
                 self.interesting_examples += 1;
+                database.save(&self.name, &u64s_to_bytes(result.record.as_slice()));
             }
         }
 
@@ -509,8 +533,6 @@ pub struct Engine {
     // this is set to Some(Finished(_)) it stays that way,
     // otherwise it is cleared on access.
     loop_response: Option<LoopCommand>,
-    name: String,
-    database: BoxedDatabase,
 
     state: EngineState,
 
@@ -526,12 +548,31 @@ impl Clone for Engine {
     }
 }
 
+fn bytes_to_u64s(bytes: &[u8]) -> Vec<u64>{
+    let mut reader = io::Cursor::new(bytes);
+    let mut result = Vec::new();
+    while let Ok(n) = reader.read_u64::<BigEndian>() {
+        result.push(n);
+    }
+    result
+}
+
+fn u64s_to_bytes(ints: &[u64]) -> Vec<u8>{
+    let mut result = Vec::new();
+    for n in ints {
+        result.write_u64::<BigEndian>(*n).unwrap();
+    }
+    result
+}
+
 impl Engine {
     pub fn new(name: String, max_examples: u64, seed: &[u32], db: BoxedDatabase) -> Engine {
         let (send_local, recv_remote) = sync_channel(1);
         let (send_remote, recv_local) = sync_channel(1);
 
         let main_loop = MainGenerationLoop {
+            database: db,
+            name: name,
             max_examples: max_examples,
             random: ChaChaRng::from_seed(seed),
             sender: send_remote,
@@ -552,8 +593,6 @@ impl Engine {
             .unwrap();
 
         Engine {
-            name: name,
-            database: db,
             loop_response: None,
             sender: send_local,
             receiver: recv_local,

--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -508,6 +508,7 @@ pub struct Engine {
     // this is set to Some(Finished(_)) it stays that way,
     // otherwise it is cleared on access.
     loop_response: Option<LoopCommand>,
+    name: String,
 
     state: EngineState,
 
@@ -524,7 +525,7 @@ impl Clone for Engine {
 }
 
 impl Engine {
-    pub fn new(max_examples: u64, seed: &[u32]) -> Engine {
+    pub fn new(name: String, max_examples: u64, seed: &[u32]) -> Engine {
         let (send_local, recv_remote) = sync_channel(1);
         let (send_remote, recv_local) = sync_channel(1);
 
@@ -549,6 +550,7 @@ impl Engine {
             .unwrap();
 
         Engine {
+            name: name,
             loop_response: None,
             sender: send_local,
             receiver: recv_local,
@@ -690,7 +692,7 @@ mod tests {
   fn run_to_results<F>(mut f: F) -> Vec<TestResult>
     where F: FnMut(&mut DataSource) -> Result<Status, FailedDraw> {
     let seed: [u32; 2] = [0, 0];
-    let mut engine = Engine::new(1000, &seed);
+    let mut engine = Engine::new("run_to_results".to_string(), 1000, &seed);
     while let Some(mut source) = engine.next_source() {
       if let Ok(status) = f(&mut source) {
         engine.mark_finished(source, status);

--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -67,7 +67,18 @@ impl MainGenerationLoop {
 
     fn run_previous_examples(&mut self) -> Result<(), LoopExitReason>{
         for v in self.database.fetch(&self.name) {
-            self.execute(DataSource::from_vec(bytes_to_u64s(&v)))?;
+            let result = self.execute(DataSource::from_vec(bytes_to_u64s(&v)))?;
+            let should_delete = match &result.status {
+                Status::Interesting(_) => 
+                    u64s_to_bytes(&result.record) != v
+                ,
+                _ => true
+            };
+            if should_delete {
+                println!("Deleting!");
+                self.database.delete(&self.name, v.as_slice());
+            }
+
         }
         Ok(())
     }

--- a/conjecture-rust/src/lib.rs
+++ b/conjecture-rust/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate core;
 extern crate crypto_hash;
+extern crate byteorder;
 extern crate rand;
 
 #[cfg(test)]

--- a/conjecture-rust/src/lib.rs
+++ b/conjecture-rust/src/lib.rs
@@ -1,7 +1,12 @@
 extern crate core;
+extern crate crypto_hash;
 extern crate rand;
 
+#[cfg(test)]
+extern crate tempdir;
+
 pub mod data;
+pub mod database;
 pub mod distributions;
 pub mod engine;
 pub mod intminimize;

--- a/hypothesis-ruby/Gemfile.lock
+++ b/hypothesis-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hypothesis-specs (0.1.1)
+    hypothesis-specs (0.1.2)
       helix_runtime (~> 0.7.0)
       rake (>= 10.0, < 13.0)
 

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds an example database to Hypothesis for Ruby. This means that when a test fails,
+it will automatically reuse the previously shown example when you rerun it, without having to
+manually pass a seed.

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -140,11 +140,20 @@ module Hypothesis
   #
   # A call to hypothesis does the following:
   #
-  # 1. It tries to *generate* a failing test case.
-  # 2. If it succeeded then it will *shrink* that failing test case.
-  # 3. Finally, it will *display* the shrunk failing test case by
+  # 1. It first tries to *reuse* failing test cases for previous runs.
+  # 2. If there were no previous failing test cases then it tries to
+  #    *generate* new failing test cases.
+  # 3. If either of the first two phases found failing test cases then
+  #    it will *shrink* those failing test cases.
+  # 4. Finally, it will *display* the shrunk failing test case by
   #    the error from its failing assertion, modified to show the
   #    givens of the test case.
+  #
+  # Reuse uses an internal representation of the test case, so examples
+  # from previous runs will obey all of the usual invariants of generation.
+  # However, this means that if you change your test then reuse may not
+  # work. Test cases that have become invalid or passing will be cleaned
+  # up automatically.
   #
   # Generation consists of randomly trying test cases until one of
   # three things has happened:
@@ -170,6 +179,11 @@ module Hypothesis
   #
   # @param max_valid_test_cases [Integer] The maximum number of valid test
   #   cases to run without finding a failing test case before stopping.
+  #
+  # @param database [String, nil, false] A path to a directory where Hypothesis
+  #   should store previously failing test cases. If it is nil, Hypothesis
+  #   will use a default of .hypothesis/examples in the current directory.
+  #   May also be set to false to disable the database functionality.
   def hypothesis(max_valid_test_cases: 200, database: nil, &block)
     unless World.current_engine.nil?
       raise UsageError, 'Cannot nest hypothesis calls'

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -176,6 +176,7 @@ module Hypothesis
     end
     begin
       World.current_engine = Engine.new(
+        self.hypothesis_stable_identifier,
         max_examples: max_valid_test_cases
       )
       World.current_engine.run(&block)

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -170,14 +170,15 @@ module Hypothesis
   #
   # @param max_valid_test_cases [Integer] The maximum number of valid test
   #   cases to run without finding a failing test case before stopping.
-  def hypothesis(max_valid_test_cases: 200, &block)
+  def hypothesis(max_valid_test_cases: 200, database: nil, &block)
     unless World.current_engine.nil?
       raise UsageError, 'Cannot nest hypothesis calls'
     end
     begin
       World.current_engine = Engine.new(
-        self.hypothesis_stable_identifier,
-        max_examples: max_valid_test_cases
+        hypothesis_stable_identifier,
+        max_examples: max_valid_test_cases,
+        database: database
       )
       World.current_engine.run(&block)
     ensure

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -7,6 +7,8 @@ require_relative '../hypothesis-ruby/native'
 require 'rspec/expectations'
 
 module Hypothesis
+  DEFAULT_DATABASE_PATH = File.join(Dir.pwd, '.hypothesis', 'examples')
+
   class Engine
     include RSpec::Matchers
 
@@ -16,17 +18,11 @@ module Hypothesis
     def initialize(name, options)
       seed = Random.rand(2**64 - 1)
 
-      begin
-        database = options.fetch(:database)
-      rescue KeyError
-        database = File.join(
-          Dir.pwd, '.hypothesis', 'examples'
-        )
-      end
+      database = options.fetch(:database, nil)
 
-      if database == false
-        database = nil
-      end
+      database = DEFAULT_DATABASE_PATH if database.nil?
+
+      database = nil if database == false
 
       @core_engine = HypothesisCoreEngine.new(
         name, database, seed, options.fetch(:max_examples)

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -13,10 +13,10 @@ module Hypothesis
     attr_reader :current_source
     attr_accessor :is_find
 
-    def initialize(options)
+    def initialize(name, options)
       seed = Random.rand(2**64 - 1)
       @core_engine = HypothesisCoreEngine.new(
-        seed, options.fetch(:max_examples)
+        name, seed, options.fetch(:max_examples)
       )
 
       @exceptions_to_tags = Hash.new { |h, k| h[k] = h.size }

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -15,8 +15,21 @@ module Hypothesis
 
     def initialize(name, options)
       seed = Random.rand(2**64 - 1)
+
+      begin
+        database = options.fetch(:database)
+      rescue KeyError
+        database = File.join(
+          Dir.pwd, '.hypothesis', 'examples'
+        )
+      end
+
+      if database == false
+        database = nil
+      end
+
       @core_engine = HypothesisCoreEngine.new(
-        name, seed, options.fetch(:max_examples)
+        name, database, seed, options.fetch(:max_examples)
       )
 
       @exceptions_to_tags = Hash.new { |h, k| h[k] = h.size }

--- a/hypothesis-ruby/spec/database_spec.rb
+++ b/hypothesis-ruby/spec/database_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe 'database usage' do
       end
     end.to raise_exception(RSpec::Expectations::ExpectationNotMetError)
   end
+
+  it 'cleans out passing examples' do
+    expect do
+      hypothesis do
+        n = any integer
+        expect(n).to be < 10
+      end
+    end.to raise_exception(RSpec::Expectations::ExpectationNotMetError)
+
+    saved = Dir.glob("#{Hypothesis::DEFAULT_DATABASE_PATH}/*/*")
+    expect(saved.length).to be == 1
+
+    hypothesis do
+      any integer
+    end
+
+    saved = Dir.glob("#{Hypothesis::DEFAULT_DATABASE_PATH}/*/*")
+    expect(saved.length).to be == 0
+  end
 end

--- a/hypothesis-ruby/spec/database_spec.rb
+++ b/hypothesis-ruby/spec/database_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe 'database usage' do
+  it 'saves a minimal failing example' do
+    expect do
+      hypothesis do
+        n = any integer
+        expect(n).to be < 10
+      end
+    end.to raise_exception(RSpec::Expectations::ExpectationNotMetError)
+
+    saved = Dir.glob("#{Hypothesis::DEFAULT_DATABASE_PATH}/*/*")
+    expect(saved.length).to be == 1
+  end
+
+  it 'can be disabled' do
+    expect do
+      hypothesis(database: false) do
+        n = any integer
+        expect(n).to be < 10
+      end
+    end.to raise_exception(RSpec::Expectations::ExpectationNotMetError)
+    expect(File.exist?(Hypothesis::DEFAULT_DATABASE_PATH)).to be false
+  end
+
+  it 'replays a previously failing example' do
+    # This is a very unlikely value to be hit on by random. The first
+    # time we run the test we fail for any value larger than it.
+    # This then shrinks to exactly equal to magic. The second time we
+    # run the test we only fail in this exact magic value. This
+    # demonstrates replay from the previous test is working.
+    magic = 17_658
+
+    expect do
+      hypothesis do
+        n = any integer
+        expect(n).to be < magic
+      end
+    end.to raise_exception(RSpec::Expectations::ExpectationNotMetError)
+
+    expect do
+      hypothesis do
+        n = any integer
+        expect(n).not_to be == magic
+      end
+    end.to raise_exception(RSpec::Expectations::ExpectationNotMetError)
+  end
+end

--- a/hypothesis-ruby/spec/multiple_failures_spec.rb
+++ b/hypothesis-ruby/spec/multiple_failures_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hypothesis::MultipleExceptionError do
       begin
         raise m
       rescue Exception => e
-        exceptions.append(e)
+        exceptions.push(e)
       end
     end
 

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -63,7 +63,7 @@ module Hypothesis
       end
       begin
         Hypothesis::World.current_engine = Hypothesis::Engine.new(
-          max_examples: options.fetch(:max_examples, 1000)
+          "find", max_examples: options.fetch(:max_examples, 1000)
         )
         Hypothesis::World.current_engine.is_find = true
         Hypothesis::World.current_engine.run(&block)

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -63,7 +63,7 @@ module Hypothesis
       end
       begin
         Hypothesis::World.current_engine = Hypothesis::Engine.new(
-          "find", max_examples: options.fetch(:max_examples, 1000)
+          'find', max_examples: options.fetch(:max_examples, 1000)
         )
         Hypothesis::World.current_engine.is_find = true
         Hypothesis::World.current_engine.run(&block)
@@ -111,4 +111,8 @@ RSpec.configure do |config|
 
   config.include(Hypothesis)
   config.include(Hypothesis::Possibilities)
+
+  config.before(:each) do
+    FileUtils.rm_rf Hypothesis::DEFAULT_DATABASE_PATH
+  end
 end

--- a/hypothesis-ruby/src/lib.rs
+++ b/hypothesis-ruby/src/lib.rs
@@ -16,6 +16,7 @@ use conjecture::data::{DataSource, Status, TestResult};
 use conjecture::distributions::Repeat;
 use conjecture::distributions;
 use conjecture::engine::Engine;
+use conjecture::database::{BoxedDatabase, NoDatabase, DirectoryDatabase};
 
 ruby! {
   class HypothesisCoreDataSource {
@@ -49,11 +50,16 @@ ruby! {
       interesting_examples: Vec<TestResult>,
     }
 
-    def initialize(helix, name: String, seed: u64, max_examples: u64){
+    def initialize(helix, name: String, database_path: Option<String>, seed: u64, max_examples: u64){
       let xs: [u32; 2] = [seed as u32, (seed >> 32) as u32];
+      let db: BoxedDatabase = match database_path {
+        None => Box::new(NoDatabase),
+        Some(path) => Box::new(DirectoryDatabase::new(path)),
+      };
+
       HypothesisCoreEngine{
         helix,
-        engine: Engine::new(name, max_examples, &xs),
+        engine: Engine::new(name, max_examples, &xs, db),
         pending: None,
         interesting_examples: Vec::new(),
       }

--- a/hypothesis-ruby/src/lib.rs
+++ b/hypothesis-ruby/src/lib.rs
@@ -49,11 +49,11 @@ ruby! {
       interesting_examples: Vec<TestResult>,
     }
 
-    def initialize(helix, seed: u64, max_examples: u64){
+    def initialize(helix, name: String, seed: u64, max_examples: u64){
       let xs: [u32; 2] = [seed as u32, (seed >> 32) as u32];
       HypothesisCoreEngine{
         helix,
-        engine: Engine::new(max_examples, &xs),
+        engine: Engine::new(name, max_examples, &xs),
         pending: None,
         interesting_examples: Vec::new(),
       }


### PR DESCRIPTION
Long overdue feature addition: This adds support for the example database to Hypothesis for Ruby.

I'm not *super* happy with some bits of it - there's a lot of places where it will just panic if bad things happen filesystem wise, but I think that's OK- generally the correct things to do there are fix the problem or disable the database, so there's not much else we can really do.

As per usual rules for Hypothesis for Ruby, this doesn't need a full review, just a green build, but feel free to look over it.