### PR TITLE
Improve memory usage and speed of long-running shrinks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release changes some of Hypothesis's internal shrinking behaviour in order to reduce memory usage and hopefully improve performance.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -101,9 +101,6 @@ class Example(object):
     start = attr.ib()
     end = attr.ib(default=None)
 
-    # Index of example in parent's children, or None if this is the root.
-    child_index = attr.ib(default=None)
-
     # An example is "trivial" if it only contains forced bytes and zero bytes.
     # All examples start out as trivial, and then get marked non-trivial when
     # we see a byte that is neither forced nor zero.
@@ -380,7 +377,6 @@ def calc_examples(self):
                 if example_stack:
                     p = example_stack[-1]
                     children = examples[p].children
-                    ex.child_index = len(children)
                     children.append(ex)
                 example_stack.append(i)
     for ex in examples:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -508,12 +508,7 @@ class Shrinker(object):
         # to the test case (alphabet_minimize) or delete data from it (the
         # rest). After these have reached a fixed point the test case should
         # be reasonably small and well normalized.
-        coarse = [
-            "alphabet_minimize",
-            "pass_to_descendant",
-            "zero_examples",
-            "adaptive_example_deletion",
-        ]
+        coarse = ["pass_to_descendant", "adaptive_example_deletion"]
         self.fixate_shrink_passes(coarse)
 
         # "fine" passes are ones that make lots of fine grained changes
