### PR TITLE
Multi-bug discovery during generation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch allows Hypothesis to try a few more examples after finding the
+first bug, in hopes of reporting multiple distinct bugs.  The heuristics
+described in :issue:`847` ensure that we avoid wasting time on fruitless
+searches, while still surfacing each bug as soon as possible.

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -21,6 +21,7 @@ import pytest
 
 from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
 from hypothesis.errors import Flaky, Unsatisfiable, UnsatisfiedAssumption
+from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.strategies import booleans, composite, integers, lists, random_module
 from tests.common.utils import no_shrink
 
@@ -59,6 +60,7 @@ def test_gives_flaky_error_if_assumption_is_flaky():
 def test_does_not_attempt_to_shrink_flaky_errors():
     values = []
 
+    @settings(database=None)
     @given(integers())
     def test(x):
         values.append(x)
@@ -66,7 +68,12 @@ def test_does_not_attempt_to_shrink_flaky_errors():
 
     with pytest.raises(Flaky):
         test()
-    assert len(set(values)) == 1
+    # We try a total of ten calls in the generation phase, each usually a
+    # unique value, looking briefly (and unsuccessfully) for another bug.
+    assert 1 < len(set(values)) <= MIN_TEST_CALLS
+    # We don't try any new values while shrinking, just execute the test
+    # twice more (to check for flakiness and to raise the bug to the user).
+    assert set(values) == set(values[:-2])
 
 
 class SatisfyMe(Exception):

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -23,6 +23,7 @@ from collections import namedtuple
 
 import hypothesis.reporting as reporting
 from hypothesis import HealthCheck, Verbosity, assume, given, note, settings
+from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.strategies import (
     binary,
     booleans,
@@ -417,7 +418,7 @@ def test_when_set_to_no_simplifies_runs_failing_example_twice():
     with raises(AssertionError):
         with capture_out() as out:
             foo()
-    assert failing == [2]
+    assert failing[0] <= MIN_TEST_CALLS + 2
     assert "Falsifying example" in out.getvalue()
     assert "Lo" in out.getvalue()
 


### PR DESCRIPTION
Closes #847.

It turns out that this is basically an update of #1589, with two important changes: I have a better idea of where to put the change, and I realized that we have to go by `call_count` because there may be a very small number of possible `valid_examples` (and so the latter may loop until timing out).

In practice I doubt we'll find multiple bugs much more often, since the "reducers are fuzzers" effect of shrinking was already fairly effective for large or complex examples and we don't try very hard for subsequent bugs in generation.  

This really shines where the simplest input causes one error and other simple inputs cause another (e.g. the "mean of list of floats" test), which is likely to be noticed when potential users are running evaluations, and hence the lower bound on calls to attempt!