### PR TITLE
New randomized algorithm for length shrinking

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release changes the order that the shrinker tries to delete data in.
+For large and slow tests this may significantly improve the performance of shrinking.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -66,14 +66,7 @@ class Shrinker(object):
     and simpler."""
 
     def __init__(
-        self,
-        initial,
-        predicate,
-        random=None,
-        full=False,
-        debug=False,
-        name=None,
-        **kwargs
+        self, initial, predicate, random, full=False, debug=False, name=None, **kwargs
     ):
         self.setup(**kwargs)
         self.current = self.make_immutable(initial)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
@@ -75,8 +75,6 @@ class Length(Shrinker):
             """Try replacing current_subset with current_subset & keep."""
 
             keep = keep & current_subset
-            if len(keep) == len(current_subset):
-                return True
             to_remove = current_subset - keep
 
             # Once we've tried and failed to delete an element we never

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/length.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.shrinking.common import Shrinker, find_integer
 
 
@@ -52,50 +53,106 @@ class Length(Shrinker):
         return len(left) < len(right)
 
     def run_step(self):
-        # Try to delete as many elements as possible from the sequence, in
-        # (roughly) one pass, from right to left.
+        # Try to delete as many elements as possible from the sequence, trying
+        # each element no more than once.
 
-        # Starting from the end of the sequence, we try to delete as many
-        # consecutive elements as possible. When we encounter an element that
-        # can't be deleted this way, we skip over it for the rest of the pass,
-        # and continue to its left. This lets us finish a pass in linear time,
-        # but the drawback is that we'll miss some possible deletions of
-        # already-skipped elements.
-        skipped = 0
+        # We convert the sequence to a set of indices. This allows us to more
+        # easily do book-keeping around which elements we've tried removing.
+        initial = self.current
 
-        # When every element has been deleted or skipped, the pass is complete.
-        while skipped < len(self.current):
-            # Number of remaining elements to the left of the skipped region.
-            # These are all candidates for attempted deletion.
-            candidates = len(self.current) - skipped
+        indices = list(hrange(len(self.current)))
 
-            # Take a stable snapshot of the current sequence, so that deleting
-            # elements doesn't mess with our slice indices.
-            start = self.current
+        # The set of indices that we have not yet removed (either because
+        # we have not yet tried to remove them or because we tried and
+        # failed).
+        current_subset = set(indices)
 
-            # Delete as many elements as possible (k) from the candidate
-            # region, from right to left. Always retain the skipped elements
-            # at the end. (See diagram below.)
-            find_integer(
-                lambda k: k <= candidates
-                and self.consider(start[: candidates - k] + start[candidates:])
+        # The set of indices in current_subset that we have not yet tried
+        # to remove.
+        candidates_for_removal = set(current_subset)
+
+        def consider_set(keep):
+            """Try replacing current_subset with current_subset & keep."""
+
+            keep = keep & current_subset
+            if len(keep) == len(current_subset):
+                return True
+            to_remove = current_subset - keep
+
+            # Once we've tried and failed to delete an element we never
+            # attempt to delete it again in the current pass. This can cause
+            # us to skip shrinks that would work, but that doesn't matter -
+            # if this pass succeeded then it will run again at some point,
+            # so those will be picked up later.
+            if not to_remove.issubset(candidates_for_removal):
+                return False
+            if self.consider([v for i, v in enumerate(initial) if i in keep]):
+                current_subset.intersection_update(keep)
+                return True
+            return False
+
+        # We iterate over the indices in random order. This is because deletions
+        # towards the end are more likely to work, while deletions from the
+        # beginning are more likely to have higher impact. In addition there
+        # tend to be large "dead" regions where nothing can be deleted, and
+        # by proceeding in random order we don't have long gaps in those where
+        # we make no progress.
+        #
+        # Note that this may be strictly more expensive than iterating from
+        # left to right or right to left. The cost of find_integer, say f, is
+        # convex. When deleting n elements starting from the left we pay f(n)
+        # invocations, but when starting from the middle we pay 2 f(n / 2)
+        # > f(n) invocations. In this case we are prioritising making progress
+        # over a possibly strictly lower cost for two reasons: Firstly, when
+        # n is small we just do linear scans anyway so this doesn't actually
+        # matter, and secondly because successfuly deletions will tend to
+        # speed up the test function and thus even when we make more test
+        # function calls we may still win on time.
+        #
+        # It's also very frustrating watching the shrinker repeatedly fail
+        # to delete, so there's a psychological benefit to prioritising
+        # progress over cost.
+        self.random.shuffle(indices)
+        for i in indices:
+            candidates_for_removal &= current_subset
+            if not candidates_for_removal:
+                break
+
+            # We have already processed this index, either because it was bulk
+            # removed or is the end point of a set that was.
+            if i not in candidates_for_removal:
+                continue
+
+            # Note that we do not update candidates_for_removal until we've
+            # actually tried removing them. This is because our consider_set
+            # predicate checks whether we've previously tried deleting them,
+            # so removing them here would result in wrong checks!
+
+            # We now try to delete a region around i. We start by trying to
+            # delete a region starting with i, i.e. [i, j) for some j > i.
+            to_right = find_integer(
+                lambda n: i + n <= len(initial)
+                and consider_set(current_subset - set(hrange(i, i + n)))
             )
 
-            # If we stopped because of an element we couldn't delete, enlarge
-            # the skipped region to include it, and continue. (If we stopped
-            # because we deleted everything, the loop is about to end anyway.)
-            skipped += 1
+            # If that succeeded we're in a deletable region. It's unlikely that
+            # we happened to pick the starting index of that region, so we try
+            # to extend it to the left too.
+            if to_right > 0:
+                to_left = find_integer(
+                    lambda n: i - n >= 0
+                    and consider_set(current_subset - set(hrange(i - n, i)))
+                )
 
+                # find_integer always tries at least n + 1 when it returns n.
+                # This means that we've tried deleting i - (to_left + 1) and
+                # failed to do so, so we can remove it from our candidates for
+                # deletion.
+                candidates_for_removal.discard(i - to_left - 1)
 
-# This diagram shows how we use two slices to delete (k) elements from the
-# candidate region, while retaining the other candidates, and retaining all of
-# the skipped elements.
-#                              <==================
-#          candidates                skipped
-#  /^^^^^^^^^^^^^^^^^^^^^^^^^\ /^^^^^^^^^^^^^^^^^\
-# +---+---+---+---+---+---+---+---+---+---+---+---+
-# |   |   |   |   |   |   |   |   |   |   |   |   |
-# +---+---+---+---+---+---+---+---+---+---+---+---+
-#  \_________________/ \#####/ \_________________/
-#    [:candidates-k]      k       [candidates:]
-#                      <======
+            # We've now tried deleting i so remove it.
+            candidates_for_removal.discard(i)
+
+            # As per comment above we've also tried deleting one past the end
+            # of the region so we remove that from the candidate set too.
+            candidates_for_removal.discard(i + to_right)

--- a/hypothesis-python/tests/common/costbounds.py
+++ b/hypothesis-python/tests/common/costbounds.py
@@ -17,29 +17,23 @@
 
 from __future__ import absolute_import, division, print_function
 
-from random import Random
+from hypothesis.internal.conjecture.shrinking.common import find_integer
 
-from hypothesis.internal.conjecture.shrinking import Integer
-from tests.common.utils import capture_out
-
-
-def test_debug_output():
-    with capture_out() as o:
-        Integer.shrink(10, lambda x: True, debug=True, random=Random(0))
-
-    assert "initial=10" in o.getvalue()
-    assert "shrinking to 0" in o.getvalue()
+FIND_INTEGER_COSTS = {}
 
 
-def test_includes_name_in_repr_if_set():
-    assert (
-        repr(Integer(10, lambda x: True, name="hi there", random=Random(0)))
-        == "Integer('hi there', initial=10, current=10)"
-    )
+def find_integer_cost(n):
+    try:
+        return FIND_INTEGER_COSTS[n]
+    except KeyError:
+        pass
 
+    cost = [0]
 
-def test_normally_contains_no_space_for_name():
-    assert (
-        repr(Integer(10, lambda x: True, random=Random(0)))
-        == "Integer(initial=10, current=10)"
-    )
+    def test(i):
+        cost[0] += 1
+        return i <= n
+
+    find_integer(test)
+
+    return FIND_INTEGER_COSTS.setdefault(n, cost[0])

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1745,16 +1745,15 @@ def test_shrink_passes_behave_sensibly_with_standard_operators():
 
 def test_shrink_pass_may_go_from_solid_to_dubious():
 
-    initial = hbytes([0, 1, 0, 0, 2, 3])
+    initial = hbytes([10])
 
     @shrinking_from(initial)
     def shrinker(data):
-        n = len(initial) - 1 - data.draw_bits(1)
-        for _ in range(n):
-            data.draw_bits(8)
-        data.mark_interesting()
+        n = data.draw_bits(8)
+        if n >= 9:
+            data.mark_interesting()
 
-    sp = shrinker.shrink_pass("adaptive_example_deletion")
+    sp = shrinker.shrink_pass("minimize_individual_blocks")
     assert sp.classification == PassClassification.CANDIDATE
     shrinker.run_shrink_pass(sp)
     assert sp.classification == PassClassification.HOPEFUL

--- a/hypothesis-python/tests/nocover/test_conjecture_length_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_length_shrinking.py
@@ -22,7 +22,9 @@ from random import Random
 
 import hypothesis.strategies as st
 from hypothesis import example, given
+from hypothesis.internal.compat import ceil, floor, hrange
 from hypothesis.internal.conjecture.shrinking import Length
+from tests.common.costbounds import find_integer_cost
 
 sizes = st.integers(0, 100)
 
@@ -51,7 +53,81 @@ def test_deletes_all_easily_deletable_elements(gap_sizes):
     data = _concat([0] * g + [1] for g in gap_sizes)[:-1]
     total = sum(data)
 
-    result = Length.shrink(data, lambda d: sum(d) == total)
+    result = Length.shrink(data, lambda d: sum(d) == total, random=Random(0))
 
     # All 0s should have been deleted, leaving only the 1s.
     assert result == (1,) * total
+
+
+@st.composite
+def poison_problem(draw):
+    list_length = draw(st.integers(1, 100))
+    poison = draw(st.integers(0, list_length - 1))
+    return draw(st.permutations(list(hrange(list_length)))), poison
+
+
+@example(problem=([0, 1], 0))
+@example(problem=([0, 1, 2, 3, 4, 5, 6, 7], 5))
+@given(problem=poison_problem())
+def test_gets_down_to_single_element_in_logarithmic_time(problem):
+    """Fairly detailed cost analysis test that checks that the adaptive
+    logic in length deletion is working properly."""
+
+    indices, poison = problem
+
+    class FakeRandom(object):
+        def shuffle(self, ls):
+            assert sorted(ls) == sorted(indices)
+            ls[:] = indices
+
+    cost = [0]
+
+    def predicate(ls):
+        cost[0] += 1
+        return poison in ls
+
+    Length.shrink(sorted(indices), predicate, random=FakeRandom())
+
+    cost = cost[0]
+
+    def halves(n):
+        return [floor(n / 2), ceil(n / 2)]
+
+    # The poison value splits the list into two halves. We then pick a
+    # random index in each of these halves and clear to its left and to
+    # its right using find_integer. This means we have four tests (the
+    # check for the empty list, the check for the poison value, and the
+    # check for each of the two random starting indices) plus the find_integer
+    # cost for clearing each of the four segments.
+    bound = 4 + sum(
+        find_integer_cost(m2)
+        for m1 in halves(len(indices) - 1)
+        for m2 in halves(m1 - 1)
+    )
+
+    assert 0 < cost <= bound
+
+
+def test_does_not_try_to_delete_endpoints():
+    """This is a fairly specific test designed to check that the logic
+    for not retrying end points is working correctly.
+
+    We first try deleting 4. This works and causes us to try deleting
+    4 and 3 together, which doesn't work because we require 3 to be
+    present in the list. This should now cause us to mark 3 as required,
+    and thus not attempt to delete it again in this run.
+    """
+    ls = [0, 1, 2, 3, 4]
+
+    class FakeRandom(object):
+        def shuffle(self, ls):
+            ls[:] = [4, 0, 1, 2, 3]
+
+    def predicate(x):
+        if not x:
+            return False
+        x = list(x)
+        assert 3 in x or x == ls[: len(x)]
+        return 3 in x and len(x) >= 3
+
+    Length.shrink(ls, predicate, random=FakeRandom())


### PR DESCRIPTION
When deleting (or making sequence manipulations in general) there's a tension between which order we want to go in. Changes early in the sequence are less likely to work, changes later in the sequence are more likely to produce tiny effects.

Previously we've chosen to do this from right to left in order to get the more likely to work effect. This works reasonably but has the problem that when the example is very large and slow we end up doing a lot of teeny tiny shrinks that don't get us to the small and fast examples that we'd like to have. 

This PR changes the algorithm to proceed in random order. This should help us strike a good happy medium - sometimes we'll try large changes which might work, sometimes we'll try small changes that probably will work. The result should be a shrinker that on average makes significantly better progress than trying either right to left or left to right would allow it to.