### PR TITLE
Don't store the entire ConjectureData object in the tree

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release changes Hypothesis's internal approach to caching the results of executing test cases.
+The result should be that it is now significantly less memory hungry, especially when shrinking large test cases.
+
+Some tests may get slower or faster depending on whether the new or old caching strategy was well suited to them,
+but any change in speed in either direction should be minor.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -191,6 +191,13 @@ class ConjectureData(object):
         top = self.start_example(TOP_LABEL)
         assert top.depth == 0
 
+    def __repr__(self):
+        return "ConjectureData(%s, %d bytes%s)" % (
+            self.status.name,
+            len(self.buffer),
+            ", frozen" if self.frozen else "",
+        )
+
     def __assert_not_frozen(self, name):
         if self.frozen:
             raise Frozen("Cannot call %s on frozen ConjectureData" % (name,))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -352,9 +352,9 @@ class ConjectureData(object):
         return result
 
     def write(self, string):
+        string = hbytes(string)
         self.__assert_not_frozen("write")
         self.__check_capacity(len(string))
-        assert isinstance(string, hbytes)
         original = self.index
         self.__write(string, forced=True)
         self.forced_indices.update(hrange(original, self.index))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -388,13 +388,6 @@ class Shrinker(object):
         be useless and returns False without running it."""
 
         buffer = hbytes(buffer[: self.shrink_target.index])
-        try:
-            existing = self.__test_function_cache[buffer]
-        except KeyError:
-            pass
-        else:
-            return self.incorporate_test_data(existing)
-
         # Sometimes an attempt at lexicographic minimization will do the wrong
         # thing because the buffer has changed under it (e.g. something has
         # turned into a write, the bit size has changed). The result would be
@@ -415,9 +408,8 @@ class Shrinker(object):
         """Takes a ConjectureData or Overrun object updates the current
         shrink_target if this data represents an improvement over it,
         returning True if it is."""
-        if data is Overrun:
+        if data is Overrun or data is self.shrink_target:
             return
-        self.__test_function_cache[data.buffer] = data
         if self.__predicate(data) and sort_key(data.buffer) < sort_key(
             self.shrink_target.buffer
         ):
@@ -433,13 +425,8 @@ class Shrinker(object):
         with status >= INVALID that would result from running this buffer."""
 
         buffer = hbytes(buffer)
-        try:
-            return self.__test_function_cache[buffer]
-        except KeyError:
-            pass
         result = self.__engine.cached_test_function(buffer)
         self.incorporate_test_data(result)
-        self.__test_function_cache[buffer] = result
         return result
 
     def debug(self, msg):

--- a/hypothesis-python/tests/cover/test_conjecture_data_tree.py
+++ b/hypothesis-python/tests/cover/test_conjecture_data_tree.py
@@ -1,0 +1,149 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from random import Random
+
+from hypothesis import HealthCheck, settings
+from hypothesis.internal.compat import hbytes
+from hypothesis.internal.conjecture.data import ConjectureData, Overrun, Status
+from hypothesis.internal.conjecture.engine import (
+    ConjectureRunner,
+    ExitReason,
+    RunIsComplete,
+)
+
+TEST_SETTINGS = settings(
+    max_examples=5000, database=None, suppress_health_check=HealthCheck.all()
+)
+
+
+def runner_for(*examples):
+    if len(examples) == 1 and isinstance(examples[0], list):
+        examples = examples[0]
+
+    def accept(tf):
+        runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
+        ran_examples = []
+        for e in examples:
+            e = hbytes(e)
+            data = ConjectureData.for_buffer(e)
+            try:
+                runner.test_function(data)
+            except RunIsComplete:
+                pass
+            ran_examples.append((e, data))
+        for e, d in ran_examples:
+            cached = runner.tree.lookup(e)
+            if d.status == Status.OVERRUN:
+                assert cached is Overrun
+            else:
+                assert cached.buffer == d.buffer
+                assert cached.status == d.status
+        return runner
+
+    return accept
+
+
+def test_can_lookup_cached_examples():
+    @runner_for(b"\0\0", b"\0\1")
+    def runner(data):
+        data.draw_bits(8)
+        data.draw_bits(8)
+
+
+def test_can_lookup_cached_examples_with_forced():
+    @runner_for(b"\0\0", b"\0\1")
+    def runner(data):
+        data.write(b"\1")
+        data.draw_bits(8)
+
+
+def test_can_detect_when_tree_is_exhausted():
+    @runner_for(b"\0", b"\1")
+    def runner(data):
+        data.draw_bits(1)
+
+    assert runner.tree.is_exhausted
+
+
+def test_can_detect_when_tree_is_exhausted_variable_size():
+    @runner_for(b"\0", b"\1\0", b"\1\1")
+    def runner(data):
+        if data.draw_bits(1):
+            data.draw_bits(1)
+
+    assert runner.tree.is_exhausted
+
+
+def test_one_dead_branch():
+    @runner_for([[0, i] for i in range(16)] + [[i] for i in range(1, 16)])
+    def runner(data):
+        i = data.draw_bits(4)
+        if i > 0:
+            data.mark_invalid()
+        data.draw_bits(4)
+
+    assert runner.tree.is_exhausted
+
+
+def test_non_dead_root():
+    @runner_for(b"\0\0", b"\1\0", b"\1\1")
+    def runner(data):
+        data.draw_bits(1)
+        data.draw_bits(1)
+
+
+def test_can_reexecute_dead_examples():
+    @runner_for(b"\0\0", b"\0\1", b"\0\0")
+    def runner(data):
+        data.draw_bits(1)
+        data.draw_bits(1)
+
+
+def test_novel_prefixes_are_novel():
+    def tf(data):
+        for _ in range(4):
+            data.write(b"\0")
+            data.draw_bits(2)
+
+    runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
+    for _ in range(100):
+        prefix = runner.tree.generate_novel_prefix(runner.random)
+        example = prefix + hbytes(8 - len(prefix))
+        assert runner.tree.lookup(example) is None
+        result = runner.cached_test_function(example)
+        assert runner.tree.lookup(example) is result
+
+
+def test_overruns_if_not_enough_bytes_for_block():
+    runner = ConjectureRunner(
+        lambda data: data.draw_bytes(2), settings=TEST_SETTINGS, random=Random(0)
+    )
+    runner.cached_test_function(b"\0\0")
+    assert runner.tree.lookup(b"\0") is Overrun
+
+
+def test_overruns_if_prefix():
+    runner = ConjectureRunner(
+        lambda data: [data.draw_bits(1) for _ in range(2)],
+        settings=TEST_SETTINGS,
+        random=Random(0),
+    )
+    runner.cached_test_function(b"\0\0")
+    assert runner.tree.lookup(b"\0") is Overrun

