### PR TITLE
Remove a large number of jobs from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ jobs:
     - stage: main
       env: TASK=check-coverage
     - env: TASK=check-py27
-    - env: TASK=check-py34
-    - env: TASK=check-py37
+    - env: TASK=check-py36
       sudo: required
       dist: xenial
     - env: TASK=check-ruby-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
     - stage: main
       env: TASK=check-coverage
     - env: TASK=check-py27
+    - env: TASK=check-py34
     - env: TASK=check-py37
       sudo: required
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,32 +40,12 @@ jobs:
 
     - stage: main
       env: TASK=check-coverage
-    - env: TASK=check-pypy
-    - env: TASK=check-pypy3
-    - env: TASK=check-py36
     - env: TASK=check-py27
-    - env: TASK=check-py34
-    - env: TASK=check-py35
     - env: TASK=check-py37
       sudo: required
       dist: xenial
-    - env: TASK=check-quality
     - env: TASK=check-ruby-tests
-
-    # Less important tests that will probably
-    # pass whenever the above do but are still
-    # worth testing.
-    - stage: extras
-      env: TASK=check-unicode
-    - env: TASK=check-py27-typing
-    - env: TASK=check-nose
-    - env: TASK=check-pytest30
-    - env: TASK=check-django21
-    - env: TASK=check-django20
     - env: TASK=check-django111
-    - env: TASK=check-pandas19
-    - env: TASK=check-pandas22
-    - env: TASK=check-pandas23
     - env: TASK=check-pandas24
 
     - stage: deploy


### PR DESCRIPTION
We live in a post-#1854 world now (thanks @Kavec!) where almost all of the jobs we run on Travis run on Azure as well, only much faster. I've marked it as required on our pull requests.

If and when we've got deploys working from Azure we can retire our Travis config entirely, but until then there's no reason we have to suffer from slow builds.

This pares back our Travis build down to a much smaller set. The reasoning behind the remaining set is that everything on this list is basically it sure would be embarrassing if we shipped something that fails these tests, and if the other tests passed prior to merge and these ones passed post merge we've probably covered most of our bases.

Note that it merges the extras and main category - there aren't enough extras left in this build set to be worth the split.