### PR TITLE
Some micro-optimisations for shrinking

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes some micro-optimisations to common operations performed during shrinking.
+Shrinking should now be slightly faster, especially for large examples with relatively fast test functions.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -113,9 +113,12 @@ class Example(object):
     # List of child examples, represented as indices into the example list.
     children = attr.ib(default=attr.Factory(list), repr=False)
 
-    @property
-    def length(self):
-        return self.end - self.start
+    # We access length a lot, and Python is annoyingly bad at basic integer
+    # arithmetic, so it makes sense to cache this on a field for speed
+    # reasons. It also reduces allocation, though most of the integers
+    # allocated from this should be easily collected garbage and/or
+    # small enough to be interned.
+    length = attr.ib(init=False, repr=False)
 
 
 @attr.s(slots=True, frozen=True)
@@ -198,6 +201,7 @@ def calc_examples(self):
                 k = example_stack.pop()
                 ex = examples[k]
                 ex.end = index
+                ex.length = ex.end - ex.start
 
                 if ex.length == 0:
                     ex.trivial = True

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -241,6 +241,7 @@ class ConjectureResult(object):
     example_boundaries = attr.ib()
     output = attr.ib()
     extra_information = attr.ib()
+    has_discards = attr.ib()
     __examples = attr.ib(init=False, default=None)
 
     index = attr.ib(init=False)
@@ -293,6 +294,7 @@ class ConjectureData(object):
         self.interesting_origin = None
         self.draw_times = []
         self.max_depth = 0
+        self.has_discards = False
 
         self.example_boundaries = []
 
@@ -335,6 +337,7 @@ class ConjectureData(object):
                 extra_information=self.extra_information
                 if self.extra_information.has_information()
                 else None,
+                has_discards=self.has_discards,
             )
         return self.__result
 
@@ -402,6 +405,8 @@ class ConjectureData(object):
     def stop_example(self, discard=False):
         if self.frozen:
             return
+        if discard:
+            self.has_discards = True
         self.current_example_labels().append(StopDiscard if discard else Stop)
         self.depth -= 1
         assert self.depth >= -1

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -892,7 +892,7 @@ class Shrinker(object):
         returns False if there is discarded data and removing it does not work,
         otherwise returns True.
         """
-        while True:
+        while self.shrink_target.has_discards:
             discarded = []
 
             for ex in self.shrink_target.examples:
@@ -903,6 +903,10 @@ class Shrinker(object):
                 ):
                     discarded.append((ex.start, ex.end))
 
+            # This can happen if we have discards but they are all of
+            # zero length. This shouldn't happen very often so it's
+            # faster to check for it here than at the point of example
+            # generation.
             if not discarded:
                 break
 

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -813,6 +813,19 @@ def test_discarding_iterates_to_fixed_point():
     assert list(shrinker.buffer) == [1, 0]
 
 
+def test_discarding_is_not_fooled_by_empty_discards():
+    @shrinking_from(hbytes([1, 1]))
+    def shrinker(data):
+        data.draw_bits(1)
+        data.start_example(0)
+        data.stop_example(discard=True)
+        data.draw_bits(1)
+        data.mark_interesting()
+
+    shrinker.remove_discarded()
+    assert shrinker.shrink_target.has_discards
+
+
 def shrink_pass(name):
     def run(self):
         self.run_shrink_pass(name)


### PR DESCRIPTION
This makes two related changes to the shrinker that are designed to speed up `remove_discarded`. We run this a *lot* so it's worth the effort (it was showing up as a couple % of the runtime for an experiment I was running where the test function was quite slow and also never discarded anything!).

The two changes are:

* We add a single boolean flag that lets us skip it entirely if we never called `stop_example` with `discard=True`. Because we might discard empty examples it's still possible that this flag can be True and `remove_discarded` can be useless but that shouldn't happen too often and we can detect when it does.
* We cache length on `Example`. Turns out that subtracting two numbers can easily become a bottleneck in Python if you do it enough times. 😢 