### PR TITLE
Clean up extra.django namespace and improve consistency with core

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+This release contains a massive cleanup of the Hypothesis for Django extra:
+
+- ``hypothesis.extra.django.models.models()`` is deprecated in favor of
+  :func:`hypothesis.extra.django.from_model`.
+- ``hypothesis.extra.django.models.add_default_field_mapping()`` is deprecated
+  in favor of :func:`hypothesis.extra.django.register_field_strategy`.
+- :func:`~hypothesis.extra.django.from_model` does not infer a strategy for
+  nullable fields or fields with a default unless passed ``infer``, like
+  :func:`~hypothesis.strategies.builds`.
+  ``models.models()`` would usually but not always infer, and a special
+  ``default_value`` marker object was required to disable inference.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -2930,8 +2930,7 @@ This is a bugfix release:
 3.33.0 - 2017-10-16
 -------------------
 
-This release supports strategy inference for more field types in Django
-:func:`~hypothesis.extra.django.models.models` - you can now omit an argument for
+This release supports strategy inference for more Django field types - you can now omit an argument for
 Date, Time, Duration, Slug, IP Address, and UUID fields.  (:issue:`642`)
 
 Strategy generation for fields with grouped choices now selects choices from
@@ -4275,7 +4274,7 @@ This is a bug fix release for a single bug:
 
 This release is entirely provided by `Lucas Wiman <https://github.com/lucaswiman>`_:
 
-Strategies constructed by :func:`~hypothesis.extra.django.models.models`
+Strategies constructed by the Django extra
 will now respect much more of Django's validations out of the box.
 Wherever possible, :meth:`~django:django.db.models.Model.full_clean` should
 succeed.

--- a/hypothesis-python/src/hypothesis/extra/django/__init__.py
+++ b/hypothesis-python/src/hypothesis/extra/django/__init__.py
@@ -15,29 +15,13 @@
 #
 # END HEADER
 
-import unittest
+from hypothesis.extra.django._fields import from_field, register_field_strategy
+from hypothesis.extra.django._impl import TestCase, TransactionTestCase, from_model
 
