### PR TITLE
"Make our own luck" in sampled_from(...).filter(...)

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds an internal special case to make
+:func:`sampled_from(...).filter(...) <hypothesis.strategies.sampled_from>`
+much more efficient when the filter rejects most elements (:issue:`1885`).

--- a/hypothesis-python/src/hypothesis/searchstrategy/misc.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/misc.py
@@ -84,4 +84,10 @@ class SampledFromStrategy(SearchStrategy):
         return is_simple_data(self.elements)
 
     def do_draw(self, data):
+        # In the simple and direct case here, we draw an index into the elements
+        # and return the corresponding value.  There are additional implementations
+        # for s.filter() and lists(s, unique=True) that use the "make your own luck"
+        # trick from our shrinking guide for better efficiency, since we can
+        # calculate the valid elements up front, choose one, and then write the
+        # corresponding index so that the first attempt works while shrinking.
         return d.choice(data, self.elements)

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -21,7 +21,7 @@ import collections
 import enum
 
 from hypothesis import given
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import FailedHealthCheck, InvalidArgument
 from hypothesis.strategies import sampled_from
 from tests.common.utils import checks_deprecated_behaviour, fails_with
 
@@ -46,6 +46,17 @@ def test_can_sample_ordereddict_without_warning():
 @given(sampled_from(an_enum))
 def test_can_sample_enums(member):
     assert isinstance(member, an_enum)
+
+
+@fails_with(FailedHealthCheck)
+@given(sampled_from(range(10)).filter(lambda x: x < 0))
+def test_unsat_filtered_sampling(x):
+    assert False
+
+
+@given(sampled_from(range(100)).filter(lambda x: x == 99))
+def test_filtered_sampling_is_efficient(x):
+    assert x == 99
 
 
 @checks_deprecated_behaviour


### PR DESCRIPTION
This generalises our trick for choosing stateful rules to any `sampled_from(...).filter(...)` strategy, and adds some optimisations for large collections.  Closes #1885.  I credit [the shrinking guide](https://github.com/HypothesisWorks/hypothesis/blob/master/guides/strategies-that-shrink.rst) with this one - as I hoped, naming useful patterns makes it easier to remember them and identify when one might be useful :smile: