### PR TITLE
Tiny micro-optimisation to reduce allocation in start_example

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release makes some micro-optimisations within Hypothesis's internal representation of test cases.
+This should cause heavily nested test cases to allocate less during generation and shrinking,
+which should speed things up slightly.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -577,7 +577,7 @@ class ConjectureData(object):
         # be until we ran the code under tracemalloc and found a rather significant
         # chunk of allocation was happening here. This was presumably due to varargs
         # or the like, but we didn't investigate further given that it was easy
-        # to fix with this check..
+        # to fix with this check.
         if self.depth > self.max_depth:
             self.max_depth = self.depth
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -572,7 +572,14 @@ class ConjectureData(object):
         self.__assert_not_frozen("start_example")
         self.current_example_labels().append(label)
         self.depth += 1
-        self.max_depth = max(self.max_depth, self.depth)
+        # Logically it would make sense for this to just be
+        # ``self.depth = max(self.depth, self.max_depth)``, which is what it used to
+        # be until we ran the code under tracemalloc and found a rather significant
+        # chunk of allocation was happening here. This was presumably due to varargs
+        # or the like, but we didn't investigate further given that it was easy
+        # to fix with this check..
+        if self.depth > self.max_depth:
+            self.max_depth = self.depth
 
     def stop_example(self, discard=False):
         if self.frozen:


### PR DESCRIPTION
tracemalloc informs me that lots of allocation is happening at this line. I side eyed it a lot and then decided to just sigh and deal with it.