### PR TITLE
Get our CI working again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,8 @@ jobs:
           TASK: check-nose
         check-pytest30:
           TASK: check-pytest30
+        check-django22:
+          TASK: check-django22
         check-django21:
           TASK: check-django21
         check-django20:

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -795,6 +795,7 @@ def test_removes_needless_steps():
     but will still fail with very high probability.
     """
 
+    @Settings(derandomize=True)
     class IncorrectDeletion(RuleBasedStateMachine):
         def __init__(self):
             super(IncorrectDeletion, self).__init__()

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -100,7 +100,7 @@ def test_includes_intermediate_results_in_verbose_mode():
     with capture_verbosity() as o:
 
         @fails
-        @settings(verbosity=Verbosity.verbose, database=None)
+        @settings(verbosity=Verbosity.verbose, database=None, derandomize=True)
         @given(lists(integers(), min_size=1))
         def test_foo(x):
             assert sum(x) < 1000000

--- a/hypothesis-python/tests/django/toys/settings.py
+++ b/hypothesis-python/tests/django/toys/settings.py
@@ -102,3 +102,30 @@ USE_TZ = os.environ.get("HYPOTHESIS_DJANGO_USETZ", "TRUE") == "TRUE"
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
 STATIC_URL = u"/static/"
+
+
+# Added these bits to avoid warnings on Django 2.2
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
+        },
+    }
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -23,7 +23,7 @@ import pytest
 from django.db import IntegrityError
 from django.test import TestCase as DjangoTestCase
 
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, Verbosity, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django import TestCase, TransactionTestCase
 from hypothesis.internal.compat import PYPY
@@ -64,7 +64,9 @@ class TestWorkflow(VanillaTestCase):
 
         class LocalTest(TestCase):
             @given(integers().map(break_the_db))
-            @settings(suppress_health_check=HealthCheck.all())
+            @settings(
+                suppress_health_check=HealthCheck.all(), verbosity=Verbosity.quiet
+            )
             def test_does_not_break_other_things(self, unused):
                 pass
 

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -114,6 +114,12 @@ commands =
     pip install django~=2.1.0
     python -m tests.django.manage test tests.django
 
+[testenv:django22]
+commands =
+    pip install .[pytz]
+    pip install django~=2.2.0
+    python -m tests.django.manage test tests.django
+
 [testenv:nose]
 deps =
     nose

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -443,10 +443,9 @@ def standard_tox_task(name):
 
 standard_tox_task("nose")
 standard_tox_task("pytest30")
-standard_tox_task("django21")
-standard_tox_task("django20")
-standard_tox_task("django111")
 
+for n in [20, 21, 22, 111]:
+    standard_tox_task("django%d" % (n,))
 for n in [19, 20, 21, 22, 23, 24]:
     standard_tox_task("pandas%d" % (n,))
 


### PR DESCRIPTION
Fixes #1909, by updating the settings for our Django app and adding Django 2.2 to our CI config.  I also fixed the leaked printing of a seed report from an expected-failing test.

Subsumes and thus closes #1910 because the tests would fail otherwise - thanks @Zalathar for working that one out!