### PR TITLE
Detect potential overflows in cached_test_function

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves some internal logic about when a test case in Hypothesis's internal representation could lead to a valid test case.
+In some circumstances this can lead to a significant speed up during shrinking.
+It may have some minor negative impact on the quality of the final result due to certain shrink passes now having access to less information about test cases in some circumstances, but this should rarely matter.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -138,6 +138,15 @@ class Block(object):
         return self.forced or self.all_zero
 
 
+class _Overrun(object):
+    status = Status.OVERRUN
+
+    def __repr__(self):
+        return "Overrun"
+
+
+Overrun = _Overrun()
+
 global_test_counter = 0
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -25,7 +25,7 @@ from functools import total_ordering
 import attr
 
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes, int_to_bytes
-from hypothesis.internal.conjecture.data import ConjectureData, Status
+from hypothesis.internal.conjecture.data import Overrun, Status
 from hypothesis.internal.conjecture.shrinking import Integer, Length, Lexical, Ordering
 from hypothesis.internal.conjecture.shrinking.common import find_integer
 
@@ -297,16 +297,13 @@ class Shrinker(object):
         if self.shrink_target.buffer.startswith(buffer):
             return False
 
-        if not self.__engine.prescreen_buffer(buffer):
-            return False
-
-        assert sort_key(buffer) <= sort_key(self.shrink_target.buffer)
-        data = ConjectureData.for_buffer(buffer)
-        self.__engine.test_function(data)
-        self.__test_function_cache[buffer] = data
-        return self.incorporate_test_data(data)
+        previous = self.shrink_target
+        self.cached_test_function(buffer)
+        return previous is not self.shrink_target
 
     def incorporate_test_data(self, data):
+        if data is Overrun:
+            return
         self.__test_function_cache[data.buffer] = data
         if self.__predicate(data) and sort_key(data.buffer) < sort_key(
             self.shrink_target.buffer
@@ -1047,14 +1044,7 @@ class Shrinker(object):
                 self.buffer[:u] + hbytes(v - u) + self.buffer[v:]
             )
 
