### PR TITLE
Small performance patch for Numpy arrays

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch removes some overhead from :func:`~hypothesis.extra.numpy.arrays`
+with a constant shape and dtype.  The resulting performance improvement is
+modest, but worthwile for small arrays.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -126,12 +126,6 @@ class ArrayStrategy(SearchStrategy):
     def __init__(self, element_strategy, shape, dtype, fill, unique):
         self.shape = tuple(shape)
         self.fill = fill
-        assert shape, "Zero-dimensional array shape is special-cased in arrays()"
-        check_argument(
-            all(isinstance(s, integer_types) for s in shape),
-            "Array shape must be integer in each dimension, provided shape was {}",
-            shape,
-        )
         self.array_size = int(np.prod(shape))
         self.dtype = dtype
         self.element_strategy = element_strategy
@@ -393,20 +387,14 @@ def arrays(
     dtype = np.dtype(dtype)
     if elements is None:
         elements = from_dtype(dtype)
-    if isinstance(shape, int):
+    if isinstance(shape, integer_types):
         shape = (shape,)
     shape = tuple(shape)
-    if shape == ():
-
-        def zero_dim_array(element):
-            # We use .itemset() instead of np.full because the latter cannot
-            # set tuples or other sequences as elements.
-            arr = np.empty(shape=(), dtype=dtype)
-            arr.itemset(element)
-            return arr
-
-        return st.builds(zero_dim_array, elements)
-
+    check_argument(
+        all(isinstance(s, integer_types) for s in shape),
+        "Array shape must be integer in each dimension, provided shape was {}",
+        shape,
+    )
     fill = fill_for(elements=elements, unique=unique, fill=fill)
     return ArrayStrategy(elements, shape, dtype, fill, unique)
 


### PR DESCRIPTION
By removing the overhead of composite when it's not needed (I did say small!).

This also makes it very easy to deprecate passing a strategy for shape and/or dtype later, which I find seriously tempting.  Looking at new shape-dependent strategies from #1829 and #1784, I think we might want to push users in the direction of "either use a constant shape, or use `@composite` or `data()` to combine several shape-dependent things".

But it's not clear when that might land or whether we want deprecate passing a strategy for dtype too, and we have until midyear to finalise any deprecations for 5.0, so I'm holding off for now.