### PR TITLE
Flatten .filter(...) chains into a single FilteredStrategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch takes the previous efficiency improvements to
+:func:`sampled_from(...).filter(...) <hypothesis.strategies.sampled_from>`
+strategies that reject most elements, and generalises them to also apply to
+``sampled_from(...).filter(...).filter(...)`` and longer chains of filters.

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -43,3 +43,21 @@ def test_filter_large_lists(n):
     run()
 
     assert cond.calls < filter_limit
+
+
+def rare_value_strategy(n, target):
+    def forbid(s, forbidden):
+        """Helper function to avoid Python variable scoping issues."""
+        return s.filter(lambda x: x != forbidden)
+
+    s = st.sampled_from(hrange(n))
+    for i in hrange(n):
+        if i != target:
+            s = forbid(s, i)
+
+    return s
+
+
+@given(rare_value_strategy(n=128, target=80))
+def test_chained_filters_find_rare_value(x):
+    assert x == 80


### PR DESCRIPTION
This PR causes chained calls to `.filter(...)` to create a single flat `FilteredStrategy` with multiple conditions, instead of a nested sequence of `FilteredStrategy`.

By itself this doesn't make much difference, but when combined with #1904 it causes the special-case handling of `sampled_from(items).filter(f)` to also apply to `sampled_from(items).filter(f).filter(g)`, and to longer filter chains. That's especially helpful when later filters are the ones that cause the sampling to become sparse.

I've written the release notes under the assumption that #1904 gets merged first, ~~and I would also like to go back and add some tests to explicitly check that sample-filter chains actually work properly.~~