### PR TITLE
Also calculate blocks lazily

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release allows Hypothesis to calculate a number of attributes of generated test cases lazily.
+This should significantly reduce memory usage and modestly improve performance,
+especially for large test cases.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -598,3 +598,15 @@ except Exception:
     # Can't use ImportError, because of e.g. Django config errors
     def bad_django_TestCase(runner):
         return False
+
+
+if PY2:
+
+    def array_or_list(code, contents):
+        if code in ("q", "Q"):
+            return list(contents)
+        return array.array(code, contents)
+
+
+else:
+    array_or_list = array.array

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -201,6 +201,7 @@ class Blocks(object):
         whole ``ConjectureData`` around."""
         assert isinstance(new_owner, ConjectureResult)
         self.owner = new_owner
+        self.__check_completion()
 
     def start(self, i):
         """Equivalent to self[i].start."""
@@ -285,14 +286,21 @@ class Blocks(object):
             self.__blocks.extend([None] * (len(self) - len(self.__blocks)))
             self.__blocks[i] = result
 
-        # If this happens then we have now fully calculated every block
-        # and don't need to keep the reference to the owner around. We delete
-        # it here so that there is no circular reference to make the gc work
-        # harder.
-        if self.__count == len(self) and isinstance(self.owner, ConjectureResult):
-            self.owner = None
+        self.__check_completion()
 
         return result
+
+    def __check_completion(self):
+        """The list of blocks is complete if we have created every ``Block``
+        object that we currently good and know that no more will be created.
+
+        If this happens then we don't need to keep the reference to the
+        owner around, and delete it so that there is no circular reference.
+        The main benefit of this is that the gc doesn't need to run to collect
+        this because normal reference counting is enough.
+        """
+        if self.__count == len(self) and isinstance(self.owner, ConjectureResult):
+            self.owner = None
 
     def __iter__(self):
         for i in hrange(len(self)):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -261,7 +261,15 @@ class Blocks(object):
 
         start = self.start(i)
         end = self.__endpoints[i]
+
+        # We keep track of the number of blocks that have actually been
+        # instantiated so that when every block that could be instantiated
+        # has been we know that the list is complete and can throw away
+        # some data that we no longer need.
         self.__count += 1
+
+        # Integrity check: We can't have allocated more blocks than we have
+        # endpoints for blocks.
         assert self.__count <= len(self.__endpoints)
         result = Block(
             start=start,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -732,7 +732,7 @@ class ConjectureData(object):
 
 
 def bits_to_bytes(n):
-    n_bytes = n // 8
-    if n % 8 != 0:
-        n_bytes += 1
-    return n_bytes
+    """The number of bytes required to represent an n-bit number.
+    Equivalent to (n + 7) // 8, but slightly faster. This really is
+    called enough times that that matters."""
+    return (n + 7) >> 3

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -208,7 +208,7 @@ class Blocks(object):
         if i == 0:
             return 0
         else:
-            return self.__endpoints[i - 1]
+            return self.end(i - 1)
 
     def end(self, i):
         """Equivalent to self[i].end."""
@@ -260,7 +260,7 @@ class Blocks(object):
             assert self.__blocks[i] is None
 
         start = self.start(i)
-        end = self.__endpoints[i]
+        end = self.end(i)
 
         # We keep track of the number of blocks that have actually been
         # instantiated so that when every block that could be instantiated

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -17,7 +17,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from array import array
 from collections import defaultdict
 from enum import IntEnum
 
@@ -25,6 +24,7 @@ import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import (
+    array_or_list,
     benchmark_time,
     bit_length,
     hbytes,
@@ -175,7 +175,7 @@ def calc_bits_to_array_codes():
         trial_number = (1 << len(result)) - 1
         assert trial_number.bit_length() == len(result)
         try:
-            array(code, [trial_number])
+            array_or_list(code, [trial_number])
             result.append(code)
         except OverflowError:
             code = next(code_iter)
@@ -206,7 +206,7 @@ class Blocks(object):
 
     def __init__(self, owner):
         self.owner = owner
-        self.__endpoints = array("B", [])
+        self.__endpoints = array_or_list("B", [])
         self.__blocks = {}
         self.__count = 0
         self.__sparse = True
@@ -222,7 +222,7 @@ class Blocks(object):
         try:
             self.__endpoints.append(n)
         except OverflowError:
-            self.__endpoints = array(
+            self.__endpoints = array_or_list(
                 BIT_LENGTH_TO_ARRAY_CODES[n.bit_length()], self.__endpoints
             )
             self.__endpoints.append(n)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -192,7 +192,7 @@ class Blocks(object):
         self.__sparse = True
 
     def add_endpoint(self, n):
-        """Add n to the list of enpoints."""
+        """Add n to the list of endpoints."""
         assert isinstance(self.owner, ConjectureData)
         self.__endpoints.append(n)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -24,7 +24,6 @@ import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import (
-    array_or_list,
     benchmark_time,
     bit_length,
     hbytes,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -251,8 +251,8 @@ class Blocks(object):
         # actual result, but this isn't the best representation once we
         # stop being sparse and want to use most of the blocks. Switch
         # over to a list at that point.
-        if self.__sparse and len(self.__blocks) * 2 >= len(self.__endpoints):
-            new_blocks = [None] * len(self.__endpoints)
+        if self.__sparse and len(self.__blocks) * 2 >= len(self):
+            new_blocks = [None] * len(self)
             for k, v in self.__blocks.items():
                 new_blocks[k] = v
             self.__sparse = False
@@ -269,8 +269,8 @@ class Blocks(object):
         self.__count += 1
 
         # Integrity check: We can't have allocated more blocks than we have
-        # endpoints for blocks.
-        assert self.__count <= len(self.__endpoints)
+        # positions for blocks.
+        assert self.__count <= len(self)
         result = Block(
             start=start,
             end=end,
@@ -282,17 +282,15 @@ class Blocks(object):
             self.__blocks[i] = result
         except IndexError:
             assert isinstance(self.__blocks, list)
-            assert len(self.__blocks) < len(self.__endpoints)
-            self.__blocks.extend([None] * (len(self.__endpoints) - len(self.__blocks)))
+            assert len(self.__blocks) < len(self)
+            self.__blocks.extend([None] * (len(self) - len(self.__blocks)))
             self.__blocks[i] = result
 
         # If this happens then we have now fully calculated every block
         # and don't need to keep the reference to the owner around. We delete
         # it here so that there is no circular reference to make the gc work
         # harder.
-        if self.__count == len(self.__endpoints) and isinstance(
-            self.owner, ConjectureResult
-        ):
+        if self.__count == len(self) and isinstance(self.owner, ConjectureResult):
             self.owner = None
 
         return result

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -76,7 +76,7 @@ class IntList(object):
     __slots__ = ("__underlying",)
 
     def __init__(self):
-        self.__underlying = array_or_list("B")
+        self.__underlying = array_or_list("B", [])
 
     def __len__(self):
         return len(self.__underlying)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -76,6 +76,7 @@ class IntList(object):
                 self.__underlying.append(n)
                 return
             except OverflowError:
+                assert n > 0
                 self.__underlying = array_or_list(
                     NEXT_ARRAY_CODE[self.__underlying.typecode], self.__underlying
                 )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -575,7 +575,7 @@ class Shrinker(object):
     def all_block_bounds(self, target=None):
         if target is None:
             target = self.shrink_target
-        return [(b.start, b.end) for b in target.blocks]
+        return target.blocks.all_bounds()
 
     @derived_value
     def examples_by_label(self):

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -21,7 +21,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import Frozen
-from hypothesis.internal.compat import hbytes
+from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
@@ -182,3 +182,15 @@ def test_can_write_empty_string():
     d.draw_bits(0, forced=0)
     d.draw_bits(1)
     assert d.buffer == hbytes([1, 1, 1])
+
+
+def test_blocks_preserve_identity():
+    n = 10
+    d = ConjectureData.for_buffer([1] * 10)
+    for _ in hrange(n):
+        d.draw_bits(1)
+    d.freeze()
+    blocks = [d.blocks[i] for i in range(n)]
+    result = d.as_result()
+    for i, b in enumerate(blocks):
+        assert result.blocks[i] is b

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -194,3 +194,28 @@ def test_blocks_preserve_identity():
     result = d.as_result()
     for i, b in enumerate(blocks):
         assert result.blocks[i] is b
+
+
+def test_compact_blocks_during_generation():
+    d = ConjectureData.for_buffer([1] * 10)
+    for _ in hrange(5):
+        d.draw_bits(1)
+    assert len(list(d.blocks)) == 5
+    for _ in hrange(5):
+        d.draw_bits(1)
+    assert len(list(d.blocks)) == 10
+
+
+def test_handles_indices_like_a_list():
+    n = 5
+    d = ConjectureData.for_buffer([1] * n)
+    for _ in hrange(n):
+        d.draw_bits(1)
+    assert d.blocks[-1] is d.blocks[n - 1]
+    assert d.blocks[-n] is d.blocks[0]
+
+    with pytest.raises(IndexError):
+        d.blocks[n]
+
+    with pytest.raises(IndexError):
+        d.blocks[-n - 1]


### PR DESCRIPTION
Hey, psst, buddy, would you like to see some really weird code? Then boy do I have the PR for you.

Following on from #1828 where we calculated `examples` on first use, this also allows us to calculate `Block` objects on first usage.

Unfortunately the big differences between `Example` and `Block` are that a) We use blocks a lot more and b) We need them during generation time. This means that the `Example` approach of just deferring until we first access the collection is a non-starter.

So this does uh something else. The basic idea is that we can create a collection that only _looks_ like a list of blocks but actually only stores the endpoints until we first ask it for each block object.

Important features:

* If we only ask for a small number of blocks then we only build a small number of blocks. e.g. stateful testing asks for the last block generated (due to slightly dodgy reasons), and doing that should not cause all blocks to be calculated.
* A lot of things that could allocate blocks are exposed as helper methods that don't.
* We do a bunch of probably over-clever stuff for transforming the representation into more memory efficient forms as we go.

Builds on top of #1826, so earlier commits are from that PR.