### PR TITLE
Don't truncate "branch-check" multiple times during coverage tests

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch makes a small internal change to fix an issue in Hypothesis's
+own coverage tests (:issue:`1718`:).
+
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -60,8 +60,9 @@ IN_COVERAGE_TESTS = os.getenv("HYPOTHESIS_INTERNAL_COVERAGE") == "true"
 
 
 if IN_COVERAGE_TESTS:
-    with open("branch-check", "w"):
-        pass
+    # By this point, "branch-check" should have already been deleted by the
+    # tox config. We can't delete it here because of #1718.
+
     written = set()  # type: Set[Tuple[str, bool]]
 
     def record_branch(name, value):

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -50,7 +50,7 @@ def pretty_file_name(f):
         pass
 
     parts = f.split(os.path.sep)
-    parts = parts[parts.index("hypothesis") :]
+    parts = parts[-parts[::-1].index("hypothesis") :]
     result = os.path.sep.join(parts)
     pretty_file_name_cache[f] = result
     return result

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -17,18 +17,23 @@
 
 from __future__ import absolute_import, division, print_function
 
+import functools
+
 import pytest
 
 from hypothesis import find, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import (
+    binary,
     booleans,
+    dictionaries,
     floats,
     frozensets,
     integers,
     lists,
     recursive,
     sets,
+    text,
 )
 from tests.common.utils import checks_deprecated_behaviour, fails_with
 
@@ -222,3 +227,22 @@ def test_given_warns_when_mixing_positional_with_keyword():
 def test_cannot_find_non_strategies():
     with pytest.raises(InvalidArgument):
         find(bool, bool)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        functools.partial(lists, elements=integers()),
+        functools.partial(dictionaries, keys=integers(), values=integers()),
+        text,
+        binary,
+    ],
+)
+@pytest.mark.parametrize("min_size,max_size", [(0, "10"), ("0", 10)])
+def test_valid_sizes(strategy, min_size, max_size):
+    @given(strategy(min_size=min_size, max_size=max_size))
+    def test(x):
+        pass
+
+    with pytest.raises(InvalidArgument):
+        test()

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -141,9 +141,12 @@ commands=
 deps =
     -r../requirements/test.txt
     -r../requirements/coverage.txt
+whitelist_externals=
+    rm
 setenv=
     HYPOTHESIS_INTERNAL_COVERAGE=true
 commands =
+    rm -f branch-check
     python -m coverage --version
     python -m coverage debug sys
     python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas --maxfail=1 --ff {posargs}


### PR DESCRIPTION
Closes #1718.

~~This is a WIP because we still need to fix (or suppress) the existing coverage holes that were unmasked by this fix.~~

(I also took the liberty of borrowing Zac's shorter-path patch from #1712, since it will make that cleanup more pleasant.)