### PR TITLE
Fix from_type on Python 2

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.strategies.from_type` on Python 2
+for classes where ``cls.__init__ is object.__init__``.
+Thanks to ccxcz for reporting :issue:`1656`.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -116,7 +116,9 @@ def required_args(target, args=(), kwargs=()):
     # Then we try to do the right thing with getfullargspec
     try:
         spec = getfullargspec(
-            target.__init__ if inspect.isclass(target) else target)
+            getattr(target, '__init__', target)
+            if inspect.isclass(target) else target
+        )
     except TypeError:  # pragma: no cover
         return None
     # self appears in the argspec of __init__ and bound methods, but it's an

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1191,7 +1191,7 @@ def builds(
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '
                               'builds(), but is only allowed as a keyword arg')
-    required = required_args(target, args, kwargs)
+    required = required_args(target, args, kwargs) or set()
     to_infer = set(k for k, v in kwargs.items() if v is infer)
     if required or to_infer:
         if isclass(target) and attr.has(target):
@@ -1332,8 +1332,7 @@ def from_type(thing):
         return sampled_from(thing)
     # If we know that builds(thing) will fail, give a better error message
     required = required_args(thing)
-    if not any([
-        not required,
+    if required and not any([
         required.issubset(get_type_hints(thing.__init__)),
         attr.has(thing),
         # NamedTuples are weird enough that we need a specific check for them.

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -91,6 +91,13 @@ class ParentUnknownType(object):
     pass
 
 
+def test_can_resolve_trivial_types():
+    # Under Python 2, this inherits a special wrapper_descriptor slots
+    # thing from object.__init__, which chokes inspect.getargspec.
+    # from_type should and does work anyway; see issues #1655 and #1656.
+    st.from_type(ParentUnknownType).example()
+
+
 class UnknownType(ParentUnknownType):
     def __init__(self, arg):
         pass
@@ -166,10 +173,10 @@ class BrokenClass(object):
 
 
 def test_uninspectable_builds():
-    with pytest.raises(InvalidArgument):
+    with pytest.raises(TypeError, match='object is not callable'):
         st.builds(BrokenClass).example()
 
 
 def test_uninspectable_from_type():
-    with pytest.raises(InvalidArgument):
+    with pytest.raises(TypeError, match='object is not callable'):
         st.from_type(BrokenClass).example()

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -159,3 +159,17 @@ class EmptyEnum(enum.Enum):
 
 def test_error_if_enum_is_empty():
     assert st.from_type(EmptyEnum).is_empty
+
+
+class BrokenClass(object):
+    __init__ = 'Hello!'
+
+
+def test_uninspectable_builds():
+    with pytest.raises(InvalidArgument):
+        st.builds(BrokenClass).example()
+
+
+def test_uninspectable_from_type():
+    with pytest.raises(InvalidArgument):
+        st.from_type(BrokenClass).example()

--- a/hypothesis-python/tests/py2/test_from_type.py
+++ b/hypothesis-python/tests/py2/test_from_type.py
@@ -29,3 +29,11 @@ def test_from_int_is_int(x):
 @given(st.from_type(long))
 def test_from_long_is_long(x):
     assert isinstance(x, long)
+
+
+class OldStyleInitlessClass:
+    pass
+
+
+def test_builds_old_style_initless_class():
+    st.builds(OldStyleInitlessClass).example()


### PR DESCRIPTION
```python
class C(object): pass
from_type(C).example()
```

Thanks to @ccxcz for reporting that this was broken on Python 2, because `required_args` returns None for non-callable types - such as the slot wrapper on `object.__init__`.  Closes #1655, closes #1656.