### PR TITLE
Don't calculate exception lists until we first need them.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This changes Hypothesis to no longer import various test frameworks by default (if they are installed).
+which will speed up the initial ``import hypothesis`` call.

--- a/hypothesis-python/tests/nocover/test_skipping.py
+++ b/hypothesis-python/tests/nocover/test_skipping.py
@@ -22,12 +22,12 @@ import unittest
 import pytest
 
 from hypothesis import given
-from hypothesis.core import EXCEPTIONS_TO_RERAISE
+from hypothesis.core import skip_exceptions_to_reraise
 from hypothesis.strategies import integers
 from tests.common.utils import capture_out
 
 
-@pytest.mark.parametrize("skip_exception", EXCEPTIONS_TO_RERAISE)
+@pytest.mark.parametrize("skip_exception", skip_exceptions_to_reraise())
 def test_no_falsifying_example_if_unittest_skip(skip_exception):
     """If a ``SkipTest`` exception is raised during a test, Hypothesis should
     not continue running the test and shrink process, nor should it print
@@ -46,3 +46,7 @@ def test_no_falsifying_example_if_unittest_skip(skip_exception):
         unittest.TextTestRunner().run(suite)
 
     assert "Falsifying example" not in o.getvalue()
+
+
+def test_skipping_is_cached():
+    assert skip_exceptions_to_reraise() is skip_exceptions_to_reraise()


### PR DESCRIPTION
It turns out that importing `pytest` is surprisingly slow, to the point that it shows up as a significant cost when running Hypothesis under a profiler.

This PR changes our imports that we use to determine skip and failure exceptions to only happen when we first catch an exception. We still have to pay the cost (if you're not using the internal API, which I am), but this makes the initial import a lot faster, which can also be relevant for interactive usage.