### PR TITLE
Derandomize some expected-failure tests to work around #1907

### DIFF
--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -795,6 +795,7 @@ def test_removes_needless_steps():
     but will still fail with very high probability.
     """
 
+    @Settings(derandomize=True)
     class IncorrectDeletion(RuleBasedStateMachine):
         def __init__(self):
             super(IncorrectDeletion, self).__init__()

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -100,7 +100,7 @@ def test_includes_intermediate_results_in_verbose_mode():
     with capture_verbosity() as o:
 
         @fails
-        @settings(verbosity=Verbosity.verbose, database=None)
+        @settings(verbosity=Verbosity.verbose, database=None, derandomize=True)
         @given(lists(integers(), min_size=1))
         def test_foo(x):
             assert sum(x) < 1000000


### PR DESCRIPTION
While I haven't figured out the precise cause of #1907, this workaround should at least prevent it from blocking all other work.