### PR TITLE
Correctly restore global RNG state after using random_module()

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug that prevented
+:func:`~hypothesis.strategies.random_module`
+from correctly restoring the previous state of the ``random`` module.
+
+The random state was instead being restored to a temporary deterministic
+state, which accidentally caused subsequent tests to see the same random values
+across multiple test runs.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -542,8 +542,8 @@ class StateForActualGivenExecution(object):
             if not hasattr(data, "can_reproduce_example_from_repr"):
                 data.can_reproduce_example_from_repr = True
             with local_settings(self.settings):
-                with BuildContext(data, is_final=is_final):
-                    with deterministic_PRNG():
+                with deterministic_PRNG():
+                    with BuildContext(data, is_final=is_final):
                         args, kwargs = data.draw(self.search_strategy)
                         if expected_failure is not None:
                             text_repr[0] = arg_string(test, args, kwargs)
@@ -1070,15 +1070,15 @@ def find(
     last_repr = [None]
 
     def template_condition(data):
-        with BuildContext(data):
-            try:
-                data.is_find = True
-                with deterministic_PRNG():
+        with deterministic_PRNG():
+            with BuildContext(data):
+                try:
+                    data.is_find = True
                     result = data.draw(search)
                     data.note(result)
                     success = condition(result)
-            except UnsatisfiedAssumption:
-                data.mark_invalid()
+                except UnsatisfiedAssumption:
+                    data.mark_invalid()
 
         if success:
             successful_examples[0] += 1
@@ -1109,8 +1109,8 @@ def find(
         data = ConjectureData.for_buffer(
             list(runner.interesting_examples.values())[0].buffer
         )
-        with BuildContext(data):
-            with deterministic_PRNG():
+        with deterministic_PRNG():
+            with BuildContext(data):
                 return data.draw(search)
     if runner.valid_examples == 0 and (runner.exit_reason != ExitReason.finished):
         raise Unsatisfiable(

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function
 
 import re
-from random import Random, seed as seed_random
+from random import Random
 
 import attr
 import pytest
@@ -335,19 +335,19 @@ def test_no_read_no_shrink():
 
 
 def test_one_dead_branch():
-    seed_random(0)
-    seen = set()
+    with deterministic_PRNG():
+        seen = set()
 
-    @run_to_buffer
-    def x(data):
-        i = data.draw_bytes(1)[0]
-        if i > 0:
-            data.mark_invalid()
-        i = data.draw_bytes(1)[0]
-        if len(seen) < 255:
-            seen.add(i)
-        elif i not in seen:
-            data.mark_interesting()
+        @run_to_buffer
+        def x(data):
+            i = data.draw_bytes(1)[0]
+            if i > 0:
+                data.mark_invalid()
+            i = data.draw_bytes(1)[0]
+            if len(seen) < 255:
+                seen.add(i)
+            elif i not in seen:
+                data.mark_interesting()
 
 
 def test_saves_on_interrupt():

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -71,6 +71,7 @@ def test_settings_are_default_in_given(x):
 def test_given_shrinks_pytest_helper_errors():
     final_value = [None]
 
+    @settings(derandomize=True)
     @given(s.integers())
     def inner(x):
         final_value[0] = x
@@ -85,6 +86,7 @@ def test_given_shrinks_pytest_helper_errors():
 def test_pytest_skip_skips_shrinking():
     values = []
 
+    @settings(derandomize=True)
     @given(s.integers())
     def inner(x):
         values.append(x)


### PR DESCRIPTION
The `random_module()` strategy sets global RNG state, and arranges for `BuildContext` to restore the original state afterwards.

However, when `deterministic_PRNG` is nested inside `BuildContext`, this causes the outer state-restoring hook to accidentally restore the deterministic state, instead of the original state.

The solution is to reverse the nesting, so that each context manager restores the intended state.

----

Fixes #1907, in conjunction with the changes to `test_one_dead_branch`.