### PR TITLE
Build example objects lazily

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release should significantly reduce the amount of memory that Hypothesis uses for representing large test cases,
+by storing information in a more compact representation and only unpacking it lazily when it is first needed.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -77,6 +77,13 @@ class IntList(object):
                 if v < 0 or not isinstance(v, integer_types):
                     raise ValueError("Could not create IntList for %r" % (values,))
 
+    @classmethod
+    def of_length(self, n):
+        return IntList(array_or_list("B", [0]) * n)
+
+    def count(self, n):
+        return self.__underlying.count(n)
+
     def __repr__(self):
         return "IntList(%r)" % (list(self),)
 
@@ -109,13 +116,22 @@ class IntList(object):
         return self.__underlying != other.__underlying
 
     def append(self, n):
+        i = len(self)
+        self.__underlying.append(0)
+        self[i] = n
+
+    def __setitem__(self, i, n):
         while True:
             try:
-                self.__underlying.append(n)
+                self.__underlying[i] = n
                 return
             except OverflowError:
                 assert n > 0
                 self.__upgrade()
+
+    def extend(self, ls):
+        for n in ls:
+            self.append(n)
 
     def __upgrade(self):
         code = NEXT_ARRAY_CODE[self.__underlying.typecode]

--- a/hypothesis-python/tests/cover/test_conjecture_intlist.py
+++ b/hypothesis-python/tests/cover/test_conjecture_intlist.py
@@ -56,3 +56,10 @@ def test_basic_equality():
 def test_error_on_invalid_value():
     with pytest.raises(ValueError):
         IntList([-1])
+
+
+def test_extend_by_too_large():
+    x = IntList()
+    ls = [1, 10 ** 6]
+    x.extend(ls)
+    assert list(x) == ls


### PR DESCRIPTION
This follows on from the work in #1830 of making the example collection *even lazier*.

The basic design principle here is to make `Example` just a thin shim indexing into a more compact representation. This representation stores a compact record of the set of `start_example/stop_example/draw_bits` call and compact representations of any property that has been accessed on an `Example` object for the current collection.

The code involves is... a bit weird. However I genuinely think a decorator that transforms a nested class into a method *is* the nicest way to represent this.

Note that there is now a certain amount of logical redundancy in the code which really should be merged. In particular `Examples` and `Blocks` work quite differently, and `ExampleRecord` and `DataObserver` are fairly similar in how they work. The medium term goal would be to merge as follows:

* `Blocks` would move to work like `Examples` does in this PR.
* `DataTree` would gain some of the logic from `ExampleRecord` so that it records the position of `start_example` and `stop_example`
* The underlying storage of `Examples` and `Blocks` would become a single list of `draw_bits` results. Replay would happen by walking the data tree.

This does *not* happen in this PR and probably won't happen fully in the next month.