--- a/hypothesis-python/tests/nocover/test_cache_implementation.py
+++ b/hypothesis-python/tests/nocover/test_cache_implementation.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from collections import Counter
+
+import hypothesis.strategies as st
+from hypothesis.internal.cache import GenericCache
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    initialize,
+    invariant,
+    rule,
+)
+
+
+class CacheWithScores(GenericCache):
+    def __init__(self, max_size):
+        super(CacheWithScores, self).__init__(max_size)
+        self.scores = {}
+
+    def new_entry(self, key, value):
+        return self.scores[key]
+
+
+class CacheRules(RuleBasedStateMachine):
+    keys = Bundle("keys")
+
+    @initialize(max_size=st.integers(1, 8))
+    def create_cache(self, max_size):
+        self.cache = CacheWithScores(max_size)
+        self.__values = {}
+
+        self.__total_pins = 0
+        self.__pins = Counter()
+        self.__live = set()
+        self.__next_value = 0
+        self.__last_key = None
+
+        def on_evict(evicted_key, value, score):
+            assert self.__pins[evicted_key] == 0
+            assert score == self.cache.scores[evicted_key]
+            assert value == self.__values[evicted_key]
+            for k in self.cache:
+                assert (
+                    self.__pins[k] > 0
+                    or self.cache.scores[k] >= score
+                    or k == self.__last_key
+                )
+
+        self.cache.on_evict = on_evict
+
+    @rule(key=st.integers(), score=st.integers(0, 100), target=keys)
+    def new_key(self, key, score):
+        if key not in self.cache.scores:
+            self.cache.scores[key] = score
+        return key
+
+    @rule(key=keys)
+    def set_key(self, key):
+        if self.__total_pins < self.cache.max_size or key in self.cache:
+            self.__last_key = key
+            self.cache[key] = self.__next_value
+            self.__values[key] = self.__next_value
+            self.__next_value += 1
+
+    @invariant()
+    def check_values(self):
+        for k in getattr(self, "cache", ()):
+            assert self.__values[k] == self.cache[k]
+
+    @rule(key=keys)
+    def pin_key(self, key):
+        if key in self.cache:
+            self.cache.pin(key)
+            if self.__pins[key] == 0:
+                self.__total_pins += 1
+            self.__pins[key] += 1
+
+    @rule(key=keys)
+    def unpin_key(self, key):
+        if self.__pins[key] > 0:
+            self.cache.unpin(key)
+            self.__pins[key] -= 1
+            if self.__pins[key] == 0:
+                self.__total_pins -= 1
+                assert self.__total_pins >= 0
+
+
+TestCache = CacheRules.TestCase


### PR DESCRIPTION
This limits the scope of the `DataTree` to only store enough information to recreate the buffer and status of the stored `ConjectureData` objects. We then use a standard cache to map the rewritten buffers to the generated `ConjectureData` objects so that the shrinker still has access to them during shrinking, but eviction is now possible.

The reasoning is that `ConjectureData` objects are really large and memory hungry, and for the overwhelming majority of our tree usage we don't actually need them, so by avoiding storing them for that we can significantly reduce the memory profile.