### PR TITLE
Adding strategies to generate arguments for numpy general universal functions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+This module includes support for strategies which generate arguments to
+functions that follow the numpy general universal function API. So, it can
+automatically generate the matrices with shapes that follow the shape
+constraints. For example, to generate test inputs for `np.dot`, one can use,
+``@gufunc_args('(m,n),(n,p)->(m,p)', dtype=np.float_, elements=floats())``
+We also allow for adding extra dimensions that follow the numpy broadcasting
+conventions via
+``@gufunc_args('(m,n),(n,p)->(m,p)', dtype=np.float_, elements=floats(), max_dims_extra=3)``
+This can be used when checking if a function follows the correct numpy
+broadcasting semantics.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
 ]
 
 templates_path = ["_templates"]

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -22,6 +22,17 @@ shapes and generate all kinds of fixed-size or compound dtypes.
    :members:
    :exclude-members: ArrayStrategy
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generalized Universal Function API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Hypothesis also offers strategies for creating arguments for functions that
+follow numpy's `Generalized Universal Function API <https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html>`_.
+
+.. automodule:: hypothesis.extra.gufunc
+   :members:
+
+
 .. _hypothesis-pandas:
 
 ------

--- a/hypothesis-python/src/hypothesis/extra/gufunc.py
+++ b/hypothesis-python/src/hypothesis/extra/gufunc.py
@@ -1,0 +1,475 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+# This module uses the numpy parser of the Generalized Universal Function API
+# signatures `_parse_gufunc_signature`, which is only available in
+# numpy>=1.12.0 and therefore requires a bump in the requirements for
+# hypothesis.
+from __future__ import absolute_import, division, print_function
+
+import string
+from collections import defaultdict
+
+import numpy as np
+import numpy.lib.function_base as npfb
+
+from hypothesis.errors import InvalidArgument
+from hypothesis.extra.numpy import arrays, order_check
+from hypothesis.internal.compat import integer_types
+from hypothesis.internal.validation import check_type, check_valid_bound
+from hypothesis.searchstrategy import SearchStrategy
+from hypothesis.strategies import (
+    builds,
+    composite,
+    fixed_dictionaries,
+    integers,
+    just,
+    tuples,
+)
+
+__all__ = ["gufunc_args", "gufunc_arg_shapes"]
+
+# Should not ever need to broadcast beyond this, but should be able to set it
+# as high as 32 before breaking assumptions in numpy.
+GLOBAL_DIMS_MAX = 12
+
+
+# Key used in min_side and max_side to indicate min/max on broadcasted dims,
+# building sentinel class so we have clean __repr__.
+class _BcastDimType(object):
+    def __repr__(self):
+        return "BCAST_DIM"
+
+
+BCAST_DIM = _BcastDimType()
+
+# Value used in default dict for max side if variable not specified
+DEFAULT_MAX_SIDE = 5
+
+# This uses "private" function of numpy, but it does the job. It throws a
+# pretty readable exception for invalid input, we don't need to add anything.
+parse_gufunc_signature = npfb._parse_gufunc_signature
+
+
+def _weird_digits(ss):
+    """In Python 3, some weird unicode characters pass `isdigit` but are not
+    0-9 characters. This function detects those cases.
+    """
+    weird = set(cc for cc in ss if cc.isdigit() and (cc not in string.digits))
+    return weird
+
+
+def _check_set_like(arg, name=""):
+    """Validate input can be searched like a `set`."""
+    try:
+        0 in arg
+    except TypeError:
+        raise InvalidArgument(
+            "Expected set-like but got %s=%r (type=%s)"
+            % (name, arg, type(arg).__name__)
+        )
+
+
+def _check_valid_size_interval(min_size, max_size, name, floor=0):
+    """Check valid for integers strategy and array shapes."""
+    # same checks as done in integers
+    check_valid_bound(min_size, name)
+    check_valid_bound(max_size, name)
+    order_check(name, floor, min_size, max_size)  # ensure non-none & above 0
+
+
+def _order_check_min_max(min_dict, max_dict):
+    """Check min and max dict compatible with integers and array shapes."""
+    _check_valid_size_interval(
+        min_dict.default_factory(), max_dict.default_factory(), "side default"
+    )
+    for kk in set(min_dict.keys()) | set(max_dict.keys()):
+        _check_valid_size_interval(min_dict[kk], max_dict[kk], "side %s" % kk)
+
+
+def _int_or_dict(x, default_val):
+    """Pre-process cases where argument `x` can be `int`, `dict`, or
+    `defaultdict`. In all cases, build a `defaultdict` and return it.
+    """
+    # case 1: x already defaultdict, leave it be, pass thru
+    if isinstance(x, defaultdict):
+        return x
+
+    check_type(integer_types, default_val, "default value")
+    try:
+        # case 2: x is or can be converted to dict
+        D = defaultdict(lambda: default_val, x)
+    except Exception:
+        # case 3: x is int => make a const dict
+        check_type(integer_types, x, "constant value")
+        D = defaultdict(lambda: x)
+    # case 4: if can't be converted to dict or int, then exception raised
+    return D
+
+
+@composite
+def _tuple_of_arrays(draw, shapes, dtype, elements, unique=False):
+    """Strategy to generate a tuple of ndarrays with specified shapes.
+
+    Parameters
+    ----------
+    shapes : list of tuples of int
+        List of tuples where each tuple is the shape of an argument. A
+        `SearchStrategy` for list of tuples is also supported.
+    dtype : list-like of dtype
+        List of numpy `dtype` for each argument. These can be either strings
+        (``'int64'``), type (``np.int64``), or numpy `dtype`
+        (``np.dtype('int64')``). Built in Python types (`int`, `float`, etc)
+        also work. A single `dtype` can be supplied for all arguments.
+    elements : list-like of strategy
+        Strategies to fill in array elements on a per argument basis. One can
+        also specify a single strategy
+        (e.g., :func:`~hypothesis.strategies.floats`)
+        and have it applied to all arguments.
+    unique : list-like of bool
+        Boolean flag to specify if all elements in an array must be unique.
+        One can also specify a single boolean to apply it to all arguments.
+
+    Returns
+    -------
+    res : tuple of ndarrays
+        Resulting ndarrays with shape of `shapes` and elements from `elements`.
+
+    """
+    if isinstance(shapes, SearchStrategy):
+        shapes = draw(shapes)
+    n = len(shapes)
+
+    # Need this since broadcast_to does not like vars of type type
+    if isinstance(dtype, type):
+        dtype = [dtype]
+    dtype = np.broadcast_to(dtype, (n,))
+
+    elements = np.broadcast_to(elements, (n,))
+    unique = np.broadcast_to(unique, (n,))
+
+    # This could somewhat easily be done using builds and avoid need for
+    # composite if shape is always given and not strategy. Otherwise, we need
+    # to chain strategies and probably not worth the effort.
+    res = tuple(
+        draw(arrays(dd, ss, elements=ee, unique=uu))
+        for dd, ss, ee, uu in zip(dtype, shapes, elements, unique)
+    )
+    return res
+
+
+def _signature_map(map_dict, parsed_sig):
+    """Map values found in parsed gufunc signature.
+
+    Parameters
+    ----------
+    map_dict : dict of str to int
+        Mapping from `str` dimension names to `int`. All strings in
+        `parsed_sig` must have entries in `map_dict`.
+    parsed_sig : list-like of tuples of str
+        gufunc signature that has already been parsed, e.g., using
+        `parse_gufunc_signature`.
+
+    Returns
+    -------
+    shapes : list of tuples of int
+        list of tuples where each tuple is the shape of an argument.
+
+    """
+    shapes = [tuple(map_dict[k] for k in arg) for arg in parsed_sig]
+    return shapes
+
+
+def _gufunc_arg_shapes(parsed_sig, min_side, max_side):
+    """Strategy to generate array shapes for arguments to a function consistent
+    with its signature.
+
+    Parameters
+    ----------
+    parsed_sig : list-like of tuples of str
+        gufunc signature that has already been parsed, e.g., using
+        `parse_gufunc_signature`.
+    min_side : defaultdict of str to int
+        Minimum size of any of the dimensions in `parsed_sig`.
+    max_side : defaultdict of str to int
+        Maximum size of any of the dimensions in `parsed_sig`.
+
+    Returns
+    -------
+    shapes : list of tuples of int
+        list of tuples where each tuple is the shape of an argument.
+
+    """
+    assert min_side.default_factory() <= max_side.default_factory()
+    min_max_ok = all(
+        min_side[kk] <= max_side[kk]
+        for kk in set(min_side.keys()) | set(max_side.keys())
+    )
+    assert min_max_ok
+
+    # Get all dimension names in signature, including numeric constants
+    all_dimensions = set([k for arg in parsed_sig for k in arg])
+
+    # Assume we have already checked for weird unicode characters that mess up
+    # isdigit in validation of signature.
+    dim_map_st = {
+        k: (
+            just(int(k))
+            if k.isdigit()
+            else integers(min_value=min_side[k], max_value=max_side[k])
+        )
+        for k in all_dimensions
+    }
+
+    # Build strategy that draws ints for dimensions and subs them in
+    return builds(
+        _signature_map,
+        map_dict=fixed_dictionaries(dim_map_st),
+        parsed_sig=just(parsed_sig),
+    )
+
+
+def _append_bcast_dims(core_dims, b_dims, set_to_1, n_extra_per_arg):
+    """Add extra broadcast dimensions to core dimensions of array shapes.
+
+    Parameters
+    ----------
+    core_dims : list of tuples of int
+        list of tuples where each tuple is the core shape of an argument. It
+        has length `n_args`.
+    b_dims : ndarray of shape (max_dims_extra,)
+        Must be of `int` dtype and >= 0. Extra dimensions to pre-pend for
+        roadcasting.
+    set_to_1 : ndarray of shape (n_args, max_dims_extra)
+        Must be of `bool` dtype. Which extra dimensions get set to 1 for
+        broadcasting.
+    n_extra_per_arg : like-like of shape (n_args,)
+        Elements must be of int type. Must be in [0, max_dims_extra], how many
+        extra dimensions to pre-pend to each argument.
+
+    Returns
+    -------
+    shapes : list of tuples of int
+        list of tuples where each tuple is the shape of an argument. Extra
+        dimensions for broadcasting will be present in the shapes. It has
+        length `n_args`.
+
+    """
+    # Build 2D array with extra dimensions
+    # e.g., extra_dims = [[2 5], [2 5]]
+    extra_dims = np.tile(b_dims, (len(core_dims), 1))
+    # e.g., extra_dims = [[1 5], [2 5]]
+    extra_dims[set_to_1] = 1  # This may be outside [min_side, max_side]
+
+    # Get full dimensions (core+extra), will chop some on left randomly
+    # e.g., shapes = [(5, 1, 3), (2, 5, 3, 1)]
+    # We use pp[len(pp) - nn:] instead of pp[-nn:] since that doesn't handle
+    # corner case with nn=0 correctly (seems like an oversight of py slicing).
+    # Call tolist() before tuple to ensure native int type.
+    shapes = [
+        tuple(pp[len(pp) - nn :].tolist()) + ss
+        for ss, pp, nn in zip(core_dims, extra_dims, n_extra_per_arg)
+    ]
+    return shapes
+
+
+def gufunc_arg_shapes(signature, excluded=(), min_side=0, max_side=5, max_dims_extra=0):
+    """Strategy to generate the shape of ndarrays for arguments to a function
+    consistent with its signature with extra dimensions to test broadcasting.
+
+    Parameters
+    ----------
+    signature : str
+        Signature for shapes to be compatible with. Expects string in format
+        of numpy generalized universal function signature, e.g.,
+        `'(m,n),(n)->(m)'` for vectorized matrix-vector multiplication.
+    excluded : set(int)
+        Set-like of integers representing the positional for which the function
+        will not be vectorized. Uses same format as :obj:`numpy.vectorize`.
+    min_side : int or dict
+        Minimum size of any side of the arrays. It is good to test the corner
+        cases of 0 or 1 sized dimensions when applicable, but if not, a min
+        size can be supplied here. Minimums can be provided on a per-dimension
+        basis using a dict, e.g. ``min_side={'n': 2}``. One can use, e.g.,
+        ``min_side={hypothesis.extra.gufunc.BCAST_DIM: 2}`` to limit the size
+        of the broadcasted dimensions.
+    max_side : int or dict
+        Maximum size of any side of the arrays. This can usually be kept small
+        and still find most corner cases in testing. Dictionaries can be
+        supplied as with `min_side`.
+    max_dims_extra : int
+        Maximum number of extra dimensions that can be appended on left of
+        arrays for broadcasting. This should be kept small as the memory used
+        grows exponentially with extra dimensions. By default, no extra
+        dimensions are added.
+
+    Returns
+    -------
+    shapes : list(tuple(int))
+        list of tuples where each tuple is the shape of an argument. Extra
+        dimensions for broadcasting will be present in the shapes.
+
+    Examples
+    --------
+    .. code-block:: pycon
+
+      >>> from hypothesis.extra.gufunc import BCAST_DIM
+      >>> gufunc_arg_shapes('(m,n),(n)->(m)',
+                            min_side={'m': 1, 'n': 2}, max_side=3).example()
+      [(2, 3), (3,)]
+      >>> gufunc_arg_shapes('(m,n),(n)->(m)', max_side=9,
+                            min_side={'m': 1, 'n': 2, BCAST_DIM: 5},
+                            max_dims_extra=3).example()
+      [(6, 6, 7), (6, 7)]
+      >>> gufunc_arg_shapes('(m,n),(n)->(m)', excluded=(0,),
+                            max_side=20, max_dims_extra=3).example()
+      [(11, 13), (1, 1, 1, 13)]
+
+    """
+    _check_set_like(excluded, name="excluded")
+    min_side = _int_or_dict(min_side, 0)
+    max_side = _int_or_dict(max_side, DEFAULT_MAX_SIDE)
+    _order_check_min_max(min_side, max_side)
+    check_type(integer_types, max_dims_extra, "extra dims")
+    order_check("extra dims", 0, max_dims_extra, GLOBAL_DIMS_MAX)
+
+    # Validate that the signature contains digits we can parse
+    weird_sig_digits = _weird_digits(signature)
+    if len(weird_sig_digits) > 0:
+        raise InvalidArgument(
+            "signature %s contains invalid digits: %s"
+            % (signature, "".join(weird_sig_digits))
+        )
+
+    # Parse out the signature: e.g., parses to [('n', 'm'), ('m', 'p')]
+    parsed_sig, _ = parse_gufunc_signature(signature)
+
+    # Get core shapes before broadcasted dimensions
+    shapes_st = _gufunc_arg_shapes(parsed_sig, min_side=min_side, max_side=max_side)
+
+    # Skip this broadcasting craziness if we don't want extra dims:
+    if max_dims_extra == 0:
+        return shapes_st
+
+    # We could use tuples instead without creating type ambiguity since
+    # max_dims_extra > 0 and avoid calling arrays, but prob ok like this.
+    bcast_dim_st = integers(
+        min_value=min_side[BCAST_DIM], max_value=max_side[BCAST_DIM]
+    )
+    extra_dims_st = arrays(np.intp, (max_dims_extra,), elements=bcast_dim_st)
+
+    set_to_1_st = arrays(np.bool_, (len(parsed_sig), max_dims_extra))
+
+    # np.clip will convert to np int but we don't really care.
+    max_extra_per_arg = [
+        0 if nn in excluded else np.clip(GLOBAL_DIMS_MAX - len(ss), 0, max_dims_extra)
+        for nn, ss in enumerate(parsed_sig)
+    ]
+    extra_per_arg_st = tuples(
+        *[integers(min_value=0, max_value=mm) for mm in max_extra_per_arg]
+    )
+
+    return builds(
+        _append_bcast_dims, shapes_st, extra_dims_st, set_to_1_st, extra_per_arg_st
+    )
+
+
+def gufunc_args(
+    signature,
+    dtype,
+    elements,
+    unique=False,
+    excluded=(),
+    min_side=0,
+    max_side=5,
+    max_dims_extra=0,
+):
+    """Strategy to generate a tuple of ndarrays for arguments to a function
+    consistent with its signature with extra dimensions to test broadcasting.
+
+    Parameters
+    ----------
+    signature : str
+        Signature for shapes to be compatible with. Expects string in format
+        of numpy generalized universal function signature, e.g.,
+        `'(m,n),(n)->(m)'` for vectorized matrix-vector multiplication.
+    dtype : list(:class:`numpy:numpy.dtype`)
+        List of numpy `dtype` for each argument. These can be either strings
+        (``'int64'``), type (``np.int64``), or numpy `dtype`
+        (``np.dtype('int64')``). Built in Python types (`int`, `float`, etc)
+        also work. A single `dtype` can be supplied for all arguments.
+    elements : list
+        List of strategies to fill in array elements on a per argument basis.
+        One can also specify a single strategy
+        (e.g., :func:`~hypothesis.strategies.floats`)
+        and have it applied to all arguments.
+    unique : list(bool)
+        Boolean flag to specify if all elements in an array must be unique.
+        One can also specify a single boolean to apply it to all arguments.
+    excluded : set(int)
+        Set of integers representing the positional for which the function will
+        not be vectorized. Uses same format as :obj:`numpy.vectorize`.
+    min_side : int or dict
+        Minimum size of any side of the arrays. It is good to test the corner
+        cases of 0 or 1 sized dimensions when applicable, but if not, a min
+        size can be supplied here. Minimums can be provided on a per-dimension
+        basis using a dict, e.g. ``min_side={'n': 2}``. One can use, e.g.,
+        ``min_side={hypothesis.extra.gufunc.BCAST_DIM: 2}`` to limit the size
+        of the broadcasted dimensions.
+    max_side : int or dict
+        Maximum size of any side of the arrays. This can usually be kept small
+        and still find most corner cases in testing. Dictionaries can be
+        supplied as with `min_side`.
+    max_dims_extra : int
+        Maximum number of extra dimensions that can be appended on left of
+        arrays for broadcasting. This should be kept small as the memory used
+        grows exponentially with extra dimensions. By default, no extra
+        dimensions are added.
+
+    Returns
+    -------
+    res : tuple(:class:`numpy:numpy.ndarray`)
+        Resulting ndarrays with shapes consistent with `signature` and elements
+        from `elements`. Extra dimensions for broadcasting will be present.
+
+    Examples
+    --------
+    .. code-block:: pycon
+
+      >>> from hypothesis.extra.gufunc import BCAST_DIM
+      >>> from hypothesis.strategies import integers, booleans
+      >>> gufunc_args('(m,n),(n)->(m)',
+                      dtype=np.int_, elements=integers(0, 9), max_side=3,
+                      min_side={'m': 1, 'n': 2, BCAST_DIM: 3}).example()
+      (array([[9, 8, 1],
+              [1, 7, 1]]), array([5, 6, 5]))
+      >>> gufunc_args('(m,n),(n)->(m)', dtype=['bool', 'int32'],
+                           elements=[booleans(), integers(0, 100)],
+                           unique=[False, True], max_dims_extra=3).example()
+      (array([[[[[ True,  True,  True,  True,  True],
+                 [False,  True,  True,  True, False]]]]], dtype=bool),
+       array([67, 43,  0, 34, 66], dtype=int32))
+
+    """
+    shape_st = gufunc_arg_shapes(
+        signature,
+        excluded=excluded,
+        min_side=min_side,
+        max_side=max_side,
+        max_dims_extra=max_dims_extra,
+    )
+    return _tuple_of_arrays(shape_st, dtype=dtype, elements=elements, unique=unique)

