### PR TITLE
Deprecate sampled_from([])

### DIFF
--- a/guides/api-style.rst
+++ b/guides/api-style.rst
@@ -77,6 +77,10 @@ We have a reasonably distinctive style when it comes to handling arguments:
   If you find yourself inclined to write something like that, instead make it
   take a strategy. If a user wants to pass a value they can wrap it in a call
   to ``just``.
+* If a combination of arguments make it impossible to generate anything,
+  ``raise InvalidArgument`` instead of ``return nothing()``.  Returning the
+  null strategy is conceptually nice, but can lead to silently dropping parts
+  from composed strategies and thus unexpectedly weak tests.
 
 ~~~~~~~~~~~~~~
 Function Names

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release deprecates :func:`~hypothesis.strategies.sampled_from` with empty
+sequences.  This returns :func:`~hypothesis.strategies.nothing`, which gives a
+clear error if used directly... but simply vanishes if combined with another
+strategy.
+
+Tests that silently generate less than expected are a serious problem for
+anyone relying on them to find bugs, and we think reliability more important
+than convenience in this case.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -675,6 +675,12 @@ def sampled_from(elements):
     """
     values = check_sample(elements, "sampled_from")
     if not values:
+        note_deprecation(
+            "sampled_from() with nothing to sample is deprecated and will be an "
+            "error in a future version.  It currently returns `st.nothing()`, "
+            "which if unexpected can make parts of a strategy silently vanish.",
+            since="RELEASEDAY",
+        )
         return nothing()
     if len(values) == 1:
         return just(values[0])
@@ -1005,7 +1011,7 @@ def text(
     elif isinstance(alphabet, SearchStrategy):
         char_strategy = alphabet
     else:
-        char_strategy = sampled_from(list(alphabet))
+        char_strategy = sampled_from(list(alphabet)) if alphabet else nothing()
         if not isinstance(alphabet, abc.Sequence):
             raise InvalidArgument(
                 "alphabet must be an ordered sequence, or tests may be "
@@ -1596,7 +1602,7 @@ def decimals(
         special.append(Decimal("Infinity"))
     if allow_infinity or (allow_infinity is min_value is None):
         special.append(Decimal("-Infinity"))
-    return strat | sampled_from(special)
+    return strat | (sampled_from(special) if special else nothing())
 
 
 def recursive(

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -93,8 +93,10 @@ class LarkStrategy(SearchStrategy):
 
         self.start = self.names_to_symbols[start]
 
-        self.ignored_symbols = st.sampled_from(
-            [self.names_to_symbols[n] for n in ignore_names]
+        self.ignored_symbols = (
+            st.sampled_from([self.names_to_symbols[n] for n in ignore_names])
+            if ignore_names
+            else st.nothing()
         )
 
         self.terminal_strategies = {

--- a/hypothesis-python/tests/cover/test_nothing.py
+++ b/hypothesis-python/tests/cover/test_nothing.py
@@ -26,7 +26,9 @@ from tests.common.debug import assert_no_examples, minimal
 
 def test_resampling():
     x = minimal(
-        st.lists(st.integers()).flatmap(lambda x: st.lists(st.sampled_from(x))),
+        st.lists(st.integers(), min_size=1).flatmap(
+            lambda x: st.lists(st.sampled_from(x))
+        ),
         lambda x: len(x) >= 10 and len(set(x)) == 1,
     )
     assert x == [0] * 10

--- a/hypothesis-python/tests/cover/test_reusable_values.py
+++ b/hypothesis-python/tests/cover/test_reusable_values.py
@@ -51,7 +51,7 @@ def reusable():
             allow_nan=st.booleans(),
         ),
         st.builds(st.just, st.builds(list)),
-        st.builds(st.sampled_from, st.lists(st.builds(list))),
+        st.builds(st.sampled_from, st.lists(st.builds(list), min_size=1)),
         st.lists(reusable).map(st.one_of),
         st.lists(reusable).map(lambda ls: st.tuples(*ls)),
     )

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -23,7 +23,7 @@ import enum
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import sampled_from
-from tests.common.utils import fails_with
+from tests.common.utils import checks_deprecated_behaviour, fails_with
 
 an_enum = enum.Enum("A", "a b c")
 
@@ -46,3 +46,8 @@ def test_can_sample_ordereddict_without_warning():
 @given(sampled_from(an_enum))
 def test_can_sample_enums(member):
     assert isinstance(member, an_enum)
+
+
+@checks_deprecated_behaviour
+def test_sampling_empty_is_deprecated():
+    assert sampled_from([]).is_empty

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -31,6 +31,7 @@ from hypothesis.errors import (
 )
 from hypothesis.internal.compat import PY2, integer_types
 from hypothesis.searchstrategy import types
+from tests.common.utils import checks_deprecated_behaviour
 
 # Build a set of all types output by core strategies
 blacklist = [
@@ -177,6 +178,7 @@ class EmptyEnum(enum.Enum):
     pass
 
 
+@checks_deprecated_behaviour
 def test_error_if_enum_is_empty():
     assert st.from_type(EmptyEnum).is_empty
 


### PR DESCRIPTION
As discussed on #1860, returning `nothing()` instead of raising an error makes it easy to lose parts of a composed strategy.  Since we only do that in one place currently, it's pretty easy to deprecate it and add a note in our API style guide not to do this again!

For the three internal uses where we want this behaviour, we convert `sampled_from(a)` to `sampled_from(a) if a else nothing()`.  For the two cases where we don't, we can improve clarity and efficiency by passing `min_size=1` to prevent generation of the empty list we tried to sample.