### PR TITLE
Obtain the last block's length without having to create it

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This change makes a tiny improvement to the core engine's bookkeeping.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -202,6 +202,8 @@ class Blocks(object):
 
     def start(self, i):
         """Equivalent to self[i].start."""
+        i = self._check_index(i)
+
         if i == 0:
             return 0
         else:
@@ -222,6 +224,10 @@ class Blocks(object):
             yield (prev, e)
             prev = e
 
+    @property
+    def last_block_length(self):
+        return self.end(-1) - self.start(-1)
+
     def __len__(self):
         return len(self.endpoints)
 
@@ -231,12 +237,16 @@ class Blocks(object):
         except (KeyError, IndexError):
             return None
 
-    def __getitem__(self, i):
+    def _check_index(self, i):
         n = len(self)
         if i < -n or i >= n:
             raise IndexError("Index %d out of range [-%d, %d)" % (i, n, n))
         if i < 0:
             i += n
+        return i
+
+    def __getitem__(self, i):
+        i = self._check_index(i)
         assert i >= 0
         result = self.__known_block(i)
         if result is not None:

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -619,7 +619,7 @@ class RuleStrategy(SearchStrategy):
         # Easy, right?
         n = len(self.rules)
         i = cu.integer_range(data, 0, n - 1)
-        block_length = data.blocks[-1].length
+        block_length = data.blocks.last_block_length
         rule = self.rules[i]
         if not self.is_valid(rule):
             valid_rules = [j for j, r in enumerate(self.rules) if self.is_valid(r)]

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -268,3 +268,35 @@ def test_calls_concluded_implicitly():
     x.freeze()
 
     assert observer.conclusion == (Status.VALID, None)
+
+
+def test_handles_start_indices_like_a_list():
+    n = 5
+    d = ConjectureData.for_buffer([1] * n)
+    for _ in hrange(n):
+        d.draw_bits(1)
+
+    for i in hrange(-2 * n, 2 * n + 1):
+        try:
+            start = d.blocks.start(i)
+        except IndexError:
+            # Directly retrieving the start position failed, so check that
+            # indexing also fails.
+            with pytest.raises(IndexError):
+                d.blocks[i]
+            continue
+
+        # Directly retrieving the start position succeeded, so check that
+        # indexing also succeeds, and gives the same position.
+        assert start == d.blocks[i].start
+
+
+def test_last_block_length():
+    d = ConjectureData.for_buffer([0] * 15)
+
+    with pytest.raises(IndexError):
+        d.blocks.last_block_length
+
+    for n in hrange(1, 5 + 1):
+        d.draw_bits(n * 8)
+        assert d.blocks.last_block_length == n


### PR DESCRIPTION
This eliminates the one call site that was causing `Block` allocation during generation, after #1830.

(It was originally a part of #1862, but I pulled it out here because it's a perfectly fine incremental improvement on its own.)

In theory this could enable some simplifications of the lazy block management code, but in practice I haven't actually investigated any of those yet.