### PR TITLE
Don't bother calculating the giant table of masks that we never use

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release removes some internal code that populates a field that is no longer used anywhere.
+This should result in some modest performance and speed improvements and no other user visible effects.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -487,7 +487,6 @@ class ConjectureData(object):
         self.start_time = benchmark_time()
         self.events = set()
         self.forced_indices = set()
-        self.masked_indices = {}
         self.interesting_origin = None
         self.draw_times = []
         self.max_depth = 0
@@ -667,13 +666,6 @@ class ConjectureData(object):
             buf = bytearray(self._draw_bytes(self, n_bytes))
         assert len(buf) == n_bytes
 
-        # If we have a number of bits that is not a multiple of 8
-        # we have to mask off the high bits.
-        if n % 8 != 0:
-            mask = (1 << (n % 8)) - 1
-            assert mask != 0
-            buf[0] &= mask
-            self.masked_indices[self.index] = mask
         buf = hbytes(buf)
         result = int_from_bytes(buf)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -453,6 +453,12 @@ Stop = UniqueIdentifier("Stop")
 StopDiscard = UniqueIdentifier("StopDiscard")
 
 
+# Masks for masking off the first byte of an n-bit buffer.
+# The appropriate mask is stored at position n % 8.
+BYTE_MASKS = [(1 << n) - 1 for n in hrange(8)]
+BYTE_MASKS[0] = 255
+
+
 class ConjectureData(object):
     @classmethod
     def for_buffer(self, buffer, observer=None):
@@ -666,6 +672,9 @@ class ConjectureData(object):
             buf = bytearray(self._draw_bytes(self, n_bytes))
         assert len(buf) == n_bytes
 
+        # If we have a number of bits that is not a multiple of 8
+        # we have to mask off the high bits.
+        buf[0] &= BYTE_MASKS[n % 8]
         buf = hbytes(buf)
         result = int_from_bytes(buf)
 


### PR DESCRIPTION
See title.

Usage of this field went away in #1846 but the field itself did not. The field itself is potentially quite big, and updating it potentially happens quite often (in my Csmith experiments all `draw_bits` calls are with `n_bits=31`. So this was getting populated on every single call. This was a poor life choice)