### PR TITLE
Compute examples lazily on demand

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release changes Hypothesis's internal representation of a test case to calculate some expensive structural information on demand rather than eagerly.
+This should reduce memory usage a fair bit, and may make generation somewhat faster.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -423,7 +423,7 @@ class ConjectureData(object):
         assert len(self.buffer) == self.index
 
         # Always finish by closing all remaining examples so that we have a
-        # valid tree..
+        # valid tree.
         while self.depth >= 0:
             self.stop_example()
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -902,14 +902,19 @@ class Shrinker(object):
         returns False if there is discarded data and removing it does not work,
         otherwise returns True.
         """
-        while self.shrink_target.has_discards:
+        while True:
             discarded = []
 
             for ex in self.shrink_target.examples:
-                if ex.discarded and (not discarded or ex.start >= discarded[-1][-1]):
+                if (
+                    ex.length > 0
+                    and ex.discarded
+                    and (not discarded or ex.start >= discarded[-1][-1])
+                ):
                     discarded.append((ex.start, ex.end))
 
-            assert discarded
+            if not discarded:
+                break
 
             attempt = bytearray(self.shrink_target.buffer)
             for u, v in reversed(discarded):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -831,7 +831,7 @@ def test_discarding_can_fail(monkeypatch):
         data.mark_interesting()
 
     shrinker.remove_discarded()
-    assert shrinker.shrink_target.has_discards
+    assert any(e.discarded and e.length > 0 for e in shrinker.shrink_target.examples)
 
 
 @pytest.mark.parametrize("bits", [3, 9])

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -117,14 +117,6 @@ def test_does_not_double_freeze_in_interval_close():
     assert not any(eg.end is None for eg in x.examples)
 
 
-def test_empty_discards_do_not_count():
-    x = ConjectureData.for_buffer(b"")
-    x.start_example(label=1)
-    x.stop_example(discard=True)
-    x.freeze()
-    assert not x.has_discards
-
-
 def test_triviality():
     d = ConjectureData.for_buffer([1, 0, 1])
 
@@ -159,3 +151,24 @@ def test_example_depth_marking():
 
     depths = set((ex.length, ex.depth) for ex in d.examples)
     assert depths == set([(2, 1), (3, 2), (6, 2), (9, 1), (12, 1), (23, 0)])
+
+
+def test_has_examples_even_when_empty():
+    d = ConjectureData.for_buffer(hbytes())
+    d.draw(st.just(False))
+    d.freeze()
+    assert d.examples
+
+
+def test_has_cached_examples_even_when_overrun():
+    d = ConjectureData.for_buffer(hbytes(1))
+    d.start_example(3)
+    d.draw_bits(1)
+    d.stop_example()
+    try:
+        d.draw_bits(1)
+    except StopTest:
+        pass
+    assert d.status == Status.OVERRUN
+    assert any(ex.label == 3 and ex.length == 1 for ex in d.examples)
+    assert d.examples is d.examples

--- a/hypothesis-python/tests/py3/test_traceback_elision.py
+++ b/hypothesis-python/tests/py3/test_traceback_elision.py
@@ -30,11 +30,11 @@ def test_tracebacks_omit_hypothesis_internals(verbosity):
     @settings(verbosity=verbosity)
     @given(st.just(False))
     def simplest_failure(x):
-        assert x
+        raise ValueError()
 
     try:
         simplest_failure()
-    except AssertionError as e:
+    except ValueError as e:
         tb = traceback.extract_tb(e.__traceback__)
         # Unless in debug mode, Hypothesis adds 1 frame - the least possible!
         # (4 frames: this one, simplest_failure, internal frame, assert False)


### PR DESCRIPTION
Note: This is just me reopening #1825 but I'm not allowed to reopen it and have to recreate it because the branch has been force pushed. 🙄 I decided that the clever solution I was going to implement needs more thought and I'll take the big win now even without the longer term cleverness.

This changes the way we calculate the examples list to happen lazily on first usage. The reasoning for this is:

* it's a _huge_ memory saving. These example trees are by far the biggest part of our memory profile during shrinking, and most of the time we don't need them (most of the time we need them _for the current shrink target_, but if most shrinks fail then we will rarely need the resulting Example object).
* I haven't benchmarked it but I expect not allocating a giant tonne of data on the hot path will speed up generation a fair bit. The amount of actual book-keeping done also goes down a bit.
* Tracking the exact locations of start and stop examples will help making our caching of `ConjectureResult` objects perfect again by allowing us to recreate the actual example (we could have always reverse engineered these from the `Example` objects, but that feels a bit ass-backwards).