### PR TITLE
Don't error on a Lambda in a line with Unicode identifiers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`1700`, where a line that contained a Unicode character
+before a lambda definition would cause an internal exception.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -383,7 +383,19 @@ def extract_lambda_source(f):
     except (AttributeError, OSError, TypeError):
         source = source[lambda_ast.col_offset :].strip()
 
+    # Note: It is possible for this line to throw a ValueError in Python 3 if:
+    #
+    #  - There's a Unicode character in the line before the Lambda, and
+    #  - For some reason we can't detect the source encoding of the file
+    #
+    # because slicing on `lambda_ast.col_offset` will account for bytes, but
+    # the slice will be on Unicode characters.
+    #
+    # In practice this seems relatively rare, and I'm going to ignore this bug
+    # until I have a compelling reason to add even more complexity here.
+    #
     source = source[source.index("lambda") :]
+
     for i in hrange(len(source), len("lambda"), -1):  # pragma: no branch
         try:
             parsed = ast.parse(source[:i])

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -367,6 +367,12 @@ def extract_lambda_source(f):
     # TypeError.  In both cases, fall back to splitting the Unicode string.
     # It's not perfect, but it's the best we can do.
     #
+    # Note 2: You can only detect the encoding with `tokenize.detect_encoding`
+    # in Python 3.2 or later.  But that's okay, because the only version that
+    # affects for us is Python 2.7, and 2.7 doesn't support non-ASCII identifiers:
+    # https://www.python.org/dev/peps/pep-3131/. In this case we'll get an
+    # AttributeError.
+    #
     try:
         encoding, _ = tokenize.detect_encoding(
             open(inspect.getsourcefile(f), "rb").readline
@@ -374,7 +380,7 @@ def extract_lambda_source(f):
         source_bytes = source.encode(encoding)
         source_bytes = source_bytes[lambda_ast.col_offset :].strip()
         source = source_bytes.decode(encoding)
-    except (TypeError, OSError):
+    except (AttributeError, OSError, TypeError):
         source = source[lambda_ast.col_offset :].strip()
 
     source = source[source.index("lambda") :]

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -383,7 +383,7 @@ def extract_lambda_source(f):
     except (AttributeError, OSError, TypeError):
         source = source[lambda_ast.col_offset :].strip()
 
-    # Note: It is possible for this line to throw a ValueError in Python 3 if:
+    # This ValueError can be thrown in Python 3 if:
     #
     #  - There's a Unicode character in the line before the Lambda, and
     #  - For some reason we can't detect the source encoding of the file
@@ -391,10 +391,12 @@ def extract_lambda_source(f):
     # because slicing on `lambda_ast.col_offset` will account for bytes, but
     # the slice will be on Unicode characters.
     #
-    # In practice this seems relatively rare, and I'm going to ignore this bug
-    # until I have a compelling reason to add even more complexity here.
-    #
-    source = source[source.index("lambda") :]
+    # In practice this seems relatively rare, so we just give up rather than
+    # trying to recover.
+    try:
+        source = source[source.index("lambda") :]
+    except ValueError:
+        return if_confused
 
     for i in hrange(len(source), len("lambda"), -1):  # pragma: no branch
         try:

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -185,10 +185,10 @@ def test_can_handle_nested_lambda_in_decorator_argument():
     )
 
 
-π = lambda x: x == 3.1415
+is_approx_π = lambda x: x == 3.1415
 
 
-@arg_decorator(π)
+@arg_decorator(is_approx_π)
 def decorator_with_unicode_wrapper():
     pass
 

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -183,18 +183,3 @@ def test_can_handle_nested_lambda_in_decorator_argument():
     assert (
         get_pretty_function_description(decorator_with_wrapper[0]) == "lambda x: x + 1"
     )
-
-
-is_approx_π = lambda x: x == 3.1415
-
-
-@arg_decorator(is_approx_π)
-def decorator_with_unicode_wrapper():
-    pass
-
-
-def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
-    f = decorator_with_unicode_wrapper[0]
-    assert (
-        get_pretty_function_description(f) == "lambda x: x == 3.1415"
-    )

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -183,3 +183,18 @@ def test_can_handle_nested_lambda_in_decorator_argument():
     assert (
         get_pretty_function_description(decorator_with_wrapper[0]) == "lambda x: x + 1"
     )
+
+
+π = lambda x: x == 3.1415
+
+
+@arg_decorator(π)
+def decorator_with_unicode_wrapper():
+    pass
+
+
+def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
+    f = decorator_with_unicode_wrapper[0]
+    assert (
+        get_pretty_function_description(f) == "lambda x: x == 3.1415"
+    )

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -24,6 +24,7 @@ from functools import partial
 import pytest
 from mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
