### PR TITLE
Speed up checks for structural changes in the shrink target

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release makes some micro-optimisations to certain calculations performed in the shrinker.
+These should particularly speed up large test cases where the shrinker makes many small changes.
+It will also reduce the amount allocated, but most of this is garbage that would have been immediately thrown away,
+so you probably won't see much effect specifically from that.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -181,11 +181,11 @@ class Blocks(object):
     be preferred to using the Block objects directly, as it will not
     have to allocate the actual object."""
 
-    __slots__ = ("__endpoints", "owner", "__blocks", "__count", "__sparse")
+    __slots__ = ("endpoints", "owner", "__blocks", "__count", "__sparse")
 
     def __init__(self, owner):
         self.owner = owner
-        self.__endpoints = IntList()
+        self.endpoints = IntList()
         self.__blocks = {}
         self.__count = 0
         self.__sparse = True
@@ -193,7 +193,7 @@ class Blocks(object):
     def add_endpoint(self, n):
         """Add n to the list of endpoints."""
         assert isinstance(self.owner, ConjectureData)
-        self.__endpoints.append(n)
+        self.endpoints.append(n)
 
     def transfer_ownership(self, new_owner):
         """Used to move ``Blocks`` over to a ``ConjectureResult`` object
@@ -212,7 +212,7 @@ class Blocks(object):
 
     def end(self, i):
         """Equivalent to self[i].end."""
-        return self.__endpoints[i]
+        return self.endpoints[i]
 
     def bounds(self, i):
         """Equivalent to self[i].bounds."""
@@ -220,15 +220,13 @@ class Blocks(object):
 
     def all_bounds(self):
         """Equivalent to [(b.start, b.end) for b in self]."""
-        result = []
         prev = 0
-        for e in self.__endpoints:
-            result.append((prev, e))
+        for e in self.endpoints:
+            yield (prev, e)
             prev = e
-        return result
 
     def __len__(self):
-        return len(self.__endpoints)
+        return len(self.endpoints)
 
     def __known_block(self, i):
         try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -118,3 +118,21 @@ def pop_random(random, values):
     i = random.randrange(0, len(values))
     values[i], values[-1] = values[-1], values[i]
     return values.pop()
+
+
+def binary_search(lo, hi, f):
+    """Binary searches in [lo , hi) to find
+    n such that f(n) == f(lo) but f(n + 1) != f(lo).
+    It is implicitly assumed and will not be checked
+    that f(hi) != f(lo).
+    """
+
+    reference = f(lo)
+
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        if f(mid) == reference:
+            lo = mid
+        else:
+            hi = mid
+    return lo

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -58,8 +58,18 @@ class IntList(object):
 
     __slots__ = ("__underlying",)
 
-    def __init__(self):
-        self.__underlying = array_or_list("B", [])
+    def __init__(self, values=()):
+        for code in ARRAY_CODES:
+            try:
+                self.__underlying = array_or_list(code, values)
+                break
+            except OverflowError:
+                pass
+        else:
+            raise ValueError("Could not create IntList for %r" % (values,))
+
+    def __repr__(self):
+        return "IntList(%r)" % (list(self),)
 
     def __len__(self):
         return len(self.__underlying)
@@ -69,6 +79,20 @@ class IntList(object):
 
     def __iter__(self):
         return iter(self.__underlying)
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, IntList):
+            return NotImplemented
+        return self.__underlying == other.__underlying
+
+    def __ne__(self, other):
+        if self is other:
+            return False
+        if not isinstance(other, IntList):
+            return NotImplemented
+        return self.__underlying != other.__underlying
 
     def append(self, n):
         while True:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -603,10 +603,8 @@ class Shrinker(object):
     def examples(self):
         return self.shrink_target.examples
 
