### PR TITLE
Making reordering examples adaptive

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release changes how Hypothesis reorders examples within a test case during shrinking.
+This should make shrinking considerably faster.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
@@ -17,7 +17,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from hypothesis.internal.conjecture.shrinking.common import Shrinker
+from hypothesis.internal.compat import hrange
+from hypothesis.internal.conjecture.shrinking.common import Shrinker, find_integer
 
 
 def identity(v):
@@ -49,44 +50,56 @@ class Ordering(Shrinker):
         assert sorted(value) == sorted(self.current)
 
     def run_step(self):
-        self.reinsert()
+        self.sort_regions()
+        self.sort_regions_with_gaps()
 
-    def reinsert(self):
-        for i in range(len(self.current)):
-            # This is essentially insertion sort, but unlike normal insertion
-            # sort because of our use of find_integer we only perform
-            # O(n(log(n))) calls. Because of the rotations we're still O(n^2)
-            # performance in terms of number of list operations, but we don't
-            # care about those so much.
-            original = self.current
+    def sort_regions(self):
+        """Guarantees that for each i we have tried to swap index i with
+        index i + 1.
 
-            insertion_points = [
-                j
-                for j in range(i)
-                if self.key(self.current[j]) > self.key(self.current[i])
-            ]
+        This uses an adaptive algorithm that works by sorting contiguous
+        regions starting from each element.
+        """
+        i = 0
+        while i + 1 < len(self.current):
+            prefix = list(self.current[:i])
+            k = find_integer(
+                lambda k: i + k <= len(self.current)
+                and self.consider(
+                    prefix
+                    + sorted(self.current[i : i + k], key=self.key)
+                    + list(self.current[i + k :])
+                )
+            )
+            i += k
 
-            def push_back_to(t):
-                if t >= len(insertion_points):
-                    return True
-                j = insertion_points[t]
-                reinserted = list(original)
-                del reinserted[i]
-                reinserted.insert(j, original[i])
-                if self.consider(reinserted):
-                    return
-                swapped = list(self.current)
-                swapped[i], swapped[j] = swapped[j], swapped[i]
-                return self.consider(swapped)
+    def sort_regions_with_gaps(self):
+        """Guarantees that for each i we have tried to swap index i with
+        index i + 2.
 
-            if push_back_to(0) or push_back_to(1):
+        This uses an adaptive algorithm that works by sorting contiguous
+        regions centered on each element, where that element is treated as
+        fixed and the elements around it are sorted..
+        """
+        for i in hrange(1, len(self.current) - 1):
+            if self.current[i - 1] <= self.current[i] <= self.current[i + 1]:
                 continue
 
-            lo = 1
-            hi = len(insertion_points)
-            while lo + 1 < hi:
-                mid = (lo + hi) // 2
-                if push_back_to(mid):
-                    hi = mid
-                else:
-                    lo = mid
+            def can_sort(a, b):
+                if a < 0 or b > len(self.current):
+                    return False
+                assert a <= i < b
+                split = i - a
+                values = sorted(self.current[a:i] + self.current[i + 1 : b])
+                return self.consider(
+                    list(self.current[:a])
+                    + values[:split]
+                    + [self.current[i]]
+                    + values[split:]
+                    + list(self.current[b:])
+                )
+
+            left = i
+            right = i + 1
+            right += find_integer(lambda k: can_sort(left, right + k))
+            find_integer(lambda k: can_sort(left - k, right))


### PR DESCRIPTION
The `reorder_examples` pass was almost comically inefficient due to how much work it was doing. 😢 

This changes it to be fully adaptive, based on the idea of sorting entire regions, possibly with one element left as a gap to work around awkward boundaries.

~~It also changes how we group items for reordering slightly. Particularly with the new algorithm, it's better to run these on *slightly* larger groups, so we now group by label and depth. Grouping by depth means that we don't have to worry about the case where one example is nested inside each other, but it also seems to be slightly faster than more sophisticated ways of achieving that.~~ This resulted in a weird failure in the quality tests that I've not been able to successfully debug and was a sufficiently marginal gain compared to the other part of this PR that I've removed it.

On a slightly contrived benchmark of running `fixate_shrink_passes(['reorder_examples'])` on my reference Csmith example this makes approximately an order of magnitude fewer calls (200 vs 2000). It's unclear how representative that will be more broadly, but I'm confident that it will be a large improvement in general. 