### PR TITLE
Make coarse passes deletion focused

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release reorders some of the operations Hypothesis performs while shrinking.
+This may result in faster shrinking for large test cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -508,12 +508,7 @@ class Shrinker(object):
         # to the test case (alphabet_minimize) or delete data from it (the
         # rest). After these have reached a fixed point the test case should
         # be reasonably small and well normalized.
-        coarse = [
-            "alphabet_minimize",
-            "pass_to_descendant",
-            "zero_examples",
-            "adaptive_example_deletion",
-        ]
+        coarse = ["pass_to_descendant", "adaptive_example_deletion"]
         self.fixate_shrink_passes(coarse)
 
         # "fine" passes are ones that make lots of fine grained changes
@@ -523,6 +518,8 @@ class Shrinker(object):
         # wasteful. As a result we only start running them after we've hit
         # a fixed point for the coarse passes at least once.
         fine = [
+            "alphabet_minimize",
+            "zero_examples",
             "reorder_examples",
             "minimize_floats",
             "minimize_duplicated_blocks",

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -508,7 +508,7 @@ class Shrinker(object):
         # to the test case (alphabet_minimize) or delete data from it (the
         # rest). After these have reached a fixed point the test case should
         # be reasonably small and well normalized.
-        coarse = [block_program("X" * i) for i in hrange(10, 0, -1)] + [
+        coarse = [block_program("X" * i) for i in hrange(5, 0, -1)] + [
             "pass_to_descendant",
             "adaptive_example_deletion",
         ]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -508,7 +508,10 @@ class Shrinker(object):
         # to the test case (alphabet_minimize) or delete data from it (the
         # rest). After these have reached a fixed point the test case should
         # be reasonably small and well normalized.
-        coarse = ["pass_to_descendant", "adaptive_example_deletion"]
+        coarse = [block_program("X" * i) for i in hrange(10, 0, -1)] + [
+            "pass_to_descendant",
+            "adaptive_example_deletion",
+        ]
         self.fixate_shrink_passes(coarse)
 
         # "fine" passes are ones that make lots of fine grained changes
@@ -533,11 +536,7 @@ class Shrinker(object):
         # weird hacks that happen to work or they're expensive passes to
         # run. Generally we hope that the emergency passes don't do anything
         # at all.
-        emergency = [
-            block_program("-XX"),
-            block_program("XX"),
-            "example_deletion_with_block_lowering",
-        ]
+        emergency = [block_program("-XX"), "example_deletion_with_block_lowering"]
 
         self.fixate_shrink_passes(coarse + fine + emergency)
 


### PR DESCRIPTION
I've been finding that often what happens is that the shrinker gets uselessly fixated on one or both of `alphabet_minimize` and `zero_examples` without making any progress at reducing the size. This PR moves them to the fine shrink passes.

This is a bit unfortunate in that it *is* often useful to run them earlier, and this problem probably requires more thought, but just moving them a bit later is a reasonable quick fix for now.

This caused the pandas tests to file, however another fix which I had been considering and seems to help on very large examples independently is to just add a lot of block programs to the coarse passes. This seems to fix the pandas tests by allowing us to route around whatever local minimum they get stuck in.