### PR TITLE
Make all block programs adaptive

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release changes certain shrink passes to make them *adaptive* - that is,
+in cases where they are successfully making progress they may now do so significantly
+faster.

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1554,3 +1554,17 @@ def test_try_shrinking_blocks_out_of_bounds():
         data.mark_interesting()
 
     assert not shrinker.try_shrinking_blocks((1,), hbytes([1]))
+
+
+def test_block_programs_are_adaptive():
+    @shrinking_from(hbytes(1000) + hbytes([1]))
+    def shrinker(data):
+        while not data.draw_bits(1):
+            pass
+        data.mark_interesting()
+
+    shrinker.clear_passes()
+    shrinker.add_new_pass(block_program("X"))
+    shrinker.shrink()
+    assert len(shrinker.shrink_target.buffer) == 1
+    assert shrinker.calls <= 40

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1567,4 +1567,4 @@ def test_block_programs_are_adaptive():
     shrinker.add_new_pass(block_program("X"))
     shrinker.shrink()
     assert len(shrinker.shrink_target.buffer) == 1
-    assert shrinker.calls <= 40
+    assert shrinker.calls <= 60


### PR DESCRIPTION
It's rare right now that our block programs do anything at all, but I've seen a couple of cases in my recent experimentation where a block program is wildly successful. Unfortunately currently "wildly successfuly" means "makes many teeny tiny shrinks". This PR changes that failure mode by making all block programs *adaptive* - when they would make `k` consecutive shrinks they instead make `O(log(k))` larger shrinks.