### PR TITLE
Track deprecation information with 'since' internally

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds information about when features were deprecated, but this
+is only recorded internally and has no user-visible effect.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -37,7 +37,7 @@ from hypothesis.errors import (
     InvalidArgument,
     InvalidState,
 )
-from hypothesis.internal.compat import text_type
+from hypothesis.internal.compat import string_types
 from hypothesis.internal.reflection import get_pretty_function_description, proxies
 from hypothesis.internal.validation import try_convert
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
@@ -420,7 +420,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         keyword arguments for each setting that will be set differently to
         parent (or settings.default, if parent is None).
         """
-        if not isinstance(name, (str, text_type)):
+        if not isinstance(name, string_types):
             note_deprecation("name=%r must be a string" % (name,), since="2018-02-27")
         if "settings" in kwargs:
             if parent is None:
@@ -440,7 +440,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
     def get_profile(name):
         # type: (str) -> settings
         """Return the profile with the given name."""
-        if not isinstance(name, (str, text_type)):
+        if not isinstance(name, string_types):
             note_deprecation("name=%r must be a string" % (name,), since="2016-01-08")
         try:
             return settings._profiles[name]
@@ -456,7 +456,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         Any setting not defined in the profile will be the library
         defined default for that setting.
         """
-        if not isinstance(name, (str, text_type)):
+        if not isinstance(name, string_types):
             note_deprecation("name=%r must be a string" % (name,), since="2016-01-08")
         settings._current_profile = name
         settings._assign_default_internal(settings.get_profile(name))

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -259,7 +259,8 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
                     get_pretty_function_description(test),
                     test._hypothesis_internal_use_settings,
                     self,
-                )
+                ),
+                since="2018-03-23",
             )
 
         test._hypothesis_internal_use_settings = self
@@ -271,7 +272,8 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         def new_test(*args, **kwargs):
             note_deprecation(
                 "Using `@settings` without `@given` does not make sense and "
-                "will be an error in a future version of Hypothesis."
+                "will be an error in a future version of Hypothesis.",
+                since="2018-03-12",
             )
             test(*args, **kwargs)
 
@@ -391,7 +393,8 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
     def __enter__(self):
         note_deprecation(
             "Settings should be determined only by global state or with the "
-            "@settings decorator."
+            "@settings decorator.",
+            since="2018-06-22",
         )
         default_context_manager = default_variable.with_value(self)
         self.defaults_stack().append(default_context_manager)
@@ -418,12 +421,13 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         parent (or settings.default, if parent is None).
         """
         if not isinstance(name, (str, text_type)):
-            note_deprecation("name=%r must be a string" % (name,))
+            note_deprecation("name=%r must be a string" % (name,), since="2018-02-27")
         if "settings" in kwargs:
             if parent is None:
                 parent = kwargs.pop("settings")
                 note_deprecation(
-                    "The `settings` argument is deprecated - " "use `parent` instead."
+                    "The `settings` argument is deprecated - " "use `parent` instead.",
+                    since="2018-02-27",
                 )
             else:
                 raise InvalidArgument(
@@ -437,7 +441,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         # type: (str) -> settings
         """Return the profile with the given name."""
         if not isinstance(name, (str, text_type)):
-            note_deprecation("name=%r must be a string" % (name,))
+            note_deprecation("name=%r must be a string" % (name,), since="2016-01-08")
         try:
             return settings._profiles[name]
         except KeyError:
@@ -453,7 +457,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         defined default for that setting.
         """
         if not isinstance(name, (str, text_type)):
-            note_deprecation("name=%r must be a string" % (name,))
+            note_deprecation("name=%r must be a string" % (name,), since="2016-01-08")
         settings._current_profile = name
         settings._assign_default_internal(settings.get_profile(name))
 
@@ -897,11 +901,11 @@ def _validate_print_blob(value):
         else:
             replacement = PrintSettings.NEVER
 
-        # TODO: Pass through `since` here
         note_deprecation(
             "Setting print_blob=%r is deprecated and will become an error "
             "in a future version of Hypothesis. Use print_blob=%r instead."
-            % (value, replacement)
+            % (value, replacement),
+            since="2018-09-30",
         )
         return replacement
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -197,7 +197,11 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         self._construction_complete = True
 
         for d in deprecations:
-            note_deprecation(d.deprecation_message, self)
+            note_deprecation(
+                d.deprecation_message,
+                since=d.deprecated_since,
+                verbosity=self.verbosity,
+            )
 
     def defaults_stack(self):
         try:

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -328,13 +328,6 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         if hide_repr is not_set:
             hide_repr = bool(deprecation_message)
 
