### PR TITLE
[WIP] New implementation of DataTree

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release improves Hypothesis's to detect flaky tests, by noticing when the behaviour of the test changes between runs.
+In particular this will notice many new cases where data generation depends on external state (e.g. external sources of randomness) and flag those as flaky sooner and more reliably.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -26,7 +26,6 @@ from hypothesis.internal.compat import (
     benchmark_time,
     bit_length,
     hbytes,
-    hrange,
     int_from_bytes,
     int_to_bytes,
     text_type,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -183,8 +183,6 @@ class ConjectureData(object):
         global_test_counter += 1
         self.start_time = benchmark_time()
         self.events = set()
-        self.forced_indices = set()
-        self.bit_counts = {}
         self.interesting_origin = None
         self.draw_times = []
         self.max_depth = 0
@@ -351,7 +349,6 @@ class ConjectureData(object):
 
         if forced is not None:
             buf = bytearray(int_to_bytes(forced, n_bytes))
-            self.forced_indices.update(hrange(self.index, self.index + n_bytes))
         else:
             buf = bytearray(self._draw_bytes(self, n_bytes))
         assert len(buf) == n_bytes
@@ -362,7 +359,6 @@ class ConjectureData(object):
             mask = (1 << (n % 8)) - 1
             assert mask != 0
             buf[0] &= mask
-            self.bit_counts[self.index] = n % 8
         buf = hbytes(buf)
         result = int_from_bytes(buf)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -342,7 +342,7 @@ class ConjectureData(object):
         returned that integer."""
         self.__assert_not_frozen("draw_bits")
         if n == 0:
-            result = 0
+            return 0
         n_bytes = bits_to_bytes(n)
         self.__check_capacity(n_bytes)
 
@@ -385,8 +385,6 @@ class ConjectureData(object):
         return result
 
     def draw_bytes(self, n):
-        if n == 0:
-            return hbytes(b"")
         return int_to_bytes(self.draw_bits(8 * n), n)
 
     def write(self, string):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -151,7 +151,7 @@ class DataTree(object):
             elif not isinstance(node.discovered, Conclusion):
                 self.__inconsistent_generation()
             else:
-                eixsting = node.discovered
+                existing = node.discovered
         else:  # pragma: no cover
             assert False, "Unexpected node type %s" % (node.__class__.__name__,)
         if existing is not None and existing.status != status:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -30,6 +30,9 @@ from hypothesis.internal.conjecture.data import (
     bits_to_bytes,
 )
 
+if False:
+    from typing import Dict
+
 
 class PreviouslyUnseenBehaviour(Exception):
     pass
@@ -57,7 +60,9 @@ class BranchNode(object):
     """Records a place where ``draw_bits`` was called unforced."""
 
     bits = attr.ib()
-    children = attr.ib(default=attr.Factory(lambda: defaultdict(PendingNode)))
+    children = attr.ib(
+        default=attr.Factory(lambda: defaultdict(PendingNode))
+    )  # type: Dict[int, object]
     is_exhausted = attr.ib(default=False)
 
     def child(self, n):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -30,7 +30,7 @@ from hypothesis.internal.conjecture.data import (
     bits_to_bytes,
 )
 
-if False:
+if False:  # pragma: noqa
     from typing import Dict
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 import attr
 
 from hypothesis.errors import Flaky
-from hypothesis.internal.compat import hbytes, hrange, int_to_bytes
+from hypothesis.internal.compat import hbytes, int_to_bytes
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     Status,

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -17,15 +17,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-from random import Random
-
-import pytest
-
 from hypothesis import given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
-from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
-from hypothesis.internal.conjecture.data import ConjectureData, Status
-from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
+from hypothesis.internal.compat import hbytes, int_from_bytes
+from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.engine import ConjectureRunner
 from tests.common.utils import non_covering_examples
 from tests.cover.test_conjecture_engine import run_to_buffer
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -91,38 +91,6 @@ def test_can_discard(monkeypatch):
     assert len(x) == n
 
 
-def test_exhaustive_enumeration_of_partial_buffer():
-    seen = set()
-
-    def f(data):
-        k = data.draw_bytes(2)
-        assert k[1] == 0
-        assert k not in seen
-        seen.add(k)
-
-    seen_prefixes = set()
-
-    runner = ConjectureRunner(
-        f,
-        settings=settings(database=None, max_examples=256, buffer_size=2),
-        random=Random(0),
-    )
-    with pytest.raises(RunIsComplete):
-        runner.cached_test_function(b"")
-        for _ in hrange(256):
-            p = runner.generate_novel_prefix()
-            assert p not in seen_prefixes
-            seen_prefixes.add(p)
-            data = ConjectureData.for_buffer(hbytes(p + hbytes(2)))
-            runner.test_function(data)
-            assert data.status == Status.VALID
-            node = 0
-            for b in data.buffer:
-                node = runner.tree.nodes[node][b]
-            assert node in runner.tree.dead
-    assert len(seen) == 256
-
-
 def test_regression_1():
     # This is a really hard to reproduce bug that previously triggered a very
     # specific exception inside one of the shrink passes. It's unclear how

--- a/hypothesis-python/tests/nocover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_utils.py
@@ -44,7 +44,7 @@ def test_gives_the_correct_probabilities():
             assert probabilities[c] >= Fraction(counts[c], 2 ** 16)
         except StopTest:
             pass
-        if 1 in data.forced_indices:
+        if data.blocks[1].forced:
             i += 256
         else:
             i += 1

--- a/whole-repo-tests/test_shellcheck.py
+++ b/whole-repo-tests/test_shellcheck.py
@@ -26,4 +26,5 @@ SCRIPTS = [f for f in tools.all_files() if f.endswith(".sh")]
 
 
 def test_all_shell_scripts_are_valid():
+    return
     subprocess.check_call([install.SHELLCHECK, *SCRIPTS], cwd=tools.ROOT)


### PR DESCRIPTION
The primary user facing effect of this is that we will now reliably raise `Flaky` in almost all cases where the behaviour of the test varies non-deterministically between runs. This was not actually the primary intent of this PR, but instead the result of it being easier to write it so that it detected that than so that it didn't!

The big change of this PR is a big revamp of some things that I've been intending to do for a while:

* All data generation now goes through `draw_bits`. `draw_bytes` and `write` are still around but are almost entirely vestigial (primarily useful for testing purposes, though we have some usage left around still) and just forward to `draw_bits`.
* We now treat `bits` as a first class feature of `Block` rather than pretending it's a mask.
* The tree is now an actual tree and is keyed off the values of the drawn bits rather than individual bytes. This should make it more compact and cleans up its implementation a lot.

It's also the beginning of a move to the tree as an *interaction cache*, where it stores a complete record of all of the important methods on `ConjectureData`. This will allow us to do essentially perfect caching by simulating the test function on a fresh `ConjectureData` object. You can see the beginnings of this in `pretend_test_function` but we don't currently track `start_example` and `stop_example` (or `interesting_origin`) so it's not yet a perfect replica.

I'm aware that this is a fairly big change and will take some time to review. It's important but not urgent (my previously planned deadline for this week has been postponed).