### PR TITLE
Derandomize test_can_disable_multiple_error_reporting to hopefully make it non-flaky

### DIFF
--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -224,7 +224,7 @@ def test_handles_flaky_tests_where_only_one_is_flaky():
 def test_can_disable_multiple_error_reporting(allow_multi):
     seen = set()
 
-    @settings(database=None, report_multiple_bugs=allow_multi)
+    @settings(database=None, derandomize=True, report_multiple_bugs=allow_multi)
     @given(st.integers(min_value=0))
     def test(i):
         # We will pass on the minimal i=0, then fail with a large i, and eventually


### PR DESCRIPTION
I noticed a flaky failure in `test_can_disable_multiple_error_reporting` at https://dev.azure.com/HypothesisWorks/Hypothesis/_build/results?buildId=1871 (via #1905).

My guess is that this test occasionally generates `i=1` and stops more-or-less immediately without finding a second bug, violating the expectations of the test. Derandomizing the test should make this edge-case impossible.

Potentially obsolete if #1781 gets merged, though I haven't tested the interaction.