-        if deprecation_message is not None and deprecated_since is None:
-            note_deprecation(
-                "Settings with a deprecation message should always include "
-                "a `deprecated_since` date.",
-                since="2018-12-17",
-            )
-
         all_settings[name] = Setting(
             name=name,
             description=description.strip(),

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -804,7 +804,8 @@ def validate_health_check_suppressions(suppressions):
                     "will be ignored, and will become an error in a future "
                     "version of Hypothesis"
                 )
-                % (s, type(s).__name__)
+                % (s, type(s).__name__),
+                since="2017-11-11",
             )
         elif s in (HealthCheck.exception_in_generation, HealthCheck.random_module):
             note_deprecation(
@@ -814,7 +815,8 @@ def validate_health_check_suppressions(suppressions):
                     "remove it from your list of suppressions to get the same "
                     "effect."
                 )
-                % (s,)
+                % (s,),
+                since="2017-11-11",
             )
     return suppressions
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -902,12 +902,11 @@ more details of this behaviour.
 settings.lock_further_definitions()
 
 
-def note_deprecation(message, s=None):
-    # type: (str, settings) -> None
-    if s is None:
-        s = settings.default
-    assert s is not None
-    verbosity = s.verbosity
+def note_deprecation(message, since, verbosity=None):
+    # type: (str, str, Verbosity) -> None
+    if verbosity is None:
+        verbosity = settings.default.verbosity
+    assert verbosity is not None
     warning = HypothesisDeprecationWarning(message)
     if verbosity > Verbosity.quiet:
         warnings.warn(warning, stacklevel=2)

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -296,6 +296,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         show_default=True,
         future_default=not_set,
         deprecation_message=None,
+        deprecated_since=None,
         hide_repr=not_set,
     ):
         """Add a new setting.
@@ -321,15 +322,23 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         if hide_repr is not_set:
             hide_repr = bool(deprecation_message)
 
+        if deprecation_message is not None and deprecated_since is None:
+            note_deprecation(
+                "Settings with a deprecation message should always include "
+                "a `deprecated_since` date.",
+                since="2018-12-17",
+            )
+
         all_settings[name] = Setting(
-            name,
-            description.strip(),
-            default,
-            options,
-            validator,
-            future_default,
-            deprecation_message,
-            hide_repr,
+            name=name,
+            description=description.strip(),
+            default=default,
+            options=options,
+            validator=validator,
+            future_default=future_default,
+            deprecation_message=deprecation_message,
+            deprecated_since=deprecated_since,
+            hide_repr=hide_repr,
         )
         setattr(settings, name, settingsProperty(name, show_default))
 
@@ -461,6 +470,7 @@ class Setting(object):
     validator = attr.ib()
     future_default = attr.ib()
     deprecation_message = attr.ib()
+    deprecated_since = attr.ib()
     hide_repr = attr.ib()
 
 
@@ -475,6 +485,7 @@ The min_satisfying_examples setting has been deprecated and disabled, due to
 overlap with the filter_too_much healthcheck and poor interaction with the
 max_examples setting.
 """,
+    deprecated_since="2018-04-08",
 )
 
 settings._define_setting(
@@ -496,6 +507,7 @@ This doesn't actually do anything, but remains for compatibility reasons.
 The max_iterations setting has been disabled, as internal heuristics are more
 useful for this purpose than a user setting.  It no longer has any effect.
 """,
+    deprecated_since="2018-04-06",
 )
 
 settings._define_setting(
@@ -520,6 +532,7 @@ setting), but any other value has no effect and uses a general heuristic.
 The max_shrinks setting has been disabled, as internal heuristics are more
 useful for this purpose than a user setting.
 """,
+    deprecated_since="2018-04-14",
 )
 
 
@@ -547,6 +560,7 @@ Hypothesis. To get the future behaviour set ``timeout=hypothesis.unlimited``
 instead (which will remain valid for a further deprecation period after this
 setting has gone away).
 """,
+    deprecated_since="2017-11-02",
     future_default=unlimited,
     validator=_validate_timeout,
 )
@@ -578,6 +592,7 @@ Strict mode is deprecated and will go away in a future version of Hypothesis.
 To get the same behaviour, use
 warnings.simplefilter('error', HypothesisDeprecationWarning).
 """,
+    deprecated_since="2017-07-16",
     future_default=False,
 )
 
