### PR TITLE
Use a dedicated TestResult object instead of keeping ConjectureData around

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release refactors the internal representation of previously run test cases.
+The main thing you should see as a result is that Hypothesis becomes somewhat less memory hungry.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -612,11 +612,12 @@ class StateForActualGivenExecution(object):
                 raise StopTest(data.testcounter)
             else:
                 tb = get_trimmed_traceback()
-                data.__expected_traceback = "".join(
+                info = data.extra_information
+                info.__expected_traceback = "".join(
                     traceback.format_exception(type(e), e, tb)
                 )
-                data.__expected_exception = e
-                verbose_report(data.__expected_traceback)
+                info.__expected_exception = e
+                verbose_report(info.__expected_traceback)
 
                 origin = traceback.extract_tb(tb)[-1]
                 filename = origin[0]
@@ -667,17 +668,19 @@ class StateForActualGivenExecution(object):
         flaky = 0
 
         for falsifying_example in self.falsifying_examples:
+            info = falsifying_example.extra_information
+
             ran_example = ConjectureData.for_buffer(falsifying_example.buffer)
             self.__was_flaky = False
-            assert falsifying_example.__expected_exception is not None
+            assert info.__expected_exception is not None
             try:
                 self.execute(
                     ran_example,
                     print_example=True,
                     is_final=True,
                     expected_failure=(
-                        falsifying_example.__expected_exception,
-                        falsifying_example.__expected_traceback,
+                        info.__expected_exception,
+                        info.__expected_traceback,
                     ),
                 )
             except (UnsatisfiedAssumption, StopTest):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -118,7 +118,8 @@ class DataTree(object):
                 break
 
         # At each node that begins a block, record the size of that block.
-        for u, v in data.all_block_bounds():
+        for b in data.blocks:
+            u, v = b.bounds
             # This can happen if we hit a dead node when walking the buffer.
             # In that case we already have this section of the tree mapped.
             if u >= len(indices):

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -109,7 +109,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
 
     assert len(ConjectureData.for_buffer(data.buffer).draw(strat)) == size
 
-    starts = data.block_starts[2]
+    starts = [b.start for b in data.blocks if b.length == 2]
     assert len(starts) % 2 == 0
 
     for i in hrange(0, len(starts), 2):


### PR DESCRIPTION
The main motivation for doing this was memory usage, but I think it actually makes the API much cleaner to have a logical distinction between its data and its result, and it's something I've vaguely felt I should do for a while but never got around to.