### PR TITLE
Make sure that unsuccessful block progam steps don't do too much work

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release changes certain shrink passes to make them more efficient when
+they aren't making progress.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1330,6 +1330,11 @@ def block_program(description):
             then this runs in ``O(log(k))`` test function calls."""
             assert i + n < len(self.shrink_target.blocks)
 
+            # First, run the block program at the chosen index. If this fails,
+            # don't do any extra work, so that failure is as cheap as possible.
+            if not self.run_block_program(i, description, original=self.shrink_target):
+                return
+
             # Because we run in a random order we will often find ourselves in the middle
             # of a region where we could run the block program. We thus start by moving
             # left to the beginning of that region if possible in order to to start from

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -137,3 +137,18 @@ def non_covering_examples(database):
     return {
         v for k, vs in database.data.items() if not k.endswith(b".coverage") for v in vs
     }
+
+
+def counts_calls(func):
+    """A decorator that counts how many times a function was called, and
+    stores that value in a ``.calls`` attribute.
+    """
+    assert not hasattr(func, "calls")
+
+    @proxies(func)
+    def _inner(*args, **kwargs):
+        _inner.calls += 1
+        return func(*args, **kwargs)
+
+    _inner.calls = 0
+    return _inner


### PR DESCRIPTION
I belatedly noticed that #1789 actually runs the block program *twice* during each unsuccessful step: first at `i - 1`, and then again at `i`.

The cache should mostly bail us out here, but it's still better to not have the extra cache pressure or bookkeeping, and the fix is very simple.