### PR TITLE
Compute examples lazily on demand

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release refactors the internal representation of previously run test cases.
+The main thing you should see as a result is that Hypothesis becomes somewhat less memory hungry.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-This release refactors the internal representation of previously run test cases.
-The main thing you should see as a result is that Hypothesis becomes somewhat less memory hungry.
+This release changes Hypothesis's internal representation of a test case to calculate some expensive structural information on demand rather than eagerly.
+This should reduce memory usage a fair bit, and may make generation somewhat faster.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -612,11 +612,12 @@ class StateForActualGivenExecution(object):
                 raise StopTest(data.testcounter)
             else:
                 tb = get_trimmed_traceback()
-                data.__expected_traceback = "".join(
+                info = data.extra_information
+                info.__expected_traceback = "".join(
                     traceback.format_exception(type(e), e, tb)
                 )
-                data.__expected_exception = e
-                verbose_report(data.__expected_traceback)
+                info.__expected_exception = e
+                verbose_report(info.__expected_traceback)
 
                 origin = traceback.extract_tb(tb)[-1]
                 filename = origin[0]
@@ -667,17 +668,19 @@ class StateForActualGivenExecution(object):
         flaky = 0
 
         for falsifying_example in self.falsifying_examples:
+            info = falsifying_example.extra_information
+
             ran_example = ConjectureData.for_buffer(falsifying_example.buffer)
             self.__was_flaky = False
-            assert falsifying_example.__expected_exception is not None
+            assert info.__expected_exception is not None
             try:
                 self.execute(
                     ran_example,
                     print_example=True,
                     is_final=True,
                     expected_failure=(
-                        falsifying_example.__expected_exception,
-                        falsifying_example.__expected_traceback,
+                        info.__expected_exception,
+                        info.__expected_traceback,
                     ),
                 )
             except (UnsatisfiedAssumption, StopTest):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -118,7 +118,8 @@ class DataTree(object):
                 break
 
         # At each node that begins a block, record the size of that block.
-        for u, v in data.all_block_bounds():
+        for b in data.blocks:
+            u, v = b.bounds
             # This can happen if we hit a dead node when walking the buffer.
             # In that case we already have this section of the tree mapped.
             if u >= len(indices):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -902,14 +902,19 @@ class Shrinker(object):
         returns False if there is discarded data and removing it does not work,
         otherwise returns True.
         """
-        while self.shrink_target.has_discards:
+        while True:
             discarded = []
 
             for ex in self.shrink_target.examples:
-                if ex.discarded and (not discarded or ex.start >= discarded[-1][-1]):
+                if (
+                    ex.length > 0
+                    and ex.discarded
+                    and (not discarded or ex.start >= discarded[-1][-1])
+                ):
                     discarded.append((ex.start, ex.end))
 
-            assert discarded
+            if not discarded:
+                break
 
             attempt = bytearray(self.shrink_target.buffer)
             for u, v in reversed(discarded):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -831,7 +831,7 @@ def test_discarding_can_fail(monkeypatch):
         data.mark_interesting()
 
     shrinker.remove_discarded()
-    assert shrinker.shrink_target.has_discards
+    assert any(e.discarded and e.length > 0 for e in shrinker.shrink_target.examples)
 
 
 @pytest.mark.parametrize("bits", [3, 9])

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -117,14 +117,6 @@ def test_does_not_double_freeze_in_interval_close():
     assert not any(eg.end is None for eg in x.examples)
 
 
-def test_empty_discards_do_not_count():
-    x = ConjectureData.for_buffer(b"")
-    x.start_example(label=1)
-    x.stop_example(discard=True)
-    x.freeze()
-    assert not x.has_discards
-
-
 def test_triviality():
     d = ConjectureData.for_buffer([1, 0, 1])
 
@@ -159,3 +151,24 @@ def test_example_depth_marking():
 
     depths = set((ex.length, ex.depth) for ex in d.examples)
     assert depths == set([(2, 1), (3, 2), (6, 2), (9, 1), (12, 1), (23, 0)])
+
+
+def test_has_examples_even_when_empty():
+    d = ConjectureData.for_buffer(hbytes())
+    d.draw(st.just(False))
+    d.freeze()
+    assert d.examples
+
+
+def test_has_cached_examples_even_when_overrun():
+    d = ConjectureData.for_buffer(hbytes(1))
+    d.start_example(3)
+    d.draw_bits(1)
+    d.stop_example()
+    try:
+        d.draw_bits(1)
+    except StopTest:
+        pass
+    assert d.status == Status.OVERRUN
+    assert any(ex.label == 3 and ex.length == 1 for ex in d.examples)
+    assert d.examples is d.examples

--- a/hypothesis-python/tests/py3/test_traceback_elision.py
+++ b/hypothesis-python/tests/py3/test_traceback_elision.py
@@ -30,11 +30,11 @@ def test_tracebacks_omit_hypothesis_internals(verbosity):
     @settings(verbosity=verbosity)
     @given(st.just(False))
     def simplest_failure(x):
-        assert x
+        raise ValueError()
 
     try:
         simplest_failure()
-    except AssertionError as e:
+    except ValueError as e:
         tb = traceback.extract_tb(e.__traceback__)
         # Unless in debug mode, Hypothesis adds 1 frame - the least possible!
         # (4 frames: this one, simplest_failure, internal frame, assert False)

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -109,7 +109,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
 
     assert len(ConjectureData.for_buffer(data.buffer).draw(strat)) == size
 
-    starts = data.block_starts[2]
+    starts = [b.start for b in data.blocks if b.length == 2]
     assert len(starts) % 2 == 0
 
     for i in hrange(0, len(starts), 2):


### PR DESCRIPTION
Note: Builds on top of #1820. Can be reviewed independently of that to some degree but will make more sense once that lands.

This changes the way we calculate the examples list to happen lazily on first usage. The reasoning for this is: 

* it's a *huge* memory saving. These example trees are by far the biggest part of our memory profile during shrinking, and most of the time we don't need them (most of the time we need them *for the current shrink target*, but if most shrinks fail then we will rarely need the resulting Example object).
* I haven't benchmarked it but I expect not allocating a giant tonne of data on the hot path will speed up generation a fair bit. The amount of actual book-keeping done also goes down a bit.
* Tracking the exact locations of start and stop examples will help making our caching of `ConjectureResult` objects perfect again by allowing us to recreate the actual example (we could have always reverse engineered these from the `Example` objects, but that feels a bit ass-backwards).