### PR TITLE
Update rubygems

### DIFF
--- a/tooling/src/hypothesistooling/installers.py
+++ b/tooling/src/hypothesistooling/installers.py
@@ -123,6 +123,8 @@ def ensure_ruby():
     ):
         subprocess.check_call([RBENV_COMMAND, "install", scripts.RBENV_VERSION])
 
+    subprocess.check_call([GEM_EXECUTABLE, "update", "--system"])
+
     if not (
         os.path.exists(BUNDLER_EXECUTABLE)
         and subprocess.call([BUNDLER_EXECUTABLE, "version"]) == 0


### PR DESCRIPTION
The build is currently failing because rather than do anything sensible like ensuring you install a compatible version of bundler, when rubygems is not up to date bundler will whine at you and fail to install. This hopefulyl fixes that by updating rubygems before we install bundler.