### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/hypothesis-python/docs/packaging.rst
+++ b/hypothesis-python/docs/packaging.rst
@@ -17,7 +17,7 @@ Release tarballs
 ----------------
 
 These are available from :gh-link:`the GitHub releases page <releases>`. The
-tarballs on pypi are intended for installation from a Python tool such as pip and should not
+tarballs on PyPI are intended for installation from a Python tool such as pip and should not
 be considered complete releases. Requests to include additional files in them will not be granted. Their absence
 is not a bug.
 

--- a/hypothesis-python/docs/quickstart.rst
+++ b/hypothesis-python/docs/quickstart.rst
@@ -170,7 +170,7 @@ running it multiple times.
 Installing
 ----------
 
-Hypothesis is :pypi:`available on pypi as "hypothesis" <hypothesis>`. You can install it with:
+Hypothesis is :pypi:`available on PyPI as "hypothesis" <hypothesis>`. You can install it with:
 
 .. code:: bash
 

--- a/hypothesis-python/docs/usage.rst
+++ b/hypothesis-python/docs/usage.rst
@@ -5,7 +5,7 @@ Open Source Projects using Hypothesis
 The following is a non-exhaustive list of open source projects I know are
 using Hypothesis. If you're aware of any others please add them to the list!
 The only inclusion criterion right now is that if it's a Python library
-then it should be available on pypi.
+then it should be available on PyPI.
 
 You can find hundreds more from `the Hypothesis page at libraries.io
 <https://libraries.io/pypi/hypothesis>`_, and over a thousand


### PR DESCRIPTION
As spelled on https://pypi.org/.