-import django.test as dt
-
-
-class HypothesisTestCase(object):
-    def setup_example(self):
-        self._pre_setup()
-
-    def teardown_example(self, example):
-        self._post_teardown()
-
-    def __call__(self, result=None):
-        testMethod = getattr(self, self._testMethodName)
-        if getattr(testMethod, u"is_hypothesis_test", False):
-            return unittest.TestCase.__call__(self, result)
-        else:
-            return dt.SimpleTestCase.__call__(self, result)
-
-
-class TestCase(HypothesisTestCase, dt.TestCase):
-    pass
-
-
-class TransactionTestCase(HypothesisTestCase, dt.TransactionTestCase):
-    pass
+__all__ = [
+    "TestCase",
+    "TransactionTestCase",
+    "from_field",
+    "from_model",
+    "register_field_strategy",
+]

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -1,0 +1,218 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import re
+import string
+from datetime import timedelta
+from decimal import Decimal
+
+import django
+import django.db.models as dm
+
+import hypothesis.strategies as st
+from hypothesis.errors import InvalidArgument
+from hypothesis.extra.pytz import timezones
+from hypothesis.internal.validation import check_type
+from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings, urls
+from hypothesis.strategies import emails
+
+if False:
+    from datetime import tzinfo  # noqa
+    from typing import Any, Type, Optional, List, Text, Callable, Union  # noqa
+
+# Mapping of field types, to strategy objects or functions of (type) -> strategy
+_global_field_lookup = {
+    dm.SmallIntegerField: st.integers(-32768, 32767),
+    dm.IntegerField: st.integers(-2147483648, 2147483647),
+    dm.BigIntegerField: st.integers(-9223372036854775808, 9223372036854775807),
+    dm.PositiveIntegerField: st.integers(0, 2147483647),
+    dm.PositiveSmallIntegerField: st.integers(0, 32767),
+    dm.BinaryField: st.binary(),
+    dm.BooleanField: st.booleans(),
+    dm.DateField: st.dates(),
+    dm.EmailField: emails(),
+    dm.FloatField: st.floats(),
+    dm.NullBooleanField: st.one_of(st.none(), st.booleans()),
+    dm.URLField: urls(),
+    dm.UUIDField: st.uuids(),
+}
+
+
+def register_for(field_type):
+    def inner(func):
+        _global_field_lookup[field_type] = func
+        return func
+
+    return inner
+
+
+@register_for(dm.DateTimeField)
+def _for_datetime(field):
+    if getattr(django.conf.settings, "USE_TZ", False):
+        return st.datetimes(timezones=timezones())
+    return st.datetimes()
+
+
+def using_sqlite():
+    try:
+        return (
+            getattr(django.conf.settings, "DATABASES", {})
+            .get("default", {})
+            .get("ENGINE", "")
+            .endswith(".sqlite3")
+        )
+    except django.core.exceptions.ImproperlyConfigured:
+        return None
+
+
+@register_for(dm.TimeField)
+def _for_time(field):
+    # SQLITE supports TZ-aware datetimes, but not TZ-aware times.
+    if getattr(django.conf.settings, "USE_TZ", False) and not using_sqlite():
+        return st.times(timezones=timezones())
+    return st.times()
+
+
+@register_for(dm.DurationField)
+def _for_duration(field):
+    # SQLite stores timedeltas as six bytes of microseconds
+    if using_sqlite():
+        delta = timedelta(microseconds=2 ** 47 - 1)
+        return st.timedeltas(-delta, delta)
+    return st.timedeltas()
+
+
+@register_for(dm.SlugField)
+def _for_slug(field):
+    return st.text(
+        alphabet=string.ascii_letters + string.digits,
+        min_size=(0 if field.blank else 1),
+        max_size=field.max_length,
+    )
+
+
+@register_for(dm.GenericIPAddressField)
+def _for_ip(field):
+    return dict(
+        ipv4=ip4_addr_strings(),
+        ipv6=ip6_addr_strings(),
+        both=ip4_addr_strings() | ip6_addr_strings(),
+    )[field.protocol.lower()]
+
+
+@register_for(dm.DecimalField)
+def _for_decimal(field):
+    bound = Decimal(10 ** field.max_digits - 1) / (10 ** field.decimal_places)
+    return st.decimals(min_value=-bound, max_value=bound, places=field.decimal_places)
+
+
+@register_for(dm.CharField)
+@register_for(dm.TextField)
+def _for_text(field):
+    # We can infer a vastly more precise strategy by considering the
+    # validators as well as the field type.  This is a minimal proof of
+    # concept, but we intend to leverage the idea much more heavily soon.
+    # See https://github.com/HypothesisWorks/hypothesis-python/issues/1116
+    regexes = [
+        re.compile(v.regex, v.flags) if isinstance(v.regex, str) else v.regex
+        for v in field.validators
+        if isinstance(v, django.core.validators.RegexValidator) and not v.inverse_match
+    ]
+    if regexes:
+        # This strategy generates according to one of the regexes, and
+        # filters using the others.  It can therefore learn to generate
+        # from the most restrictive and filter with permissive patterns.
+        # Not maximally efficient, but it makes pathological cases rarer.
+        # If you want a challenge: extend https://qntm.org/greenery to
+        # compute intersections of the full Python regex language.
+        return st.one_of(*[st.from_regex(r) for r in regexes])
+    # If there are no (usable) regexes, we use a standard text strategy.
+    return st.text(
+        alphabet=st.characters(
+            blacklist_characters=u"\x00", blacklist_categories=("Cs",)
+        ),
+        min_size=(0 if field.blank else 1),
+        max_size=field.max_length,
+    )
+
+
+def register_field_strategy(field_type, strategy):
+    # type: (Type[dm.Field], st.SearchStrategy) -> None
+    """Add an entry to the global field-to-strategy lookup used by from_field.
+
+    ``field_type`` must be a subtype of django.db.models.Field, which must not
+    already be registered.  ``strategy`` must be a SearchStrategy.
+    """
+    if not issubclass(field_type, dm.Field):
+        raise InvalidArgument(
+            "field_type=%r must be a subtype of Field" % (field_type,)
+        )
+    check_type(st.SearchStrategy, strategy, "strategy")
+    if field_type in _global_field_lookup:
+        raise InvalidArgument(
+            "field_type=%r already has a registered strategy (%r)"
+            % (field_type, _global_field_lookup[field_type])
+        )
+    if issubclass(field_type, dm.AutoField):
+        raise InvalidArgument("Cannot register a strategy for an AutoField")
+    _global_field_lookup[field_type] = strategy
+
+
+def from_field(field):
+    # type: (Type[dm.Field]) -> st.SearchStrategy[dm.Field]
+    """Return a strategy for values that fit the given field.
+
+    This is pretty similar to the core `from_type` function, with a subtle
+    but important difference: `from_field` takes a Field *instance*, rather
+    than a Field *subtype*, so that it has access to instance attributes
+    such as string length and validators.
+    """
+    check_type(dm.Field, field, "field")
+    if field.choices:
+        choices = []  # type: list
+        for value, name_or_optgroup in field.choices:
+            if isinstance(name_or_optgroup, (list, tuple)):
+                choices.extend(key for key, _ in name_or_optgroup)
+            else:
+                choices.append(value)
+        if isinstance(field, (dm.CharField, dm.TextField)) and field.blank:
+            choices.insert(0, u"")
+        strategy = st.sampled_from(choices)
+    else:
+        if type(field) not in _global_field_lookup:
+            if field.null:
+                return st.none()
+            raise InvalidArgument("Could not infer a strategy for %r", (field,))
+        strategy = _global_field_lookup[type(field)]
+        if not isinstance(strategy, st.SearchStrategy):
+            strategy = strategy(field)
+    assert isinstance(strategy, st.SearchStrategy)
+    if field.validators:
+
+        def validate(value):
+            try:
+                field.run_validators(value)
+                return True
+            except django.core.exceptions.ValidationError:
+                return False
+
+        strategy = strategy.filter(validate)
+    if field.null:
+        return st.none() | strategy
+    return strategy

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+import django.db.models as dm
+import django.test as dt
+from django.db import IntegrityError
+
+import hypothesis._strategies as st
+from hypothesis import reject
+from hypothesis.errors import InvalidArgument
+from hypothesis.extra.django._fields import from_field
+from hypothesis.utils.conventions import infer
+
+if False:
+    from datetime import tzinfo  # noqa
+    from typing import Any, Type, Optional, List, Text, Callable, Union  # noqa
+    from hypothesis.utils.conventions import InferType  # noqa
+
+
+class HypothesisTestCase(object):
+    def setup_example(self):
+        self._pre_setup()
+
+    def teardown_example(self, example):
+        self._post_teardown()
+
+    def __call__(self, result=None):
+        testMethod = getattr(self, self._testMethodName)
+        if getattr(testMethod, u"is_hypothesis_test", False):
+            return unittest.TestCase.__call__(self, result)
+        else:
+            return dt.SimpleTestCase.__call__(self, result)
+
+
+class TestCase(HypothesisTestCase, dt.TestCase):
+    pass
+
+
+class TransactionTestCase(HypothesisTestCase, dt.TransactionTestCase):
+    pass
+
+
+@st.defines_strategy
+def from_model(
+    model,  # type: Type[dm.Model]
+    **field_strategies  # type: Union[st.SearchStrategy[Any], InferType]
+):
+    # type: (...) -> st.SearchStrategy[Any]
+    """Return a strategy for examples of ``model``.
+
+    .. warning::
+        Hypothesis creates saved models. This will run inside your testing
+        transaction when using the test runner, but if you use the dev console
+        this will leave debris in your database.
+
+    ``model`` must be an subclass of :class:`~django:django.db.models.Model`.
+    Strategies for fields may be passed as keyword arguments, for example
+    ``is_staff=st.just(False)``.
+
+    Hypothesis can often infer a strategy based the field type and validators,
+    and will attempt to do so for any required fields.  No strategy will be
+    inferred for ``AutoField``s, nullable fields, fields for which a keyword
+    argument is passed to ``from_model()``, or foreign keys.  For example,
+    a Shop type with a foreign key to Company could be generated with::
+
+        shop_strategy = from_model(Shop, company=from_model(Company))
+
+    Like for :func:`~hypothesis.strategies.builds`, you can pass
+    :obj:`~hypothesis.infer` as a keyword argument to infer a strategy for
+    a field which has a default value instead of using the default.
+    """
+    if not issubclass(model, dm.Model):
+        raise InvalidArgument("model=%r must be a subtype of Model" % (model,))
+
+    fields_by_name = {f.name: f for f in model._meta.concrete_fields}
+    for name, value in sorted(field_strategies.items()):
+        if value is infer:
+            field_strategies[name] = from_field(fields_by_name[name])
+    for name, field in sorted(fields_by_name.items()):
+        if (
+            name not in field_strategies
+            and not field.auto_created
+            and field.default is dm.fields.NOT_PROVIDED
+        ):
+            field_strategies[name] = from_field(field)
+
+    for field in field_strategies:
+        if model._meta.get_field(field).primary_key:
+            # The primary key is generated as part of the strategy. We
+            # want to find any existing row with this primary key and
+            # overwrite its contents.
+            kwargs = {field: field_strategies.pop(field)}
+            kwargs["defaults"] = st.fixed_dictionaries(field_strategies)  # type: ignore
+            return _models_impl(st.builds(model.objects.update_or_create, **kwargs))
+
+    # The primary key is not generated as part of the strategy, so we
+    # just match against any row that has the same value for all
+    # fields.
+    return _models_impl(st.builds(model.objects.get_or_create, **field_strategies))
+
+
+@st.composite
+def _models_impl(draw, strat):
+    """Handle the nasty part of drawing a value for models()"""
+    try:
+        return draw(strat)[0]
+    except IntegrityError:
+        reject()

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -17,169 +17,25 @@
 
 from __future__ import absolute_import, division, print_function
 
