### PR TITLE
Various minor cleanups

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch removes some unused code, which makes the internals
+a bit easier to understand.  There is no user-visible impact.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -37,7 +37,7 @@ faster.
 4.7.4 - 2019-02-22
 ------------------
 
-This is a docs-only patch, noting that because :pypi:`Lark` is under active
+This is a docs-only patch, noting that because the :pypi:`lark-parser` is under active
 development at version 0.x, ``hypothesis[lark]`` APIs may break in minor
 releases if necessary to keep up with the upstream package.
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -98,7 +98,6 @@ class ConjectureRunner(object):
         self.target_selector = TargetSelector(self.random)
 
         self.interesting_examples = {}
-        self.covering_examples = {}
 
         self.shrunk_examples = set()
 
@@ -646,8 +645,6 @@ class ConjectureRunner(object):
                     result = uniform(self.random, n)
                 return self.__zero_bound(data, result)
 
-            targets_found = len(self.covering_examples)
-
             last_data = ConjectureData(
                 max_length=self.settings.buffer_size, draw_bytes=draw_bytes
             )
@@ -702,16 +699,12 @@ class ConjectureRunner(object):
             else:
                 origin = self.target_selector.select()
                 mutations += 1
-                targets_found = len(self.covering_examples)
                 data = ConjectureData(
                     draw_bytes=mutator(origin), max_length=self.settings.buffer_size
                 )
                 self.test_function(data)
                 data.freeze()
-                if (
-                    data.status > origin.status
-                    or len(self.covering_examples) > targets_found
-                ):
+                if data.status > origin.status:
                     mutations = 0
                 elif data.status < origin.status or mutations >= 10:
                     # Cap the variations of a single example and move on to

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -96,7 +96,7 @@ def test_DatetimeStrategy_draw_may_fail():
             return False
 
     strat = DatetimeStrategy(dt.datetime.min, dt.datetime.max, none())
-    failure_inducing = minimal(binary(), is_failure_inducing)
+    failure_inducing = minimal(binary(), is_failure_inducing, timeout_after=30)
     data = ConjectureData.for_buffer(failure_inducing * 100)
     with pytest.raises(StopTest):
         data.draw(strat)

--- a/hypothesis-python/tests/pytest/test_skipping.py
+++ b/hypothesis-python/tests/pytest/test_skipping.py
@@ -17,6 +17,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 pytest_plugins = str("pytester")
 
 
@@ -27,13 +29,21 @@ import pytest
 
 @given(xs=integers())
 def test_to_be_skipped(xs):
+    # We always try the simplest example first, raising a Skipped exception
+    # which we know to propagate immediately...
     if xs == 0:
         pytest.skip()
+    # But the pytest 3.0 internals don't have such an exception, so we keep
+    # going and raise a MultipleFailures error.  Ah well.
     else:
         assert xs == 0
 """
 
 
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.0"),
+    reason="Pytest 3.0 predates a Skipped exception type, so we can't hook into it.",
+)
 def test_no_falsifying_example_if_pytest_skip(testdir):
     """If ``pytest.skip() is called during a test, Hypothesis should not
     continue running the test and shrink process, nor should it print anything


### PR DESCRIPTION
#1781 keeps causing odd problems, so I'd like to reduce the diff a bit - if nothing else rebasing will be easier.  So we have an independent pull, to:

- remove the now-pointless tracking of `covering_examples` on the engine
- skip a test for skipping behaviour under pytest 3.0, where it only passes by coincidence
- fix a bad link in the changelog
- increase the timeout in  `minimal` for a slow test

In unrelated news, `git grep " - 2019-" -- hypothesis-python/docs/changes.rst | wc -l` informs me that we have made 52 releases over the 54 days of the year to date.  Not bad!