### PR TITLE
Remove two quadratic shrink passes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release removes two shrink passes that Hypothesis runs late in the process.
+These were very expensive when the test function was slow and often didn't do anything useful.
+
+Shrinking should get faster for most failing tests.
+If you see any regression in example quality as a result of this release, please let us know.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -234,8 +234,6 @@ class Shrinker(object):
             block_program("-XX"),
             block_program("XX"),
             "example_deletion_with_block_lowering",
-            "shrink_offset_pairs",
-            "minimize_block_pairs_retaining_sum",
         ]
 
     def derived_value(fn):
@@ -846,70 +844,6 @@ class Shrinker(object):
         if new_offset == offset:
             self.clear_change_tracking()
 
-    def shrink_offset_pairs(self):
-        """Lowers pairs of blocks that need to maintain a constant difference
-        between their respective values.
-
-        Before this shrink pass, two blocks explicitly offset from each
-        other would not get minimized properly:
-         >>> b = st.integers(0, 255)
-         >>> find(st.tuples(b, b), lambda x: x[0] == x[1] + 1)
-        (149,148)
-
-        This expensive (O(n^2)) pass goes through every pair of non-zero
-        blocks in the current shrink target and sees if the shrink
-        target can be improved by applying a negative offset to both of them.
-        """
-
-        def int_from_block(i):
-            u, v = self.blocks[i].bounds
-            block_bytes = self.shrink_target.buffer[u:v]
-            return int_from_bytes(block_bytes)
-
-        def block_len(i):
-            return self.blocks[i].length
-
-        # Try reoffseting every pair
-        def reoffset_pair(pair, o):
-            n = len(self.blocks)
-            # Number of blocks may have changed, need to validate
-            valid_pair = [
-                p
-                for p in pair
-                if p < n and int_from_block(p) > 0 and self.is_payload_block(p)
-            ]
-
-            if len(valid_pair) < 2:
-                return
-
-            m = min([int_from_block(p) for p in valid_pair])
-
-            new_blocks = [
-                self.shrink_target.buffer[u:v]
-                for u, v in self.shrink_target.all_block_bounds()
-            ]
-            for i in valid_pair:
-                new_blocks[i] = int_to_bytes(int_from_block(i) + o - m, block_len(i))
-            buffer = hbytes().join(new_blocks)
-            return self.incorporate_new_buffer(buffer)
-
-        def is_non_zero_payload(block):
-            return not block.all_zero and self.is_payload_block(block.index)
-
-        for block_i, block_j in self.each_pair_of_blocks(
-            is_non_zero_payload, is_non_zero_payload
-        ):
-            i = block_i.index
-            j = block_j.index
-
-            value_i = int_from_block(i)
-            value_j = int_from_block(j)
-
-            offset = min(value_i, value_j)
-            Integer.shrink(
-                offset, lambda o: reoffset_pair((i, j), o), random=self.random
-            )
-
     def mark_shrinking(self, blocks):
         """Mark each of these blocks as a shrinking block: That is, lowering
         its value lexicographically may cause less data to be drawn after."""
@@ -1382,60 +1316,6 @@ class Shrinker(object):
                     j += 1
 
             i += 1
