### PR TITLE
Don't leak open files

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release fixes an open file leak that used to cause ``ResourceWarning``\ s.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -374,9 +374,9 @@ def extract_lambda_source(f):
     # AttributeError.
     #
     try:
-        encoding, _ = tokenize.detect_encoding(
-            open(inspect.getsourcefile(f), "rb").readline
-        )
+        with open(inspect.getsourcefile(f), "rb") as src_f:
+            encoding, _ = tokenize.detect_encoding(src_f.readline)
+
         source_bytes = source.encode(encoding)
         source_bytes = source_bytes[lambda_ast.col_offset :].strip()
         source = source_bytes.decode(encoding)


### PR DESCRIPTION
This hopefully fixes the warnings that hypothesis currently generates:

```
ResourceWarning: unclosed file <_io.BufferedReader name='…/lib/python3.7/site-packages/hypothesis/provisional.py'>
```