### PR TITLE
Run data generation and test body with the same deterministic PRNG

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes :issue:`1813`, a bug introduced in :ref:`3.59.1 <v3.59.1>`,
+which caused :py:meth:`~hypothesis.strategies.random_module` to no longer affect the body of the test:
+Although Hypothesis would claim to be seeding the random module in fact tests would always run with a seed of zero.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -533,26 +533,24 @@ class StateForActualGivenExecution(object):
                 with BuildContext(data, is_final=is_final):
                     with deterministic_PRNG():
                         args, kwargs = data.draw(self.search_strategy)
-                    if expected_failure is not None:
-                        text_repr[0] = arg_string(test, args, kwargs)
+                        if expected_failure is not None:
+                            text_repr[0] = arg_string(test, args, kwargs)
 
-                    if print_example:
-                        example = "%s(%s)" % (
-                            test.__name__,
-                            arg_string(test, args, kwargs),
-                        )
-                        try:
-                            ast.parse(example)
-                        except SyntaxError:
-                            data.can_reproduce_example_from_repr = False
-                        report("Falsifying example: %s" % (example,))
-                    elif current_verbosity() >= Verbosity.verbose:
-                        report(
-                            lambda: "Trying example: %s(%s)"
-                            % (test.__name__, arg_string(test, args, kwargs))
-                        )
-
-                    with deterministic_PRNG():
+                        if print_example:
+                            example = "%s(%s)" % (
+                                test.__name__,
+                                arg_string(test, args, kwargs),
+                            )
+                            try:
+                                ast.parse(example)
+                            except SyntaxError:
+                                data.can_reproduce_example_from_repr = False
+                            report("Falsifying example: %s" % (example,))
+                        elif current_verbosity() >= Verbosity.verbose:
+                            report(
+                                lambda: "Trying example: %s(%s)"
+                                % (test.__name__, arg_string(test, args, kwargs))
+                            )
                         return test(*args, **kwargs)
 
         result = self.test_runner(data, run)

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -103,3 +103,12 @@ def test_registered_Random_is_seeded_by_random_module_strategy():
 
     entropy.RANDOMS_TO_MANAGE.remove(r)
     assert r not in entropy.RANDOMS_TO_MANAGE
+
+
+@given(st.random_module())
+def test_will_actually_use_the_random_seed(rnd):
+    a = random.randint(0, 100)
+    b = random.randint(0, 100)
+    random.seed(rnd.seed)
+    assert a == random.randint(0, 100)
+    assert b == random.randint(0, 100)


### PR DESCRIPTION
Fixes #1813, which was caused by restoring the random state before we ever ran the body of the test.