@@ -625,6 +640,7 @@ setting, and will be removed in a future version.  It only exists at
 all for complicated historical reasons and you should just use
 `database` instead.
 """,
+    deprecated_since="2018-04-01",
 )
 
 
@@ -774,6 +790,7 @@ attempting to actually execute your test.
 This setting is deprecated, as `perform_health_check=False` duplicates the
 effect of `suppress_health_check=HealthCheck.all()`.  Use that instead!
 """,
+    deprecated_since="2018-04-05",
 )
 
 
@@ -834,6 +851,7 @@ settings._define_setting(
     deprecation_message="""
 use_coverage no longer does anything and can be removed from your settings.
 """,
+    deprecated_since="2017-09-14",
     description="""
 A flag to enable a feature that no longer exists. This setting is present
 only for backwards compatibility purposes.
@@ -873,6 +891,7 @@ def _validate_print_blob(value):
         else:
             replacement = PrintSettings.NEVER
 
+        # TODO: Pass through `since` here
         note_deprecation(
             "Setting print_blob=%r is deprecated and will become an error "
             "in a future version of Hypothesis. Use print_blob=%r instead."

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -530,7 +530,8 @@ class StateForActualGivenExecution(object):
                                 "slower than this into an error, or you can set "
                                 "it to None to disable this check entirely."
                             )
-                            % (self.test.__name__, runtime, ceil(runtime / 100) * 100)
+                            % (self.test.__name__, runtime, ceil(runtime / 100) * 100),
+                            since="2017-11-20",
                         )
                 else:
                     current_deadline = self.settings.deadline
@@ -665,7 +666,8 @@ class StateForActualGivenExecution(object):
                         "To get the future behaviour, update your settings to "
                         "include database=None."
                     )
-                    % (self.test.__name__,)
+                    % (self.test.__name__,),
+                    since="2018-09-01",
                 )
             if self.__had_seed:
                 note_deprecation(
@@ -675,7 +677,8 @@ class StateForActualGivenExecution(object):
                         "from the database. To get the future behaviour, update "
                         "your settings for this test to include database=None."
                     )
-                    % (self.test.__name__,)
+                    % (self.test.__name__,),
+                    since="2018-09-01",
                 )
 
         timed_out = runner.exit_reason == ExitReason.timeout
@@ -893,7 +896,8 @@ def given(
                         "@given(booleans()) @given(integers()), you could write "
                         "@given(booleans(), integers())"
                     )
-                    % (test.__name__,)
+                    % (test.__name__,),
+                    since="2018-09-01",
                 )
 
             settings = wrapped_test._hypothesis_internal_use_settings

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -667,7 +667,7 @@ class StateForActualGivenExecution(object):
                         "include database=None."
                     )
                     % (self.test.__name__,),
-                    since="2018-09-01",
+                    since="2017-11-29",
                 )
             if self.__had_seed:
                 note_deprecation(
@@ -678,7 +678,7 @@ class StateForActualGivenExecution(object):
                         "your settings for this test to include database=None."
                     )
                     % (self.test.__name__,),
-                    since="2018-09-01",
+                    since="2017-11-29",
                 )
 
         timed_out = runner.exit_reason == ExitReason.timeout

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -46,7 +46,8 @@ def _db_for_path(path=None):
                 "The $HYPOTHESIS_DATABASE_FILE environment variable is "
                 "deprecated, and will be ignored by a future version of "
                 "Hypothesis.  Configure your database location via a "
-                "settings profile instead."
+                "settings profile instead.",
+                since="2018-04-01",
             )
             return _db_for_path(path)
         # Note: storage_directory attempts to create the dir in question, so
@@ -162,14 +163,16 @@ class SQLiteExampleDatabase(ExampleDatabase):
             note_deprecation(
                 "The SQLite database backend has been deprecated. "
                 'Use InMemoryExampleDatabase or set database_file=":memory:" '
-                "instead."
+                "instead.",
+                since="2017-09-12",
             )
         else:
             note_deprecation(
                 "The SQLite database backend has been deprecated. "
                 "Set database_file to some path name not ending in .db, "
                 ".sqlite or .sqlite3 to get the new directory based database "
-                "backend instead."
+                "backend instead.",
+                since="2017-09-12",
             )
 
     def connection(self):

--- a/hypothesis-python/src/hypothesis/extra/datetime.py
+++ b/hypothesis-python/src/hypothesis/extra/datetime.py
@@ -81,7 +81,8 @@ def datetimes(allow_naive=None, timezones=None, min_year=None, max_year=None):
     """
     note_deprecation(
         "Use hypothesis.strategies.datetimes, which supports "
-        "full-precision bounds and has a simpler API."
+        "full-precision bounds and has a simpler API.",
+        since="2017-04-29",
     )
     min_dt = convert_year_bound(min_year, dt.datetime.min)
     max_dt = convert_year_bound(max_year, dt.datetime.max)
@@ -100,7 +101,8 @@ def dates(min_year=None, max_year=None):
     """
     note_deprecation(
         "Use hypothesis.strategies.dates, which supports bounds "
-        "given as date objects for single-day resolution."
+        "given as date objects for single-day resolution.",
+        since="2017-04-29",
     )
     return st.dates(
         convert_year_bound(min_year, dt.date.min),
@@ -120,6 +122,7 @@ def times(allow_naive=None, timezones=None):
     """
     note_deprecation(
         "Use hypothesis.strategies.times, which supports "
-        "min_time and max_time arguments."
+        "min_time and max_time arguments.",
+        since="2017-04-29",
     )
     return st.times(timezones=tz_args_strat(allow_naive, timezones, "times"))

--- a/hypothesis-python/src/hypothesis/extra/fakefactory.py
+++ b/hypothesis-python/src/hypothesis/extra/fakefactory.py
@@ -33,7 +33,8 @@ def fake_factory(source, locale=None, locales=None, providers=()):
     note_deprecation(
         "hypothesis.extra.fakefactory has been deprecated, because it does "
         "not support example discovery or shrinking.  Consider using a lower-"
-        "level strategy (such as st.text()) instead."
+        "level strategy (such as st.text()) instead.",
+        since="2017-12-02",
     )
     check_valid_identifier(source)
     if source[0] == u"_":

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -175,7 +175,8 @@ class ArrayStrategy(SearchStrategy):
                 "Generated array element %r from %r cannot be represented as "
                 "dtype %r - instead it becomes %r .  Consider using a more "
                 "precise strategy, as this will be an error in a future "
-                "version." % (val, strategy, self.dtype, result[idx])
+                "version." % (val, strategy, self.dtype, result[idx]),
+                since="2018-07-31",
             )
             # Because the message includes the value of the generated element,
             # it would be easy to spam users with thousands of warnings.

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -188,7 +188,8 @@ def pytest_collection_modifyitems(items):
                     "but pytest has collected it as a test function.  This "
                     "is useless as the function body will never be executed."
                     "To define a test function, use @given instead of "
