### PR TITLE
Limit generated emails to 254 characters

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes an off-by-one error in the maximum length of :func:`~hypothesis.strategies.emails`.
+Thanks to Krzysztof Jurewicz for :pull:`1812`.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -2161,5 +2161,5 @@ def emails():
     local_part = text(local_chars, min_size=1, max_size=64)
     # TODO: include dot-atoms, quoted strings, escaped chars, etc in local part
     return builds(u"{}@{}".format, local_part, domains()).filter(
-        lambda addr: len(addr) <= 255
+        lambda addr: len(addr) <= 254
     )

--- a/hypothesis-python/tests/nocover/test_emails.py
+++ b/hypothesis-python/tests/nocover/test_emails.py
@@ -24,6 +24,7 @@ from hypothesis.strategies import emails
 @given(emails())
 def test_is_valid_email(address):
     local, at_, domain = address.rpartition("@")
+    assert len(address) <= 254
     assert at_ == "@"
     assert local
     assert domain


### PR DESCRIPTION
[RFC 5321](https://tools.ietf.org/html/rfc5321) states that “The maximum total length of a reverse-path or forward-path is 256 octets (including the punctuation and element separators).”, hence, as path has to contain two angle brackets, it limits email length to 254 characters.

See https://stackoverflow.com/a/574698 for more details.