-
-    def minimize_block_pairs_retaining_sum(self):
-        """This pass minimizes pairs of blocks subject to the constraint that
-        their sum when interpreted as integers remains the same. This allow us
-        to normalize a number of examples that we would otherwise struggle on.
-        e.g. consider the following:
-
-        m = data.draw_bits(8)
-        n = data.draw_bits(8)
-        if m + n >= 256:
-            data.mark_interesting()
-
-        The ideal example for this is m=1, n=255, but we will almost never
-        find that without a pass like this - we would only do so if we
-        happened to draw n=255 by chance.
-
-        This kind of scenario comes up reasonably often in the context of e.g.
-        triggering overflow behaviour.
-        """
-        for block_i, block_j in self.each_pair_of_blocks(
-            lambda block: (self.is_payload_block(block.index) and not block.all_zero),
-            lambda block: self.is_payload_block(block.index),
-        ):
-            if block_i.length != block_j.length:
-                continue
-
-            u, v = block_i.bounds
-            r, s = block_j.bounds
-
-            m = int_from_bytes(self.shrink_target.buffer[u:v])
-            n = int_from_bytes(self.shrink_target.buffer[r:s])
-
-            def trial(x, y):
-                if s > len(self.shrink_target.buffer):
-                    return False
-                attempt = bytearray(self.shrink_target.buffer)
-                try:
-                    attempt[u:v] = int_to_bytes(x, v - u)
-                    attempt[r:s] = int_to_bytes(y, s - r)
-                except OverflowError:
-                    return False
-                return self.incorporate_new_buffer(attempt)
-
-            # We first attempt to move 1 from m to n. If that works
-            # then we treat that as a sign that it's worth trying
-            # a more expensive minimization. But if m was already 1
-            # (we know it's > 0) then there's no point continuing
-            # because the value there is now zero.
-            if trial(m - 1, n + 1) and m > 1:
-                m = int_from_bytes(self.shrink_target.buffer[u:v])
-                n = int_from_bytes(self.shrink_target.buffer[r:s])
-
-                tot = m + n
-                Integer.shrink(m, lambda x: trial(x, tot - x), random=self.random)
 
     def reorder_examples(self):
         """This pass allows us to reorder the children of each example.

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -27,7 +27,7 @@ from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from tests.common.utils import non_covering_examples
-from tests.cover.test_conjecture_engine import run_to_buffer, shrink, shrinking_from
+from tests.cover.test_conjecture_engine import run_to_buffer, shrinking_from
 
 
 def test_lot_of_dead_nodes():
@@ -139,51 +139,6 @@ def test_regression_1():
     assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
 
     assert int_from_bytes(x[-2:]) in (254, 512)
-
-
-def test_shrink_offset_pairs_handles_block_structure_change():
-    """Regression test for a rare error in ``shrink_offset_pairs``.
-
-    This test should run without raising an ``IndexError`` in the
-    shrinker.
-    """
-
-    @shrink([235, 0, 0, 255], "shrink_offset_pairs")
-    def f(data):
-        x = data.draw_bytes(1)[0]
-
-        # Change the block structure in response to a shrink improvement,
-        # to trigger the bug.
-        if x == 10:
-            data.draw_bytes(1)
-            data.draw_bytes(1)
-        else:
-            data.draw_bytes(2)
-
-        y = data.draw_bytes(1)[0]
-
-        # Require the target blocks to be non-trivial and have a fixed
-        # difference, so that the intended shrinker pass is used.
-        if x >= 10 and y - x == 20:
-            data.mark_interesting()
-
-    assert f == [10, 0, 0, 30]
-
-
-def test_retaining_sum_considers_zero_destination_blocks():
-    """Explicitly test that this shrink pass will try to move data into blocks
-    that are currently all-zero."""
-
-    @shrink([100, 0, 0], "minimize_block_pairs_retaining_sum")
-    def f(data):
-        x = data.draw_bytes(1)[0]
-        data.draw_bytes(1)
-        y = data.draw_bytes(1)[0]
-
-        if x >= 10 and (x + y) == 100:
-            data.mark_interesting()
-
-    assert f == [10, 0, 90]
 
 
 @given(st.integers(0, 255), st.integers(0, 255))


### PR DESCRIPTION
We have two quadratic passes in the shrinker which are there to handle some quite specific scenarios. This works fine when the test cases are small and the test functions are fast, but it proves to be quite a burden when that is not the case.

This removes those passes (with apologies to the people who contributed them). I still like the idea and it would still be nice if we could handle the situations that these are designed to deal with, but it's not worth the performance cost.

We still retain the worst-case quadratic `example_deletion_with_block_lowering` because that solves a genuine and common user need. It is also somewhat less expensive due to the restriction of only considering shrinking blocks. I'd like to make it less expensive, but I think that needs a clever idea.