### PR TITLE
Use new Hypothesis trove classifier!

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This is a no-op release to add the new ``Framework :: Hypothesis``
+`trove classifier <https://pypi.org/classifiers/>`_ to
+:pypi:`hypothesis` on PyPI.
+
+You can `use it as a filter <https://pypi.org/search/?c=Framework+%3A%3A+Hypothesis>`_
+to find Hypothesis-related packages such as extensions as they add the tag
+over the coming weeks, or simply visit :doc:`our curated list <strategies>`.

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -4,8 +4,9 @@ Projects extending Hypothesis
 
 Hypothesis has been eagerly used and extended by the open source community.
 This page lists extensions and applications; you can find more or newer
-packages by `searching PyPI <https://pypi.org/search/?q=hypothesis>`_ or
-`libraries.io <https://libraries.io/search?languages=Python&q=hypothesis>`_.
+packages by searching PyPI `by keyword <https://pypi.org/search/?q=hypothesis>`_
+or `filter by classifier <https://pypi.org/search/?c=Framework+%3A%3A+Hypothesis>`_,
+or search `libraries.io <https://libraries.io/search?languages=Python&q=hypothesis>`_.
 
 If there's something missing which you think should be here, let us know!
 
@@ -77,7 +78,8 @@ happy to review and help with external packages as well as pull requests!
 
 If you're thinking about writing an extension, please name it
 ``hypothesis-{something}`` - a standard prefix makes the community more
-visible and searching for extensions easier.
+visible and searching for extensions easier.  And make sure you use the
+``Framework :: Hypothesis`` trove classifier!
 
 On the other hand, being inside gets you access to some deeper implementation
 features (if you need them) and better long-term guarantees about maintenance.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -100,6 +100,8 @@ setuptools.setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
+        'Framework :: Hypothesis',
+        'Framework :: Pytest',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Operating System :: Unix',
@@ -115,7 +117,6 @@ setuptools.setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',
-        'Framework :: Pytest',
     ],
     entry_points={
         'pytest11': ['hypothesispytest = hypothesis.extra.pytestplugin'],


### PR DESCRIPTION
As follow-up to #1661, I asked for a new trove classifier as described in [the PyPI FAQ](https://pypi.org/help/#new-classifier) (pypa/warehouse#4973).  They quickly created `Framework :: Hypothesis`, which can be used by all Hypothesis-related packages to make it easy for users to find them.  Thanks to @fkromer for prompting me to ask PyPA for this!

Next steps: contact all our featured extensions and encourage them to add the classifier.  After that, we can rely on natural growth :rocket: