### PR TITLE
Change how we run shrink pass steps

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This changes the order in which Hypothesis runs certain operations during shrinking.
+This should significantly decrease memory usage and speed up shrinking of large examples.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -44,6 +44,7 @@ from hypothesis.internal.conjecture.data import (
     StopTest,
 )
 from hypothesis.internal.conjecture.datatree import DataTree
+from hypothesis.internal.conjecture.junkdrawer import pop_random
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import debug_report
@@ -893,20 +894,6 @@ def _draw_successor(rnd, xs):
 
 def uniform(random, n):
     return int_to_bytes(random.getrandbits(n * 8), n)
-
-
-def pop_random(random, values):
-    """Remove a random element of values, possibly changing the ordering of its
-    elements."""
-
-    # We pick the element at a random index. Rather than removing that element
-    # from the list (which would be an O(n) operation), we swap it to the end
-    # and return the last element of the list. This changes the order of
-    # the elements, but as long as these elements are only accessed through
-    # random sampling that doesn't matter.
-    i = random.randrange(0, len(values))
-    values[i], values[-1] = values[-1], values[i]
-    return values.pop()
 
 
 class TargetSelector(object):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -80,3 +80,17 @@ class IntList(object):
                 self.__underlying = array_or_list(
                     NEXT_ARRAY_CODE[self.__underlying.typecode], self.__underlying
                 )
+
+
+def pop_random(random, values):
+    """Remove a random element of values, possibly changing the ordering of its
+    elements."""
+
+    # We pick the element at a random index. Rather than removing that element
+    # from the list (which would be an O(n) operation), we swap it to the end
+    # and return the last element of the list. This changes the order of
+    # the elements, but as long as these elements are only accessed through
+    # random sampling that doesn't matter.
+    i = random.randrange(0, len(values))
+    values[i], values[-1] = values[-1], values[i]
+    return values.pop()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -28,7 +28,7 @@ from hypothesis.internal.conjecture.floats import (
     float_to_lex,
     lex_to_float,
 )
-from hypothesis.internal.conjecture.junkdrawer import replace_all
+from hypothesis.internal.conjecture.junkdrawer import pop_random, replace_all
 from hypothesis.internal.conjecture.shrinking import Float, Integer, Lexical, Ordering
 from hypothesis.internal.conjecture.shrinking.common import find_integer
 
@@ -551,11 +551,6 @@ class Shrinker(object):
             for sp in passes:
                 sp.runs += 1
 
-            passes_with_steps = [
-                (sp, step) for sp in passes for step in sp.generate_steps()
-            ]
-            self.random.shuffle(passes_with_steps)
-
             # We run remove_discarded after every step to do cleanup
             # keeping track of whether that actually works. Either there is
             # no discarded data and it is basically free, or it reliably works
@@ -564,10 +559,31 @@ class Shrinker(object):
             # try again once all of the passes have been run.
             can_discard = self.remove_discarded()
 
-            for sp, step in passes_with_steps:
-                sp.run_step(step)
-                if can_discard:
-                    can_discard &= self.remove_discarded()
+            passes_with_steps = [(sp, None) for sp in passes]
+
+            while passes_with_steps:
+                to_run_next = []
+
+                for sp, steps in passes_with_steps:
+                    if steps is None:
+                        steps = sp.generate_steps()
+
+                    failures = 0
+                    max_failures = 3
+
+                    while steps and failures < max_failures:
+                        prev_calls = self.calls
+                        prev = self.shrink_target
+                        sp.run_step(pop_random(self.random, steps))
+                        if prev_calls != self.calls:
+                            if can_discard:
+                                can_discard = self.remove_discarded()
+                            if prev is self.shrink_target:
+                                failures += 1
+                    if steps:
+                        to_run_next.append((sp, steps))
+                passes_with_steps = to_run_next
+
         for sp in passes:
             sp.fixed_point_at = self.shrink_target
 


### PR DESCRIPTION
Previously we were interleaving all shrink pass steps and then running them. This was a fairly huge improvement over running each sequentially, because it avoids stalls where one pass is just completely not working, but it has a fairly major problem: When the test case is large, the step collections are *huge*, and computing them all up front ends up being slow and memory hungry.

Additionally, it's not always a very sensible ordering - if we have some steps that reduce the size and some that don't, we really want to run the ones that reduce the size of the example first.

This PR solves both these problems by adding an initial phase to `fixate_shrink_passes` where it doesn't really try to get to any sort of fixed point, it just really aggressively chews the shrink target down to size, by selecting for shrink passes and steps that reduce the size, running them as long as they seem like they're doing a decent job of reducing the size, and discarding them if it seems like they won't.

Once we've done that, we move on to the previous algorithm. The result is that by the time we get to the "real work" of trying to find the fixed point, we have a much smaller example with fewer steps. Additionally because it is now likely to be quite close to a size fixed point, the shape of the example is more stable and the passes should tend to remain valid more often.

On the Csmith example I've been using for most of my benchmarking (overfitting, what's that?) this causs almost 35% fewer test case executions.