### PR TITLE
Re-enabling pytest30 using pytest-xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,7 @@ jobs:
       env: TASK=check-unicode
     - env: TASK=check-py27-typing
     - env: TASK=check-nose
-    # https://github.com/HypothesisWorks/hypothesis/issues/1702
-    # - env: TASK=check-pytest30
+    - env: TASK=check-pytest30
     - env: TASK=check-faker070
     - env: TASK=check-faker-latest
     - env: TASK=check-django21

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -132,6 +132,7 @@ commands=
 deps =
     -r../requirements/test.txt
 commands=
+    pip install pytest-xdist==1.24
     pip install pytest==3.0
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 


### PR DESCRIPTION
Closes #1702 

#1699 updated `pytest-xdist` to version 1.25.0 which depreciated versions of pytest<3.6.0

By running pytest30 in an environment with pytest-xdist==1.24 we are able to use versions of pytest>=3.0.0

I'm aware that the information in RELEASE.rst might be wrong or too verbose, so if you have a suggestion please do not hesitate to share!