### PR TITLE
Fix flaky test_reusable_strategies_are_all_reusable

### DIFF
--- a/hypothesis-python/tests/cover/test_reusable_values.py
+++ b/hypothesis-python/tests/cover/test_reusable_values.py
@@ -21,7 +21,7 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import example, given, reject
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
 
 base_reusable_strategies = (
     st.text(),
@@ -65,7 +65,7 @@ assert not reusable.is_empty
 def test_reusable_strategies_are_all_reusable(s):
     try:
         s.validate()
-    except InvalidArgument:
+    except (InvalidArgument, HypothesisDeprecationWarning):
         reject()
 
     assert s.has_reusable_values


### PR DESCRIPTION
Fixes #1892.

It's slightly annoying that this won't automatically detect when `HypothesisDeprecationWarning` is no longer necessary (when #1860 becomes a hard error), but I don't know of a reasonable way to make that happen.