### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release blocks installation of Hypothesis on Python 3.4, which
+:PEP:`reached its end of life date on 2019-03-18 <429>`.
+
+This should not be of interest to anyone but downstream maintainers -
+if you are affected, migrate to a secure version of Python as soon as
+possible or at least seek commercial support.

--- a/hypothesis-python/docs/supported.rst
+++ b/hypothesis-python/docs/supported.rst
@@ -11,7 +11,7 @@ for the details.
 Python versions
 ---------------
 
-Hypothesis is supported and tested on CPython 2.7 and CPython 3.4+, i.e.
+Hypothesis is supported and tested on CPython 2.7 and CPython 3.5+, i.e.
 `all versisions of CPython with upstream support <https://devguide.python.org/#status-of-python-branches>`_,
 
 Hypothesis also supports the latest PyPy for both Python 2 (until 2020) and Python 3.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -93,7 +93,7 @@ setuptools.setup(
     zip_safe=False,
     extras_require=extras,
     install_requires=install_requires,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Hypothesis",
@@ -106,7 +106,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/hypothesis-python/src/hypothesis/searchstrategy/regex.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/regex.py
@@ -55,10 +55,8 @@ BYTES_LOOKUP = {
     sre.CATEGORY_NOT_WORD: BYTES_ALL - BYTES_WORD,
 }
 
-# On Python < 3.4 (including 2.7), the following unicode chars are weird.
-# They are matched by the \W, meaning 'not word', but unicodedata.category(c)
-# returns one of the word categories above.  There's special handling below.
-HAS_WEIRD_WORD_CHARS = sys.version_info[:2] < (3, 4)
+# On Python 2, these unicode chars are matched by \W, meaning 'not word',
+# but unicodedata.category(c) returns one of the word categories above.
 UNICODE_WEIRD_NONWORD_CHARS = set(u"\U00012432\U00012433\U00012456\U00012457")
 
 
@@ -164,16 +162,12 @@ class CharactersBuilder(object):
         elif category == sre.CATEGORY_WORD:
             self._categories |= UNICODE_WORD_CATEGORIES
             self._whitelist_chars.add(u"_")
-            if HAS_WEIRD_WORD_CHARS and self._unicode:  # pragma: no cover
-                # This code is workaround of weird behavior in
-                # specific Python versions and run only on those versions
+            if self._unicode and not PY3:  # pragma: no cover
                 self._blacklist_chars |= UNICODE_WEIRD_NONWORD_CHARS
         elif category == sre.CATEGORY_NOT_WORD:
             self._categories |= UNICODE_CATEGORIES - UNICODE_WORD_CATEGORIES
             self._blacklist_chars.add(u"_")
-            if HAS_WEIRD_WORD_CHARS and self._unicode:  # pragma: no cover
-                # This code is workaround of weird behavior in
-                # specific Python versions and run only on those versions
+            if self._unicode and not PY3:  # pragma: no cover
                 self._whitelist_chars |= UNICODE_WEIRD_NONWORD_CHARS
         else:  # pragma: no cover
             raise AssertionError("Unknown character category: %s" % category)

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -28,7 +28,6 @@ from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import PY3, hrange, hunichr
 from hypothesis.searchstrategy.regex import (
-    HAS_WEIRD_WORD_CHARS,
     SPACE_CHARS,
     UNICODE_DIGIT_CATEGORIES,
     UNICODE_SPACE_CATEGORIES,
@@ -63,7 +62,7 @@ def is_word(s):
     return all(
         c == "_"
         or (
-            (not HAS_WEIRD_WORD_CHARS or c not in UNICODE_WEIRD_NONWORD_CHARS)
+            (PY3 or c not in UNICODE_WEIRD_NONWORD_CHARS)
             and unicodedata.category(c) in UNICODE_WORD_CATEGORIES
         )
         for c in s

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,py27}-{brief,prettyquick,full,custom}
+envlist = py{27,35,36,37,py27}-{brief,prettyquick,full,custom}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -96,11 +96,7 @@ function InstallPip ($python_home) {
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.4") {
-        $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
-    } else {
-        $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
-    }
+    $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
     $url = $MINICONDA_URL + $filename
 
     $basedir = $pwd.Path + "\"

--- a/tooling/scripts/install-python.sh
+++ b/tooling/scripts/install-python.sh
@@ -91,9 +91,6 @@ for var in "$@"; do
     2.7.3)
       install 2.7.3 python2.7.3
       ;;
-    3.4)
-      install 3.4.9 python3.4
-      ;;
     3.5)
       install 3.5.6 python3.5
       ;;

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -368,7 +368,6 @@ def run_tox(task, version):
 
 
 PY27 = "2.7.14"
-PY34 = "3.4.8"
 PY35 = "3.5.5"
 PY36 = "3.6.5"
 PY37 = "3.7.0"
@@ -384,7 +383,7 @@ def install_core():
 
 ALIASES = {PYPY2: "pypy", PYPY3: "pypy3"}
 
-for n in [PY27, PY34, PY35, PY36, PY37]:
+for n in [PY27, PY35, PY36, PY37]:
     major, minor, patch = n.split(".")
     ALIASES[n] = "python%s.%s" % (major, minor)
 
@@ -401,11 +400,6 @@ python_tests = task(
 @python_tests
 def check_py27():
     run_tox("py27-full", PY27)
-
-
-@python_tests
-def check_py34():
-    run_tox("py34-full", PY34)
 
 
 @python_tests


### PR DESCRIPTION
With [the release of 3.4.10](https://www.python.org/downloads/release/python-3410/), Python 3.4 is end-of-life upstream and that means it's time for us to drop (free) support too.  Just [nine months to go](https://pythonclock.org/) before Python 2!

The diff is mostly cleaning up install commands we no longer need, but there's also a nice clarification to regex handling where certain inconsistent treatment of unicode digits is now "just" another 2/3 difference.