### PR TITLE
Run useful shrink passes to completion before resuming others

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release modifies how Hypothesis selects operations to run during shrinking,
+by causing it to deprioritise previously useless classes of shrink until others have reached a fixed point.
+
+This avoids certain pathological cases where the shrinker gets very close to finishing and then takes a very long time to finish the last small changes because it tries many useless shrinks for each useful one towards the end.
+It also should cause a more modest improvement (probably no more than about 30%) in shrinking performance for most tests.

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -18,14 +18,12 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-import pytest
 
 import hypothesis.extra.numpy as npst
 import hypothesis.extra.pandas as pdst
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, given, reject, settings
-from hypothesis.types import RandomWithSeed as Random
-from tests.common.debug import find_any, minimal
+from tests.common.debug import find_any
 from tests.pandas.helpers import supported_by_pandas
 
 

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -126,34 +126,6 @@ def test_can_fill_in_missing_elements_from_dict(df):
     assert np.isnan(df["A"]).all()
 
 
-subsets = ["", "A", "B", "C", "AB", "AC", "BC", "ABC"]
-
-
-@pytest.mark.parametrize("disable_fill", subsets)
-@pytest.mark.parametrize("non_standard_index", [True, False])
-def test_can_minimize_based_on_two_columns_independently(
-    disable_fill, non_standard_index
-):
-    columns = [
-        pdst.column(
-            name, dtype=bool, fill=st.nothing() if name in disable_fill else None
-        )
-        for name in ["A", "B", "C"]
-    ]
-
-    x = minimal(
-        pdst.data_frames(
-            columns, index=pdst.indexes(dtype=int) if non_standard_index else None
-        ),
-        lambda x: x["A"].any() and x["B"].any() and x["C"].any(),
-        random=Random(0),
-    )
-    assert len(x["A"]) == 1
-    assert x["A"][0] == 1
-    assert x["B"][0] == 1
-    assert x["C"][0] == 1
-
-
 @st.composite
 def column_strategy(draw):
     name = draw(st.none() | st.text())


### PR DESCRIPTION
I was staring at a long running shrink wondering why it took so long for a while before I figured out what was happening: It had successfully got to the point where the emergency passes were running, and something about that had unlocked `minimize_individual_blocks`. The result was that it was no longer at a fixed point for that pass, but *was* for every other (or possible almost every other? I didn't check that carefully) pass.

Unfortunately, this meant that every time it ran a loop to make progress on  `minimize_individual_blocks`, it had to run every other shrink pass as well, none of which did any good. This was expensive, obviously.

The solution is this: When we call `fixate_shrink_passes` and have run all of the shrink passes, we check if only some of them worked. If that is the case, we recursively call `fixate_shrink_passes` with the smaller list of currently useful passes, get them all to fixed points, and then resume as before. This avoids situations like the above where useless passes become a tax on the useful ones. 

This turns out to be *such* a good selection algorithm compared to what we were doing before that it causes all of our weird special case handling and manual dancing around "ok first run these unstructured deletions, then..." to be totally useless and indeed actively harmful. The `test_shrink_quality` tests go from about 30 seconds to about 28 seconds (on my machine) with the base change, but if you then just unify all the passes they go to about 21 seconds!

(They actually get *slightly* faster seemingly if you keep `example_deletion_with_block_lowering` as an emergency pass, but there's not much in it and that might just be an artifact of what we test here, so I decided it wasn't worth the added complexity)

ETA: Oh I also added a bunch of comments to the code that was already there, because if it took *me* that long staring at it to remember what it was doing I doubt it was easy for anyone else.