### PR TITLE
Improve error message if flatmap function doesn't return a strategy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -226,6 +226,7 @@ their individual contributions.
 * `Joshua Boone <https://www.github.com/patchedwork>`_ (joshuaboone4190@gmail.com)
 * `jmhsi <https://www.github.com/jmhsi>`_
 * `jwg4 <https://www.github.com/jwg4>`_
+* `Kai Chen <https://www.github.com/kx-chen>`_ (kaichen120@gmail.com)
 * `Karthikeyan Singaravelan <https://www.github.com/tirkarthi>`_ (tir.karthi@gmail.com)
 * `kbara <https://www.github.com/kbara>`_
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves the error message if the function ``f`` in
+:ref:`s.flatmap(f) <flatmap>` does not return a strategy.
+
+Thanks to Kai Chen for this change!

--- a/hypothesis-python/src/hypothesis/searchstrategy/flatmapped.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/flatmapped.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, division, print_function
 
 from hypothesis.internal.reflection import get_pretty_function_description
+from hypothesis.internal.validation import check_type
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
 
@@ -40,7 +41,9 @@ class FlatMapStrategy(SearchStrategy):
 
     def do_draw(self, data):
         source = data.draw(self.flatmapped_strategy)
-        return data.draw(self.expand(source))
+        expanded_source = self.expand(source)
+        check_type(SearchStrategy, expanded_source)
+        return data.draw(expanded_source)
 
     @property
     def branches(self):

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 
 import pytest
 
+from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import text_type
 from hypothesis.searchstrategy.strategies import one_of_strategies
 from hypothesis.strategies import booleans, integers, just, randoms, tuples
@@ -93,3 +94,8 @@ def test_can_map_nameless():
 def test_can_flatmap_nameless():
     f = nameless_const(just(3))
     assert repr(f) in repr(integers().flatmap(f))
+
+
+def test_flatmap_with_invalid_expand():
+    with pytest.raises(InvalidArgument):
+        just(100).flatmap(lambda n: "a").example()


### PR DESCRIPTION
This improves the error message if the `flatmap` function doesn't return a `SeachStrategy`