-            # FIXME: IOU one attempt to debug this - DRMacIver
-            # This is a mysterious problem that should be impossible to trigger
-            # but isn't. I don't know what's going on, and it defeated my
-            # my attempts to reproduce or debug it. I'd *guess* it's related to
-            # nondeterminism in the test function. That should be impossible in
-            # the cases where I'm seeing it, but I haven't been able to put
-            # together a reliable reproduction of it.
-            if ex.index >= len(attempt.examples):  # pragma: no cover
+            if attempt is Overrun:
                 continue
 
             in_replacement = attempt.examples[ex.index]

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -30,7 +30,12 @@ from hypothesis import HealthCheck, Phase, Verbosity, settings, unlimited
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
-from hypothesis.internal.conjecture.data import MAX_DEPTH, ConjectureData, Status
+from hypothesis.internal.conjecture.data import (
+    MAX_DEPTH,
+    ConjectureData,
+    Overrun,
+    Status,
+)
 from hypothesis.internal.conjecture.engine import (
     ConjectureRunner,
     ExitReason,
@@ -51,17 +56,17 @@ from tests.common.utils import checks_deprecated_behaviour, no_shrink
 SOME_LABEL = calc_label_from_name("some label")
 
 
+TEST_SETTINGS = settings(
+    max_examples=5000,
+    buffer_size=1024,
+    database=None,
+    suppress_health_check=HealthCheck.all(),
+)
+
+
 def run_to_buffer(f):
     with deterministic_PRNG():
-        runner = ConjectureRunner(
-            f,
-            settings=settings(
-                max_examples=5000,
-                buffer_size=1024,
-                database=None,
-                suppress_health_check=HealthCheck.all(),
-            ),
-        )
+        runner = ConjectureRunner(f, settings=TEST_SETTINGS)
         runner.run()
         assert runner.interesting_examples
         last_data, = runner.interesting_examples.values()
@@ -722,7 +727,11 @@ def test_can_delete_intervals(monkeypatch):
 
 
 def test_detects_too_small_block_starts():
+    call_count = [0]
+
     def f(data):
+        assert call_count[0] == 0
+        call_count[0] += 1
         data.draw_bytes(8)
         data.mark_interesting()
 
@@ -730,7 +739,10 @@ def test_detects_too_small_block_starts():
     r = ConjectureData.for_buffer(hbytes(8))
     runner.test_function(r)
     assert r.status == Status.INTERESTING
-    assert not runner.prescreen_buffer(hbytes([255] * 7))
+    assert call_count[0] == 1
+    r2 = runner.cached_test_function(hbytes([255] * 7))
+    assert r2.status == Status.OVERRUN
+    assert call_count[0] == 1
 
 
 def test_shrinks_both_interesting_examples(monkeypatch):
@@ -1909,3 +1921,23 @@ def test_target_selector_will_eventually_reuse_examples():
     for _ in range(2):
         x = selector.select()
         assert x.global_identifier in seen
+
+
+def test_cached_test_function_does_not_reinvoke_on_prefix():
+    call_count = [0]
+
+    def test_function(data):
+        call_count[0] += 1
+        data.draw_bits(8)
+        data.write(hbytes([7]))
+        data.draw_bits(8)
+
+    with deterministic_PRNG():
+        runner = ConjectureRunner(test_function, settings=TEST_SETTINGS)
+
+        data = runner.cached_test_function(hbytes(3))
+        assert data.status == Status.VALID
+        for n in [2, 1, 0]:
+            prefix_data = runner.cached_test_function(hbytes(n))
+            prefix_data is Overrun
+        assert call_count[0] == 1

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1939,5 +1939,5 @@ def test_cached_test_function_does_not_reinvoke_on_prefix():
         assert data.status == Status.VALID
         for n in [2, 1, 0]:
             prefix_data = runner.cached_test_function(hbytes(n))
-            prefix_data is Overrun
+            assert prefix_data is Overrun
         assert call_count[0] == 1

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -70,21 +70,6 @@ def test_saves_data_while_shrinking(monkeypatch):
     assert in_db == seen
 
 
-@given(st.randoms(), st.random_module())
-@settings(
-    phases=no_shrink, deadline=None, suppress_health_check=[HealthCheck.hung_test]
-)
-def test_maliciously_bad_generator(rnd, seed):
-    @run_to_buffer
-    def x(data):
-        for _ in range(rnd.randint(1, 100)):
-            data.draw_bytes(rnd.randint(1, 10))
-        if rnd.randint(0, 1):
-            data.mark_invalid()
-        else:
-            data.mark_interesting()
-
-
 def test_can_discard(monkeypatch):
     n = 8
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -21,12 +21,12 @@ from random import Random
 
 import pytest
 
-from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
-from tests.common.utils import no_shrink, non_covering_examples
+from tests.common.utils import non_covering_examples
 from tests.cover.test_conjecture_engine import run_to_buffer, shrink, shrinking_from
 
 
@@ -184,26 +184,6 @@ def test_retaining_sum_considers_zero_destination_blocks():
             data.mark_interesting()
 
     assert f == [10, 0, 90]
-
-
-@given(st.integers(0, 255), st.integers(0, 255))
-def test_prescreen_with_masked_byte_agrees_with_results(byte_a, byte_b):
-    def f(data):
-        data.draw_bits(2)
-
-    runner = ConjectureRunner(f)
-
-    data_a = ConjectureData.for_buffer(hbytes([byte_a]))
-    data_b = ConjectureData.for_buffer(hbytes([byte_b]))
-
-    runner.test_function(data_a)
-    prescreen_b = runner.prescreen_buffer(hbytes([byte_b]))
-    # Always test buffer B, to check whether the prescreen was correct.
-    runner.test_function(data_b)
-
-    # If the prescreen passed, then the buffers should be different.
-    # If it failed, then the buffers should be the same.
-    assert prescreen_b == (data_a.buffer != data_b.buffer)
 
 
 @given(st.integers(0, 255), st.integers(0, 255))


### PR DESCRIPTION
This fixes a long-standing issue that we would often uselessly re-execute
the test function in cases where we knew full well it couldn't possibly succeed.
We do this by returning a dummy standin object for a full ConjectureData instance.

This allows us to unify prescreen_buffer and cached_test_function because the
former only existed to handle cases that are now correctly handled by the latter.