### PR TITLE
Move Windows, OSX builds to Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         check-whole-repo-tests:
           TASK: check-whole-repo-tests
     steps:
-    - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
+    - script: sudo apt-get install libreadline-dev libsqlite3-dev
       displayName: Install apt dependencies
     - script: ./build.sh check-installed
       displayName: Install Python
@@ -35,7 +35,7 @@ jobs:
         check-rust-tests:
           TASK: check-rust-tests
     steps:
-    - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
+    - script: sudo apt-get install libreadline-dev libsqlite3-dev
       displayName: Install apt dependencies
     - script: ./build.sh check-installed
       displayName: Install Python
@@ -89,7 +89,7 @@ jobs:
         check-pandas24:
           TASK: check-pandas24
     steps:
-    - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
+    - script: sudo apt-get install libreadline-dev libsqlite3-dev
       displayName: Install apt dependencies
     - script: ./build.sh check-installed
       displayName: Install Python
@@ -127,7 +127,7 @@ jobs:
         python -m pip install setuptools -r requirements/test.txt
         python -m pip install hypothesis-python/
       displayName: Install dependencies
-    - script: "python -m pytest hypothesis-python\\tests\\cover"
+    - script: python -m pytest hypothesis-python/tests/cover
       displayName: Run tests
 
   - job: osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,4 @@
 # https://aka.ms/yaml
-variables:
-  # Current tooling indexes directly into os.environ and will
-  # fail without this defined
-  # TODO: Implement specific PR logic and then fix up tooling to be okay
-  # without this environment variable set
-  travis_event_type: ''
-
 
 jobs:
   - job: precheck_concurrent

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,4 +124,23 @@ jobs:
     - script: "python -m pytest hypothesis-python\\tests\\cover"
       displayName: Run tests
 
+  - job: osx
+    dependsOn: precheck
+    pool:
+      vmImage: 'macOS-10.13'
+    strategy:
+      matrix:
+        check-py27:
+          TASK: check-py27
+        check-py36:
+          TASK: check-py36
+    steps:
+    - script: |
+        brew update
+        brew install readline xz ncurses
+        ./build.sh install-core
+      displayName: Install dependencies
+    - script: ./build.sh
+      displayName: Run tests
+
 # TODO: Deploy jobs dependent on above

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
       displayName: Install apt dependencies
+    - script: ./build.sh check-installed
+      displayName: Install Python
     - script: ./build.sh
       displayName: Run build tasks
 
@@ -35,6 +37,8 @@ jobs:
     steps:
     - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
       displayName: Install apt dependencies
+    - script: ./build.sh check-installed
+      displayName: Install Python
     - script: ./build.sh
       displayName: Run build tasks
 
@@ -87,6 +91,8 @@ jobs:
     steps:
     - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
       displayName: Install apt dependencies
+    - script: ./build.sh check-installed
+      displayName: Install Python
     - script: ./build.sh
       displayName: Run tests
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,4 +90,38 @@ jobs:
     - script: ./build.sh
       displayName: Run tests
 
+  - job: windows
+    dependsOn: precheck
+    pool:
+      vmImage: 'windows-2019'
+    strategy:
+      matrix:
+        check-py27-x64:
+          python.version: '2.7'
+          python.architecture: 'x64'
+        check-py27-x86:
+          python.version: '2.7'
+          python.architecture: 'x86'
+        check-py36-x64:
+          python.version: '3.6'
+          python.architecture: 'x64'
+        check-py36-x86:
+          python.version: '3.6'
+          python.architecture: 'x86'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+        architecture: '$(python.architecture)'
+    # TODO: installing `hypothesis-python/[all]` leads to some Numpy-related
+    # errors at pytest collection time, but I'm not sure why.  Once we fix
+    # that, we can test the extras on Windows, and thus drop Appveyor.
+    - script: |
+        python -m pip install --upgrade setuptools pip wheel twine
+        python -m pip install setuptools -r requirements/test.txt
+        python -m pip install hypothesis-python/
+      displayName: Install dependencies
+    - script: "python -m pytest hypothesis-python\\tests\\cover"
+      displayName: Run tests
+
 # TODO: Deploy jobs dependent on above

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,6 @@
-# https://aka.ms/yaml
+# Schema docs at https://aka.ms/yaml
+trigger:
+  - master
 
 jobs:
   - job: precheck_concurrent

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ jobs:
   - job: precheck_concurrent
     # This job schedules long-running tasks concurrently with the rest of the
     # build pipeline ensuring that later stages don't block on them
