### PR TITLE
Add strategy for generating values for the numpy-axis argument

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds the strategy :func:`~hypothesis.extra.numpy.valid_tuple_axes`,
+which generates tuples of axis-indices that can be passed to the ``axis`` in NumPy's
+sequential functions (e.g. ``numpy.sum``).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
 This release adds the strategy :func:`~hypothesis.extra.numpy.valid_tuple_axes`,
-which generates tuples of axis-indices that can be passed to the ``axis`` in NumPy's
-sequential functions (e.g. ``numpy.sum``).
+which generates tuples of axis-indices that can be passed to the ``axis`` argument
+in NumPy's sequential functions (e.g. ``numpy.sum``).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -2,4 +2,4 @@ RELEASE_TYPE: minor
 
 This release adds the strategy :func:`~hypothesis.extra.numpy.valid_tuple_axes`,
 which generates tuples of axis-indices that can be passed to the ``axis`` argument
-in NumPy's sequential functions (e.g. ``numpy.sum``).
+in NumPy's sequential functions (e.g. :func:`numpy:numpy.sum`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,3 +3,5 @@ RELEASE_TYPE: minor
 This release adds the strategy :func:`~hypothesis.extra.numpy.valid_tuple_axes`,
 which generates tuples of axis-indices that can be passed to the ``axis`` argument
 in NumPy's sequential functions (e.g. :func:`numpy:numpy.sum`).
+
+Thanks to Ryan Soklaski for this strategy.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -654,9 +654,9 @@ def nested_dtypes(
 @st.defines_strategy
 def valid_tuple_axes(ndim, min_size=0, max_size=None):
     # type: (int, int, Optional[int]) -> st.SearchStrategy[Tuple[int, ...]]
-    """ Return a strategy for generating permissible tuple-values for the
+    """Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.
-    :class:`numpy.sum <numpy:numpy.sum>`), given an array of the specified
+    :func:`numpy.sum <numpy:numpy.sum>`), given an array of the specified
     dimensionality.
 
     All tuples will have an length >= min_size and <= max_size. The default
@@ -677,7 +677,9 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
     check_valid_magnitude(ndim, "ndim")
 
     order_check("len", 0, min_size, max_size)
-    check_argument(min_size <= ndim, "min_len={} is larger than ndim={}", min_size, ndim)
+    check_argument(
+        min_size <= ndim, "min_len={} is larger than ndim={}", min_size, ndim
+    )
     check_type(integer_types, min_size, "min_len")
     check_type(integer_types, max_size, "max_len")
 
@@ -685,8 +687,7 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
 
     # shrink axis values from negative to positive
     return st.integers(min_size, max_size).flatmap(
-        lambda num_axes: st.permutations(tuple(zip(range(ndim), range(-ndim, 0, 1)))).map(
-            lambda axes: axes[:num_axes]).flatmap(
-            lambda x: st.tuples(*(st.sampled_from(item) for item in x))
-        )
+        lambda num_axes: st.permutations(tuple(zip(range(ndim), range(-ndim, 0, 1))))
+        .map(lambda axes: axes[:num_axes])
+        .flatmap(lambda x: st.tuples(*(st.sampled_from(item) for item in x)))
     )

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -656,7 +656,7 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
     # type: (int, int, Optional[int]) -> st.SearchStrategy[Tuple[int, ...]]
     """Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.
-    :func:`numpy.sum <numpy:numpy.sum>`), given an array of the specified
+    :func: `numpy:numpy.sum`), given an array of the specified
     dimensionality.
 
     All tuples will have an length >= min_size and <= max_size. The default

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -653,7 +653,7 @@ def nested_dtypes(
 
 @st.defines_strategy
 def valid_tuple_axes(ndim, min_size=0, max_size=None):
-    # type: (int, int, Optional[int]) -> st.SearchStrategy[Tuple[int, ...]]
+    # type: (int, int, int) -> st.SearchStrategy[Tuple[int, ...]]
     """Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.
     :func: `numpy:numpy.sum`), given an array of the specified

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -662,13 +662,24 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
     All tuples will have an length >= min_size and <= max_size. The default
     value for max_len is ``ndim``.
 