--- a/hypothesis-python/tests/numpy/test_gufunc.py
+++ b/hypothesis-python/tests/numpy/test_gufunc.py
@@ -1,0 +1,675 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import string
+from collections import defaultdict
+from functools import reduce
+
+import numpy as np
+import numpy.lib.function_base as npfb
+
+import hypothesis.extra.gufunc as gu
+from hypothesis import given
+from hypothesis.errors import InvalidArgument
+from hypothesis.extra.numpy import from_dtype, scalar_dtypes
+from hypothesis.internal.compat import hunichr, integer_types
+from hypothesis.strategies import (
+    booleans,
+    composite,
+    data,
+    dictionaries,
+    from_regex,
+    integers,
+    just,
+    lists,
+    one_of,
+    sampled_from,
+    sets,
+    tuples,
+)
+
+# Use to sample from simple names, we also can sample from npfb._SIGNATURE
+# regex to get all possible signatures. This regex also doesn't start with
+# digits because if it is parsed as number we could end up with very large
+# dimensions that blow out memory.
+VALID_DIM_NAMES = r"\A[a-zA-Z_][a-zA-Z0-9_]*\Z"
+
+_st_shape = lists(integers(min_value=0, max_value=5), min_size=0, max_size=3).map(tuple)
+
+
+def no_weird_digits(ss):
+    ok = all((not cc.isdigit()) or (cc in string.digits) for cc in ss)
+    return ok
+
+
+def pad_left(L, size, padding):
+    L = (padding,) * max(0, size - len(L)) + L
+    return L
+
+
+def validate_elements(L, dtype, unique=False, choices=None):
+    for drawn in L:
+        assert drawn.dtype == np.dtype(dtype)
+
+        if unique:
+            assert len(set(drawn.ravel())) == drawn.size
+
+        if choices is not None:
+            assert drawn.dtype == choices.dtype
+            vals = set(drawn.ravel())
+            assert vals.issubset(choices)
+
+
+def validate_shapes(L, parsed_sig, min_side, max_side):
+    assert type(L) == list
+    assert len(parsed_sig) == len(L)
+    size_lookup = {}
+    for spec, drawn in zip(parsed_sig, L):
+        assert type(drawn) == tuple
+        assert len(spec) == len(drawn)
+        for ss, dd in zip(spec, drawn):
+            assert isinstance(dd, integer_types)
+            if ss.isdigit():
+                assert int(ss) == dd
+            else:
+                mm = min_side.get(ss, 0) if isinstance(min_side, dict) else min_side
+                assert mm <= dd
+                mm = (
+                    max_side.get(ss, gu.DEFAULT_MAX_SIDE)
+                    if isinstance(max_side, dict)
+                    else max_side
+                )
+                assert dd <= mm
+                var_size = size_lookup.setdefault(ss, dd)
+                assert var_size == dd
+
+
+def validate_bcast_shapes(
+    shapes, parsed_sig, excluded, min_side, max_side, max_dims_extra
+):
+    # Ok to be above GLOBAL_DIMS_MAX if core dims are too
+    assert all(
+        len(ss) <= gu.GLOBAL_DIMS_MAX or len(ss) == len(pp)
+        for ss, pp in zip(shapes, parsed_sig)
+    )
+
+    assert type(shapes) is list
+    assert all(type(ss) is tuple for ss in shapes)
+    assert all(all(type(v) is int for v in ss) for ss in shapes)
+
+    assert all(
+        (ii not in excluded) or len(ss) == len(pp)
+        for ii, (ss, pp) in enumerate(zip(shapes, parsed_sig))
+    )
+
+    # chop off extra dims then same as gufunc_shape
+    core_dims = [tt[len(tt) - len(pp) :] for tt, pp in zip(shapes, parsed_sig)]
+    validate_shapes(core_dims, parsed_sig, min_side, max_side)
+
+    # check max_dims_extra
+    b_dims = [tt[: len(tt) - len(pp)] for tt, pp in zip(shapes, parsed_sig)]
+    assert all(len(tt) <= max_dims_extra for tt in b_dims)
+
+    # Convert dims to matrix form
+    b_dims2 = np.array([pad_left(bb, max_dims_extra, 1) for bb in b_dims], dtype=int)
+    # The extra broadcast dims be set to one regardless of min, max sides
+    mm = min_side.get(gu.BCAST_DIM, 0) if isinstance(min_side, dict) else min_side
+    assert np.all((b_dims2 == 1) | (mm <= b_dims2))
+    mm = (
+        max_side.get(gu.BCAST_DIM, gu.DEFAULT_MAX_SIDE)
+        if isinstance(max_side, dict)
+        else max_side
+    )
+    assert np.all((b_dims2 == 1) | (b_dims2 <= mm))
+    # make sure 1 or same
+    for ii in range(max_dims_extra):
+        vals = set(b_dims2[:, ii])
+        # Must all be 1 or a const size
+        assert len(vals) <= 2
+        assert len(vals) < 2 or (1 in vals)
+
+
+def assertInvalidArgument(f, *args, **kwargs):
+    try:
+        f(*args, **kwargs)
+    except InvalidArgument:
+        return
+    assert False, "expected InvalidArgument exception"
+
+
+def unparse(parsed_sig):
+    assert len(parsed_sig) > 0, "gufunc sig does not support no argument funcs"
+
+    i_sig = [",".join(vv) for vv in parsed_sig[0]]
+    i_sig = "(" + "),(".join(i_sig) + ")"
+
+    o_sig = [",".join(vv) for vv in parsed_sig[1]]
+    o_sig = "(" + "),(".join(o_sig) + ")"
+
+    sig = "->".join((i_sig, o_sig))
+    return sig
+
+
+def real_scalar_dtypes():
+    def to_native(dtype):
+        tt = dtype.type
+        # Only keep if invertible
+        tt = tt if np.dtype(tt) == dtype else dtype
+        return tt
+
+    def cast_it(args):
+        return args[0](args[1])
+
+    dtypes = scalar_dtypes()
+    return one_of(dtypes, dtypes.map(str), dtypes.map(to_native))
+
+
+def real_from_dtype(dtype, N=10):
+    dtype = np.dtype(dtype)
+
+    def clean_up(x):
+        x = np.nan_to_num(x).astype(dtype)
+        assert x.dtype == dtype  # hard to always get this it seems
+        return x
+
+    S = lists(from_dtype(dtype), min_size=N, max_size=N).map(clean_up)
+    return S
+
+
+def parsed_sigs(big=False):
+    """Strategy to generate a parsed gufunc signature.
+
+    Note that in general functions can take no-args, but the function signature
+    formalism is for >= 1 args. So, there is always at least 1 arg here.
+    """
+    max_dims = 3
+    max_args = 5
+    # Use | to sample from digits since we would like (small) pure numbers too
+    shapes = lists(
+        from_regex(VALID_DIM_NAMES) | sampled_from(string.digits),
+        min_size=0,
+        max_size=max_dims,
+    ).map(tuple)
+    S = lists(shapes, min_size=1, max_size=max_args)
+    S = tuples(S, S)
+
+    if big:
+        # Or throw in anything compatible with regex sig
+        all_sigs = from_regex(npfb._SIGNATURE).filter(no_weird_digits)
+        S |= all_sigs.map(gu.parse_gufunc_signature)
+
+    return S
+
+
+@composite
+def parsed_sigs_and_sizes(draw, big=False):
+    min_min_side = 0
+    max_max_side = 100 if big else 5
+
+    parsed_sig = draw(parsed_sigs(big))
+    # list of all labels used in sig, includes ints which is ok to include in
+    # dict as distractors.
+    labels = list(set([k for arg in parsed_sig[0] for k in arg]))
+    # Also sometimes put the broadcast flag in as label
+    labels.append(gu.BCAST_DIM)
+
+    # Using a split to decide which numbers we use for min sides and which
+    # numbers we use for max side, to avoid min > max. This strategy does not
+    # cover whole search space, but should should be good enough.
+    split = draw(integers(min_min_side, gu.DEFAULT_MAX_SIDE))
+
+    if draw(booleans()):
+        min_side = draw(
+            dictionaries(sampled_from(labels), integers(min_min_side, split))
+        )
+    else:
+        min_side = draw(integers(min_min_side, split))
+
+    if draw(booleans()):
+        max_side = draw(
+            dictionaries(sampled_from(labels), integers(split, max_max_side))
+        )
+    else:
+        max_side = draw(integers(split, max_max_side))
+
+    return parsed_sig, min_side, max_side
+
+
+def test_check_functions():
+    assertInvalidArgument(gu._check_valid_size_interval, "1", 5, "")
+    assertInvalidArgument(gu._check_valid_size_interval, 1, "5", "")
+    assertInvalidArgument(gu._check_valid_size_interval, 5, 1, "")
+    assertInvalidArgument(gu._check_valid_size_interval, 0, 5, "", floor=1)
+
+    assertInvalidArgument(gu._int_or_dict, {}, "5")
+    assertInvalidArgument(gu._int_or_dict, "1", 5)
+
+    assertInvalidArgument(gu.gufunc_arg_shapes, "()->()", max_dims_extra="5")
+    assertInvalidArgument(gu.gufunc_arg_shapes, "()->()", max_dims_extra=-1)
+    assertInvalidArgument(gu.gufunc_arg_shapes, "()->()", max_dims_extra=50)
+
+
+@given(parsed_sigs(big=True))
+def test_unparse_parse(sig):
+    i_parsed_sig, o_parsed_sig = sig
+
+    # We don't care about the output for this function
+    signature = unparse((i_parsed_sig, o_parsed_sig))
+    # This is a 'private' function of np, so need to test it still works as we
+    # think it does.
+    inp, out = gu.parse_gufunc_signature(signature)
+
+    assert i_parsed_sig == inp
+    assert o_parsed_sig == out
+
+
+def test_check_set_like():
+    """Need for 100% coverage"""
+    assertInvalidArgument(gu._check_set_like, 0)
+    assertInvalidArgument(gu._check_set_like, "0")
+    assertInvalidArgument(gu._check_set_like, "foobar")
+
+
+@given(dictionaries(from_regex(VALID_DIM_NAMES), integers()), integers(), integers())
+def test_ddict_int_or_dict(D, default_val, default_val2):
+    DD = defaultdict(lambda: default_val, D)
+
+    DD2 = gu._int_or_dict(DD, default_val2)
+
+    # just pass thru
+    assert DD is DD2
+    # default_val2 is ignored
+    assert DD2.default_factory() == default_val
+
+
+@given(dictionaries(from_regex(VALID_DIM_NAMES), integers()), integers())
+def test_dict_int_or_dict(D, default_val):
+    DD = gu._int_or_dict(D, default_val)
+
+    assert DD == D
+    assert DD["---"] == default_val
+
+
+@given(integers(), integers())
+def test_int_int_or_dict(default_val, default_val2):
+    DD = gu._int_or_dict(default_val, default_val2)
+
+    assert len(DD) == 0
+    assert DD["---"] == default_val
+
+
+@given(real_scalar_dtypes(), _st_shape, data())
+def test_arrays(dtype, shape, data):
+    # unique argument to arrays gets tested in the tuple of arrays tests
+    choices = data.draw(real_from_dtype(dtype))
+
+    elements = sampled_from(choices)
+    S = gu._arrays(dtype, shape, elements)
+    X = data.draw(S)
+
+    assert np.shape(X) == shape
+    validate_elements([X], dtype=dtype, choices=choices)
+
+    assert type(X) == np.ndarray
+
+
+@given(real_scalar_dtypes(), _st_shape, data())
+def test_just_arrays(dtype, shape, data):
+    # unique argument to arrays gets tested in the tuple of arrays tests
+    choices = data.draw(real_from_dtype(dtype))
+
+    # test again, but this time pass in strategy to make sure it can handle it
+    elements = sampled_from(choices)
+    S = gu._arrays(just(dtype), just(shape), elements)
+    X = data.draw(S)
+
+    assert np.shape(X) == shape
+    validate_elements([X], dtype=dtype, choices=choices)
+
+    assert type(X) == np.ndarray
+
+
+# hypothesis.extra.numpy.array_shapes does not support 0 min_size so we roll
+# our own in this case.
+@given(
+    lists(_st_shape, min_size=0, max_size=5), real_scalar_dtypes(), booleans(), data()
+)
+def test_shapes_tuple_of_arrays(shapes, dtype, unique, data):
+    elements = from_dtype(np.dtype(dtype))
+
+    S = gu._tuple_of_arrays(shapes, dtype, elements=elements, unique=unique)
+    X = data.draw(S)
+
+    validate_elements(X, dtype=dtype, unique=unique)
+
+    assert len(shapes) == len(X)
+    for spec, drawn in zip(shapes, X):
+        assert tuple(spec) == np.shape(drawn)
+
+
+# hypothesis.extra.numpy.array_shapes does not support 0 min_size so we roll
+# our own in this case.
+@given(
+    lists(_st_shape, min_size=0, max_size=5), real_scalar_dtypes(), booleans(), data()
+)
+def test_just_shapes_tuple_of_arrays(shapes, dtype, unique, data):
+    elements = from_dtype(np.dtype(dtype))
+
+    # test again, but this time pass in strategy to make sure it can handle it
+    S = gu._tuple_of_arrays(
+        just(shapes), just(dtype), elements=elements, unique=just(unique)
+    )
+    X = data.draw(S)
+
+    validate_elements(X, dtype=dtype, unique=unique)
+
+    assert len(shapes) == len(X)
+    for spec, drawn in zip(shapes, X):
+        assert tuple(spec) == np.shape(drawn)
+
+
+@given(lists(_st_shape, min_size=0, max_size=5), real_scalar_dtypes(), data())
+def test_elements_tuple_of_arrays(shapes, dtype, data):
+    choices = data.draw(real_from_dtype(dtype))
+
+    elements = sampled_from(choices)
+    S = gu._tuple_of_arrays(shapes, dtype, elements=elements)
+    X = data.draw(S)
+
+    validate_elements(X, choices=choices, dtype=dtype)
+
+
+@given(
+    gu.gufunc_args(
+        "(1),(1),(1),()->()",
+        dtype=["object", "object", "object", "bool"],
+        elements=[_st_shape, scalar_dtypes(), just(None), booleans()],
+        min_side=1,
+        max_dims_extra=1,
+    ),
+    data(),
+)
+def test_bcast_tuple_of_arrays(args, data):
+    """Now testing broadcasting of tuple_of_arrays, kind of crazy since it uses
+    gufuncs to test itself. Some awkwardness here since there are a lot of
+    corner cases when dealing with object types in the numpy extension.
+
+    For completeness, should probably right a function like this for the other
+    functions, but there always just pass dtype, elements, unique to
+    `_tuple_of_arrays` anyway, so this should be pretty good.
+    """
+    shapes, dtype, elements, unique = args
+
+    shapes = shapes.ravel()
+    # Need to squeeze out due to weird behaviour of object
+    dtype = np.squeeze(dtype, -1)
+    elements = np.squeeze(elements, -1)
+
+    elements_shape = max(dtype.shape, elements.shape)
+    dtype_ = np.broadcast_to(dtype, elements_shape)
+    if elements_shape == ():
+        elements = from_dtype(dtype_.item())
+    else:
+        elements = [from_dtype(dd) for dd in dtype_]
+
+    shapes_shape = max(shapes.shape, dtype.shape, elements_shape, unique.shape)
+    shapes = np.broadcast_to(shapes, shapes_shape)
+
+    S = gu._tuple_of_arrays(shapes, dtype, elements=elements, unique=unique)
+    X = data.draw(S)
+
+    assert len(shapes) == len(X)
+    for spec, drawn in zip(shapes, X):
+        assert tuple(spec) == np.shape(drawn)
+
+    for ii, xx in enumerate(X):
+        dd = dtype[ii] if dtype.size > 1 else dtype.item()
+        uu = unique[ii] if unique.size > 1 else unique.item()
+        validate_elements([xx], dtype=dd, unique=uu)
+
+
+@given(parsed_sigs(big=True))
+def test_const_signature_map(parsed_sig):
+    parsed_sig, _ = parsed_sig
+
+    # Map all dims to zero
+    all_dims = reduce(set.union, [set(arg) for arg in parsed_sig])
+    map_dict = {k: 0 for k in all_dims}
+
+    p_ = gu._signature_map(map_dict, parsed_sig)
+
+    assert all(all(v == 0 for v in arg) for arg in p_)
+
+
+@given(parsed_sigs(big=True))
+def test_inverse_signature_map(parsed_sig):
+    parsed_sig, _ = parsed_sig
+
+    # Build an arbitrary map
+    all_dims = sorted(reduce(set.union, [set(arg) for arg in parsed_sig]))
+    map_dict = dict(zip(all_dims, all_dims[::-1]))
+
+    inv_map = {v: k for k, v in map_dict.items()}
+
+    p_ = gu._signature_map(map_dict, parsed_sig)
+    p_ = gu._signature_map(inv_map, p_)
+
+    assert p_ == parsed_sig
+
+
+# Allow bigger sizes since we only generate the shapes and never alloc arrays
+# Try +3 to see what happens if we put something too big in
+@given(parsed_sigs_and_sizes(big=True), data())
+def test_shapes_gufunc_arg_shapes(parsed_sig_and_size, data):
+    parsed_sig, min_side, max_side = parsed_sig_and_size
+
+    # This private function assumes already preprocessed sizes to default dict
+    min_side = gu._int_or_dict(min_side, 0)
+    max_side = gu._int_or_dict(max_side, gu.DEFAULT_MAX_SIDE)
+
+    S = gu._gufunc_arg_shapes(parsed_sig[0], min_side=min_side, max_side=max_side)
+
+    shapes = data.draw(S)
+    validate_shapes(shapes, parsed_sig[0], min_side, max_side)
+
+
+def test_validation_gufunc_arg_shapes():
+    sig_template_1 = u"(3),(%s)->()"
+    sig_template_2 = u"(x,4),(foo%s)->(5)"
+    weird_chars = (1632, 1633, 1634, 65303, 65304, 65305)  # There are more
+
+    for cc in weird_chars:
+        assertInvalidArgument(gu.gufunc_arg_shapes, sig_template_1 % hunichr(cc))
+        assertInvalidArgument(gu.gufunc_arg_shapes, sig_template_2 % hunichr(cc))
+
+
+@given(parsed_sigs_and_sizes(big=False), real_scalar_dtypes(), booleans(), data())
+def test_shapes_gufunc_args(parsed_sig_and_size, dtype, unique, data):
+    parsed_sig, min_side, max_side = parsed_sig_and_size
+
+    signature = unparse(parsed_sig)
+
+    # We could also test using elements strategy that then requires casting,
+    # but that would be kind of complicated to come up with compatible combos
+    elements = from_dtype(np.dtype(dtype))
+
+    # Assumes zero broadcast dims by default
+    S = gu.gufunc_args(
+        signature,
+        min_side=min_side,
+        max_side=max_side,
+        dtype=dtype,
+        elements=elements,
+        unique=unique,
+    )
+
+    X = data.draw(S)
+    shapes = [np.shape(xx) for xx in X]
+
+    validate_shapes(shapes, parsed_sig[0], min_side, max_side)
+    validate_elements(X, dtype=dtype, unique=unique)
+
+
+@given(
+    parsed_sigs(big=False), integers(0, 5), integers(0, 5), real_scalar_dtypes(), data()
+)
+def test_elements_gufunc_args(parsed_sig, min_side, max_side, dtype, data):
+    choices = data.draw(real_from_dtype(dtype))
+    elements = sampled_from(choices)
+
+    signature = unparse(parsed_sig)
+
+    min_side, max_side = sorted([min_side, max_side])
+
+    S = gu.gufunc_args(
+        signature, min_side=min_side, max_side=max_side, dtype=dtype, elements=elements
+    )
+
+    X = data.draw(S)
+
+    validate_elements(X, choices=choices, dtype=dtype)
+
+
+@given(
+    gu.gufunc_args(
+        "(n),(m),(n,m),(n)->()",
+        dtype=["object", int, bool, int],
+        elements=[_st_shape, integers(0, 100), booleans(), integers(0, 100)],
+        min_side={"n": 1},
+    )
+)  # always at least one arg
+def test_append_bcast_dims(args):
+    core_dims, b_dims, set_to_1, n_extra_per_arg = args
+
+    max_extra = len(b_dims)
+    # Put all in range [0, max_extra]
+    n_extra_per_arg = tuple(n_extra_per_arg % (max_extra + 1))
+
+    shapes = gu._append_bcast_dims(core_dims, b_dims, set_to_1, n_extra_per_arg)
+
+    for ii, ss in enumerate(shapes):
+        bb = np.asarray(ss[: len(ss) - len(core_dims[ii])])
+        cc = ss[len(ss) - len(core_dims[ii]) :]
+
+        st1 = set_to_1[ii]
+        st1 = st1[len(st1) - len(bb) :]
+
+        assert len(bb) == n_extra_per_arg[ii]
+        assert cc == core_dims[ii]
+        assert np.all(bb[st1] == 1)
+        assert np.all(bb[~st1] == b_dims[len(b_dims) - len(bb) :][~st1])
+
+
+@given(parsed_sigs_and_sizes(big=True), integers(0, gu.GLOBAL_DIMS_MAX), data())
+def test_broadcast_shapes_gufunc_arg_shapes(parsed_sig_and_size, max_dims_extra, data):
+    parsed_sig, min_side, max_side = parsed_sig_and_size
+
+    signature = unparse(parsed_sig)
+    parsed_sig, _ = parsed_sig
+
+    excluded = data.draw(sets(integers(0, len(parsed_sig) - 1)).map(tuple))
+
+    S = gu.gufunc_arg_shapes(
+        signature,
+        excluded=excluded,
+        min_side=min_side,
+        max_side=max_side,
+        max_dims_extra=max_dims_extra,
+    )
+
+    shapes = data.draw(S)
+
+    validate_bcast_shapes(
+        shapes, parsed_sig, excluded, min_side, max_side, max_dims_extra
+    )
+
+
+@given(
+    parsed_sigs_and_sizes(big=False),
+    integers(0, 3),
+    real_scalar_dtypes(),
+    booleans(),
+    data(),
+)
+def test_broadcast_shapes_gufunc_args(
+    parsed_sig_and_size, max_dims_extra, dtype, unique, data
+):
+    parsed_sig, min_side, max_side = parsed_sig_and_size
+
+    signature = unparse(parsed_sig)
+    parsed_sig, _ = parsed_sig
+
+    excluded = data.draw(sets(integers(0, len(parsed_sig) - 1)).map(tuple))
+
+    elements = from_dtype(np.dtype(dtype))
+
+    S = gu.gufunc_args(
+        signature,
+        excluded=excluded,
+        min_side=min_side,
+        max_side=max_side,
+        max_dims_extra=max_dims_extra,
+        dtype=dtype,
+        elements=elements,
+        unique=unique,
+    )
+
+    X = data.draw(S)
+    shapes = [np.shape(xx) for xx in X]
+
+    validate_bcast_shapes(
+        shapes, parsed_sig, excluded, min_side, max_side, max_dims_extra
+    )
+    validate_elements(X, dtype=dtype, unique=unique)
+
+
+@given(
+    parsed_sigs(big=False),
+    integers(0, 5),
+    integers(0, 5),
+    integers(0, 3),
+    real_scalar_dtypes(),
+    data(),
+)
+def test_broadcast_elements_gufunc_args(
+    parsed_sig, min_side, max_side, max_dims_extra, dtype, data
+):
+    signature = unparse(parsed_sig)
+    parsed_sig, _ = parsed_sig
+
+    excluded = data.draw(sets(integers(0, len(parsed_sig) - 1)).map(tuple))
+
+    min_side, max_side = sorted([min_side, max_side])
+
+    choices = data.draw(real_from_dtype(dtype))
+    elements = sampled_from(choices)
+
+    S = gu.gufunc_args(
+        signature,
+        excluded=excluded,
+        min_side=min_side,
+        max_side=max_side,
+        max_dims_extra=max_dims_extra,
+        dtype=dtype,
+        elements=elements,
+    )
+
+    X = data.draw(S)
+
+    validate_elements(X, choices=choices, dtype=dtype)

