### PR TITLE
Clarify the API and docs for st.text()

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+The ``alphabet`` argument for :func:`~hypothesis.strategies.text` now
+uses its default value of ``characters(blacklist_categories=('Cs',))``
+directly, instead of hiding that behind ``alphabet=None`` and replacing
+it within the function.  Passing ``None`` is therefore deprecated.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -198,7 +198,7 @@ Thanks to Benjamin Lee for this contribution!
 -------------------
 
 This release deprecates  the use of ``min_size=None``, setting the default
-``min_size`` to 0 (:issue: `1618`).
+``min_size`` to 0 (:issue:`1618`).
 
 .. _v3.74.3:
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/strings.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/strings.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import charmap
-from hypothesis.internal.compat import hunichr, text_type, binary_type
+from hypothesis.internal.compat import hunichr, binary_type
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
@@ -28,9 +28,6 @@ from hypothesis.searchstrategy.strategies import SearchStrategy, \
 
 class OneCharStringStrategy(SearchStrategy):
     """A strategy which generates single character strings of text type."""
-
-    specifier = text_type
-    zero_point = ord('0')
 
     def __init__(self,
                  whitelist_categories=None,
@@ -64,10 +61,6 @@ class OneCharStringStrategy(SearchStrategy):
                     '%s=%r' % arg for arg in arguments if arg[1] is not None)
             )
         self.intervals = IntervalSet(intervals)
-        if whitelist_characters:
-            self.whitelist_characters = set(whitelist_characters)
-        else:
-            self.whitelist_characters = set()
         self.zero_point = self.intervals.index_above(ord('0'))
 
     def do_draw(self, data):

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -1000,14 +1000,6 @@ def text(
     if alphabet is None:
         note_deprecation('alphabet=None is deprecated; just omit the argument')
         char_strategy = characters(blacklist_categories=('Cs',))
-    elif not alphabet:
-        if (min_size or 0) > 0:
-            raise InvalidArgument(
-                'Invalid min_size %r > 0 for empty alphabet' % (
-                    min_size,
-                )
-            )
-        return just(u'')
     elif isinstance(alphabet, SearchStrategy):
         char_strategy = alphabet
     else:
@@ -1036,6 +1028,8 @@ def text(
                 'will be an error in future:  %r' % (not_one_char,)
             )
         char_strategy = sampled_from(alphabet)
+    if (max_size == 0 or char_strategy.is_empty) and not min_size:
+        return just(u'')
     return StringStrategy(lists(
         char_strategy, min_size=min_size, max_size=max_size
     ))

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -966,7 +966,9 @@ def characters(
 @cacheable
 @defines_strategy_with_reusable_values
 def text(
-    alphabet=None,  # type: Union[Sequence[Text], SearchStrategy[Text]]
+    alphabet=characters(
+        blacklist_categories=('Cs',)
+    ),  # type: Union[Sequence[Text], SearchStrategy[Text]]
     min_size=0,   # type: int
     average_size=None,   # type: None
     max_size=None  # type: int
@@ -996,6 +998,7 @@ def text(
     """
     check_valid_sizes(min_size, average_size, max_size)
     if alphabet is None:
+        note_deprecation('alphabet=None is deprecated; just omit the argument')
         char_strategy = characters(blacklist_categories=('Cs',))
     elif not alphabet:
         if (min_size or 0) > 0:

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -139,5 +139,10 @@ def test_alphabet_breaking_size_limit():
 
 
 @checks_deprecated_behaviour
+def test_explicit_alphabet_None_is_deprecated():
+    text(alphabet=None).example()
+
+
+@checks_deprecated_behaviour
 def test_alphabet_non_string():
     text([1, 2, 3]).example()

--- a/whole-repo-tests/test_doctests.py
+++ b/whole-repo-tests/test_doctests.py
@@ -28,6 +28,7 @@ def test_doctests():
     env['PYTHONPATH'] = 'src'
 
     pip_tool(
-        'sphinx-build', '-W', '-b', 'doctest', '-d', 'docs/_build/doctrees',
+        'sphinx-build', '-n', '-W', '--keep-going', '-T',
+        '-b', 'doctest', '-d', 'docs/_build/doctrees',
         'docs', 'docs/_build/html', env=env, cwd=BASE_DIR,
     )


### PR DESCRIPTION
Extracted from #1621, because we have a one-feature-per-release policy and because the deeper internals changes there are taking a long time to get right.

- Expands documentation of `text()`, because Unicode is hard!
- Makes the default alphabet explicit, because that's better than implicit.
- Kills a bunch of dead code, some dating to Hypothesis 1!