### PR TITLE
Add simple heuristic for clearing the data tree

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release improve's Hypothesis's memory usage during long running shrinks,
+by allowing it to occasionally clear its internal caching.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -112,6 +112,11 @@ class ConjectureRunner(object):
         # executed test case.
         self.__data_cache = LRUReusedCache(CACHE_SIZE)
 
+    def reset_tree(self):
+        """Clears the example cache. This is sometimes useful to do in
+        long-running shrink operations."""
+        self.tree = DataTree()
+
     def __tree_is_exhausted(self):
         return self.tree.is_exhausted
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -284,6 +284,7 @@ class Shrinker(object):
         self.__pending_shrink_explanation = None
 
         self.initial_size = len(initial.buffer)
+        self.last_cleared_tree_at = self.initial_size
 
         # We keep track of the current best example on the shrink_target
         # attribute.
@@ -865,6 +866,10 @@ class Shrinker(object):
         else:
             self.__all_changed_blocks = set()
             self.__last_checked_changed_at = new_target
+
+        if len(new_target.buffer) <= 0.9 * self.last_cleared_tree_at:
+            self.__engine.reset_tree()
+            self.last_cleared_tree_at = len(new_target.buffer)
 
         self.shrink_target = new_target
         self.__shrinking_block_cache = {}

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1598,3 +1598,18 @@ def test_occasionally_clears_cache():
 
     shrinker.adaptive_example_deletion()
     assert 1 <= reset_tree.call_count <= 20
+
+
+def test_does_not_clear_the_cache_when_size_does_not_change():
+    @shrinking_from(hbytes([1] * 100 + [0]))
+    def shrinker(data):
+        for _ in hrange(101):
+            data.draw_bits(1)
+        data.mark_interesting()
+
+    reset_tree = Mock()
+
+    shrinker._Shrinker__engine.reset_tree = reset_tree
+
+    shrinker.zero_examples()
+    assert reset_tree.call_count == 0


### PR DESCRIPTION
The data tree still has a tendency to get quite large, even with the new more compact representation, so this adds a fairly simple heuristtic for clearing it every now and then. A more sophisticated heuristic would probably be worthwhile, but I looked into it for a bit and decided it would probably have a very high complexity compared to the extra benefit. Something to think about in the long run.