### PR TITLE
Allow long type dimension for arrays on python 2

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -246,6 +246,7 @@ their individual contributions.
 * `Paul Stiverson <https://github.com/thismatters>`_
 * `Peadar Coyle <https://github.com/springcoil>`_ (peadarcoyle@gmail.com)
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
+* `Ryan Turner <https://github.com/rdturnermtl>`_ (ryan.turner@uber.com)
 * `Sam Hames <https://www.github.com/SamHames>`_
 * `Sanyam Khurana <https://github.com/CuriousLearner>`_
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (s.shanabrook@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Fixes bug in `hypothesis.extra.numpy.arrays` on Python2 where `long` type
+dimensions are not allowed in the shape.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -26,7 +26,7 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis import Verbosity
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange, text_type, integer_types
+from hypothesis.internal.compat import hrange, integer_types, text_type
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
 from hypothesis.internal.validation import check_type

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -26,7 +26,7 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis import Verbosity
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange, text_type
+from hypothesis.internal.compat import hrange, text_type, integer_types
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
 from hypothesis.internal.validation import check_type
@@ -132,7 +132,7 @@ class ArrayStrategy(SearchStrategy):
             shape,
         )
         check_argument(
-            all(isinstance(s, int) for s in shape),
+            all(isinstance(s, integer_types) for s in shape),
             "Array shape must be integer in each dimension, provided shape was {}",
             shape,
         )

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -92,6 +92,7 @@ def test_generates_unsigned_ints(x):
 
 @given(st.data())
 def test_can_handle_long_shapes(data):
+    """We can eliminate this test once we drop Py2 support."""
     for tt in six.integer_types:
         X = data.draw(nps.arrays(float, (tt(5),)))
         assert X.shape == (5,)

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -22,8 +22,6 @@ import sys
 import numpy as np
 import pytest
 import six
-from tests.common.debug import find_any, minimal
-from tests.common.utils import checks_deprecated_behaviour, flaky
 
 import hypothesis.extra.numpy as nps
 import hypothesis.strategies as st
@@ -31,6 +29,8 @@ from hypothesis import assume, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import binary_type, text_type
 from hypothesis.searchstrategy import SearchStrategy
+from tests.common.debug import find_any, minimal
+from tests.common.utils import checks_deprecated_behaviour, flaky
 
 STANDARD_TYPES = list(
     map(

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -21,6 +21,9 @@ import sys
 
 import numpy as np
 import pytest
+import six
+from tests.common.debug import find_any, minimal
+from tests.common.utils import checks_deprecated_behaviour, flaky
 
 import hypothesis.extra.numpy as nps
 import hypothesis.strategies as st
@@ -28,8 +31,6 @@ from hypothesis import assume, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import binary_type, text_type
 from hypothesis.searchstrategy import SearchStrategy
-from tests.common.debug import find_any, minimal
-from tests.common.utils import checks_deprecated_behaviour, flaky
 
 STANDARD_TYPES = list(
     map(
@@ -87,6 +88,15 @@ def test_can_handle_zero_dimensions(x):
 @given(nps.arrays(u"uint32", (5, 5)))
 def test_generates_unsigned_ints(x):
     assert (x >= 0).all()
+
+
+@given(st.data())
+def test_can_handle_long_shapes(data):
+    for tt in six.integer_types:
+        X = data.draw(nps.arrays(float, (tt(5),)))
+        assert X.shape == (5,)
+        X = data.draw(nps.arrays(float, (tt(5), tt(5))))
+        assert X.shape == (5, 5)
 
 
 @given(nps.arrays(int, (1,)))


### PR DESCRIPTION
Fixes bug in `hypothesis.extra.numpy.arrays` on Python2 where `long` type dimensions are not allowed in the shape.

See https://github.com/HypothesisWorks/hypothesis/pull/1784#discussion_r253251114.