### PR TITLE
Clarify where StopTest gets caught and discarded

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release makes a small internal refactoring to clarify how Hypothesis
+instructs tests to stop running when appropriate. There is no user-visible
+change.

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -153,6 +153,10 @@ class DeadlineExceeded(HypothesisException):
 
 
 class StopTest(BaseException):
+    """Raised when a test should stop running and return control to
+    the Hypothesis engine, which should then continue normally.
+    """
+
     def __init__(self, testcounter):
         super(StopTest, self).__init__(repr(testcounter))
         self.testcounter = testcounter


### PR DESCRIPTION
A couple of times now I've tried to track down the precise location that actually catches and discards a `StopTest` after it has stopped its test.

Unfortunately it's quite tricky to find, because the special-case handling for re-raising a `StopTest` draws attention and makes the normal code path easy to miss.

This PR aims to fix this by creating a helper method that is clearly responsible for intercepting stops, and has an explicit code path for doing so that won't be concealed by the special-case path.

---

A side benefit of introducing this method is that the path for re-raising a `StopTest` no longer needs its own separate `self.save_buffer(data.buffer)` call, because that is now handled uniformly by the `except` block out in `test_function`.