### PR TITLE
Just use indices as stable identifiers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release replaces the identifiers Hypothesis uses to refer to parts of a test case with integer indices.
+This will result in significantly lower memory usage. It may either slow down or speed up shrinking,
+depending on the nature of the problem.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1384,62 +1384,19 @@ class Shrinker(object):
             else:
                 lo = mid
 
-    @derived_value
-    def example_to_stable_identifier_cache(self):
-        return []
-
-    @derived_value
-    def stable_identifier_to_example_cache(self):
-        return {}
-
     def stable_identifier_for_example(self, example):
         """A stable identifier is one that we can reasonably reliably
         count on referring to "logically the same" example between two
         different test runs. It is currently represented as a path from
         the root."""
-
-        i = example.index
-        n = len(self.example_to_stable_identifier_cache)
-        if i >= n:
-            self.example_to_stable_identifier_cache.extend([None] * (i - n + 1))
-            assert i < len(self.example_to_stable_identifier_cache)
-        result = self.example_to_stable_identifier_cache[i]
-        if result is None:
-            if i == 0:
-                result = ""
-            else:
-                parent = self.stable_identifier_for_example(
-                    self.examples[example.parent]
-                )
-                child = str(example.child_index)
-                if parent:
-                    result = parent + "," + child
-                else:
-                    result = child
-            self.example_to_stable_identifier_cache[i] = result
-        return result
+        return example.index
 
     def example_for_stable_identifier(self, identifier):
         """Returns the example in the current shrink target corresponding
         to this stable identifier, or None if no such example exists."""
-        if not identifier:
-            return self.examples[0]
-
-        cache = self.stable_identifier_to_example_cache
-        try:
-            return cache[identifier]
-        except KeyError:
-            pass
-        path = list(map(int, identifier.split(",")))
-        ex = self.examples[0]
-        for i in path:
-            try:
-                ex = ex.children[i]
-            except IndexError:
-                ex = None
-                break
-        cache[identifier] = ex
-        return ex
+        if identifier >= len(self.examples):
+            return None
+        return self.shrink_target.examples[identifier]
 
     def run_block_program(self, i, description, original, repeats=1):
         """Block programs are a mini-DSL for block rewriting, defined as a sequence

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -18,14 +18,12 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-import pytest
 
 import hypothesis.extra.numpy as npst
 import hypothesis.extra.pandas as pdst
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, given, reject, settings
-from hypothesis.types import RandomWithSeed as Random
-from tests.common.debug import find_any, minimal
+from tests.common.debug import find_any
 from tests.pandas.helpers import supported_by_pandas
 
 
@@ -124,34 +122,6 @@ def test_can_specify_both_rows_and_columns_dict(d):
 )
 def test_can_fill_in_missing_elements_from_dict(df):
     assert np.isnan(df["A"]).all()
-
-
-subsets = ["", "A", "B", "C", "AB", "AC", "BC", "ABC"]
-
-
-@pytest.mark.parametrize("disable_fill", subsets)
-@pytest.mark.parametrize("non_standard_index", [True, False])
-def test_can_minimize_based_on_two_columns_independently(
-    disable_fill, non_standard_index
-):
-    columns = [
-        pdst.column(
-            name, dtype=bool, fill=st.nothing() if name in disable_fill else None
-        )
-        for name in ["A", "B", "C"]
-    ]
-
-    x = minimal(
-        pdst.data_frames(
-            columns, index=pdst.indexes(dtype=int) if non_standard_index else None
-        ),
-        lambda x: x["A"].any() and x["B"].any() and x["C"].any(),
-        random=Random(0),
-    )
-    assert len(x["A"]) == 1
-    assert x["A"][0] == 1
-    assert x["B"][0] == 1
-    assert x["C"][0] == 1
 
 
 @st.composite


### PR DESCRIPTION
This walks back part of the stable identifiers PR and just refers to examples by their indices.

This works less well in some cases (I'm unsure how less well, I haven't benchmarked), but these stable identifiers were actually a major source of memory usage (unsurprisingly in retrospect) which isn't worth the performance cost.

I'm surprised and a bit embarrassed that not only does (seemingly) the entire test suite continue to pass after this change but also it got *faster*. 😢 