### PR TITLE
Don't use a fresh context manager on every debug call

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release adds a micro-optimisation to how Hypothesis handles debug reporting internally.
+Hard to shrink test may see a slight performance improvement, but in most common scenarios it is unlikely to be noticeable.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -46,7 +46,7 @@ from hypothesis.internal.conjecture.datatree import DataTree, TreeRecordingObser
 from hypothesis.internal.conjecture.junkdrawer import pop_random, uniform
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
-from hypothesis.reporting import debug_report
+from hypothesis.reporting import base_report
 
 # Tell pytest to omit the body of this module from tracebacks
 # https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
@@ -339,8 +339,8 @@ class ConjectureRunner(object):
             self.event_call_counts[event] += 1
 
     def debug(self, message):
-        with local_settings(self.settings):
-            debug_report(message)
+        if self.settings.verbosity >= Verbosity.debug:
+            base_report(message)
 
     @property
     def report_debug_info(self):

--- a/hypothesis-python/src/hypothesis/reporting.py
+++ b/hypothesis-python/src/hypothesis/reporting.py
@@ -64,14 +64,18 @@ def to_text(textish):
 
 def verbose_report(text):
     if current_verbosity() >= Verbosity.verbose:
-        current_reporter()(to_text(text))
+        base_report(text)
 
 
 def debug_report(text):
     if current_verbosity() >= Verbosity.debug:
-        current_reporter()(to_text(text))
+        base_report(text)
 
 
 def report(text):
     if current_verbosity() >= Verbosity.normal:
-        current_reporter()(to_text(text))
+        base_report(text)
+
+
+def base_report(text):
+    current_reporter()(to_text(text))


### PR DESCRIPTION
I was moderately surprised to discover that of all things `_settings.py` was now one of the allocation hotspots. This turns out to be because we are calling `local_settings` on every `debug` call in the engine, which is a bit hungrier than I thought it would be. 😳 

Anyway, this PR fixes that. It's unlikely to have a *huge* impact, but it should have a small one, and gets this method out of the allocation reports which makes it easier to notice what's going on with other things.