### PR TITLE
Tighten validation of several settings

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release significantly tightens validation in :class:`hypothesis.settings`.
+:obj:`~hypothesis.settings.max_examples`, :obj:`~hypothesis.settings.buffer_size`,
+and :obj:`~hypothesis.settings.stateful_step_count` must be positive integers;
+:obj:`~hypothesis.settings.deadline` must be a positive number or ``None``; and
+:obj:`~hypothesis.settings.derandomize` must be either ``True`` or ``False``.
+
+As usual, this replaces existing errors with a more helpful error and starts new
+validation checks as deprecation warnings.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -426,6 +426,12 @@ def _ensure_positive_int(x, name, since, min_value=0):
 
 def _max_examples_validator(x):
     x = _ensure_positive_int(x, "max_examples", since="RELEASEDAY", min_value=0)
+    if x == 0:
+        note_deprecation(
+            "max_examples=%r should be at least one. You can disable example "
+            "generation with the `phases` setting instead." % (x,),
+            since="RELEASEDAY",
+        )
     return x
 
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -440,19 +440,13 @@ your tests slower.
 )
 
 
-def _validate_timeout(n):
-    if n in (not_set, unlimited):
-        return n
-    raise InvalidArgument("The timeout setting has been removed.")
-
-
 settings._define_setting(
     "timeout",
     default=not_set,
     description="The timeout setting has been deprecated and no longer does anything.",
     deprecation_message="The timeout setting can safely be removed with no effect.",
     deprecated_since="2017-11-02",
-    validator=_validate_timeout,
+    options=(not_set, unlimited),
 )
 
 settings._define_setting(

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -86,14 +86,10 @@ def try_convert(typ, value, name):
         return value
     try:
         return typ(value)
-    except TypeError:
+    except (TypeError, OverflowError, ValueError, ArithmeticError):
         raise InvalidArgument(
             "Cannot convert %s=%r of type %s to type %s"
             % (name, value, type(value).__name__, typ.__name__)
-        )
-    except (OverflowError, ValueError, ArithmeticError):
-        raise InvalidArgument(
-            "Cannot convert %s=%r to type %s" % (name, value, typ.__name__)
         )
 
 

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -22,7 +22,7 @@ from fractions import Fraction
 
 import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies as st
-from hypothesis import HealthCheck, assume, example, given, settings
+from hypothesis import HealthCheck, Phase, assume, example, given, settings
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
@@ -129,7 +129,7 @@ def weights(draw):
 @settings(
     deadline=None,
     suppress_health_check=HealthCheck.all(),
-    max_examples=0 if IN_COVERAGE_TESTS else settings.default.max_examples,
+    phases=[Phase.explicit] if IN_COVERAGE_TESTS else tuple(Phase),
 )
 @given(st.lists(weights(), min_size=1))
 def test_sampler_distribution(weights):

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -21,7 +21,7 @@ from unittest import TestCase
 
 import pytest
 
-from hypothesis import Verbosity, example, given, note, reporting, settings
+from hypothesis import Phase, Verbosity, example, given, note, reporting, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import integer_types, print_unicode
 from hypothesis.strategies import integers, text
@@ -193,7 +193,7 @@ def test_examples_are_tried_in_order():
     @example(x=1)
     @example(x=2)
     @given(integers())
-    @settings(max_examples=0)
+    @settings(phases=[Phase.explicit])
     @example(x=3)
     def test(x):
         print_unicode(u"x -> %d" % (x,))

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -85,7 +85,7 @@ def single_bool_lists(draw):
 @example([False, True, False, False], [3], None)
 @example([False, False, True, False], [3], None)
 @example([False, False, False, True], [3], None)
-@settings(max_examples=0)
+@settings(deadline=None)
 @given(lists(booleans()) | single_bool_lists(), lists(integers(1, 3)), random_module())
 def test_failure_sequence_inducing(building, testing, rnd):
     buildit = iter(building)

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -112,6 +112,7 @@ def test_can_set_verbosity():
     settings(verbosity=Verbosity.quiet)
     settings(verbosity=Verbosity.normal)
     settings(verbosity=Verbosity.verbose)
+    settings(verbosity=Verbosity.debug)
 
 
 def test_can_not_set_verbosity_to_non_verbosity():
@@ -400,3 +401,39 @@ def test_can_not_set_timeout_to_time():
 def test_derandomise_with_explicit_database_is_invalid():
     with pytest.raises(InvalidArgument):
         settings(derandomize=True, database=ExampleDatabase(":memory:"))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(max_examples=-1),
+        dict(buffer_size=-1),
+        dict(stateful_step_count=-1),
+        dict(deadline=-1),
+        dict(deadline=0),
+    ],
+)
+def test_invalid_settings_are_errors(kwargs):
+    with pytest.raises(InvalidArgument):
+        settings(**kwargs)
+
+
+@checks_deprecated_behaviour
+def test_boolean_deadlines():
+    settings(deadline=True)
+    with pytest.raises(InvalidArgument):
+        settings(deadline=False)
+
+
+@checks_deprecated_behaviour
+def test_non_boolean_derandomize():
+    assert settings(derandomize=1).derandomize is True
+    assert settings(derandomize=0).derandomize is False
+
+
+@pytest.mark.parametrize("name", ["max_examples", "buffer_size", "stateful_step_count"])
+@checks_deprecated_behaviour
+def test_dubious_settings_deprecations(name):
+    settings(**{name: 2.5})
+    with pytest.raises(InvalidArgument):
+        settings(**{name: "2.5"})  # deprecation warning, then type cast error.

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -437,3 +437,19 @@ def test_dubious_settings_deprecations(name):
     settings(**{name: 2.5})
     with pytest.raises(InvalidArgument):
         settings(**{name: "2.5"})  # deprecation warning, then type cast error.
+
+
+@checks_deprecated_behaviour
+def test_max_example_eq_0_warns_and_disables_generation():
+    # Terrible way to disable generation, but did predate the phases setting
+    # and existed in our test suite so it's not an error *just* yet.
+    @example(None)
+    @given(st.integers())
+    @settings(max_examples=0)
+    def inner(x):
+        calls[0] += 1
+        assert x is None
+
+    calls = [0]
+    inner()
+    assert calls[0] == 1


### PR DESCRIPTION
Per our style guide, validation is good... so now we validate *all* the arguments to `settings`, not just some.  It's a minor release because of the new warnings, but it's also conceivable that someone was doing something very strange with a setting that we just ignored and now error on - IMO those cases were never part of the supported public API.

I've also deprecated `max_examples=0` in favor of the `phases` setting, which is generally a cleaner way to turn off generation.  This has already turned up a few cases in our own tests!