### PR TITLE
Handle errors that occur once a data object is already frozen

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug where certain places Hypothesis internal errors could be
+raised during shrinking when a user exception occurred that suppressed an exception
+Hypothesis uses internally in its generation.
+
+The two known ways to trigger this problem were:
+
+* Errors raised in stateful tests' teardown function.
+* Errors raised in finally blocks that wrapped a call to ``data.draw``.
+
+These cases will now be handled correctly.

--- a/hypothesis-python/tests/cover/test_error_in_draw.py
+++ b/hypothesis-python/tests/cover/test_error_in_draw.py
@@ -28,7 +28,7 @@ def test_error_is_in_finally():
     @given(st.data())
     def test(d):
         try:
-            d.draw(st.lists(st.integers(min_value=0), min_size=3, unique=True))
+            d.draw(st.lists(st.integers(), min_size=3, unique=True))
         finally:
             raise ValueError()
 
@@ -36,4 +36,4 @@ def test_error_is_in_finally():
         with pytest.raises(ValueError):
             test()
 
-    assert "[0, 1, 2]" in o.getvalue()
+    assert "[0, 1, -1]" in o.getvalue()

--- a/hypothesis-python/tests/cover/test_error_in_draw.py
+++ b/hypothesis-python/tests/cover/test_error_in_draw.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import given
+from tests.common.utils import capture_out
+
+
+def test_error_is_in_finally():
+    @given(st.data())
+    def test(d):
+        try:
+            d.draw(st.lists(st.integers(min_value=0), min_size=3, unique=True))
+        finally:
+            raise ValueError()
+
+    with capture_out() as o:
+        with pytest.raises(ValueError):
+            test()
+
+    assert "[0, 1, 2]" in o.getvalue()

--- a/hypothesis-python/tests/cover/test_intervalset.py
+++ b/hypothesis-python/tests/cover/test_intervalset.py
@@ -63,6 +63,7 @@ def test_intervals_match_indexes(intervals):
         assert ls.index(v) == intervals.index(v)
 
 
+@example(intervals=IntervalSet(()), v=0)
 @given(Intervals, st.integers())
 def test_error_for_index_of_not_present_value(intervals, v):
     assume(v not in intervals)


### PR DESCRIPTION
Turns out that the reason that #1729's build is failing is because of a bug that has been latent for a *long* time. Essentially, errors in finally blocks are not handled correctly by `given`. @Zac-HD's port of the stateful testing to be given based meant that we could now also trigger this bug in stateful testing, it's just that we'd been lucky enough not to before now.

Basically the problem is that if in the course of shrinking or generation we do something that causes the data to be frozen, but we do so in such a way that user code can raise an error after that happened, we would try to call `mark_interesting` on an already frozen data object, which is forbidden.

The fix is to not do that and instead to raise a new `StopTest` to replace the one that was suppressed by the user error.