### PR TITLE
Patch cathetus floating-point imprecision which broke complex_numbers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a very rare overflow bug (:issue:`1748`) which could raise an
+``InvalidArgument`` error in :func:`~hypothesis.strategies.complex_numbers`
+even though the arguments were valid.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -1878,13 +1878,13 @@ def complex_numbers(
         # this and the max_magnitude
         if max_magnitude is None:
             zi = draw(floats(**allow_kw))
-            rmax = float("inf")
+            rmax = None
         else:
             zi = draw(floats(-max_magnitude, max_magnitude, **allow_kw))
             rmax = cathetus(max_magnitude, zi)
         # Draw the real part from the allowed range given the imaginary part
         if min_magnitude is None or math.fabs(zi) >= min_magnitude:
-            zr = draw(floats(-rmax, rmax, **allow_kw))
+            zr = draw(floats(None if rmax is None else -rmax, rmax, **allow_kw))
         else:
             zr = draw(floats(cathetus(min_magnitude, zi), rmax, **allow_kw))
         # Order of conditions carefully tuned so that for a given pair of

--- a/hypothesis-python/src/hypothesis/internal/cathetus.py
+++ b/hypothesis-python/src/hypothesis/internal/cathetus.py
@@ -55,13 +55,17 @@ def cathetus(h, a):
     if h < a:
         return float(u"nan")
 
+    # Thanks to floating-point precision issues when performing multiple
+    # operations on extremely large or small values, we may rarely calculate
+    # a side length that is longer than the hypotenuse.  This is clearly an
+    # error, so we clip to the hypotenuse as the best available estimate.
     if h > sqrt(float_info.max):
         if h > float_info.max / 2:
-            return sqrt(h - a) * sqrt(h / 2 + a / 2) * sqrt(2)
+            b = sqrt(h - a) * sqrt(h / 2 + a / 2) * sqrt(2)
         else:
-            return sqrt(h - a) * sqrt(h + a)
-
-    if h < sqrt(float_info.min):
-        return sqrt(h - a) * sqrt(h + a)
-
-    return sqrt((h - a) * (h + a))
+            b = sqrt(h - a) * sqrt(h + a)
+    elif h < sqrt(float_info.min):
+        b = sqrt(h - a) * sqrt(h + a)
+    else:
+        b = sqrt((h - a) * (h + a))
+    return min(b, h)

--- a/hypothesis-python/tests/cover/test_cathetus.py
+++ b/hypothesis-python/tests/cover/test_cathetus.py
@@ -23,7 +23,9 @@ from sys import float_info
 
 import pytest
 
+from hypothesis import assume, given
 from hypothesis.internal.cathetus import cathetus
+from hypothesis.strategies import floats
 
 
 def test_cathetus_subnormal_underflow():
@@ -97,6 +99,17 @@ def test_cathetus_infinite(h, a):
 )
 def test_cathetus_signs(h, a, b):
     assert abs(cathetus(h, a) - b) <= abs(b) * float_info.epsilon
+
+
+@given(
+    h=floats(0) | floats(min_value=1e308, allow_infinity=False),
+    a=floats(0, allow_infinity=False)
+    | floats(min_value=0, max_value=1e250, allow_infinity=False),
+)
+def test_cathetus_always_leq_hypot(h, a):
+    assume(h >= a)
+    b = cathetus(h, a)
+    assert 0 <= b <= h
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1748.  In short:

- When `cathetus` was passed an extremely large hypotenuse and relatively small side length, it could calculate the remaining side as slightly longer than the hypotenuse.  In rarer circumstances still, this could return infinity for finite inputs.
- `complex_numbers` calculates the bounds on the real part of each example based on the imaginary part.  If `allow_infinity=False` is passed, all bounds should be finite.  However, by the above bug it was possible to get an intermediate infinity which is also a bug.
- `floats` now raises `InvalidArgument` if passed `min_value=inf, allow_infinity=False` because there is no legal value.  This bubbled out of `complex_numbers`, instead of both strategies silently generating disallowed values.

So we now clip the side length in the problematic cases, and the bug is fixed.