### PR TITLE
Efficient unique collections with elements from a sampled_from 

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of unique collections such as
+:func:`hypothesis.strategies.sets` when the elements are drawn from a
+:func:`hypothesis.strategies.sampled_from` strategy (:issue:`1115`).

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -427,8 +427,7 @@ def get_pretty_function_description(f):
         return repr(f)
     name = f.__name__
     if name == "<lambda>":
-        result = extract_lambda_source(f)
-        return result
+        return extract_lambda_source(f)
     elif isinstance(f, types.MethodType):
         self = f.__self__
         if not (self is None or inspect.isclass(self)):

--- a/hypothesis-python/src/hypothesis/searchstrategy/misc.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/misc.py
@@ -27,7 +27,7 @@ class BoolStrategy(SearchStrategy):
     distribution."""
 
     def __repr__(self):
-        return u"BoolStrategy()"
+        return "BoolStrategy()"
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import Phase, given, settings
+from hypothesis import Phase, assume, given, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import Flaky, MultipleFailures
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
@@ -36,6 +36,9 @@ def test_raises_multiple_failures_with_varying_type():
         if abs(i) < 1000:
             return
         if target[0] is None:
+            # Ensure that we have some space to shrink into, so we can't
+            # trigger an minimal example and mask the other exception type.
+            assume(1003 < abs(i))
             target[0] = i
         exc_class = TypeError if target[0] == i else ValueError
         raise exc_class()

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -21,8 +21,9 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import given
+from hypothesis.errors import FailedHealthCheck
 from hypothesis.internal.compat import hrange
-from tests.common.utils import counts_calls
+from tests.common.utils import counts_calls, fails_with
 
 
 @pytest.mark.parametrize("n", [100, 10 ** 5, 10 ** 6, 2 ** 25])
@@ -61,3 +62,14 @@ def rare_value_strategy(n, target):
 @given(rare_value_strategy(n=128, target=80))
 def test_chained_filters_find_rare_value(x):
     assert x == 80
+
+
+@fails_with(FailedHealthCheck)
+@given(st.sets(st.sampled_from(range(10)), min_size=11))
+def test_unsat_sets_of_samples(x):
+    assert False
+
+
+@given(st.sets(st.sampled_from(range(50)), min_size=50))
+def test_efficient_sets_of_samples(x):
+    assert x == set(range(50))


### PR DESCRIPTION
The "make your own luck" trick from our shrinking guide can make `lists(sampled_from(...), unique=True)` practical even when the list is of around the same length as the sampled sequence.  That closes #1115, by optimising the implementation of a naive `sets(sampled_from(elements))` strategy - though it used to be a common cause of the filtered-too-much HealthCheck.