### PR TITLE
Don't recalculate shrink pass argument on usage

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release reduces the number of operations the shrinker will try when reordering parts of a test case.
+This should in some circumstances significantly speed up shrinking. It *may* result in different final test cases,
+and if so usually slightly worse ones, but it should not generally have much impact on the end result as the operations removed were typically useless.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -99,6 +99,9 @@ class Example(object):
     start = attr.ib()
     end = attr.ib(default=None)
 
+    # Index of example in parent's children, or None if this is the root.
+    child_index = attr.ib(default=None)
+
     # An example is "trivial" if it only contains forced bytes and zero bytes.
     # All examples start out as trivial, and then get marked non-trivial when
     # we see a byte that is neither forced nor zero.
@@ -223,7 +226,9 @@ def calc_examples(self):
                 examples.append(ex)
                 if example_stack:
                     p = example_stack[-1]
-                    examples[p].children.append(ex)
+                    children = examples[p].children
+                    ex.child_index = len(children)
+                    children.append(ex)
                 example_stack.append(i)
     for ex in examples:
         assert ex.end is not None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1200,15 +1200,6 @@ class Shrinker(object):
         del buf[ex.start : ex.end]
         self.incorporate_new_buffer(buf)
 
-    @derived_value
-    def groups_for_reordering(self):
-        result = defaultdict(list)
-        for e in self.examples:
-            result[(e.parent, e.label)].append(e)
-        groups = [v for v in result.values() if len(v) > 1]
-        groups.sort(key=lambda ls: ls[0].index)
-        return groups
-
     @defines_shrink_pass(
         lambda self: [
             (self.stable_identifier_for_example(e), l)

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1573,6 +1573,7 @@ def test_block_programs_are_adaptive():
     assert shrinker.calls <= 60
 
 
+<<<<<<< d0f96579a10a76f5badbd4a2cf81bde46172f24d
 def test_zero_examples_is_adaptive():
     @shrinking_from(hbytes([1]) * 1001)
     def shrinker(data):
@@ -1604,3 +1605,26 @@ def test_zero_examples_does_not_try_to_adapt_across_different_sizes():
     # single-bit block. Did not try to expand regions into the trivial two-byte
     # blocks on each side.
     assert shrinker.calls == initial + 12
+
+
+def test_stable_identifiers_match_their_examples():
+    def tree(data):
+        data.start_example(1)
+        n = data.draw_bits(1)
+        label = data.draw_bits(8)
+        if n:
+            tree(data)
+            tree(data)
+        data.stop_example(1)
+        return label
+
+    initial = hbytes([1, 10, 0, 0, 1, 0, 0, 10, 0, 0])
+
+    @shrinking_from(initial)
+    def shrinker(data):
+        tree(data)
+        data.mark_interesting()
+
+    for ex in shrinker.examples:
+        id = shrinker.stable_identifier_for_example(ex)
+        assert shrinker.example_for_stable_identifier(id) is ex

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1411,7 +1411,7 @@ def test_pandas_hack():
         if data.draw_bits(8) == 7:
             data.mark_interesting()
 
-    shrinker.run_shrink_pass(block_program('-XX'))
+    shrinker.run_shrink_pass(block_program("-XX"))
     assert list(shrinker.shrink_target.buffer) == [1, 7]
 
 

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1411,7 +1411,7 @@ def test_pandas_hack():
         if data.draw_bits(8) == 7:
             data.mark_interesting()
 
-    shrinker.run_shrink_pass("block_program('-XX')")
+    shrinker.run_shrink_pass(block_program('-XX'))
     assert list(shrinker.shrink_target.buffer) == [1, 7]
 
 


### PR DESCRIPTION
In the new system every shrink pass generates a series of arguments to its step function. This leads to the question of what you do when running arguments that were generated with an old version of the shrink target.

The current approach is to try to ensure that that doesn't happen by only storing indices and recalculating the collection each time we run a step if it's changed since then. This was clever but turns out to be a very bad idea for two main reasons:

* When the shrink target is large calculating these collections is expensive.
* The indices very rapidly get out of sync to the point where they're essentially just point to an arbitrary member of the collection.

This changes the process by using the arguments collection directly, with shrink pass steps now updated so that they do the correct thing in the presence of a stale argument.

In order to further reduce the desync problem, for examples it introduces the notion of a stable identifier. The stable identifier for an example is the path that you'd take to get there from the root. This is more robust than the index in the list because it means that changes inside other examples are a bit more contained. e.g. if we had `((A, B), (C, D))` and changed it to `((B,), (C, D))` then the indices of `C` and `D` would change but their stable identifier would not.

Note that there is no equivalent stable identifier system for blocks, those just use the indices. I thought about it, but by the time we'ere doing block level operations the shape of the example isn't changing too much, so the bookkeeping is unlikely to be worth it.

*ZHD edit: closes #1839*