### PR TITLE
Add explicit error for assigning to settings attribute of state machine

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+:obj:`hypothesis.stateful.GenericStateMachine` and
+:obj:`hypothesis.stateful.RuleBasedStateMachine` now raise an explicit error
+when instances of :obj:`hypothesis.settings` are assigned to the classes'
+settings attribute. Error directs users to use correct assignment methods.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,4 +3,6 @@ RELEASE_TYPE: minor
 :obj:`hypothesis.stateful.GenericStateMachine` and
 :obj:`hypothesis.stateful.RuleBasedStateMachine` now raise an explicit error
 when instances of :obj:`hypothesis.settings` are assigned to the classes'
-settings attribute. Error directs users to use correct assignment methods.
+settings attribute, which is a no-op (:issue:`1643`). Instead assign to
+``SomeStateMachine.TestCase.settings``, or use ``@settings(...)`` as a class
+decorator to handle this automatically.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,8 +1,8 @@
 RELEASE_TYPE: minor
 
-:obj:`hypothesis.stateful.GenericStateMachine` and
-:obj:`hypothesis.stateful.RuleBasedStateMachine` now raise an explicit error
-when instances of :obj:`hypothesis.settings` are assigned to the classes'
+:class:`~hypothesis.stateful.GenericStateMachine` and
+:class:`~hypothesis.stateful.RuleBasedStateMachine` now raise an explicit error
+when instances of :obj:`~hypothesis.settings` are assigned to the classes'
 settings attribute, which is a no-op (:issue:`1643`). Instead assign to
 ``SomeStateMachine.TestCase.settings``, or use ``@settings(...)`` as a class
 decorator to handle this automatically.

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -130,8 +130,17 @@ class GenericStateMachineMeta(type):
         if name == 'settings':
             raise AttributeError(
                 ('Cannot assign to the property {0}.settings - '
-                 'settings can be applied to this stateful test by assigning '
-                 'to {0}.TestCase.settings').format(self.__name__)
+                 'settings can be applied to {0} by either '
+                 'assigning to the settings attribute of {0}.TestCase:\n'
+                 '\n'
+                 '    {0}.TestCase.settings = settings(...) \n'
+                 '\n'
+                 'Or applying the settings object as a decorator to {0}\'s '
+                 'declaration:\n'
+                 '\n'
+                 '    @settings(...)\n'
+                 '    class {0}(...):\n'
+                 '        ...').format(self.__name__)
             )
         return type.__setattr__(self, name, value)
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -146,8 +146,8 @@ class GenericStateMachineMeta(type):
 
 
 class GenericStateMachine(
-        GenericStateMachineMeta('GenericStateMachine',
-                                (object,), {})  # type: ignore
+        GenericStateMachineMeta('GenericStateMachine', # type: ignore
+                                (object,), {})
 ):
     """A GenericStateMachine is the basic entry point into Hypothesis's
     approach to stateful testing.

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -121,7 +121,25 @@ def run_state_machine_as_test(state_machine_factory, settings=None):
     )
 
 
-class GenericStateMachine(object):
+class GenericStateMachineMeta(type):
+
+    def __init__(self, *args, **kwargs):
+        super(GenericStateMachineMeta, self).__init__(*args, **kwargs)
+
+    def __setattr__(self, name, value):
+        if name == 'settings':
+            raise AttributeError(
+                ('Cannot assign to the property {0}.settings - '
+                 'settings can be applied to this stateful test by assigning '
+                 'to {0}.TestCase.settings').format(self.__name__)
+            )
+        return type.__setattr__(self, name, value)
+
+
+class GenericStateMachine(
+        GenericStateMachineMeta('GenericStateMachine',
+                                (object,), {})  # type: ignore
+):
     """A GenericStateMachine is the basic entry point into Hypothesis's
     approach to stateful testing.
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -127,27 +127,18 @@ class GenericStateMachineMeta(type):
         super(GenericStateMachineMeta, self).__init__(*args, **kwargs)
 
     def __setattr__(self, name, value):
-        if name == 'settings':
+        if name == 'settings' and isinstance(value, Settings):
             raise AttributeError(
-                ('Cannot assign to the property {0}.settings - '
-                 'settings can be applied to {0} by either '
-                 'assigning to the settings attribute of {0}.TestCase:\n'
-                 '\n'
-                 '    {0}.TestCase.settings = settings(...) \n'
-                 '\n'
-                 'Or applying the settings object as a decorator to {0}\'s '
-                 'declaration:\n'
-                 '\n'
-                 '    @settings(...)\n'
-                 '    class {0}(...):\n'
-                 '        ...').format(self.__name__)
+                ('Assigning {cls}.settings = {value} does nothing. Assign '
+                 'to {cls}.TestCase.settings, or use @{value} as a decorator '
+                 'on the {cls} class.').format(cls=self.__name__, value=value)
             )
         return type.__setattr__(self, name, value)
 
 
 class GenericStateMachine(
-        GenericStateMachineMeta('GenericStateMachine', # type: ignore
-                                (object,), {})
+    GenericStateMachineMeta('GenericStateMachine',  # type: ignore
+                            (object,), {})
 ):
     """A GenericStateMachine is the basic entry point into Hypothesis's
     approach to stateful testing.

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -33,7 +33,8 @@ from tests.common.utils import validate_deprecation, \
     checks_deprecated_behaviour
 from hypothesis.database import ExampleDatabase, \
     DirectoryBasedExampleDatabase
-from hypothesis.stateful import RuleBasedStateMachine, rule
+from hypothesis.stateful import GenericStateMachine, \
+    RuleBasedStateMachine, rule
 from hypothesis._settings import Verbosity, PrintSettings, settings, \
     default_variable, note_deprecation
 from hypothesis.utils.conventions import not_set
@@ -463,7 +464,7 @@ def test_settings_decorator_applied_to_non_state_machine_class_raises_error():
 
 def test_assigning_to_settings_attribute_on_state_machine_raises_error():
     with pytest.raises(AttributeError):
-        class StateMachine(RuleBasedStateMachine):
+        class StateMachine(GenericStateMachine):
             pass
         StateMachine.settings = settings()
 

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -459,3 +459,13 @@ def test_settings_decorator_applied_to_non_state_machine_class_raises_error():
         @settings()
         class NonStateMachine:
             pass
+
+
+def test_assigning_to_settings_attribute_on_state_machine_raises_error():
+    with pytest.raises(AttributeError):
+        class StateMachine(RuleBasedStateMachine):
+            pass
+        StateMachine.settings = settings()
+
+    state_machine_instance = StateMachine()
+    state_machine_instance.settings = 'any value'


### PR DESCRIPTION
This PR adds an explicit error to help prevent users from mistakenly assigning settings to the settings attribute of their state machine class. Ex:
```python
class Machine(GenericStateMachine):
     pass
Machine.settings = settings(...)  # will now raise an error
```
I'm getting a strange error on when I run `./build.sh check-coverage` locally. I'm interested to see if this error shows up in CI.

Closes #1643.