### PR TITLE
Point to latest RTD docs instead of master one

### DIFF
--- a/hypothesis-python/README.rst
+++ b/hypothesis-python/README.rst
@@ -43,7 +43,7 @@ Links of interest
 The main Hypothesis site is at `hypothesis.works <https://hypothesis.works/>`_, and contains a lot
 of good introductory and explanatory material.
 
-Extensive documentation and examples of usage are `available at readthedocs <https://hypothesis.readthedocs.io/en/master/>`_.
+Extensive documentation and examples of usage are `available at readthedocs <https://hypothesis.readthedocs.io/en/latest/>`_.
 
 If you want to talk to people about using Hypothesis, `we have both an IRC channel
 and a mailing list <https://hypothesis.readthedocs.io/en/latest/community.html>`_.


### PR DESCRIPTION
Currently [master](https://hypothesis.readthedocs.io/en/master/changes.html) and [lastest](https://hypothesis.readthedocs.io/en/latest/changes.html) builds are different about 4.0+ things. 

RTD [guarantee](https://docs.readthedocs.io/en/latest/versions.html#how-we-envision-versions-working) that the `lastest`  will always point to the most up to date code version. With Hypothesis CD strategy that also means that the `latest` version is always the latest release.

Probably, there are some hooks on RTD side which keeps `latest` always up to date, while `master` one get triggered by some other ways.
