### PR TITLE
Only run Black on modified files

### DIFF
--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis-python
 #
-# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -163,7 +163,7 @@ HEADER = """
 @task()
 def format():
     def should_format_file(path):
-        if os.path.basename(path) in ("header.py", "test_lambda_formatting.py"):
+        if os.path.basename(path) in ("header.py",):
             return False
         if "vendor" in path.split(os.path.sep):
             return False

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -216,7 +216,7 @@ def format():
             o.write("\n")
     pip_tool("isort", *files_to_format)
 
-    pip_tool("black", tools.ROOT)
+    pip_tool("black", *files_to_format)
 
 
 VALID_STARTS = ("# coding=utf-8", "#!/usr/bin/env python")


### PR DESCRIPTION
This restores the intelligent file selection that the previous formatter was set up to use.

(From https://github.com/HypothesisWorks/hypothesis/commit/71489455c9b62abf1de813c468094ddf63c279af#r31775407 in #1692.)