### PR TITLE
Emit more information when triggering dtype bug

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch prints an explanatory note when :issue:`1798` is triggered,
+because the error message from Numpy is too terse to locate the problem.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -27,8 +27,8 @@ information to the contrary.
 4.5.4 - 2019-02-08
 ------------------
 
-Fixes bug in `hypothesis.extra.numpy.arrays` on Python2 where `long` type
-dimensions are not allowed in the shape.
+In Python 2, ``long`` integers are not allowed in the shape argument to
+:func:`~hypothesis.extra.numpy.arrays`.  Thanks to Ryan Turner for fixing this.
 
 .. _v4.5.3:
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -430,7 +430,20 @@ def defines_dtype_strategy(strat):
     @st.defines_strategy
     @proxies(strat)
     def inner(*args, **kwargs):
-        return strat(*args, **kwargs).map(np.dtype)
+        strategy = strat(*args, **kwargs)
+
+        def convert_to_dtype(x):
+            """Helper to debug issue #1798."""
+            try:
+                return np.dtype(x)
+            except ValueError:
+                print(
+                    "Got invalid dtype value=%r from strategy=%r, function=%r"
+                    % (x, strategy, strat)
+                )
+                raise
+
+        return strategy.map(convert_to_dtype)
 
     return inner
 


### PR DESCRIPTION
I spent a few hours tracing #1798 yesterday, and couldn't trigger it *or* see any code that I thought could cause it - but clearly it does happen!

This patch therefore inserts a `print()` call to show us the problematic value and strategy before re-raising the error, so we can get it next time :boot::bug:.