+from hypothesis import given, strategies as st
 from hypothesis.internal.compat import PY3, FullArgSpec, getfullargspec
 from hypothesis.internal.reflection import (
     arg_string,
@@ -666,3 +667,13 @@ class Target(object):
 def test_required_args(target, args, kwargs, expected):
     # Mostly checking that `self` (and only self) is correctly excluded
     assert required_args(target, args, kwargs) == expected
+
+
+def test_regression_issue_1700():
+    π = 3.1415
+
+    @given(st.floats(min_value=-π, max_value=π).filter(lambda x: abs(x) > 1e-5))
+    def test_nonzero(x):
+        assert x != 0
+
+    test_nonzero()

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -24,7 +24,6 @@ from functools import partial
 import pytest
 from mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
-from hypothesis import given, strategies as st
 from hypothesis.internal.compat import PY3, FullArgSpec, getfullargspec
 from hypothesis.internal.reflection import (
     arg_string,
@@ -667,13 +666,3 @@ class Target(object):
 def test_required_args(target, args, kwargs, expected):
     # Mostly checking that `self` (and only self) is correctly excluded
     assert required_args(target, args, kwargs) == expected
-
-
-def test_regression_issue_1700():
-    π = 3.1415
-
-    @given(st.floats(min_value=-π, max_value=π).filter(lambda x: abs(x) > 1e-5))
-    def test_nonzero(x):
-        assert x != 0
-
-    test_nonzero()

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -692,3 +692,18 @@ def test_can_render_lambda_with_no_encoding():
         assert get_pretty_function_description(is_positive) == "lambda x: x > 0"
     finally:
         tokenize.detect_encoding = old_detect_encoding
+
+
+@pytest.mark.skipif(PY2, reason="detect_encoding does not exist in Python 2")
+def test_does_not_crash_on_utf8_lambda_without_encoding():
+    # Monkey-patching out the `tokenize.detect_encoding` method here means
+    # that our reflection can't detect the encoding of the source file, and
+    # has to fall back to assuming it's ASCII.
+    import tokenize
+
+    old_detect_encoding = tokenize.detect_encoding
+    try:
+        del tokenize.detect_encoding
+        assert get_pretty_function_description(is_str_pi) == "lambda x: <unknown>"
+    finally:
+        tokenize.detect_encoding = old_detect_encoding

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -673,18 +673,21 @@ pi = "π"; is_str_pi = lambda x: x == pi  # noqa: E731
 # fmt: on
 
 
-if PY2:
-    def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
-        assert get_pretty_function_description(is_str_pi) == "lambda x: x == pi"
-else:
-    def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
-        # Monkey-patching out the `tokenize.detect_encoding` method here means
-        # that our reflection can't detect the encoding of the source file, and
-        # has to fall back to assuming it's ASCII.
-        import tokenize
-        old_detect_encoding = tokenize.detect_encoding
-        try:
-            del tokenize.detect_encoding
-            assert get_pretty_function_description(is_str_pi) == "lambda x: x == pi"
-        finally:
-            tokenize.detect_encoding = old_detect_encoding
+def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
+    assert get_pretty_function_description(is_str_pi) == "lambda x: x == pi"
+
+
+@pytest.mark.skipif(PY2, reason="detect_encoding does not exist in Python 2")
+def test_can_render_lambda_with_no_encoding():
+    is_positive = lambda x: x > 0
+
+    # Monkey-patching out the `tokenize.detect_encoding` method here means
+    # that our reflection can't detect the encoding of the source file, and
+    # has to fall back to assuming it's ASCII.
+    import tokenize
+    old_detect_encoding = tokenize.detect_encoding
+    try:
+        del tokenize.detect_encoding
+        assert get_pretty_function_description(is_positive) == "lambda x: x > 0"
+    finally:
+        tokenize.detect_encoding = old_detect_encoding

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -685,6 +685,7 @@ def test_can_render_lambda_with_no_encoding():
     # that our reflection can't detect the encoding of the source file, and
     # has to fall back to assuming it's ASCII.
     import tokenize
+
     old_detect_encoding = tokenize.detect_encoding
     try:
         del tokenize.detect_encoding

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -668,7 +668,9 @@ def test_required_args(target, args, kwargs, expected):
     assert required_args(target, args, kwargs) == expected
 
 
+# fmt: off
 pi = "π"; is_str_pi = lambda x: x == pi  # noqa: E731
+# fmt: on
 
 
 if PY2:

--- a/hypothesis-python/tests/py3/test_unicode_identifiers.py
+++ b/hypothesis-python/tests/py3/test_unicode_identifiers.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from hypothesis.internal.reflection import proxies
+from hypothesis.internal.reflection import get_pretty_function_description, proxies
 
 
 def test_can_copy_argspec_of_unicode_args():
@@ -40,3 +40,10 @@ def test_can_copy_argspec_of_unicode_name():
         return 2
 
     assert bar() == 2
+
+
+is_approx_π = lambda x: x == 3.1415  # noqa: E731
+
+
+def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
+    assert get_pretty_function_description(is_approx_π) == "lambda x: x == 3.1415"

--- a/hypothesis-python/tests/py3/test_unicode_identifiers.py
+++ b/hypothesis-python/tests/py3/test_unicode_identifiers.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from hypothesis import given, strategies as st
 from hypothesis.internal.reflection import get_pretty_function_description, proxies
 
 
@@ -47,3 +48,13 @@ is_approx_π = lambda x: x == 3.1415  # noqa: E731
 
 def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
     assert get_pretty_function_description(is_approx_π) == "lambda x: x == 3.1415"
+
+
+def test_regression_issue_1700():
+    π = 3.1415
+
+    @given(st.floats(min_value=-π, max_value=π).filter(lambda x: abs(x) > 1e-5))
+    def test_nonzero(x):
+        assert x != 0
+
+    test_nonzero()


### PR DESCRIPTION
Closes #1700.

@lucaswiman’s guess is correct:

> This seems to be an off-by-two error with this example (source is 'mbda x: abs(x) > 1e-5))'), so I'm guessing it's probably that col_offset is computed on the bytes of the original file (UTF-8 encoded in this case)

The `inspect` module gives you source code as Unicode strings, but computes the index with the raw bytes. Doing a quick round-trip to bytes and back (using the same encoding detection as inspect is using) seems to fix this particular issue.

Fun little bug to dig into.