### PR TITLE
Add url strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-Add a provisional URL strategy.
-This patch is a step towards solving :issue:`1388`.
+Hypothesis can now automatically generate values for Django models with a
+`URLfield`, thanks to a new provisional strategy for URLs (:issue:`1388`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Add a provisional URL strategy.
+This patch is a step towards solving :issue:`1388`.

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -32,7 +32,7 @@ import hypothesis.strategies as st
 from hypothesis import reject
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
-from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings
+from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings, urls
 from hypothesis.strategies import emails
 from hypothesis.utils.conventions import DefaultValueType
 

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -72,6 +72,7 @@ def field_mappings():
             dm.FloatField: st.floats(),
             dm.NullBooleanField: st.one_of(st.none(), st.booleans()),
             dm.TimeField: st.times(timezones=get_tz_strat()),
+            dm.URLField: urls(),
             dm.UUIDField: st.uuids(),
         }
 

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -43,14 +43,18 @@ def urls():
         return scheme + "://" + host + port + path
 
     schemes = st.sampled_from(["http", "https"])
-    ports = st.one_of(
-        st.just(""), st.integers(min_value=0, max_value=2 ** 16 - 1).map(lambda x: ":%d" % x)
-    )
+    ports = st.integers(min_value=0, max_value=2 ** 16 - 1)
     paths = st.lists(st.text(string.printable).map(url_encode)).map(
         lambda path: "/".join([""] + path)
     )
 
-    return st.builds(create_url, schemes, domains(), ports, paths)
+    return st.builds(
+        create_url,
+        schemes,
+        domains(),
+        st.one_of(st.just(""), ports.map(lambda x: ":%d" % x)),
+        paths,
+    )
 
 
 @st.defines_strategy_with_reusable_values

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -33,7 +33,7 @@ import hypothesis._strategies as st
 
 @st.defines_strategy_with_reusable_values
 def urls():
-    """"A strategy for :rfc:`3986`, generating http/https URLs."""
+    """A strategy for :rfc:`3986`, generating http/https URLs."""
 
     def url_encode(s):
         safe_chars = set(string.ascii_letters + string.digits + "$-_.+!*'(),")

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -39,21 +39,14 @@ def urls():
         safe_chars = set(string.ascii_letters + string.digits + "$-_.+!*'(),")
         return "".join(c if c in safe_chars else "%%%02X" % ord(c) for c in s)
 
-    def create_url(scheme, host, port, path):
-        return scheme + "://" + host + port + path
-
     schemes = st.sampled_from(["http", "https"])
-    ports = st.integers(min_value=0, max_value=2 ** 16 - 1)
+    ports = st.integers(min_value=0, max_value=2 ** 16 - 1).map(":{}".format)
     paths = st.lists(st.text(string.printable).map(url_encode)).map(
         lambda path: "/".join([""] + path)
     )
 
     return st.builds(
-        create_url,
-        schemes,
-        domains(),
-        st.one_of(st.just(""), ports.map(lambda x: ":%d" % x)),
-        paths,
+        "{}://{}{}{}".format, schemes, domains(), st.one_of(st.just(""), ports), paths
     )
 
 

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -17,10 +17,23 @@
 
 from __future__ import absolute_import, division, print_function
 
+import re
+import string
 from binascii import unhexlify
 
 from hypothesis import given
-from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings
+from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings, urls
+
+
+@given(urls())
+def test_is_URL(url):
+    allowed_chars = set(string.ascii_letters + string.digits + "$-_.+!*'(),%/")
+    url_schemeless = url.split("://", maxsplit=1)[1]
+    path = url_schemeless.split("/", maxsplit=1)[1] if "/" in url_schemeless else ""
+    assert all(c in allowed_chars for c in path)
+    assert all(
+        re.match("^[0-9A-Fa-f]{2}", after_perc) for after_perc in path.split("%")[1:]
+    )
 
 
 @given(ip4_addr_strings())

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -28,8 +28,8 @@ from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings, urls
 @given(urls())
 def test_is_URL(url):
     allowed_chars = set(string.ascii_letters + string.digits + "$-_.+!*'(),%/")
-    url_schemeless = url.split("://", maxsplit=1)[1]
-    path = url_schemeless.split("/", maxsplit=1)[1] if "/" in url_schemeless else ""
+    url_schemeless = url.split("://", 1)[1]
+    path = url_schemeless.split("/", 1)[1] if "/" in url_schemeless else ""
     assert all(c in allowed_chars for c in path)
     assert all(
         re.match("^[0-9A-Fa-f]{2}", after_perc) for after_perc in path.split("%")[1:]

--- a/hypothesis-python/tests/django/toystore/models.py
+++ b/hypothesis-python/tests/django/toystore/models.py
@@ -92,6 +92,7 @@ class ManyTimes(models.Model):
 class OddFields(models.Model):
     uuid = models.UUIDField()
     slug = models.SlugField()
+    url = models.URLField()
     ipv4 = models.GenericIPAddressField(protocol="IPv4")
     ipv6 = models.GenericIPAddressField(protocol="IPv6")
 


### PR DESCRIPTION
Add an HTTP/HTTPS URL strategy.
Work toward solving issue #1388 

> #### What I have added:
> * path generation
> * port generation
> 
> #### What I haven't done:
> * utf-8 support (only ASCII URLs for now)
> * query support (the part after the `?`)
> * using an IP address in lieu of a domain
> * using mixed (upper and lowercase) case hexadecimal for escaping
> * percent encoding random safe characters
> 
> For the hosts, I'm reusing the `domains()` strategy.
> For the path, non safe characters get [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding) according to [RFC 1738](https://tools.ietf.org/html/rfc1738#section-5).
> Right now I am encoding `;`, `:`, `@`, `&`, `=`, even though they are technically valid for HTTP URLs.
> 
> #### Things I am not sure about
> * I am unsure if it's ok not encoding some characters that [RFC 1738](https://tools.ietf.org/html/rfc1738#section-5) allows, or I should do a typical [URI percent encoding](https://en.wikipedia.org/wiki/Percent-encoding). The former leads to some weirder paths that include commas, and parenthesis, which are less common, but valid.
> * Before URL encoding, I only choose printable characters for the path.

