### PR TITLE
Iterate over block pairs in a different order.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This changes the order that the shrinker tries certain operations in its "emergency" phase which runs late in the process.
+The new order should be better at avoiding long stalls where the shrinker is failing to make progress,
+which may be helpful if you have difficult to shrink test cases.
+However this will not be noticeabe in the vast majority of use cases.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,4 +3,4 @@ RELEASE_TYPE: patch
 This changes the order that the shrinker tries certain operations in its "emergency" phase which runs late in the process.
 The new order should be better at avoiding long stalls where the shrinker is failing to make progress,
 which may be helpful if you have difficult to shrink test cases.
-However this will not be noticeabe in the vast majority of use cases.
+However this will not be noticeable in the vast majority of use cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -583,17 +583,17 @@ class Shrinker(object):
         # have more opportunities to make shrinks that speed up the tests or
         # that reduce the number of viable shrinks at the next gap size because
         # we've lowered some values.
-        gap = 1
-        while gap < len(self.blocks):
+        offset = 1
+        while offset < len(self.blocks):
             i = 0
-            while i + gap < len(self.blocks):
-                j = i + gap
+            while i + offset < len(self.blocks):
+                j = i + offset
                 block_i = self.blocks[i]
                 block_j = self.blocks[j]
                 if accept_first(block_i) and accept_second(block_j):
                     yield (block_i, block_j)
                 i += 1
-            gap += 1
+            offset += 1
 
     def pass_to_descendant(self):
         """Attempt to replace each example with a descendant example.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -570,24 +570,30 @@ class Shrinker(object):
         """Yield each pair of blocks ``(a, b)``, such that ``a.index <
         b.index``, but only if ``accept_first(a)`` and ``accept_second(b)`` are
         both true."""
-        i = 0
-        while i < len(self.blocks):
-            j = i + 1
-            while j < len(self.blocks):
+
+        # Iteration order here is significant: Rather than fixing i and looping
+        # over each j, then doing the same, etc. we iterate over the gap between
+        # i and j and then over i. The reason for this is that it ensures that
+        # we try a different value for i and j on each iteration of the inner
+        # loop. This stops us from stalling if we happen to hit on a value of i
+        # where nothing useful can be done.
+        #
+        # In the event that nothing works, this doesn't help and we still make
+        # the same number of calls, but by ensuring that we make progress we
+        # have more opportunities to make shrinks that speed up the tests or
+        # that reduce the number of viable shrinks at the next gap size because
+        # we've lowered some values.
+        gap = 1
+        while gap < len(self.blocks):
+            i = 0
+            while i + gap < len(self.blocks):
+                j = i + gap
                 block_i = self.blocks[i]
-                if not accept_first(block_i):
-                    break
                 block_j = self.blocks[j]
-                if not accept_second(block_j):
-                    j += 1
-                    continue
-
-                yield (block_i, block_j)
-                # After this point, the shrink target could have changed,
-                # so blocks need to be re-checked.
-
-                j += 1
-            i += 1
+                if accept_first(block_i) and accept_second(block_j):
+                    yield (block_i, block_j)
+                i += 1
+            gap += 1
 
     def pass_to_descendant(self):
         """Attempt to replace each example with a descendant example.


### PR DESCRIPTION
I noticed that this was a better iteration order for pairs in another context.

The idea is that rather than iterating based on a nested for loop over indices we should iterate over the gap size and the start index. So say we had three blocks, our iteration order should be:

```
(0, 1)
(1, 2)
(0, 2)
```

Where previously it would have been


```
(0, 1)
(0, 2)
(1, 2)
```

The reasoning for this is twofold:

* Blocks closer together are more likely to be related and thus if we want to make progress early on should run those sooner than blocks that are further apart.
* If there is some block that we actually can't change at all, we spread out the attempts on that block and so don't spend a long time "stalled"

It's unfortunately difficult to demonstrate that things like this are an improvement, but I'm pretty sure the intuition is valid - this order makes the shrinker much more likely to make progress early on, which will tend to speed up the test and reduces the amount of work it has to do later.