### PR TITLE
Remove old references to "header.py" from the build system

### DIFF
--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -163,8 +163,6 @@ HEADER = """
 @task()
 def format():
     def should_format_file(path):
-        if os.path.basename(path) in ("header.py",):
-            return False
         if "vendor" in path.split(os.path.sep):
             return False
         return path.endswith(".py")
@@ -172,9 +170,6 @@ def format():
     changed = tools.modified_files()
 
     format_all = os.environ.get("FORMAT_ALL", "").lower() == "true"
-    if "scripts/header.py" in changed:
-        # We've changed the header, so everything needs its header updated.
-        format_all = True
     if "requirements/tools.txt" in changed:
         # We've changed the tools, which includes a lot of our formatting
         # logic, so we need to rerun formatters.


### PR DESCRIPTION
This is a minor cleanup of some seemingly-unnecessary build system code that I noticed while working on #1715.

It seems that at some point the Python file header template was stored in a `scripts/header.py`, which was then excluded from formatting. But there is currently no such file, since the header is stored inline in `hypothesistooling/__main__.py`.