### PR TITLE
Shrink errors from pytest.fail() in given, not just stateful testing

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+Tests using :func:`@given <hypothesis.given>` now shrink errors raised from
+:pypi:`pytest` helper functions, instead of reporting the first example found.
+
+This was previously fixed in :ref:`version 3.56.0 <v3.56.0>`, but only for
+stateful testing.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -567,7 +567,7 @@ class StateForActualGivenExecution(object):
             StopTest,
         ) + EXCEPTIONS_TO_RERAISE:
             raise
-        except Exception as e:
+        except EXCEPTIONS_TO_FAIL as e:
             escalate_hypothesis_internal_error()
             tb = get_trimmed_traceback()
             data.__expected_traceback = ''.join(


### PR DESCRIPTION
Extracted from #1609 to match the behavior added to stateful testing in #1373, without the multiple-user-facing-feature 🔊klaxon🔊 going off.