### PR TITLE
Only attempt to reorder examples with the same label

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release reduces the number of operations the shrinker will try when reordering parts of a test case.
+This should in some circumstances significantly speed up shrinking. It *may* result in different final test cases,
+and if so usually slightly worse ones, but it should not generally have much impact on the end result as the operations removed were typically useless.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -92,6 +92,9 @@ class Example(object):
     # Index of this example inside the overall list of examples.
     index = attr.ib()
 
+    # Index of the parent of this example, or None if this is the root.
+    parent = attr.ib()
+
     start = attr.ib()
     end = attr.ib(default=None)
 
@@ -210,6 +213,7 @@ def calc_examples(self):
                     label=label,
                     start=index,
                     trivial=index not in non_trivial_block_starts,
+                    parent=example_stack[-1] if example_stack else None,
                 )
                 examples.append(ex)
                 if example_stack:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""A module for miscellaneous useful bits and bobs that don't
+obviously belong anywhere else. If you spot a better home for
+anything that lives here, please move it."""
+
+
+from __future__ import absolute_import, division, print_function
+
+from hypothesis.internal.compat import hbytes
+
+
+def replace_all(buffer, replacements):
+    """Substitute multiple replacement values into a buffer.
+
+    Replacements is a list of (start, end, value) triples.
+    """
+
+    result = bytearray()
+    prev = 0
+    offset = 0
+    for u, v, r in replacements:
+        result.extend(buffer[prev:u])
+        result.extend(r)
+        prev = v
+        offset += len(r) - (v - u)
+    result.extend(buffer[prev:])
+    assert len(result) == len(buffer) + offset
+    return hbytes(result)


### PR DESCRIPTION
The current `reorder_examples` implementation is pretty expensive. There are two proximate causes for this:

* It rarely works
* It often tries running the `Ordering` shrinker on fairly large collections.

This PR attempts to mitigate that (I wouldn't say it wholly fixes it, but it's at least *better*) by not attempting to swap examples with different labels. This a) Prioritise swaps that are likely to work over ones that are unlikely to work and b) Reduces the size of the collections it runs on, potentially considerably.

This will be particularly useful when you have things like, say, `tuples(integers(), text())` - there's absolutely no point trying to swap the elements of this tuple, but the previous implementation would and the new implementation wouldn't.

##  Side notes for the interested reviewer

* This also adds parentage information to `Example`. This is not *strictly* necessary - it would be reasonably cheap to just group and filter the children at the point where it runs - but I've got half a dozen different things I've been tinkering with that use parentage information and *one* of them is going to land eventually so it might as well happen here.
* Same story with `hypothesis.internal.conjecture.junkdrawer` module - I could have just put `replace_example` in the shrinker file, but the junk drawer is going to happen sooner or later and there are a bunch of little utility functions that are e.g. currently in `engine` that it would be nice to use in `shrinker` and we might as well put them somewhere common.
* You may note that the `Ordering` shrinker doesn't pass a `key` argument. Logically it would make more sense to pass `key=sort_key` so we produce a more user friendly concept of things shrinking in order of increased complexity. In fact, this does not work, because unless the examples compare smaller lexicographically then `incorporate_new_buffer` will reject them without ever running the test function, and it will be right to do so - it's not a shortlex shrink! "Well-behaved" strategies will not run into this problem but it may be something worth thinking further about.