--- a/hypothesis-python/tests/numpy/test_gufunc.py
+++ b/hypothesis-python/tests/numpy/test_gufunc.py
@@ -314,37 +314,6 @@ def test_int_int_or_dict(default_val, default_val2):
     assert DD["---"] == default_val
 
 
-@given(real_scalar_dtypes(), _st_shape, data())
-def test_arrays(dtype, shape, data):
-    # unique argument to arrays gets tested in the tuple of arrays tests
-    choices = data.draw(real_from_dtype(dtype))
-
-    elements = sampled_from(choices)
-    S = gu._arrays(dtype, shape, elements)
-    X = data.draw(S)
-
-    assert np.shape(X) == shape
-    validate_elements([X], dtype=dtype, choices=choices)
-
-    assert type(X) == np.ndarray
-
-
-@given(real_scalar_dtypes(), _st_shape, data())
-def test_just_arrays(dtype, shape, data):
-    # unique argument to arrays gets tested in the tuple of arrays tests
-    choices = data.draw(real_from_dtype(dtype))
-
-    # test again, but this time pass in strategy to make sure it can handle it
-    elements = sampled_from(choices)
-    S = gu._arrays(just(dtype), just(shape), elements)
-    X = data.draw(S)
-
-    assert np.shape(X) == shape
-    validate_elements([X], dtype=dtype, choices=choices)
-
-    assert type(X) == np.ndarray
-
-
 # hypothesis.extra.numpy.array_shapes does not support 0 min_size so we roll
 # our own in this case.
 @given(


### PR DESCRIPTION
This is a squashed commit version of the pull request:
Adding strategies to generate arguments for numpy general universal functions #1760

This module includes support for strategies which generate arguments to
functions that follow the numpy general universal function API. So, it can
automatically generate the matrices with shapes that follow the shape
constraints. For example, to generate test inputs for `np.dot`, one can use,
```
@gufunc_args('(m,n),(n,p)->(m,p)', dtype=np.float_, elements=floats())
```
We also allow for adding extra dimensions that follow the numpy broadcasting
conventions via
```
@gufunc_args('(m,n),(n,p)->(m,p)', dtype=np.float_, elements=floats(),
             max_dims_extra=3)
```
This can be used when checking if a function follows the correct numpy
broadcasting semantics.