-                    "@composite." % (item.nodeid,)
+                    "@composite." % (item.nodeid,),
+                    since="2018-11-02",
                 )
 
             item.obj = note_strategy_is_not_test

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -147,7 +147,8 @@ def as_general_categories(cats, name="cats"):
         elif c not in cs:
             note_deprecation(
                 "In %s=%r, %r is not a valid Unicode category.  This will "
-                "be an error in a future version." % (name, cats, c)
+                "be an error in a future version." % (name, cats, c),
+                since="2018-02-21",
             )
     return tuple(c for c in cs if c in out)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -350,7 +350,8 @@ class ConjectureRunner(object):
                     "hypothesis.unlimited."
                 )
                 % (self.settings.timeout, self.valid_examples),
-                self.settings,
+                since="2018-07-29",
+                verbosity=self.settings.verbosity,
             )
             self.exit_with(ExitReason.timeout)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -131,7 +131,8 @@ def check_sample(values, strategy_name):
                     "to a one-dimensional array, or tuple(values) if you "
                     "want to sample slices.  Sampling a multi-dimensional "
                     "array will be an error in a future version of Hypothesis."
-                ).format(ndim=values.ndim, shape=values.shape)
+                ).format(ndim=values.ndim, shape=values.shape),
+                since="2018-05-09",
             )
     elif not isinstance(values, (OrderedDict, abc.Sequence, enum.EnumMeta)):
         note_deprecation(
@@ -145,7 +146,8 @@ def check_sample(values, strategy_name):
             "handling - and note that when simplifying an example, "
             "Hypothesis treats earlier values as simpler.".format(
                 values=repr(values), strategy=strategy_name
-            )
+            ),
+            since="2017-04-12",
         )
     return tuple(values)
 

--- a/hypothesis-python/src/hypothesis/internal/renaming.py
+++ b/hypothesis-python/src/hypothesis/internal/renaming.py
@@ -27,8 +27,8 @@ if False:
     from hypothesis.searchstrategy.strategies import T  # noqa
 
 
