### PR TITLE
Add special-case filtering for SampledFromStrategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds an internal special case to make
+:func:`sampled_from(...).filter(...) <hypothesis.strategies.sampled_from>`
+much more efficient when the filter rejects most elements (:issue:`1885`).

--- a/hypothesis-python/src/hypothesis/searchstrategy/lazy.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/lazy.py
@@ -155,6 +155,11 @@ class LazyStrategy(SearchStrategy):
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)
 
+    def do_filtered_draw(self, data, filter_strategy):
+        return self.wrapped_strategy.do_filtered_draw(
+            data=data, filter_strategy=filter_strategy
+        )
+
     @property
     def label(self):
         return self.wrapped_strategy.label

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -21,7 +21,8 @@ import collections
 import enum
 
 from hypothesis import given
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import FailedHealthCheck, InvalidArgument
+from hypothesis.internal.compat import hrange
 from hypothesis.strategies import sampled_from
 from tests.common.utils import checks_deprecated_behaviour, fails_with
 
@@ -51,3 +52,19 @@ def test_can_sample_enums(member):
 @checks_deprecated_behaviour
 def test_sampling_empty_is_deprecated():
     assert sampled_from([]).is_empty
+
+
+@fails_with(FailedHealthCheck)
+@given(sampled_from(hrange(10)).filter(lambda x: x < 0))
+def test_unsat_filtered_sampling(x):
+    assert False
+
+
+def test_easy_filtered_sampling():
+    x = sampled_from(hrange(100)).filter(lambda x: x == 0).example()
+    assert x == 0
+
+
+@given(sampled_from(hrange(100)).filter(lambda x: x == 99))
+def test_filtered_sampling_finds_rare_value(x):
+    assert x == 99

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import given
+from hypothesis.internal.compat import hrange
+from tests.common.utils import counts_calls
+
+
+@pytest.mark.parametrize("n", [100, 10 ** 5, 10 ** 6, 2 ** 25])
+def test_filter_large_lists(n):
+    filter_limit = 100 * 10000
+
+    @counts_calls
+    def cond(x):
+        assert cond.calls < filter_limit
+        return x % 2 != 0
+
+    s = st.sampled_from(hrange(n)).filter(cond)
+
+    @given(s)
+    def run(x):
+        assert x % 2 != 0
+
+    run()
+
+    assert cond.calls < filter_limit


### PR DESCRIPTION
Closes #1885. Follow-up to my #1862 and Zac's #1890.

I abandoned most of my earlier work, and instead focused on taking #1890 and replacing its hard-coded special case in `FilteredStrategy` with a more general hook mechanism.

Some things that are specifically *not* in this PR:

- Updating `RuleStrategy.do_draw` to use `sampled_from(...).filter(...)` internally
- Adding special-case handling for `integers(a, b)`
- Extending special-case handling to chained `filter` calls (#1894)