### PR TITLE
Commonize API on draw_bits

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release is a purely internal refactoring of Hypothesis's API for representing test cases.
+There should be no user visible effect.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -28,6 +28,7 @@ from hypothesis.internal.compat import (
     hbytes,
     hrange,
     int_from_bytes,
+    int_to_bytes,
     text_type,
     unicode_safe_repr,
 )
@@ -275,7 +276,6 @@ class ConjectureData(object):
         self.max_length = max_length
         self.is_find = False
         self._draw_bytes = draw_bytes
-        self.overdraw = 0
         self.block_starts = {}
         self.blocks = []
         self.buffer = bytearray()
@@ -437,84 +437,95 @@ class ConjectureData(object):
         self.events = frozenset(self.events)
         del self._draw_bytes
 
-    def draw_bits(self, n):
+    def draw_bits(self, n, forced=None):
+        """Return an ``n``-bit integer from the underlying source of
+        bytes. If ``forced`` is set to an integer will instead
+        ignore the underlying source and simulate a draw as if it had
+        returned that integer."""
         self.__assert_not_frozen("draw_bits")
         if n == 0:
-            result = 0
-        elif n % 8 == 0:
-            return int_from_bytes(self.draw_bytes(n // 8))
+            return 0
+        assert n > 0
+        n_bytes = bits_to_bytes(n)
+        self.__check_capacity(n_bytes)
+
+        if forced is not None:
+            buf = bytearray(int_to_bytes(forced, n_bytes))
         else:
-            n_bytes = (n // 8) + 1
-            self.__check_capacity(n_bytes)
             buf = bytearray(self._draw_bytes(self, n_bytes))
-            assert len(buf) == n_bytes
+        assert len(buf) == n_bytes
+
+        # If we have a number of bits that is not a multiple of 8
+        # we have to mask off the high bits.
+        if n % 8 != 0:
             mask = (1 << (n % 8)) - 1
+            assert mask != 0
             buf[0] &= mask
             self.masked_indices[self.index] = mask
-            buf = hbytes(buf)
-            self.__write(buf)
-            result = int_from_bytes(buf)
+        buf = hbytes(buf)
+        result = int_from_bytes(buf)
+
+        self.start_example(DRAW_BYTES_LABEL)
+        initial = self.index
+
+        block = Block(
+            start=initial,
+            end=initial + n_bytes,
+            index=len(self.blocks),
+            forced=forced is not None,
+            all_zero=result == 0,
+        )
+
+        if block.forced:
+            self.forced_indices.update(hrange(block.start, block.end))
+        self.block_starts.setdefault(n_bytes, []).append(block.start)
+        self.blocks.append(block)
+        assert self.blocks[block.index] is block
+        assert self.index == initial
+        self.buffer.extend(buf)
+        self.index = len(self.buffer)
+        self.stop_example()
 
         assert bit_length(result) <= n
         return result
 
+    def draw_bytes(self, n):
+        """Draw n bytes from the underlying source."""
+        return int_to_bytes(self.draw_bits(8 * n), n)
+
     def write(self, string):
-        string = hbytes(string)
+        """Write ``string`` to the output buffer."""
         self.__assert_not_frozen("write")
-        self.__check_capacity(len(string))
-        original = self.index
-        self.__write(string, forced=True)
-        self.forced_indices.update(hrange(original, self.index))
-        return string
+        string = hbytes(string)
+        if not string:
+            return
+        self.draw_bits(len(string) * 8, forced=int_from_bytes(string))
+        return self.buffer[-len(string) :]
 
     def __check_capacity(self, n):
         if self.index + n > self.max_length:
-            self.overdraw = self.index + n - self.max_length
-            self.status = Status.OVERRUN
-            self.freeze()
-            raise StopTest(self.testcounter)
+            self.mark_overrun()
 
-    def __write(self, result, forced=False):
-        self.start_example(DRAW_BYTES_LABEL)
-        initial = self.index
-        n = len(result)
-
-        block = Block(
-            start=initial,
-            end=initial + n,
-            index=len(self.blocks),
-            forced=forced,
-            all_zero=not any(result),
-        )
-
-        self.block_starts.setdefault(n, []).append(block.start)
-        self.blocks.append(block)
-        assert self.blocks[block.index] is block
-        assert len(result) == n
-        assert self.index == initial
-        self.buffer.extend(result)
-        self.index = len(self.buffer)
-        self.stop_example()
-
-    def draw_bytes(self, n):
-        self.__assert_not_frozen("draw_bytes")
-        if n == 0:
-            return hbytes(b"")
-        self.__check_capacity(n)
-        result = self._draw_bytes(self, n)
-        assert len(result) == n
-        self.__write(result)
-        return hbytes(result)
+    def conclude_test(self, status, interesting_origin=None):
+        assert (interesting_origin is None) or (status == Status.INTERESTING)
+        self.__assert_not_frozen("conclude_test")
+        self.interesting_origin = interesting_origin
+        self.status = status
+        self.freeze()
+        raise StopTest(self.testcounter)
 
     def mark_interesting(self, interesting_origin=None):
-        self.__assert_not_frozen("mark_interesting")
-        self.interesting_origin = interesting_origin
-        self.status = Status.INTERESTING
-        self.freeze()
-        raise StopTest(self.testcounter)
+        self.conclude_test(Status.INTERESTING, interesting_origin)
 
     def mark_invalid(self):
-        self.__assert_not_frozen("mark_invalid")
-        self.status = Status.INVALID
-        self.freeze()
-        raise StopTest(self.testcounter)
+        self.conclude_test(Status.INVALID)
+
+    def mark_overrun(self):
+        self.conclude_test(Status.OVERRUN)
+
+
+def bits_to_bytes(n):
+    n_bytes = n // 8
+    if n % 8 != 0:
+        n_bytes += 1
+    return n_bytes

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -421,6 +421,7 @@ class ConjectureRunner(object):
             choices = data.block_starts.get(n, [])
             if choices:
                 i = self.random.choice(choices)
+                assert i + n <= len(data.buffer)
                 return hbytes(data.buffer[i : i + n])
             else:
                 result = uniform(self.random, n)
@@ -480,11 +481,13 @@ class ConjectureRunner(object):
             if data.index + n > len(target_data[0].buffer):
                 result = uniform(self.random, n)
             else:
-                result = self.random.choice(bits)(data, n)
+                draw = self.random.choice(bits)
+                result = draw(data, n)
             p = prefix[0]
             if data.index < len(p):
                 start = p[data.index : data.index + n]
                 result = start + result[len(start) :]
+            assert len(result) == n
             return self.__zero_bound(data, result)
 
         return mutate_from

--- a/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import, division, print_function
 
 from array import array
 
-from hypothesis.internal.compat import hbytes, hrange, int_to_bytes
+from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.floats import float_to_int, int_to_float
 
@@ -246,6 +246,6 @@ def draw_float(data):
 
 
 def write_float(data, f):
-    data.write(int_to_bytes(float_to_lex(abs(f)), 8))
+    data.draw_bits(64, forced=float_to_lex(abs(f)))
     sign = float_to_int(f) >> 63
-    data.write(hbytes([sign]))
+    data.draw_bits(1, forced=sign)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -154,12 +154,25 @@ def choice(data, values):
     return values[integer_range(data, 0, len(values) - 1)]
 
 
+def getrandbits(data, n):
+    # This method is equivalent to data.draw_bits(n) except that it fails
+    # to set the mask. This method should die but is currently maintaining
+    # bugwards compatibility with some oddities of behaviour that we've
+    # not yet fully debugged. See
+    # https://github.com/HypothesisWorks/hypothesis/issues/1827
+    # for details.
+    n_bytes = n // 8
+    if n % 8 != 0:
+        n_bytes += 1
+    return data.draw_bits(n_bytes * 8) & ((1 << n) - 1)
+
+
 FLOAT_PREFIX = 0b1111111111 << 52
 FULL_FLOAT = int_to_float(FLOAT_PREFIX | ((2 << 53) - 1)) - 1
 
 
 def fractional_float(data):
-    return (int_to_float(FLOAT_PREFIX | data.draw_bits(52)) - 1) / FULL_FLOAT
+    return (int_to_float(FLOAT_PREFIX | getrandbits(data, 52)) - 1) / FULL_FLOAT
 
 
 def boolean(data):

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -172,3 +172,13 @@ def test_has_cached_examples_even_when_overrun():
     assert d.status == Status.OVERRUN
     assert any(ex.label == 3 and ex.length == 1 for ex in d.examples)
     assert d.examples is d.examples
+
+
+def test_can_write_empty_string():
+    d = ConjectureData.for_buffer([1, 1, 1])
+    d.draw_bits(1)
+    d.write(hbytes())
+    d.draw_bits(1)
+    d.draw_bits(0, forced=0)
+    d.draw_bits(1)
+    assert d.buffer == hbytes([1, 1, 1])

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -26,6 +26,7 @@ from hypothesis import HealthCheck, assume, example, given, settings
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
+from tests.cover.test_conjecture_engine import run_to_buffer
 
 
 def test_does_draw_data_for_empty_range():
@@ -146,3 +147,12 @@ def test_sampler_distribution(weights):
         calculated[base] += (1 - p_alternate) / n
         calculated[alternate] += p_alternate / n
     assert probabilities == calculated
+
+
+def test_get_randbits_can_set_high_bit():
+    @run_to_buffer
+    def x(data):
+        if cu.getrandbits(data, 8) >> 7:
+            data.mark_interesting()
+
+    assert x == hbytes([1 << 7])

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -88,20 +88,6 @@ def test_unbiased_coin_has_no_second_order():
     assert counts[False] == counts[True] > 0
 
 
-def test_can_get_odd_number_of_bits():
-    counts = Counter()
-    for i in range(256):
-        x = cu.getrandbits(ConjectureData.for_buffer([i]), 3)
-        assert 0 <= x <= 7
-        counts[x] += 1
-    assert len(set(counts.values())) == 1
-
-
-def test_8_bits_just_reads_stream():
-    for i in range(256):
-        assert cu.getrandbits(ConjectureData.for_buffer([i]), 8) == i
-
-
 def test_drawing_certain_coin_still_writes():
     data = ConjectureData.for_buffer([0, 1])
     assert not data.buffer


### PR DESCRIPTION
This pulls out most of the `ConjectureData` changes from #1819 - `draw_bits` is now the central API of `ConjectureData` and `draw_bytes` and `write` are now just specialised calls to it.

`draw_bytes` and `write` are now *mostly* vestigial. There's a fair bit of usage of them in the test suite, and one remaining use of `draw_bytes` in the main code base that is I think legitimate (it's literally for a strategy for drawing fixed size blocks of bytes).