### PR TITLE
Reorder operations in example_deletion_with_block_lowering

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This is another release changing the order of certain operations in emergency phases.
+These ones primarily affect shrinking examples that involve length-like parameters (e.g. drawing an integer and then drawing that many elements).
+In some cases large examples which fit this pattern should now shrink noticeably faster,
+but most use cases are likely to be unaffected.

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -242,7 +242,13 @@ def test_each_pair_of_blocks_with_filters():
 
 
 @pytest.mark.parametrize("intervene_at", [(0, 1), (0, 6), (1, 3)])
-def test_each_pair_of_blocks_handles_change(intervene_at):
+@given(
+    exclude_first=st.frozensets(st.integers(0, 9)),
+    exclude_second=st.frozensets(st.integers(0, 9)),
+)
+def test_each_pair_of_blocks_handles_change(
+    intervene_at, exclude_first, exclude_second
+):
     initial = hbytes([9] + [0] * 10)
 
     @shrinking_from(initial)
@@ -255,7 +261,8 @@ def test_each_pair_of_blocks_handles_change(intervene_at):
     def blocks(intervene=False):
         blocks = []
         for a, b in shrinker.each_pair_of_blocks(
-            lambda block: True, lambda block: True
+            lambda block: block.index not in exclude_first,
+            lambda block: block.index not in exclude_second,
         ):
             assert a.index < b.index < len(shrinker.shrink_target.blocks)
             if intervene and (a.index, b.index) == intervene_at:


### PR DESCRIPTION
Continuing my program of avoiding long stalls in the shrinker, this does exactly what #1751 does but for a different shrink pass.

Basic idea: When we're lowering a block and simultaneously deleting example after that block (which we need to do so we can deal with e.g. length parameters), rather than trying every possible example for the block, we try one and then immediately move on to the next block. An offset parameter then controls which examples we run.

This is a little fiddlier than in #1751 because the relationship between the blocks and the examples is more complicated, but the reasoning is the similar: If the current block is *not* actually usefully treated as a length parameter, previously we would get very long stalls while the shrinker diligently tried exach example. Now although we will try all of the same combinations in the event that nothing works, if we successfully manage some deletions then future iterations will have a smaller example to work with and thus be faster.