### PR TITLE
Save index rather than recalculating it each time we use it

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release is a trivial micro-optimisation inside Hypothesis which should result in it using significantly less memory.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -170,6 +170,7 @@ class ConjectureData(object):
         self.block_starts = {}
         self.blocks = []
         self.buffer = bytearray()
+        self.index = 0
         self.output = u""
         self.status = Status.VALID
         self.frozen = False
@@ -207,10 +208,6 @@ class ConjectureData(object):
         # We always have a single example wrapping everything. We want to treat
         # that as depth 0 rather than depth 1.
         return len(self.example_stack) - 1
-
-    @property
-    def index(self):
-        return len(self.buffer)
 
     def all_block_bounds(self):
         return [block.bounds for block in self.blocks]
@@ -307,6 +304,7 @@ class ConjectureData(object):
             assert isinstance(self.buffer, hbytes)
             return
         self.finish_time = benchmark_time()
+        assert len(self.buffer) == self.index
 
         while self.example_stack:
             self.stop_example()
@@ -387,6 +385,7 @@ class ConjectureData(object):
         assert len(result) == n
         assert self.index == initial
         self.buffer.extend(result)
+        self.index = len(self.buffer)
         self.stop_example()
 
     def draw_bytes(self, n):


### PR DESCRIPTION
OK, this looks like a ridiculously pointless little micro-optimisation that can't *possibly* help anything.

Instead it's a ridiculous little micro-optimisation that helps a really annoying amount. It doesn't help *speed* much because we're doing too many slow things right now so this is lost in the noise, but what it helps a lot is memory usage. The problem is that unless our buffers are short enough to fit in the small integer cache, we're allocating a new integer object each time index is called. These end up as the endpoints for examples and buffers, so we end up keeping many copies of the same integer object spread all around the place. This adds up surprisingly rapidly in my (admittedly fairly imprecise) benchmarking.

(As it happens I have plans that will make us want to be able to vary the index independently of the buffer length so would have wanted to do this eventually anyway, but that's neither here nor there)