### PR TITLE
Return correct dtypes for zero dimensional arrays

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release changes some inconsistent behavior of :func:`~hypothesis.extra.numpy.arrays`
+from the Numpy extra when asked for an array of ``shape=()``.
+:func:`~hypothesis.extra.numpy.arrays` will now always return a Numpy
+:class:`~numpy:numpy.ndarray`, and the array will always be of the requested dtype.
+
+Thanks to Ryan Turner for this change.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -126,11 +126,7 @@ class ArrayStrategy(SearchStrategy):
     def __init__(self, element_strategy, shape, dtype, fill, unique):
         self.shape = tuple(shape)
         self.fill = fill
-        check_argument(
-            shape,
-            "Array shape must have at least one dimension, provided shape was {}",
-            shape,
-        )
+        assert shape, "Zero-dimensional array shape is special-cased in arrays()"
         check_argument(
             all(isinstance(s, integer_types) for s in shape),
             "Array shape must be integer in each dimension, provided shape was {}",
@@ -393,8 +389,7 @@ def arrays(
         shape = (shape,)
     shape = tuple(shape)
     if not shape:
-        if dtype.kind != u"O":
-            return draw(elements)
+        return np.full(shape=(), fill_value=draw(elements), dtype=dtype)
     fill = fill_for(elements=elements, unique=unique, fill=fill)
     return draw(ArrayStrategy(elements, shape, dtype, fill, unique))
 

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -41,7 +41,6 @@ def e(a, **kwargs):
         e(nps.array_shapes, min_side=0),
         e(nps.arrays, dtype=float, shape=(0.5,)),
         e(nps.arrays, dtype=object, shape=1),
-        e(nps.arrays, dtype=object, shape=(), elements=st.none()),
         e(nps.arrays, dtype=float, shape=1, fill=3),
         e(nps.byte_string_dtypes, min_len=-1),
         e(nps.byte_string_dtypes, min_len=2, max_len=1),

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -76,8 +76,9 @@ def test_produces_instances(t):
 
 
 @given(nps.arrays(float, ()))
-def test_empty_dimensions_are_scalars(x):
-    assert isinstance(x, np.dtype(float).type)
+def test_empty_dimensions_are_arrays(x):
+    assert isinstance(x, np.ndarray)
+    assert x.dtype.kind == u"f"
 
 
 @given(nps.arrays(float, (1, 0, 1)))
@@ -239,10 +240,43 @@ def test_can_specify_size_as_an_int(dt):
 
 
 @given(st.data())
-def test_can_draw_shapeless_from_scalars(data):
+def test_can_draw_arrays_from_scalars(data):
     dt = data.draw(nps.scalar_dtypes())
     result = data.draw(nps.arrays(dtype=dt, shape=()))
-    assert isinstance(result, dt.type)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == dt
+
+
+@given(st.data())
+def test_can_cast_for_scalars(data):
+    # Note: this only passes with castable datatypes, certain dtype
+    # combinations will result in an error if numpy is not able to cast them.
+    dt_elements = np.dtype(data.draw(st.sampled_from(["bool", "<i2", ">i2"])))
+    dt_desired = np.dtype(
+        data.draw(st.sampled_from(["<i2", ">i2", "float16", "float32", "float64"]))
+    )
+    result = data.draw(
+        nps.arrays(dtype=dt_desired, elements=nps.from_dtype(dt_elements), shape=())
+    )
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == dt_desired
+
+
+@given(st.data())
+def test_can_cast_for_arrays(data):
+    # Note: this only passes with castable datatypes, certain dtype
+    # combinations will result in an error if numpy is not able to cast them.
+    dt_elements = np.dtype(data.draw(st.sampled_from(["bool", "<i2", ">i2"])))
+    dt_desired = np.dtype(
+        data.draw(st.sampled_from(["<i2", ">i2", "float16", "float32", "float64"]))
+    )
+    result = data.draw(
+        nps.arrays(
+            dtype=dt_desired, elements=nps.from_dtype(dt_elements), shape=(1, 2, 3)
+        )
+    )
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == dt_desired
 
 
 @given(st.data())


### PR DESCRIPTION
Fixes bug in `hypothesis.extra.numpy.arrays` where the desired data type is not always returned when a scalar array is requested. This change also ensures that a numpy `ndarray` is always returned from the `arrays` strategy. See discussion in pull request #1784.  For example,
```
>>> S=arrays('int32',(),elements=booleans())
>>> x=S.example()
>>> x
True
```
and
```
>>> S=arrays('>i2',())
>>> x=S.example()
>>> x
-31543
>>> x.dtype
dtype('int16')
>>> x.dtype == '>i2'
False
```