### PR TITLE
Replacing depreciated decorator

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -222,6 +222,7 @@ their individual contributions.
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)
 * `Joey Tuong <https://github.com/tetrapus>`_
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)
+* `Joshua Boone <https://www.github.com/patchedwork>`_ (joshuaboone4190@gmail.com)
 * `jmhsi <https://www.github.com/jmhsi>`_
 * `jwg4 <https://www.github.com/jwg4>`_
 * `Karthikeyan Singaravelan <https://www.github.com/tirkarthi>`_ (tir.karthi@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,4 @@
 RELEASE_TYPE: patch
 
-This patch replaces the deprecated use of
-pytest.mark with the new pytest.hookimpl
-as of python version 2.8.0
+This patch updates the Hypothesis pytest plugin to avoid a recently 
+deprecated hook interface.  There is no user-visible change.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
++ RELEASE_TYPE: patch
++ 
++ This patch replaces the deprecated use of
++ pytest.mark with the new pytest.hookimpl
++ as of python version 2.8.0

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
-+ RELEASE_TYPE: patch
-+ 
-+ This patch replaces the deprecated use of
-+ pytest.mark with the new pytest.hookimpl
-+ as of python version 2.8.0
+RELEASE_TYPE: patch
+
+This patch replaces the deprecated use of
+pytest.mark with the new pytest.hookimpl
+as of python version 2.8.0

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -110,7 +110,7 @@ def pytest_configure(config):
 gathered_statistics = OrderedDict()  # type: dict
 
 
-@pytest.mark.hookwrapper
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     if not (hasattr(item, "obj") and is_hypothesis_test(item.obj)):
         yield
@@ -129,7 +129,7 @@ def pytest_runtest_call(item):
             item.hypothesis_report_information = list(store.results)
 
 
-@pytest.mark.hookwrapper
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     report = (yield).get_result()
     if hasattr(item, "hypothesis_report_information"):


### PR DESCRIPTION
Closes #1708 

Python 2.8.0 switched from pytest.mark to pytest.hookimpl / pytest.hookspec "for setting impl/spec specific parameters."

Please let me know if there is anything I've overlooked or if I have missed anything important documentation wise! 