### PR TITLE
Don't rewrite novel buffers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release adds a micro-optimisation to how Hypothesis caches test cases.
+This will cause a small improvement in speed and memory usage for large test cases,
+but in most common scenarios it is unlikely to be noticeable.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -294,7 +294,7 @@ class DataTree(object):
             self.simulate_test_function(data)
             return (data.buffer, data.status)
         except PreviouslyUnseenBehaviour:
-            return (hbytes(data.buffer) + buffer[len(data.buffer) :], None)
+            return (buffer, None)
 
     def simulate_test_function(self, data):
         """Run a simulated version of the test function recorded by


### PR DESCRIPTION
Another "oh this is one of the the allocation hotspots and there's no good reason for it to be" PR which is unlikely to have a huge impact in and of its own right but is small enough that it's worth doing anyway.

When we look up a buffer we rewrite it to see if it corresponds to something we've previously run, but if there's a novel behaviour then we definitely *haven't* run it before, so there's no point in rewriting it. When the buffer is large, doing so can involve a bunch of useless allocations.