-    Examples from this strategy shrink towards an empty tuple.
+    Examples from this strategy shrink towards an empty tuple, which render
+    most sequential functions as no-ops.
 
+    The following are some examples drawn from this strategy.
 
     .. code-block:: pycon
 
         >>> [valid_tuple_axes(3).example() for i in range(4)]
         [(-3, 1), (0, 1, -1), (0, 2), (0, -2, 2)]
+
+    ``valid_tuple_axes`` can be joined with other strategies to generate
+    any type of valid axis object, i.e. integers, tuples, and ``None``:
+
+    .. code-block:: pycon
+    >>> from hypothesis.strategies import integers, none
+    >>> from hypothesis.extra.numpy import valid_tuple_axes
+    >>> def valid_axes(ndim):
+    ...     return none() | integers(-ndim, ndim - 1) | valid_tuple_axes(ndim)
     """
     if max_size is None:
         max_size = ndim

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -34,7 +34,7 @@ from hypothesis.reporting import current_verbosity
 from hypothesis.searchstrategy import SearchStrategy
 
 if False:
-    from typing import Any, Union, Sequence, Tuple, Optional  # noqa
+    from typing import Any, Union, Sequence, Tuple  # noqa
     from hypothesis.searchstrategy.strategies import T  # noqa
 
 TIME_RESOLUTIONS = tuple("Y  M  D  h  m  s  ms  us  ns  ps  fs  as".split())

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -676,10 +676,12 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
     any type of valid axis object, i.e. integers, tuples, and ``None``:
 
     .. code-block:: pycon
-    >>> from hypothesis.strategies import integers, none
-    >>> from hypothesis.extra.numpy import valid_tuple_axes
-    >>> def valid_axes(ndim):
-    ...     return none() | integers(-ndim, ndim - 1) | valid_tuple_axes(ndim)
+
+        >>> from hypothesis.strategies import integers, none
+        >>> from hypothesis.extra.numpy import valid_tuple_axes
+        >>> def valid_axes(ndim):
+        ...     return none() | integers(-ndim, ndim - 1) | valid_tuple_axes(ndim)
+
     """
     if max_size is None:
         max_size = ndim

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -677,10 +677,7 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
 
     .. code-block:: pycon
 
