### PR TITLE
Add multiple items to a bundle

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Introduces :func:`hypothesis.stateful.multiple`, which allows rules in rule
+based state machines to send multiple results at once to their target Bundle,
+or none at all.

--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -188,6 +188,8 @@ instead.
 
 .. autofunction:: hypothesis.stateful.consumes
 
+.. autofunction:: hypothesis.stateful.multiple
+
 -----------
 Initializes
 -----------


### PR DESCRIPTION
Enable rules to add multiple results to their target bundle(s), or to add no result at all. Please review and tell me what to think of this approach, and if the public functions should be named differently. 

Closes #321.