-import re
-import string
-from datetime import timedelta
-from decimal import Decimal
-
 import django.db.models as dm
-from django.conf import settings as django_settings
-from django.core import validators
-from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 import hypothesis.strategies as st
 from hypothesis import reject
 from hypothesis.errors import InvalidArgument
-from hypothesis.extra.pytz import timezones
-from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings, urls
-from hypothesis.strategies import emails
+from hypothesis.extra.django import from_field, register_field_strategy
 from hypothesis.utils.conventions import DefaultValueType
 
 if False:
-    from datetime import tzinfo  # noqa
-    from typing import Any, Type, Optional, List, Text, Callable, Union  # noqa
-
-
-def get_tz_strat():
-    # type: () -> st.SearchStrategy[Optional[tzinfo]]
-    if getattr(django_settings, "USE_TZ", False):
-        return timezones()
-    return st.none()
-
-
-__default_field_mappings = None
-
-
-def field_mappings():
-    global __default_field_mappings
-
-    if __default_field_mappings is None:
-        # Sized fields are handled in _get_strategy_for_field()
-        # URL fields are not yet handled
-        __default_field_mappings = {
-            dm.SmallIntegerField: st.integers(-32768, 32767),
-            dm.IntegerField: st.integers(-2147483648, 2147483647),
-            dm.BigIntegerField: st.integers(-9223372036854775808, 9223372036854775807),
-            dm.PositiveIntegerField: st.integers(0, 2147483647),
-            dm.PositiveSmallIntegerField: st.integers(0, 32767),
-            dm.BinaryField: st.binary(),
-            dm.BooleanField: st.booleans(),
-            dm.DateField: st.dates(),
-            dm.DateTimeField: st.datetimes(timezones=get_tz_strat()),
-            dm.DurationField: st.timedeltas(),
-            dm.EmailField: emails(),
-            dm.FloatField: st.floats(),
-            dm.NullBooleanField: st.one_of(st.none(), st.booleans()),
-            dm.TimeField: st.times(timezones=get_tz_strat()),
-            dm.URLField: urls(),
-            dm.UUIDField: st.uuids(),
-        }
-
-        # SQLite does not support timezone-aware times, or timedeltas that
-        # don't fit in six bytes of microseconds, so we override those
-        db = getattr(django_settings, "DATABASES", {}).get("default", {})
-        if db.get("ENGINE", "").endswith(".sqlite3"):  # pragma: no branch
-            sqlite_delta = timedelta(microseconds=2 ** 47 - 1)
-            __default_field_mappings.update(
-                {
-                    dm.TimeField: st.times(),
-                    dm.DurationField: st.timedeltas(-sqlite_delta, sqlite_delta),
-                }
-            )
-
-    return __default_field_mappings
+    from typing import Any, Type, List, Text, Union  # noqa
 
 
 def add_default_field_mapping(field_type, strategy):
     # type: (Type[dm.Field], st.SearchStrategy[Any]) -> None