-        >>> from hypothesis.strategies import integers, none
-        >>> from hypothesis.extra.numpy import valid_tuple_axes
-        >>> def valid_axes(ndim):
-        ...     return none() | integers(-ndim, ndim - 1) | valid_tuple_axes(ndim)
+        any_axis_strategy = none() | integers(-ndim, ndim - 1) | valid_tuple_axes(ndim)
 
     """
     if max_size is None:

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -693,8 +693,7 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
     check_valid_interval(max_size, ndim, "max_size", "ndim")
 
     # shrink axis values from negative to positive
-    return st.integers(min_size, max_size).flatmap(
-        lambda num_axes: st.permutations(tuple(zip(range(ndim), range(-ndim, 0, 1))))
-        .map(lambda axes: axes[:num_axes])
-        .flatmap(lambda x: st.tuples(*(st.sampled_from(item) for item in x)))
+    axes = st.integers(0, max(0, 2 * ndim - 1)).map(
+        lambda x: x if x < ndim else x - 2 * ndim
     )
+    return st.lists(axes, min_size, max_size, unique_by=lambda x: x % ndim).map(tuple)

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -29,7 +29,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import hrange, integer_types, text_type
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
-from hypothesis.internal.validation import check_type, check_valid_magnitude
+from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.reporting import current_verbosity
 from hypothesis.searchstrategy import SearchStrategy
 
@@ -685,16 +685,10 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
         max_size = ndim
 
     check_type(integer_types, ndim, "ndim")
-    check_valid_magnitude(ndim, "ndim")
-
-    order_check("len", 0, min_size, max_size)
-    check_argument(
-        min_size <= ndim, "min_len={} is larger than ndim={}", min_size, ndim
-    )
-    check_type(integer_types, min_size, "min_len")
-    check_type(integer_types, max_size, "max_len")
-
-    max_size = min(ndim, max_size)
+    check_type(integer_types, min_size, "min_size")
+    check_type(integer_types, max_size, "max_size")
+    order_check("size", 0, min_size, max_size)
+    check_valid_interval(max_size, ndim, "max_size", "ndim")
 
     # shrink axis values from negative to positive
     return st.integers(min_size, max_size).flatmap(

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -59,6 +59,13 @@ def e(a, **kwargs):
         e(nps.from_dtype, dtype=float),
         e(nps.from_dtype, dtype=numpy.int8),
         e(nps.from_dtype, dtype=1),
+        e(nps.valid_tuple_axes, ndim=-1),
+        e(nps.valid_tuple_axes, ndim=2, min_size=-1),
+        e(nps.valid_tuple_axes, ndim=2, min_size=3, max_size=10),
+        e(nps.valid_tuple_axes, ndim=2, min_size=2, max_size=1),
+        e(nps.valid_tuple_axes, ndim=2., min_size=2, max_size=1),
+        e(nps.valid_tuple_axes, ndim=2, min_size=1.0, max_size=2),
+        e(nps.valid_tuple_axes, ndim=2, min_size=1, max_size=2.0),
     ],
 )
 def test_raise_invalid_argument(function, kwargs):

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -66,6 +66,7 @@ def e(a, **kwargs):
         e(nps.valid_tuple_axes, ndim=2.0, min_size=2, max_size=1),
         e(nps.valid_tuple_axes, ndim=2, min_size=1.0, max_size=2),
         e(nps.valid_tuple_axes, ndim=2, min_size=1, max_size=2.0),
+        e(nps.valid_tuple_axes, ndim=2, min_size=1, max_size=3),
     ],
 )
 def test_raise_invalid_argument(function, kwargs):

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -63,7 +63,7 @@ def e(a, **kwargs):
         e(nps.valid_tuple_axes, ndim=2, min_size=-1),
         e(nps.valid_tuple_axes, ndim=2, min_size=3, max_size=10),
         e(nps.valid_tuple_axes, ndim=2, min_size=2, max_size=1),
-        e(nps.valid_tuple_axes, ndim=2., min_size=2, max_size=1),
+        e(nps.valid_tuple_axes, ndim=2.0, min_size=2, max_size=1),
         e(nps.valid_tuple_axes, ndim=2, min_size=1.0, max_size=2),
         e(nps.valid_tuple_axes, ndim=2, min_size=1, max_size=2.0),
     ],

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -483,11 +483,7 @@ def test_axes_are_valid_inputs_to_sum(shape, data):
 def test_minimize_tuple_axes(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
     max_size = data.draw(st.integers(min_size, ndim), label="max_size")
-    smallest = minimal(
-        nps.valid_tuple_axes(
-            ndim, min_size, max_size
-        )
-    )
+    smallest = minimal(nps.valid_tuple_axes(ndim, min_size, max_size))
     assert len(smallest) == min_size and all(k > -1 for k in smallest)
 
 
@@ -497,9 +493,6 @@ def test_minimize_negative_tuple_axes(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
     max_size = data.draw(st.integers(min_size, ndim), label="max_size")
     smallest = minimal(
-        nps.valid_tuple_axes(
-            ndim, min_size, max_size
-        ),
-        lambda x: all(i < 0 for i in x)
+        nps.valid_tuple_axes(ndim, min_size, max_size), lambda x: all(i < 0 for i in x)
     )
     assert len(smallest) == min_size

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -453,3 +453,53 @@ def test_inferred_floats_do_not_overflow(arr):
 )
 def test_unique_array_with_fill_can_use_all_elements(arr):
     assume(len(set(arr)) == arr.size)
+
+
+@given(ndim=st.integers(0, 5), data=st.data())
+def test_mapped_positive_axes_are_unique(ndim, data):
+    min_size = data.draw(st.integers(0, ndim), label="min_size")
+    max_size = data.draw(st.integers(min_size, ndim), label="max_size")
+    axes = data.draw(nps.valid_tuple_axes(ndim, min_size, max_size), label="axes")
+    assert len(set(axes)) == len(set([i if 0 < i else ndim + i for i in axes]))
+
+
+@given(ndim=st.integers(0, 5), data=st.data())
+def test_length_bounds_are_satisfied(ndim, data):
+    min_size = data.draw(st.integers(0, ndim), label="min_size")
+    max_size = data.draw(st.integers(min_size, ndim), label="max_size")
+    axes = data.draw(nps.valid_tuple_axes(ndim, min_size, max_size), label="axes")
+    assert min_size <= len(axes) <= max_size
+
+
+@given(shape=nps.array_shapes(), data=st.data())
+def test_axes_are_valid_inputs_to_sum(shape, data):
+    x = np.zeros(shape)
+    axes = data.draw(nps.valid_tuple_axes(ndim=len(shape)), label="axes")
+    np.sum(x, axes)
+
+
+@settings(deadline=None)
+@given(ndim=st.integers(0, 5), data=st.data())
+def test_minimize_tuple_axes(ndim, data):
+    min_size = data.draw(st.integers(0, ndim), label="min_size")
+    max_size = data.draw(st.integers(min_size, ndim), label="max_size")
+    smallest = minimal(
+        nps.valid_tuple_axes(
+            ndim, min_size, max_size
+        )
+    )
+    assert len(smallest) == min_size and all(k > -1 for k in smallest)
+
+
+@settings(deadline=None)
+@given(ndim=st.integers(0, 5), data=st.data())
+def test_minimize_negative_tuple_axes(ndim, data):
+    min_size = data.draw(st.integers(0, ndim), label="min_size")
+    max_size = data.draw(st.integers(min_size, ndim), label="max_size")
+    smallest = minimal(
+        nps.valid_tuple_axes(
+            ndim, min_size, max_size
+        ),
+        lambda x: all(i < 0 for i in x)
+    )
+    assert len(smallest) == min_size

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -479,7 +479,7 @@ def test_axes_are_valid_inputs_to_sum(shape, data):
 
 
 @settings(deadline=None)
-@given(ndim=st.integers(0, 5), data=st.data())
+@given(ndim=st.integers(0, 3), data=st.data())
 def test_minimize_tuple_axes(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
     max_size = data.draw(st.integers(min_size, ndim), label="max_size")
@@ -488,7 +488,7 @@ def test_minimize_tuple_axes(ndim, data):
 
 
 @settings(deadline=None)
-@given(ndim=st.integers(0, 5), data=st.data())
+@given(ndim=st.integers(0, 3), data=st.data())
 def test_minimize_negative_tuple_axes(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
     max_size = data.draw(st.integers(min_size, ndim), label="max_size")

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -455,6 +455,14 @@ def test_unique_array_with_fill_can_use_all_elements(arr):
     assume(len(set(arr)) == arr.size)
 
 
+@given(nps.arrays(dtype="uint8", shape=25, unique=True, fill=st.nothing()))
+def test_unique_array_without_fill(arr):
+    # This test covers the collision-related branchs for fully dense unique arrays.
+    # Choosing 25 of 256 possible elements means we're almost certain to see colisions
+    # thanks to the 'birthday paradox', but finding unique elemennts is still easy.
+    assume(len(set(arr)) == arr.size)
+
+
 @given(ndim=st.integers(0, 5), data=st.data())
 def test_mapped_positive_axes_are_unique(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")


### PR DESCRIPTION
Users can leverage this strategy to generate all permissible tuple-valued inputs to  `axis` argument in [NumPy's sequential functions](https://www.pythonlikeyoumeanit.com/Module3_IntroducingNumpy/VectorizedOperations.html#Sequential-Functions), e.g. `numpy.sum`.

Ultimately, this does the real heavy lifting needed to exhaust the permissible values for axis arguments. Specifically,

```python
from hypothesis.strategies import integers, none
from hypothesis.extra import valid_tuple_axes
def valid_axes(ndim):
    return integers(-ndim, ndim - 1) | valid_tuple_axes(ndim) | none()
```
can generate all permissible values `Optional[int, Tuple[int, ...]]`, including negative axis-indices.