### PR TITLE
More efficient reorder_examples implementation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release changes how the shrinker handles reordering examples within
+a failing test case.
+
+This is primarily an efficiency improvement, and should result in significant
+improvements to shrinking speed in large examples. You may also see some changes
+in example quality, but they should generally be improvements and are likely
+minor at best.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
@@ -53,40 +53,18 @@ class Ordering(Shrinker):
 
     def reinsert(self):
         for i in range(len(self.current)):
-            # This is essentially insertion sort, but unlike normal insertion
-            # sort because of our use of find_integer we only perform
-            # O(n(log(n))) calls. Because of the rotations we're still O(n^2)
-            # performance in terms of number of list operations, but we don't
-            # care about those so much.
-            original = self.current
-
             insertion_points = [
                 j
                 for j in range(i)
                 if self.key(self.current[j]) > self.key(self.current[i])
             ]
 
-            def push_back_to(t):
-                if t >= len(insertion_points):
-                    return True
-                j = insertion_points[t]
-                reinserted = list(original)
+            for j in insertion_points[:2]:
+                reinserted = list(self.current)
                 del reinserted[i]
-                reinserted.insert(j, original[i])
+                reinserted.insert(j, self.current[i])
                 if self.consider(reinserted):
-                    return
+                    continue
                 swapped = list(self.current)
                 swapped[i], swapped[j] = swapped[j], swapped[i]
-                return self.consider(swapped)
-
-            if push_back_to(0) or push_back_to(1):
-                continue
-
-            lo = 1
-            hi = len(insertion_points)
-            while lo + 1 < hi:
-                mid = (lo + hi) // 2
-                if push_back_to(mid):
-                    hi = mid
-                else:
-                    lo = mid
+                self.consider(swapped)


### PR DESCRIPTION
A thing I've been noticing recently is that the `reorder_examples` pass as implemented has the following unfortunate combination of traits:

1. It's likely to work but not reduce the length of the example
2. It's _really_ expensive, primarily because it tries many reorderings that don't work.

This means we end up paying a lot for that functionality.

This PR makes it cheaper by replacing it with something that's more well suited to Hypothesis examples, using the `label` property of examples to partition the reordering so we only swap examples with the same label.

In my informal Csmith experiments this seems to work really well: `reorder_examples` has gone from having 99% of its attempts failing to shrink to 90% of its attempts succeeding at shrinking (numbers made up but about the right ballpark)