### PR TITLE
Fix assertion failure in sampled_from(...).filter(...) when there are few elements and all are rejected

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug introduced in :ref:`Hypothesis 4.14.3 <v4.14.3>`
+that would sometimes cause
+:func:`sampled_from(...).filter(...) <hypothesis.strategies.sampled_from>`
+to encounter an internal assertion failure when there are three or fewer
+elements, and every element is rejected by the filter.

--- a/hypothesis-python/src/hypothesis/searchstrategy/misc.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/misc.py
@@ -112,6 +112,11 @@ class SampledFromStrategy(SearchStrategy):
             if check_index(i):
                 return self.elements[i]
 
+        # If we've tried all the possible elements, give up now.
+        max_good_indices = len(self.elements) - len(known_bad_indices)
+        if not max_good_indices:
+            return filter_not_satisfied
+
         # Figure out the bit-length of the index that we will write back after
         # choosing an allowed element.
         write_length = bit_length(len(self.elements))
@@ -119,11 +124,11 @@ class SampledFromStrategy(SearchStrategy):
         # Impose an arbitrary cutoff to prevent us from wasting too much time
         # on very large element lists.
         cutoff = 10000
+        max_good_indices = min(max_good_indices, cutoff)
 
         # Before building the list of allowed indices, speculatively choose
         # one of them. We don't yet know how many allowed indices there will be,
         # so this choice might be out-of-bounds, but that's OK.
-        max_good_indices = min(len(self.elements) - len(known_bad_indices), cutoff)
         speculative_index = d.integer_range(data, 0, max_good_indices - 1)
 
         # Calculate the indices of allowed values, so that we can choose one

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -21,7 +21,7 @@ import collections
 import enum
 
 from hypothesis import given
-from hypothesis.errors import FailedHealthCheck, InvalidArgument
+from hypothesis.errors import FailedHealthCheck, InvalidArgument, Unsatisfiable
 from hypothesis.internal.compat import hrange
 from hypothesis.strategies import sampled_from
 from tests.common.utils import checks_deprecated_behaviour, fails_with
@@ -57,6 +57,14 @@ def test_sampling_empty_is_deprecated():
 @fails_with(FailedHealthCheck)
 @given(sampled_from(hrange(10)).filter(lambda x: x < 0))
 def test_unsat_filtered_sampling(x):
+    assert False
+
+
+@fails_with(Unsatisfiable)
+@given(sampled_from(hrange(2)).filter(lambda x: x < 0))
+def test_unsat_filtered_sampling_in_rejection_stage(x):
+    # Rejecting all possible indices before we calculate the allowed indices
+    # takes an early exit path, so we need this test to cover that branch.
     assert False
 
 


### PR DESCRIPTION
This bug was accidentally introduced in #1904.

This fix was originally part of #1891 and #1921, but has been isolated into its own PR for a standalone release.