### PR TITLE
Remove lingering Block allocation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release removes some redundant code that was no longer needed but was still running a significant amount of computation and allocation on the hot path.
+This should result in a modest speed improvement for most tests, especially those with large test cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -682,17 +682,6 @@ class ConjectureData(object):
         self.start_example(DRAW_BYTES_LABEL)
         initial = self.index
 
-        block = Block(
-            start=initial,
-            end=initial + n_bytes,
-            index=len(self.blocks),
-            forced=forced is not None,
-            all_zero=result == 0,
-        )
-
-        if block.forced:
-            self.forced_indices.update(hrange(block.start, block.end))
-
         self.buffer.extend(buf)
         self.index = len(self.buffer)
 


### PR DESCRIPTION
Turns out that as well as lazily allocating `Block` objects as of #1830 we're *also* allocating them on the hot path. 🙄 This removes that code.

I think this must have got screwed up in a rebase as I had a bunch of branches in flight at the time.