### PR TITLE
Fix pytest30 compat build

### DIFF
--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -117,8 +117,7 @@ commands=
 deps =
     -r../requirements/test.txt
 commands=
-    pip install pytest-xdist==1.24
-    pip install pytest==3.0
+    pip install pytest==3.0 pytest-xdist==1.24 pytest-forked==0.2
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -34,7 +34,10 @@ from hypothesistooling import fix_doctests as fd
 from hypothesistooling.scripts import pip_tool
 
 TASKS = {}
-BUILD_FILES = tuple(os.path.join(tools.ROOT, f) for f in ["tooling", ".travis.yml"])
+BUILD_FILES = tuple(
+    os.path.join(tools.ROOT, f)
+    for f in ["tooling", "requirements", ".travis.yml", "hypothesis-python/tox.ini"]
+)
 
 
 def task(if_changed=()):


### PR DESCRIPTION
And ensure that changing pinned requirements or `tox.ini` triggers a full build.  Closes #1762.