### PR TITLE
Fix occasional IndexError in shrinking

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release fixes an internal ``IndexError`` in Hypothesis that could sometimes be triggered during shrinking.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -805,6 +805,9 @@ class Shrinker(object):
             n = min(self.blocks[block].length, len(b))
             initial_attempt[v - n : v] = b[-n:]
 
+        if not blocks:
+            return False
+
         start = self.shrink_target.blocks[blocks[0]].start
         end = self.shrink_target.blocks[blocks[-1]].end
 

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1545,3 +1545,12 @@ def test_will_evict_entries_from_the_cache(monkeypatch):
     # calls will have been evicted, so each call to
     # cached_test_function will have to reexecute.
     assert count[0] == 30
+
+
+def test_try_shrinking_blocks_out_of_bounds():
+    @shrinking_from(hbytes([1]))
+    def shrinker(data):
+        data.draw_bits(1)
+        data.mark_interesting()
+
+    assert not shrinker.try_shrinking_blocks((1,), hbytes([1]))


### PR DESCRIPTION
Sometimes `blocks` will end up empty in `try_shrinking_blocks` and we'll get an `IndexError` as a result. Unfortunately I don't understand exactly *why* this happens, but I've seen it once in the wild.

There may be some deeper issue at play here, but I don't have time to debug it in depth right now, and it's fairly reasonable for `try_shrinking_blocks` to want to handle this correctly, so this PR just fixes the symptom rather than the root cause. 😞 