### PR TITLE
Remove Shrinker.clear_passes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch removes some unused code from the shrinker.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -288,17 +288,6 @@ class Shrinker(object):
         self.initial_calls = self.__engine.call_count
 
         self.passes_by_name = {}
-        self.clear_passes()
-
-    def clear_passes(self):
-        """Reset all passes on the shrinker, leaving it in a blank state.
-
-        This is mostly useful for testing.
-        """
-        # Note that we deliberately do not clear passes_by_name. This means
-        # that we can still look up and explicitly run the standard passes,
-        # they just won't be avaiable by default.
-
         self.passes = []
 
     def add_new_pass(self, run):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -930,14 +930,6 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
     assert x == hbytes([1, 1])
 
 
-def fixate_shrink_passes(shrinker, *passes):
-    prev = None
-    while prev is not shrinker.shrink_target:
-        prev = shrinker.shrink_target
-        for sp in passes:
-            shrinker.run_shrink_pass(sp)
-
-
 def test_can_zero_subintervals(monkeypatch):
     @shrinking_from(hbytes([3, 0, 0, 0, 1]) * 10)
     def shrinker(data):
@@ -950,7 +942,7 @@ def test_can_zero_subintervals(monkeypatch):
                 return
         data.mark_interesting()
 
-    fixate_shrink_passes(shrinker, "zero_examples")
+    shrinker.fixate_shrink_passes(["zero_examples"])
     assert list(shrinker.buffer) == [0, 1] * 10
 
 
@@ -976,7 +968,7 @@ def test_can_pass_to_an_indirect_descendant(monkeypatch):
         if hbytes(data.buffer) in good:
             data.mark_interesting()
 
-    fixate_shrink_passes(shrinker, "pass_to_descendant")
+    shrinker.fixate_shrink_passes(["pass_to_descendant"])
 
     assert shrinker.shrink_target.buffer == target
 
@@ -1220,7 +1212,7 @@ def test_finding_a_minimal_balanced_binary_tree():
         if not b:
             data.mark_interesting()
 
-    fixate_shrink_passes(shrinker, "adaptive_example_deletion", "reorder_examples")
+    shrinker.fixate_shrink_passes(["adaptive_example_deletion", "reorder_examples"])
 
     assert list(shrinker.shrink_target.buffer) == [1, 0, 1, 0, 1, 0, 0]
 

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -746,9 +746,7 @@ def test_accidental_duplication(monkeypatch):
         if len(set(b)) == 1:
             data.mark_interesting()
 
-    shrinker.clear_passes()
-    shrinker.add_new_pass("minimize_duplicated_blocks")
-    shrinker.shrink()
+    shrinker.fixate_shrink_passes(["minimize_duplicated_blocks"])
     assert list(shrinker.buffer) == [5] * 7
 
 
@@ -1555,8 +1553,8 @@ def test_block_programs_are_adaptive():
             pass
         data.mark_interesting()
 
-    shrinker.clear_passes()
-    shrinker.add_new_pass(block_program("X"))
-    shrinker.shrink()
+    p = shrinker.add_new_pass(block_program("X"))
+    shrinker.fixate_shrink_passes([p.name])
+
     assert len(shrinker.shrink_target.buffer) == 1
     assert shrinker.calls <= 60

--- a/hypothesis-python/tests/quality/test_integers.py
+++ b/hypothesis-python/tests/quality/test_integers.py
@@ -101,10 +101,7 @@ def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
 
     shrinker = runner.new_shrinker(v, lambda x: x.status == Status.INTERESTING)
 
-    shrinker.clear_passes()
-    shrinker.add_new_pass("minimize_individual_blocks")
-
-    shrinker.shrink()
+    shrinker.fixate_shrink_passes(["minimize_individual_blocks"])
 
     v = shrinker.shrink_target
 


### PR DESCRIPTION
After #1801 removed most of this method's body, calling it from tests no longer had any useful effect.

As a result, some shrinker tests were accidentally running the entire pass suite, instead of just a specific pass as intended.

Fortunately those tests all still seem to pass after restoring the intended behaviour.