+    # We'll merge it back into the `precheck` stage once Pipelines has caching.
     pool:
       vmImage: 'Ubuntu 16.04'
     strategy:
@@ -13,9 +14,7 @@ jobs:
         check-whole-repo-tests:
           TASK: check-whole-repo-tests
     steps:
-    - script: >
-        sudo apt-get install
-        libreadline-dev libsqlite3-dev
+    - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
       displayName: Install apt dependencies
     - script: ./build.sh
       displayName: Run build tasks
@@ -34,9 +33,7 @@ jobs:
         check-rust-tests:
           TASK: check-rust-tests
     steps:
-    - script: >
-        sudo apt-get install
-        libreadline-dev libsqlite3-dev
+    - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
       displayName: Install apt dependencies
     - script: ./build.sh
       displayName: Run build tasks
@@ -57,9 +54,6 @@ jobs:
           TASK: check-py36
         check-py27:
           TASK: check-py27
-        # Python 3.4 doesn't build against libssl-dev on Azure, failing checks
-        #check-py34:
-        #  TASK: check-py34
         check-py35:
           TASK: check-py35
         check-py37:
@@ -91,11 +85,9 @@ jobs:
         check-pandas24:
           TASK: check-pandas24
     steps:
-    - script: >
-        sudo apt-get install
-        libreadline-dev libsqlite3-dev
+    - script: "sudo apt-get install libreadline-dev libsqlite3-dev"
       displayName: Install apt dependencies
     - script: ./build.sh
-      displayName: Run build tasks
+      displayName: Run tests
 
 # TODO: Deploy jobs dependent on above

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -260,9 +260,9 @@ def upgrade_requirements():
 
 
 def is_pyup_branch():
-    return os.environ["TRAVIS_EVENT_TYPE"] == "pull_request" and os.environ[
+    return os.environ.get("TRAVIS_EVENT_TYPE") == "pull_request" and os.environ.get(
         "TRAVIS_PULL_REQUEST_BRANCH"
-    ].startswith("pyup-scheduled-update")
+    ).startswith("pyup-scheduled-update")
 
 
 def push_pyup_requirements_commit():

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -260,9 +260,15 @@ def upgrade_requirements():
 
 
 def is_pyup_branch():
-    return os.environ.get("TRAVIS_EVENT_TYPE") == "pull_request" and os.environ.get(
-        "TRAVIS_PULL_REQUEST_BRANCH"
-    ).startswith("pyup-scheduled-update")
+    if os.environ.get("TRAVIS_EVENT_TYPE") == "pull_request" and os.environ.get(
+        "TRAVIS_PULL_REQUEST_BRANCH", ""
+    ).startswith("pyup-scheduled-update"):
+        return True
+    return (
+        os.environ.get("Build.SourceBranchName", "").startswith("pyup-scheduled-update")
+        and os.environ.get("System.PullRequest.IsFork") == "False"
+        and os.environ.get("Build.Reason") == "PullRequest"
+    )
 
 
 def push_pyup_requirements_commit():


### PR DESCRIPTION
An experiment in pursuit of #1571.  Results so far:

- Installing a specific Python on the build agent is hard, but using the provided Python version selectors is both easy and a *lot* faster given the caching situation.

- upstream UX issue for @vtbassmatt: if the config is invalid, github will show "Waiting for status to be reported" indefinitely instead of an error state.  Not a big problem, but it's usually worth removing any friction in onboarding.

- For some reason installing Numpy gets me `AttributeError`s in `searchstrategy.types`.  No idea why, but numpy-on-win-x86 is one of the jobs we really can't give up.  Still working on this one.