### PR TITLE
Minor docs updates about our dependencies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This is a docs-only patch, noting that because :pypi:`Lark` is under active
+development at version 0.x, ``hypothesis[lark]`` APIs may break in minor
+releases if necessary to keep up with the upstream package.

--- a/hypothesis-python/docs/community.rst
+++ b/hypothesis-python/docs/community.rst
@@ -4,14 +4,14 @@ Community
 
 The Hypothesis community is small for the moment but is full of excellent people
 who can answer your questions and help you out. Please do join us.
-
 The two major places for community discussion are:
 
 * `The mailing list <https://groups.google.com/forum/#!forum/hypothesis-users>`_.
 * An IRC channel, #hypothesis on freenode, which is more active than the mailing list.
 
 Feel free to use these to ask for help, provide feedback, or discuss anything remotely
-Hypothesis related at all.
+Hypothesis related at all.  If you post a question on StackOverflow, please use the
+`python-hypothesis <https://stackoverflow.com/questions/tagged/python-hypothesis>`__ tag!
 
 Please note that `the Hypothesis code of conduct <https://github.com/HypothesisWorks/hypothesis/blob/master/CODE_OF_CONDUCT.rst>`_
 applies in all Hypothesis community spaces.

--- a/hypothesis-python/docs/extras.rst
+++ b/hypothesis-python/docs/extras.rst
@@ -1,10 +1,12 @@
-===================
-Additional packages
-===================
+======================
+First-party extensions
+======================
 
-Hypothesis itself does not have any dependencies, but there are some packages that
-need additional things installed in order to work.
+Hypothesis has minimal dependencies (just :pypi:`attrs`), to maximise
+compatibility and make installing Hypothesis as easy as possible.
 
+Our integrations with specific packages are therefore provided by ``extra``
+modules that need their individual dependencies installed in order to work.
 You can install these dependencies using the setuptools extra feature as e.g.
 ``pip install hypothesis[django]``. This will check installation of compatible versions.
 

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -29,6 +29,11 @@ Lark already `supports loading grammars
 <https://github.com/lark-parser/lark#how-to-use-nearley-grammars-in-lark>`_
 from `nearley.js <https://nearley.js.org/>`_, so you may not have to write
 your own at all.
+
+Note that as Lark is at version 0.x, this module *may* break API compatibility
+in minor releases if supporting the latest version of Lark would otherwise be
+infeasible.  We may also be quite aggressive in bumping the minimum version of
+Lark, unless someone volunteers to either fund or do the maintainence.
 """
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
- we have [a StackOverflow tag](https://stackoverflow.com/questions/tagged/python-hypothesis)
- we do in fact depend on `attrs`, but it's still worth having extras packages
- Lark is still at 0.x, so our integration may break API if needed to support latest upstream