@@ -523,6 +518,8 @@ class Shrinker(object):
         # wasteful. As a result we only start running them after we've hit
         # a fixed point for the coarse passes at least once.
         fine = [
+            "alphabet_minimize",
+            "zero_examples",
             "reorder_examples",
             "minimize_floats",
             "minimize_duplicated_blocks",

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1384,62 +1384,19 @@ class Shrinker(object):
             else:
                 lo = mid
 
-    @derived_value
-    def example_to_stable_identifier_cache(self):
-        return []
-
-    @derived_value
-    def stable_identifier_to_example_cache(self):
-        return {}
-
     def stable_identifier_for_example(self, example):
         """A stable identifier is one that we can reasonably reliably
         count on referring to "logically the same" example between two
         different test runs. It is currently represented as a path from
         the root."""
-
-        i = example.index
-        n = len(self.example_to_stable_identifier_cache)
-        if i >= n:
-            self.example_to_stable_identifier_cache.extend([None] * (i - n + 1))
-            assert i < len(self.example_to_stable_identifier_cache)
-        result = self.example_to_stable_identifier_cache[i]
-        if result is None:
-            if i == 0:
-                result = ""
-            else:
-                parent = self.stable_identifier_for_example(
-                    self.examples[example.parent]
-                )
-                child = str(example.child_index)
-                if parent:
-                    result = parent + "," + child
-                else:
-                    result = child
-            self.example_to_stable_identifier_cache[i] = result
-        return result
+        return example.index
 
     def example_for_stable_identifier(self, identifier):
         """Returns the example in the current shrink target corresponding
         to this stable identifier, or None if no such example exists."""
-        if not identifier:
-            return self.examples[0]
-
-        cache = self.stable_identifier_to_example_cache
-        try:
-            return cache[identifier]
-        except KeyError:
-            pass
-        path = list(map(int, identifier.split(",")))
-        ex = self.examples[0]
-        for i in path:
-            try:
-                ex = ex.children[i]
-            except IndexError:
-                ex = None
-                break
-        cache[identifier] = ex
-        return ex
+        if identifier >= len(self.examples):
+            return None
+        return self.shrink_target.examples[identifier]
 
     def run_block_program(self, i, description, original, repeats=1):
         """Block programs are a mini-DSL for block rewriting, defined as a sequence

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -504,19 +504,52 @@ class Shrinker(object):
         it twice will have exactly the same effect as calling it once.
         """
 
-        # "coarse" passes are ones which either make large scale modifications
-        # to the test case (alphabet_minimize) or delete data from it (the
-        # rest). After these have reached a fixed point the test case should
-        # be reasonably small and well normalized.
-        coarse = ["pass_to_descendant", "adaptive_example_deletion"]
-        self.fixate_shrink_passes(coarse)
+        # The two main parts of shortlex optimisation are of course making
+        # the test case "short" and "lex" (that is to say, lexicographically.
+        # smaller). Sometimes these are intertwined and it's hard to do one
+        # without the other, but as far as we can we *vastly* prefer to make
+        # the test case shorter over making it lexicographically smaller.
+        # The reason for this is that we can only make O(n) progress on
+        # reducing the size, but at a fixed size there are O(256^n)
+        # lexicographically smaller values. As a result it's easier to
+        # reach a fixed point on size and also every reduction we make
+        # in size reduces the amount of work we have to do lexicographically.
+        # On top of that, reducing the size makes generation much faster,
+        # so even if reducing the size earlier doesn't reduce the number
+        # of test cases we run it may still result in significantly faster
+        # tests.
+        #
+        # As a result of this we start by running a bunch of operations
+        # that are primarily designed to reduce the size of the test.
+        #
+        # These fall into two categories:
+        #
+        # * "structured" ones respect the boundaries of draw calls and are
+        #   likely to correspond to semantically meaningful transformations
+        #   of the generated test case (e.g. deleting an element of a list,
+        #   replacing a tree node with one of its children).
+        # * "unstructured" ones will often not correspond to any meaningful
+        #   transformation but may succeed by accident or because they happen
+        #   to correspond to an unexpectedly meaningful operation (e.g.
+        #   merging two adjacent lists).
+        #
+        # Generally we expect unstructured ones to succeed early on when
+        # the test case has a lot of redundancy because they have plenty
+        # of opportunity to work by accident, and after that they're mostly
+        # unlikely work. As a result we do a slightly odd thing where we
+        # run unstructured deletions as part of the initial pass, but then
+        # we hold off on running them to a fixed point until we've turned
+        # the emergency passes on later.
+        unstructured_deletions = [block_program("X" * i) for i in hrange(5, 0, -1)]
+        structured_deletions = ["pass_to_descendant", "adaptive_example_deletion"]
+        self.fixate_shrink_passes(unstructured_deletions + structured_deletions)
 
-        # "fine" passes are ones that make lots of fine grained changes
-        # to the shrink target. Typically we might expect these to make many
-        # small changes, with some changes unlocking others. Additionally,
-        # if there's more data left to delete then often running these is
-        # wasteful. As a result we only start running them after we've hit
-        # a fixed point for the coarse passes at least once.
+        # "fine" passes are ones that are primarily concerned with lexicographic
+        # reduction. They may still delete data (either deliberately or by accident)
+        # but the distinguishing feature is that it is possible for them to
+        # succeed without the length of the test case changing.
+        # As a result we only start running them after we've hit a fixed point
+        # for the deletion passes at least once.
         fine = [
             "alphabet_minimize",
             "zero_examples",
@@ -526,20 +559,20 @@ class Shrinker(object):
             "minimize_individual_blocks",
         ]
 
-        self.fixate_shrink_passes(coarse + fine)
+        self.fixate_shrink_passes(structured_deletions + fine)
 
         # "emergency" shrink passes are ones that handle cases that we
         # can't currently handle more elegantly - either they're slightly
         # weird hacks that happen to work or they're expensive passes to
         # run. Generally we hope that the emergency passes don't do anything
-        # at all.
-        emergency = [
-            block_program("-XX"),
-            block_program("XX"),
-            "example_deletion_with_block_lowering",
-        ]
+        # at all. We also re-enable the unstructured deletions at this point
+        # in case new ones have been unlocked since we last ran them, but
+        # don't expect that to be a common occurrence..
+        emergency = [block_program("-XX"), "example_deletion_with_block_lowering"]
 
-        self.fixate_shrink_passes(coarse + fine + emergency)
+        self.fixate_shrink_passes(
+            unstructured_deletions + structured_deletions + fine + emergency
+        )
 
     def fixate_shrink_passes(self, passes):
         """Run steps from each pass in ``passes`` until the current shrink target


### PR DESCRIPTION
This PR unfortunately combines a couple of things, in particular #1871 and #1870, because they both triggered the same problem (failing pandas tests) and needed the same solution. However each commit should be independently reviewable.

The main motivators for this are:

* Replacing the stable identifiers with just using integer indices. The stable identifiers are probably *better* but they're very expensive in terms of memory usage, especially for large and deeply nested test cases.
* Moving shrink passes that can have purely lexical steps later in the process. The shrinker tends to get a bit distracted by these early on and do a lot of needless work.

The problem this runs into is that some of the pandas tests start failing if you introduce *either* of these changes. This is because these tests were quite brittle - it turns out that we actually don't guarantee passing them, it's just that we do so with sufficiently high probability, and there are local minima that we can get stuck in that we couldn't make progress past. Somehow both of these changes put us in one of those local minima with high probability.

In order to fix this, we add another set of shrink passes which are just block programs that try deleting short sequences of blocks. This seems to reliably get us out of these local minima. I *think* it might guarantee it, but I have not actually checked. Certainly it gets us out of the ones that we were previously getting stuck in.

This also removes the `child_index` field from `ConjectureData` because with the stable identifier change we no longer use it.