### PR TITLE
Make zero_examples adaptive

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release slightly improves the shrinker's ability to replace parts of a test case with their minimal version,
+by allowing it to do so in bulk rather than one at a time. Where this is effective, shrinker performance should be modestly improved.


### PR DESCRIPTION
I noticed that `zero_examples` will often make a lot of small changes. This attempts to offset that by adding an adaptive step to it.

It doesn't help *that* much (it saves about 20% of the calls on the example I was trying, which was largish), but the implementation is cautious enough that it should almost never hurt and it has the possibility of winning big.