### PR TITLE
Run shrink operations from each pass before the whole set

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This changes the order in which Hypothesis runs certain operations during shrinking.
+The main effect should be that it uses significantly less memory on large test cases,
+but it may also result in faster (or, hopefully more rarely, slower) shrinking.


### PR DESCRIPTION
Currently we are calculating the operations for all shrink passes up front and then running them in a random order. This turns out to be a poor idea when the test cases are large and there are many shrink steps, for values of poor idea meaning "Oh that's why Hypothesis was using 10GB of memory on this one example".

This PR changes it to give each shrink pass a bit of an opportunity to run before we calculate the steps for the next one. If the shrink pass seems to be working well we give it longer to run, if it's working sufficiently badly we don't give it much time at all. This means that hopefully by the time we calculate the steps for the next shrink pass we will have made the target a fair bit smaller and so will have fewer steps to calculate. At the bare minimum it means that we recalculate these large collections fewer times.

The worst case scenario for this is still just as bad as it was - if we're making no progress we have to compute the whole collections - but in that case *everything* we can do is going to suck.