-def renamed_arguments(**rename_mapping):
-    # type: (**str) -> Callable[[T], T]
+def renamed_arguments(since, **rename_mapping):
+    # type: (str, **str) -> Callable[[T], T]
     """Helper function for deprecating arguments that have been renamed to a
     new form.
 
@@ -51,7 +51,8 @@ def renamed_arguments(**rename_mapping):
                             "name will go away in a future version of "
                             "Hypothesis."
                         )
-                        % (k, t)
+                        % (k, t),
+                        since=since,
                     )
                     kwargs[t] = kwargs.pop(k)
             return f(**kwargs)

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -108,7 +108,10 @@ def check_valid_size(value, name):
         if name == "min_size":
             from hypothesis._settings import note_deprecation
 
-            note_deprecation("min_size=None is deprecated; use min_size=0 instead.")
+            note_deprecation(
+                "min_size=None is deprecated; use min_size=0 instead.",
+                since="2018-10-06",
+            )
         return
     if isinstance(value, float):
         if math.isnan(value):
@@ -117,7 +120,8 @@ def check_valid_size(value, name):
 
         note_deprecation(
             "Float size are deprecated: "
-            "%s should be an integer, got %r" % (name, value)
+            "%s should be an integer, got %r" % (name, value),
+            since="2018-10-11",
         )
     else:
         check_type(integer_types, value)
@@ -149,7 +153,8 @@ def check_valid_sizes(min_size, average_size, max_size):
         note_deprecation(
             "You should remove the average_size argument, because it is "
             "deprecated and no longer has any effect.  Please open an issue "
-            "if the default distribution of examples does not work for you."
+            "if the default distribution of examples does not work for you.",
+            since="2018-03-10",
         )
 
     check_valid_size(min_size, "min_size")

--- a/hypothesis-python/src/hypothesis/searchstrategy/collections.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/collections.py
@@ -92,7 +92,8 @@ class ListStrategy(SearchStrategy):
             note_deprecation(
                 "Cannot create a collection of max_size=%r, because no "
                 "elements can be drawn from the element strategy %r"
-                % (self.max_size, self.element_strategy)
+                % (self.max_size, self.element_strategy),
+                since="2018-03-11",
             )
 
     def calc_is_empty(self, recur):

--- a/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
@@ -277,7 +277,8 @@ class SearchStrategy(Generic[Ex]):
                     "https://hypothesis.readthedocs.io/en/latest/data.html"
                     "#hypothesis.strategies.builds or "
                     "https://hypothesis.readthedocs.io/en/latest/data.html"
-                    "#composite-strategies for more details."
+                    "#composite-strategies for more details.",
+                    since="2017-09-04",
                 )
             else:
                 note_deprecation(
@@ -288,7 +289,8 @@ class SearchStrategy(Generic[Ex]):
                     "hypothesis.strategies.data() to draw "
                     "more examples during testing. See "
                     "https://hypothesis.readthedocs.io/en/latest/data.html"
-                    "#drawing-interactively-in-tests for more details."
+                    "#drawing-interactively-in-tests for more details.",
+                    since="2017-09-04",
                 )
 
         from hypothesis import find, settings, Verbosity

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -310,7 +310,8 @@ def _convert_targets(targets, target):
                 "Passing both targets=%r and target=%r is redundant, and "
                 "will become an error in a future version of Hypothesis.  "
                 "Pass targets=%r instead."
-                % (targets, target, tuple(targets) + (target,))
+                % (targets, target, tuple(targets) + (target,)),
+                since="2018-08-18",
             )
         targets = tuple(targets) + (target,)
 
@@ -319,7 +320,8 @@ def _convert_targets(targets, target):
         if isinstance(t, string_types):
             note_deprecation(
                 "Got %r as a target, but passing the name of a Bundle is "
-                "deprecated - please pass the Bundle directly." % (t,)
+                "deprecated - please pass the Bundle directly." % (t,),
+                since="2018-08-18",
             )
         elif not isinstance(t, Bundle):
             msg = (

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -414,13 +414,15 @@ def integers(min_value=None, max_value=None):
         note_deprecation(
             "min_value=%r of type %r cannot be exactly represented as an "
             "integer, which will be an error in a future version.  "
-            "Use %r instead." % (min_value, type(min_value), min_int_value)
+            "Use %r instead." % (min_value, type(min_value), min_int_value),
+            since="2018-10-10",
         )
     if max_value != max_int_value:
         note_deprecation(
             "max_value=%r of type %r cannot be exactly represented as an "
             "integer, which will be an error in a future version.  "
-            "Use %r instead." % (max_value, type(max_value), max_int_value)
+            "Use %r instead." % (max_value, type(max_value), max_int_value),
+            since="2018-10-10",
         )
 
     if (
@@ -1788,7 +1790,9 @@ def permutations(values):
 
 
 @defines_strategy_with_reusable_values
-@renamed_arguments(min_datetime="min_value", max_datetime="max_value")
+@renamed_arguments(
+    since="2017-08-22", min_datetime="min_value", max_datetime="max_value"
+)
 def datetimes(
     min_value=dt.datetime.min,  # type: dt.datetime
     max_value=dt.datetime.max,  # type: dt.datetime
@@ -1854,7 +1858,7 @@ def datetimes(
 
 
 @defines_strategy_with_reusable_values
-@renamed_arguments(min_date="min_value", max_date="max_value")
+@renamed_arguments(since="2017-08-22", min_date="min_value", max_date="max_value")
 def dates(min_value=dt.date.min, max_value=dt.date.max, min_date=None, max_date=None):
     # type: (dt.date, dt.date, dt.date, dt.date) -> SearchStrategy[dt.date]
     """A strategy for dates between ``min_value`` and ``max_value``.