-    field_mappings()[field_type] = strategy
+    register_field_strategy(field_type, strategy)
 
 
 default_value = DefaultValueType(u"default_value")
-
-
-def validator_to_filter(f):
-    # type: (Type[dm.Field]) -> Callable[[Any], bool]
-    """Converts the field run_validators method to something suitable for use
-    in filter."""
-
-    def validate(value):
-        try:
-            f.run_validators(value)
-            return True
-        except ValidationError:
-            return False
-
-    return validate
-
-
-def _get_strategy_for_field(f):
-    # type: (Type[dm.Field]) -> st.SearchStrategy[Any]
-    if f.choices:
-        choices = []  # type: list
-        for value, name_or_optgroup in f.choices:
-            if isinstance(name_or_optgroup, (list, tuple)):
-                choices.extend(key for key, _ in name_or_optgroup)
-            else:
-                choices.append(value)
-        if isinstance(f, (dm.CharField, dm.TextField)) and f.blank:
-            choices.insert(0, u"")
-        strategy = st.sampled_from(choices)
-    elif type(f) == dm.SlugField:
-        strategy = st.text(
-            alphabet=string.ascii_letters + string.digits,
-            min_size=(0 if f.blank else 1),
-            max_size=f.max_length,
-        )
-    elif type(f) == dm.GenericIPAddressField:
-        lookup = {
-            "both": ip4_addr_strings() | ip6_addr_strings(),
-            "ipv4": ip4_addr_strings(),
-            "ipv6": ip6_addr_strings(),
-        }
-        strategy = lookup[f.protocol.lower()]
-    elif type(f) in (dm.TextField, dm.CharField):
-        strategy = st.text(
-            alphabet=st.characters(
-                blacklist_characters=u"\x00", blacklist_categories=("Cs",)
-            ),
-            min_size=(0 if f.blank else 1),
-            max_size=f.max_length,
-        )
-        # We can infer a vastly more precise strategy by considering the
-        # validators as well as the field type.  This is a minimal proof of
-        # concept, but we intend to leverage the idea much more heavily soon.
-        # See https://github.com/HypothesisWorks/hypothesis-python/issues/1116
-        re_validators = [
-            v
-            for v in f.validators
-            if isinstance(v, validators.RegexValidator) and not v.inverse_match
-        ]
-        if re_validators:
-            regexes = [
-                re.compile(v.regex, v.flags) if isinstance(v.regex, str) else v.regex
-                for v in re_validators
-            ]
-            # This strategy generates according to one of the regexes, and
-            # filters using the others.  It can therefore learn to generate
-            # from the most restrictive and filter with permissive patterns.
-            # Not maximally efficient, but it makes pathological cases rarer.
-            # If you want a challenge: extend https://qntm.org/greenery to
-            # compute intersections of the full Python regex language.
-            strategy = st.one_of(*[st.from_regex(r) for r in regexes])
-    elif type(f) == dm.DecimalField:
-        bound = Decimal(10 ** f.max_digits - 1) / (10 ** f.decimal_places)
-        strategy = st.decimals(
-            min_value=-bound, max_value=bound, places=f.decimal_places
-        )
-    else:
-        strategy = field_mappings().get(type(f), st.nothing())
-    if f.validators:
-        strategy = strategy.filter(validator_to_filter(f))
-    if f.null:
-        strategy = st.one_of(st.none(), strategy)
-    return strategy
 
 
 def models(
@@ -219,7 +75,7 @@ def models(
     missed = []  # type: List[Text]
     for f in model._meta.concrete_fields:
         if not (f.name in field_strategies or isinstance(f, dm.AutoField)):
-            result[f.name] = _get_strategy_for_field(f)
+            result[f.name] = from_field(f)
             if result[f.name].is_empty:
                 missed.append(f.name)
     if missed:

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -20,8 +20,9 @@ from __future__ import absolute_import, division, print_function
 import django.db.models as dm
 from django.db import IntegrityError
 
-import hypothesis.strategies as st
+import hypothesis._strategies as st
 from hypothesis import reject
+from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django import from_field, register_field_strategy
 from hypothesis.utils.conventions import DefaultValueType
@@ -32,12 +33,18 @@ if False:
 
 def add_default_field_mapping(field_type, strategy):
     # type: (Type[dm.Field], st.SearchStrategy[Any]) -> None
+    note_deprecation(
+        "This function is deprecated; use `hypothesis.extra.django."
+        "register_field_strategy` instead.",
+        since="RELEASEDAY",
+    )
     register_field_strategy(field_type, strategy)
 
 
 default_value = DefaultValueType(u"default_value")
 
 
+@st.defines_strategy
 def models(
     model,  # type: Type[dm.Model]
     **field_strategies  # type: Union[st.SearchStrategy[Any], DefaultValueType]
@@ -68,6 +75,11 @@ def models(
 
       shop_strategy = models(Shop, company=models(Company))
     """
+    note_deprecation(
+        "This function is deprecated; use `hypothesis.extra.django."
+        "from_model` instead.",
+        since="RELEASEDAY",
+    )
     result = {}
     for k, v in field_strategies.items():
         if not isinstance(v, DefaultValueType):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -582,14 +582,16 @@ else:
 
 try:
     from django.test import TransactionTestCase
-    from hypothesis.extra.django import HypothesisTestCase
 
     def bad_django_TestCase(runner):
         if runner is None:
             return False
-        return isinstance(runner, TransactionTestCase) and not isinstance(
-            runner, HypothesisTestCase
-        )
+        if not isinstance(runner, TransactionTestCase):
+            return False
+
+        from hypothesis.extra.django._impl import HypothesisTestCase
+
+        return not isinstance(runner, HypothesisTestCase)
 
 
 except Exception:

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -23,10 +23,15 @@ from uuid import UUID
 from django.conf import settings as django_settings
 from django.contrib.auth.models import User
 
-from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import HealthCheck, assume, given, infer, settings
 from hypothesis.control import reject
 from hypothesis.errors import HypothesisException, InvalidArgument
-from hypothesis.extra.django import TestCase, TransactionTestCase
+from hypothesis.extra.django import (
+    TestCase,
+    TransactionTestCase,
+    from_model,
+    register_field_strategy,
+)
 from hypothesis.extra.django.models import (
     add_default_field_mapping,
     default_value,
@@ -35,6 +40,7 @@ from hypothesis.extra.django.models import (
 from hypothesis.internal.compat import text_type
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies import binary, just, lists
+from tests.common.utils import checks_deprecated_behaviour
 from tests.django.toystore.models import (
     Company,
     CompanyExtension,
@@ -52,20 +58,30 @@ from tests.django.toystore.models import (
     Store,
 )
 
-add_default_field_mapping(CustomishField, just(u"a"))
+register_field_strategy(CustomishField, just(u"a"))
 
 
 class TestGetsBasicModels(TestCase):
-    @given(models(Company))
+    @checks_deprecated_behaviour
+    def test_add_default_field_mapping_is_deprecated(self):
+        class UnregisteredCustomishField(CustomishField):
+            """Just to get deprecation warning when registered."""
+
+        add_default_field_mapping(UnregisteredCustomishField, just(u"a"))
+        with self.assertRaises(InvalidArgument):
+            # Double-registering is an error, and registry is shared.
+            register_field_strategy(UnregisteredCustomishField, just(u"a"))
+
+    @given(from_model(Company))
     def test_is_company(self, company):
         self.assertIsInstance(company, Company)
         self.assertIsNotNone(company.pk)
 
-    @given(models(Store, company=models(Company)))
+    @given(from_model(Store, company=from_model(Company)))
     def test_can_get_a_store(self, store):
         assert store.company.pk
 
-    @given(lists(models(Company)))
+    @given(lists(from_model(Company)))
     def test_can_get_multiple_models_with_unique_field(self, companies):
         assume(len(companies) > 1)
         for c in companies:
@@ -75,61 +91,82 @@ class TestGetsBasicModels(TestCase):
         )
 
     @settings(suppress_health_check=[HealthCheck.too_slow])
-    @given(models(Customer))
+    @given(from_model(Customer))
     def test_is_customer(self, customer):
         self.assertIsInstance(customer, Customer)
         self.assertIsNotNone(customer.pk)
         self.assertIsNotNone(customer.email)
 
     @settings(suppress_health_check=[HealthCheck.too_slow])
-    @given(models(Customer))
+    @given(from_model(Customer))
     def test_tz_presence(self, customer):
         if django_settings.USE_TZ:
             self.assertIsNotNone(customer.birthday.tzinfo)
         else:
             self.assertIsNone(customer.birthday.tzinfo)
 
-    @given(models(CouldBeCharming))
+    @given(from_model(CouldBeCharming))
     def test_is_not_charming(self, not_charming):
         self.assertIsInstance(not_charming, CouldBeCharming)
         self.assertIsNotNone(not_charming.pk)
         self.assertIsNone(not_charming.charm)
 
-    @given(models(SelfLoop))
+    @given(from_model(SelfLoop))
     def test_sl(self, sl):
         self.assertIsNone(sl.me)
 
-    @given(lists(models(ManyNumerics)))
+    @given(lists(from_model(ManyNumerics)))
     def test_no_overflow_in_integer(self, manyints):
         pass
 
-    @given(models(Customish))
+    @given(from_model(Customish))
     def test_custom_field(self, x):
         assert x.customish == u"a"
 
     def test_mandatory_fields_are_mandatory(self):
-        self.assertRaises(InvalidArgument, models, Store)
+        self.assertRaises(InvalidArgument, from_model(Store).example)
+
+    @checks_deprecated_behaviour
+    def test_mandatory_fields_are_mandatory_old(self):
+        self.assertRaises(InvalidArgument, models(Store).example)
 
     def test_mandatory_computed_fields_are_mandatory(self):
-        self.assertRaises(InvalidArgument, models, MandatoryComputed)
+        with self.assertRaises(InvalidArgument):
+            from_model(MandatoryComputed).example()
+
+    @checks_deprecated_behaviour
+    def test_mandatory_computed_fields_are_mandatory_old(self):
+        with self.assertRaises(InvalidArgument):
+            models(MandatoryComputed).example()
 
     def test_mandatory_computed_fields_may_not_be_provided(self):
+        mc = from_model(MandatoryComputed, company=from_model(Company))
+        self.assertRaises(RuntimeError, mc.example)
+
+    @checks_deprecated_behaviour
+    def test_mandatory_computed_fields_may_not_be_provided_old(self):
         mc = models(MandatoryComputed, company=models(Company))
         self.assertRaises(RuntimeError, mc.example)
 
+    @checks_deprecated_behaviour
     @given(models(MandatoryComputed, company=default_value))
     def test_mandatory_computed_field_default(self, x):
         assert x.company.name == x.name + u"_company"
 
-    @given(models(CustomishDefault))
+    @given(from_model(CustomishDefault, customish=infer))
     def test_customish_default_generated(self, x):
-        assert x.customish == u"a"
-
-    @given(models(CustomishDefault, customish=default_value))
-    def test_customish_default_not_generated(self, x):
         assert x.customish == u"b"
 
-    @given(models(OddFields))
+    @given(from_model(CustomishDefault, customish=infer))
+    def test_customish_infer_uses_registered_instead_of_default(self, x):
+        assert x.customish == u"a"
+
+    @checks_deprecated_behaviour
+    @given(models(CustomishDefault, customish=default_value))
+    def test_customish_default_generated(self, x):
+        assert x.customish == u"b"
+
+    @given(from_model(OddFields))
     def test_odd_fields(self, x):
         assert isinstance(x.uuid, UUID)
         assert isinstance(x.slug, text_type)
@@ -140,13 +177,13 @@ class TestGetsBasicModels(TestCase):
         assert isinstance(x.ipv6, text_type)
         assert set(x.ipv6).issubset(set(u"0123456789abcdefABCDEF:."))
 
-    @given(models(ManyTimes))
+    @given(from_model(ManyTimes))
     def test_time_fields(self, x):
         assert isinstance(x.time, dt.time)
         assert isinstance(x.date, dt.date)
         assert isinstance(x.duration, dt.timedelta)
 
-    @given(models(Company))
+    @given(from_model(Company))
     def test_no_null_in_charfield(self, x):
         # regression test for #1045.  Company just has a convenient CharField.
         assert u"\x00" not in x.name
@@ -154,8 +191,8 @@ class TestGetsBasicModels(TestCase):
     @given(binary(min_size=10))
     def test_foreign_key_primary(self, buf):
         # Regression test for #1307
-        company_strategy = models(Company, name=just("test"))
-        strategy = models(
+        company_strategy = from_model(Company, name=just("test"))
+        strategy = from_model(
             CompanyExtension, company=company_strategy, self_modifying=just(2)
         )
         try:
@@ -171,11 +208,11 @@ class TestGetsBasicModels(TestCase):
 class TestsNeedingRollback(TransactionTestCase):
     def test_can_get_examples(self):
         for _ in range(200):
-            models(Company).example()
+            from_model(Company).example()
 
 
 class TestRestrictedFields(TestCase):
-    @given(models(RestrictedFields))
+    @given(from_model(RestrictedFields))
     def test_constructs_valid_instance(self, instance):
         self.assertTrue(isinstance(instance, RestrictedFields))
         instance.full_clean()
@@ -192,6 +229,6 @@ class TestRestrictedFields(TestCase):
 
 
 class TestValidatorInference(TestCase):
-    @given(models(User))
+    @given(from_model(User))
     def test_user_issue_1112_regression(self, user):
         assert user.username


### PR DESCRIPTION
- ``hypothesis.extra.django.models.models()`` is deprecated in favor of `hypothesis.extra.django.from_model`.
- ``hypothesis.extra.django.models.add_default_field_mapping()`` is deprecated in favor of `hypothesis.extra.django.register_field_strategy`.
- `hypothesis.extra.django.from_model` does not infer a strategy for nullable fields or fields with a default unless passed ``infer``, like `hypothesis.strategies.builds`.  ``models.models()`` would usually but not always infer, and a special ``default_value`` marker object was required to disable inference.

TLDR: closes #1695 by moving two functions and making them more consistent with core strategies.