-    def all_block_bounds(self, target=None):
-        if target is None:
-            target = self.shrink_target
-        return target.blocks.all_bounds()
+    def all_block_bounds(self):
+        return self.shrink_target.blocks.all_bounds()
 
     @derived_value
     def examples_by_label(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -787,7 +787,7 @@ class Shrinker(object):
             self.shrinks += 1
             if (
                 len(new_target.blocks) != len(self.shrink_target.blocks)
-                or self.all_block_bounds(new_target) != self.all_block_bounds()
+                or new_target.blocks.endpoints != self.shrink_target.blocks.endpoints
             ):
                 self.clear_change_tracking()
             else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -736,7 +736,7 @@ class Shrinker(object):
 
         current = self.shrink_target
 
-        blocked = [current.buffer[u:v] for u, v in self.all_block_bounds(current)]
+        blocked = [current.buffer[u:v] for u, v in self.all_block_bounds()]
 
         changed = [
             i

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -775,7 +775,8 @@ class Shrinker(object):
             self.__shrinking_prefixes.add(prefix)
 
     def clear_change_tracking(self):
-        self.__changed_blocks.clear()
+        self.__last_checked_changed_at = self.shrink_target
+        self.__all_changed_blocks = set()
 
     def mark_changed(self, i):
         self.__changed_blocks.add(i)

--- a/hypothesis-python/tests/cover/test_conjecture_intlist.py
+++ b/hypothesis-python/tests/cover/test_conjecture_intlist.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import hypothesis.strategies as st
+from hypothesis import assume, given
+from hypothesis.internal.conjecture.junkdrawer import IntList
+
+non_neg_lists = st.lists(st.integers(min_value=0, max_value=2 ** 63 - 1))
+
+
+@given(non_neg_lists)
+def test_intlist_is_equal_to_itself(ls):
+    assert IntList(ls) == IntList(ls)
+
+
+@given(non_neg_lists, non_neg_lists)
+def test_distinct_int_lists_are_not_equal(x, y):
+    assume(x != y)
+    assert IntList(x) != IntList(y)
+
+
+def test_basic_equality():
+    x = IntList([1, 2, 3])
+    assert x == x
+    t = x != x
+    assert not t
+    assert x != "foo"

--- a/hypothesis-python/tests/cover/test_conjecture_intlist.py
+++ b/hypothesis-python/tests/cover/test_conjecture_intlist.py
@@ -17,6 +17,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 import hypothesis.strategies as st
 from hypothesis import assume, given
 from hypothesis.internal.conjecture.junkdrawer import IntList
@@ -41,3 +43,11 @@ def test_basic_equality():
     t = x != x
     assert not t
     assert x != "foo"
+
+    s = x == "foo"
+    assert not s
+
+
+def test_error_on_invalid_value():
+    with pytest.raises(ValueError):
+        IntList([-1])

--- a/hypothesis-python/tests/cover/test_conjecture_intlist.py
+++ b/hypothesis-python/tests/cover/test_conjecture_intlist.py
@@ -21,6 +21,7 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import assume, given
+from hypothesis.internal.compat import PY2
 from hypothesis.internal.conjecture.junkdrawer import IntList
 
 non_neg_lists = st.lists(st.integers(min_value=0, max_value=2 ** 63 - 1))
@@ -48,6 +49,10 @@ def test_basic_equality():
     assert not s
 
 
+@pytest.mark.skipif(
+    PY2,
+    reason="The Python 2 list fallback handles this and we don't really care enough to validate it there.",
+)
 def test_error_on_invalid_value():
     with pytest.raises(ValueError):
         IntList([-1])


### PR DESCRIPTION
When we update the shrink target we check which blocks have changed. The way we previously did this did a lot of unneccessary work. This mainly shows up as a large pile of unneccessary allocations, but it's a non-trivial time cost too.

This reduces that work in the following two ways:

* Don't allocate a bunch of useless block boundaries just to check if they're equal - this will return true if and only if the endpoint lists are equal
* Rather than doing a linear scan of the full list of blocks, we use a binary search to narrow down to a hopefully much smaller list of blocks that have changed (due to needing to check the whole prefix/suffix in that search this doesn't actually improve the time complexity, but it involves a cheaper per block check).