@@ -1870,7 +1874,7 @@ def dates(min_value=dt.date.min, max_value=dt.date.max, min_date=None, max_date=
 
 
 @defines_strategy_with_reusable_values
-@renamed_arguments(min_time="min_value", max_time="max_value")
+@renamed_arguments(since="2017-08-22", min_time="min_value", max_time="max_value")
 def times(
     min_value=dt.time.min,  # type: dt.time
     max_value=dt.time.max,  # type: dt.time
@@ -1902,7 +1906,7 @@ def times(
 
 
 @defines_strategy_with_reusable_values
-@renamed_arguments(min_delta="min_value", max_delta="max_value")
+@renamed_arguments(since="2017-08-22", min_delta="min_value", max_delta="max_value")
 def timedeltas(
     min_value=dt.timedelta.min,  # type: dt.timedelta
     max_value=dt.timedelta.max,  # type: dt.timedelta

--- a/hypothesis-python/src/hypothesis/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies.py
@@ -537,13 +537,15 @@ def floats(
         note_deprecation(
             "min_value=%r cannot be exactly represented as a float of width "
             "%d, which will be an error in a future version. Use min_value=%r "
-            "instead." % (min_value, width, min_arg)
+            "instead." % (min_value, width, min_arg),
+            since="2018-10-10",
         )
     if max_value != max_arg:
         note_deprecation(
             "max_value=%r cannot be exactly represented as a float of width "
             "%d, which will be an error in a future version. Use max_value=%r "
-            "instead" % (max_value, width, max_arg)
+            "instead" % (max_value, width, max_arg),
+            since="2018-10-10",
         )
 
     check_valid_interval(min_value, max_value, "min_value", "max_value")
@@ -737,7 +739,8 @@ def lists(
         note_deprecation(
             "Passing a strategy for `elements` of the list will be required "
             "in a future version of Hypothesis.  To create lists that are "
-            "always empty, use `builds(list)` or `lists(nothing())`."
+            "always empty, use `builds(list)` or `lists(nothing())`.",
+            since="2018-03-10",
         )
         if min_size or average_size or max_size:
             # Checked internally for lists with an elements strategy, but
@@ -793,7 +796,8 @@ def sets(
         note_deprecation(
             "Passing a strategy for `elements` of the set will be required "
             "in a future version of Hypothesis.  To create sets that are "
-            "always empty, use `builds(set)` or `sets(nothing())`."
+            "always empty, use `builds(set)` or `sets(nothing())`.",
+            since="2018-03-10",
         )
     return lists(
         elements=elements,
@@ -820,7 +824,8 @@ def frozensets(
             "Passing a strategy for `elements` of the frozenset will be "
             "required in a future version of Hypothesis.  To create "
             "frozensets that are always empty, use `builds(frozenset)` "
-            "or `frozensets(nothing())`."
+            "or `frozensets(nothing())`.",
+            since="2018-03-10",
         )
     return lists(
         elements=elements,
@@ -867,7 +872,8 @@ def iterables(
         note_deprecation(
             "Passing a strategy for `elements` of the iterable will be "
             "required in a future version of Hypothesis.  To create "
-            "iterables that are always empty, use `iterables(nothing())`."
+            "iterables that are always empty, use `iterables(nothing())`.",
+            since="2018-03-10",
         )
 
     return lists(
@@ -950,7 +956,8 @@ def streaming(elements):
     """
     note_deprecation(
         "streaming() has been deprecated. Use the data() strategy instead and "
-        "replace stream iteration with data.draw() calls."
+        "replace stream iteration with data.draw() calls.",
+        since="2017-07-02",
     )
 
     check_strategy(elements)
@@ -1098,7 +1105,9 @@ def text(
     """
     check_valid_sizes(min_size, average_size, max_size)
     if alphabet is None:
-        note_deprecation("alphabet=None is deprecated; just omit the argument")
+        note_deprecation(
+            "alphabet=None is deprecated; just omit the argument", since="2018-10-05"
+        )
         char_strategy = characters(blacklist_categories=("Cs",))
     elif isinstance(alphabet, SearchStrategy):
         char_strategy = alphabet
@@ -1107,14 +1116,16 @@ def text(
             note_deprecation(
                 "alphabet must be an ordered sequence, or tests may be "
                 "flaky and shrinking weaker, but a %r is not a type of "
-                "sequence.  This will be an error in future." % (type(alphabet),)
+                "sequence.  This will be an error in future." % (type(alphabet),),
+                since="2018-06-18",
             )
         alphabet = list(alphabet)
         non_string = [c for c in alphabet if not isinstance(c, string_types)]
         if non_string:
             note_deprecation(
                 "The following elements in alphabet are not unicode "
-                "strings, which will be an error in future:  %r" % (non_string,)
+                "strings, which will be an error in future:  %r" % (non_string,),
+                since="2018-06-18",
             )
             alphabet = [str(c) for c in alphabet]
         not_one_char = [
@@ -1124,7 +1135,8 @@ def text(
             note_deprecation(
                 "The following elements in alphabet are not of length "
                 "one, which leads to violation of size constraints and "
-                "will be an error in future:  %r" % (not_one_char,)
+                "will be an error in future:  %r" % (not_one_char,),
+                since="2018-06-18",
             )
         char_strategy = sampled_from(alphabet)
     if (max_size == 0 or char_strategy.is_empty) and not min_size:
@@ -1287,7 +1299,8 @@ def builds(
         args = ()
         note_deprecation(
             "Specifying the target as a keyword argument to builds() is "
-            "deprecated. Provide it as the first positional argument instead."
+            "deprecated. Provide it as the first positional argument instead.",
+            since="2018-02-12",
         )
         target = kwargs.pop("target")
     else:
@@ -1536,7 +1549,8 @@ def fractions(
                 note_deprecation(
                     "The min_value=%r has a denominator greater than the "
                     "max_denominator=%r, which will be an error in a future "
-                    "version." % (min_value, max_denominator)
+                    "version." % (min_value, max_denominator),
+                    since="2018-10-12",
                 )
             _, min_value = fraction_bounds(min_value)
         if max_value is not None:
@@ -1544,7 +1558,8 @@ def fractions(
                 note_deprecation(
                     "The max_value=%r has a denominator greater than the "
                     "max_denominator=%r, which will be an error in a future "
-                    "version." % (max_value, max_denominator)
+                    "version." % (max_value, max_denominator),
+                    since="2018-10-12",
                 )
             max_value, _ = fraction_bounds(max_value)
 
@@ -2115,7 +2130,8 @@ def choices():
 
     note_deprecation(
         "choices() has been deprecated. Use the data() strategy instead and "
-        "replace its usage with data.draw(sampled_from(elements))) calls."
+        "replace its usage with data.draw(sampled_from(elements))) calls.",
+        since="2017-07-02",
     )
 
     return shared(ChoiceStrategy(), key="hypothesis.strategies.chooser.choice_function")

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, division, print_function
 
 import contextlib
+import datetime
 import sys
 import traceback
 from io import BytesIO, StringIO
@@ -114,3 +115,7 @@ def non_covering_examples(database):
     return {
         v for k, vs in database.data.items() if not k.endswith(b".coverage") for v in vs
     }
+
+
+def today():
+    return datetime.datetime.now().strftime("%Y-%m-%d")

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import, division, print_function
 
 import contextlib
-import datetime
 import sys
 import traceback
 from io import BytesIO, StringIO
@@ -115,7 +114,3 @@ def non_covering_examples(database):
     return {
         v for k, vs in database.data.items() if not k.endswith(b".coverage") for v in vs
     }
-
-
-def today():
-    return datetime.datetime.now().strftime("%Y-%m-%d")

--- a/hypothesis-python/tests/cover/test_renaming.py
+++ b/hypothesis-python/tests/cover/test_renaming.py
@@ -20,10 +20,10 @@ from __future__ import absolute_import, division, print_function
 import inspect
 
 from hypothesis.internal.renaming import renamed_arguments
-from tests.common.utils import checks_deprecated_behaviour
+from tests.common.utils import checks_deprecated_behaviour, today
 
 
-@renamed_arguments(old_arg="new_arg")
+@renamed_arguments(since=today(), old_arg="new_arg")
 def f(new_arg=None, old_arg=None):
     return new_arg
 
@@ -41,7 +41,7 @@ def test_using_old_args():
     assert f.__doc__ is None
 
 
-@renamed_arguments(old_arg="new_arg")
+@renamed_arguments(since=today(), old_arg="new_arg")
 def g(new_arg=None, old_arg=None):
     """Hi.
 

--- a/hypothesis-python/tests/cover/test_renaming.py
+++ b/hypothesis-python/tests/cover/test_renaming.py
@@ -20,10 +20,10 @@ from __future__ import absolute_import, division, print_function
 import inspect
 
 from hypothesis.internal.renaming import renamed_arguments
-from tests.common.utils import checks_deprecated_behaviour, today
+from tests.common.utils import checks_deprecated_behaviour
 
 
-@renamed_arguments(since=today(), old_arg="new_arg")
+@renamed_arguments(since="RELEASEDAY", old_arg="new_arg")
 def f(new_arg=None, old_arg=None):
     return new_arg
 
@@ -41,7 +41,7 @@ def test_using_old_args():
     assert f.__doc__ is None
 
 
-@renamed_arguments(since=today(), old_arg="new_arg")
+@renamed_arguments(since="RELEASEDAY", old_arg="new_arg")
 def g(new_arg=None, old_arg=None):
     """Hi.
 

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -293,7 +293,7 @@ def test_cannot_assign_default():
 
 def test_does_not_warn_if_quiet():
     with pytest.warns(None) as rec:
-        note_deprecation("This is bad", settings(verbosity=Verbosity.quiet))
+        note_deprecation("This is bad", since="RELEASEDAY", verbosity=Verbosity.quiet)
     assert len(rec) == 0
 
 

--- a/hypothesis-python/tests/nocover/test_regressions.py
+++ b/hypothesis-python/tests/nocover/test_regressions.py
@@ -22,7 +22,6 @@ import warnings
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.strategies import composite, integers
-from tests.common.utils import today
 
 
 def test_note_deprecation_blames_right_code_issue_652():
@@ -31,7 +30,7 @@ def test_note_deprecation_blames_right_code_issue_652():
     @composite
     def deprecated_strategy(draw):
         draw(integers())
-        note_deprecation(msg, since=today())
+        note_deprecation(msg, since="RELEASEDAY")
 
     with warnings.catch_warnings(record=True) as log:
         warnings.simplefilter("always")

--- a/hypothesis-python/tests/nocover/test_regressions.py
+++ b/hypothesis-python/tests/nocover/test_regressions.py
@@ -22,6 +22,7 @@ import warnings
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.strategies import composite, integers
+from tests.common.utils import today
 
 
 def test_note_deprecation_blames_right_code_issue_652():
@@ -30,7 +31,7 @@ def test_note_deprecation_blames_right_code_issue_652():
     @composite
     def deprecated_strategy(draw):
         draw(integers())
-        note_deprecation(msg)
+        note_deprecation(msg, since=today())
 
     with warnings.catch_warnings(record=True) as log:
         warnings.simplefilter("always")


### PR DESCRIPTION
This adds the initial "since=" argument to note_deprecation, as described in #1697, but currently we don't act upon it.

I made it a required argument immediately because:

1. It's not part of the public API
2. I had a way to guess when most deprecations were introduced (see script below)
3. It saves us extra work later

```python
#!/usr/bin/env python
# -*- encoding: utf-8

import subprocess


for line in subprocess.check_output(
    "grep -rnI note_deprecation hypothesis-python --exclude-dir=.tox | tr ':' ' ' |  grep -v def | grep -v import",
    shell=True
).decode("utf8").splitlines():
    filename, lineno, *_ = line.split()
    diff_output = subprocess.check_output(
        f"git log --pretty=format:'%ai' -L {lineno},{lineno}:{filename}", shell=True
    ).decode("utf8")
    date_str = diff_output.splitlines()[0].split()[0]
    print(f"{filename}:{lineno} {date_str}")
```