### PR TITLE
Speed and stability improvements for our Numpy tests

### DIFF
--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -37,6 +37,7 @@ from hypothesis.strategies import (
     tuples,
 )
 from tests.common.debug import find_any, minimal
+from tests.common.utils import flaky
 
 
 @pytest.mark.parametrize(
@@ -128,6 +129,7 @@ def test_lists_of_lower_bounded_length(n):
     assert sum(x) == 2 * n
 
 
+@flaky(min_passes=1, max_runs=2)
 def test_can_find_unique_lists_of_non_set_order():
     # This test checks that our strategy for unique lists doesn't accidentally
     # depend on the iteration order of sets.

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -24,7 +24,7 @@ from hypothesis import Phase, given, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import Flaky, MultipleFailures
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
-from tests.common.utils import capture_out, non_covering_examples
+from tests.common.utils import capture_out, flaky, non_covering_examples
 
 
 def test_raises_multiple_failures_with_varying_type():
@@ -242,7 +242,10 @@ def test_can_disable_multiple_error_reporting(allow_multi):
     assert seen == {TypeError, ValueError}
 
 
+@flaky(max_runs=3, min_passes=2)
 def test_finds_multiple_failures_in_generation():
+    # Very rarely, this raises ZeroDivisionError instead of MultipleFailure,
+    # because we never generated NaN.  We therefore allow one additional run.
     @settings(phases=[Phase.generate])
     @given(st.lists(st.floats()))
     def test(x):

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -30,7 +30,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import binary_type, text_type
 from hypothesis.searchstrategy import SearchStrategy
 from tests.common.debug import find_any, minimal
-from tests.common.utils import checks_deprecated_behaviour, flaky
+from tests.common.utils import checks_deprecated_behaviour, fails_with, flaky
 
 STANDARD_TYPES = list(
     map(
@@ -319,46 +319,37 @@ def test_may_fill_with_nan_when_unique_is_set():
     )
 
 
-def test_is_still_unique_with_nan_fill():
-    @given(
-        nps.arrays(
-            dtype=float,
-            elements=st.floats(allow_nan=False),
-            shape=10,
-            unique=True,
-            fill=st.just(float("nan")),
-        )
+@given(
+    nps.arrays(
+        dtype=float,
+        elements=st.floats(allow_nan=False),
+        shape=10,
+        unique=True,
+        fill=st.just(float("nan")),
     )
-    def test(xs):
-        assert len(set(xs)) == len(xs)
+)
+def test_is_still_unique_with_nan_fill(xs):
+    assert len(set(xs)) == len(xs)
 
-    test()
 
-
-def test_may_not_fill_with_non_nan_when_unique_is_set():
-    @given(
-        nps.arrays(
-            dtype=float,
-            elements=st.floats(allow_nan=False),
-            shape=10,
-            unique=True,
-            fill=st.just(0.0),
-        )
+@fails_with(InvalidArgument)
+@given(
+    nps.arrays(
+        dtype=float,
+        elements=st.floats(allow_nan=False),
+        shape=10,
+        unique=True,
+        fill=st.just(0.0),
     )
-    def test(arr):
-        pass
-
-    with pytest.raises(InvalidArgument):
-        test()
+)
+def test_may_not_fill_with_non_nan_when_unique_is_set(arr):
+    pass
 
 
-def test_may_not_fill_with_non_nan_when_unique_is_set_and_type_is_not_number():
-    @given(nps.arrays(dtype="U", shape=10, unique=True, fill=st.just(u"")))
-    def test(arr):
-        pass
-
-    with pytest.raises(InvalidArgument):
-        test()
+@fails_with(InvalidArgument)
+@given(nps.arrays(dtype="U", shape=10, unique=True, fill=st.just(u"")))
+def test_may_not_fill_with_non_nan_when_unique_is_set_and_type_is_not_number(arr):
+    pass
 
 
 @given(

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -171,7 +171,7 @@ def test_can_generate_array_shapes(shape):
     assert all(isinstance(i, int) for i in shape)
 
 
-@settings(deadline=None)
+@settings(deadline=None, max_examples=10)
 @given(st.integers(0, 10), st.integers(0, 9), st.integers(0), st.integers(0))
 def test_minimise_array_shapes(min_dims, dim_range, min_side, side_range):
     smallest = minimal(
@@ -477,7 +477,7 @@ def test_axes_are_valid_inputs_to_sum(shape, data):
     np.sum(x, axes)
 
 
-@settings(deadline=None)
+@settings(deadline=None, max_examples=10)
 @given(ndim=st.integers(0, 3), data=st.data())
 def test_minimize_tuple_axes(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
@@ -486,7 +486,7 @@ def test_minimize_tuple_axes(ndim, data):
     assert len(smallest) == min_size and all(k > -1 for k in smallest)
 
 
-@settings(deadline=None)
+@settings(deadline=None, max_examples=10)
 @given(ndim=st.integers(0, 3), data=st.data())
 def test_minimize_negative_tuple_axes(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
@@ -497,7 +497,7 @@ def test_minimize_negative_tuple_axes(ndim, data):
     assert len(smallest) == min_size
 
 
-@settings(deadline=None, max_examples=1000)
+@settings(deadline=None)
 @given(
     shape=nps.array_shapes(min_side=0, max_side=4, min_dims=0, max_dims=3),
     data=st.data(),
@@ -521,7 +521,7 @@ def test_broadcastable_shape_bounds_are_satisfied(shape, data):
             label="bshape",
         )
     except InvalidArgument:
-        return
+        assume(False)
 
     if max_dim is None:
         max_dim = max(len(shape), min_dim) + 2
@@ -569,7 +569,7 @@ def test_broadcastable_shape_has_good_default_values(shape, data):
     np.broadcast(a, b)  # error if drawn shape for b is not broadcast-compatible
 
 
-@settings(deadline=None, max_examples=1000)
+@settings(deadline=None)
 @given(
     min_dim=st.integers(0, 5),
     shape=nps.array_shapes(min_dims=0, max_dims=3, min_side=0, max_side=10),
@@ -593,7 +593,7 @@ def test_broadcastable_shape_can_broadcast(min_dim, shape, data):
     np.broadcast(a, b)  # error if drawn shape for b is not broadcast-compatible
 
 
-@settings(deadline=None)
+@settings(deadline=None, max_examples=10)
 @given(
     min_dim=st.integers(0, 5),
     shape=nps.array_shapes(min_dims=0, max_dims=3, min_side=0, max_side=5),
@@ -639,7 +639,7 @@ def test_broadcastable_shape_adjusts_max_dim_with_explicit_bounds(max_dim, data)
     np.broadcast(a, b)  # error if drawn shape for b is not broadcast-compatible
 
 
-@settings(deadline=None)
+@settings(deadline=None, max_examples=10)
 @given(min_dim=st.integers(0, 4), min_side=st.integers(2, 3), data=st.data())
 def test_broadcastable_shape_shrinking_with_singleton_out_of_bounds(
     min_dim, min_side, data

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -472,7 +472,7 @@ def test_length_bounds_are_satisfied(ndim, data):
 
 @given(shape=nps.array_shapes(), data=st.data())
 def test_axes_are_valid_inputs_to_sum(shape, data):
-    x = np.zeros(shape)
+    x = np.zeros(shape, dtype="uint8")
     axes = data.draw(nps.valid_tuple_axes(ndim=len(shape)), label="axes")
     np.sum(x, axes)
 
@@ -556,7 +556,7 @@ def _draw_valid_bounds(data, shape, max_dim, permit_none=True):
 
 @settings(deadline=None, max_examples=1000)
 @given(
-    shape=nps.array_shapes(min_dims=0, max_dims=6, min_side=1, max_side=20),
+    shape=nps.array_shapes(min_dims=0, max_dims=6, min_side=1, max_side=5),
     data=st.data(),
 )
 def test_broadcastable_shape_has_good_default_values(shape, data):
@@ -564,8 +564,8 @@ def test_broadcastable_shape_has_good_default_values(shape, data):
     broadcastable_shape = data.draw(
         nps.broadcastable_shapes(shape), label="broadcastable_shapes"
     )
-    a = np.zeros(shape)
-    b = np.zeros(broadcastable_shape)
+    a = np.zeros(shape, dtype="uint8")
+    b = np.zeros(broadcastable_shape, dtype="uint8")
     np.broadcast(a, b)  # error if drawn shape for b is not broadcast-compatible
 
 
@@ -588,8 +588,8 @@ def test_broadcastable_shape_can_broadcast(min_dim, shape, data):
         ),
         label="broadcastable_shapes",
     )
-    a = np.zeros(shape)
-    b = np.zeros(broadcastable_shape)
+    a = np.zeros(shape, dtype="uint8")
+    b = np.zeros(broadcastable_shape, dtype="uint8")
     np.broadcast(a, b)  # error if drawn shape for b is not broadcast-compatible
 
 
@@ -634,8 +634,8 @@ def test_broadcastable_shape_adjusts_max_dim_with_explicit_bounds(max_dim, data)
         label="broadcastable_shapes",
     )
     assert len(broadcastable_shape) == 3
-    a = np.zeros(shape)
-    b = np.zeros(broadcastable_shape)
+    a = np.zeros(shape, dtype="uint8")
+    b = np.zeros(broadcastable_shape, dtype="uint8")
     np.broadcast(a, b)  # error if drawn shape for b is not broadcast-compatible
 
 


### PR DESCRIPTION
This PR makes some tweaks to our Numpy tests:

- "unwraps" a few so that Pytest can call them directly, in some cases using our `@fails_with(exception_type)` decorator.
- Caps the side length in `test_broadcastable_shape_has_good_default_values`, where I once saw a `MemoryError` for a large shape.
- Add a dtype to `np.zeros(shape, dtype="uint8")` for efficient memory allocation and smaller size (the default is `float32`).
- Reduce the `max_examples` on tests that have a `minimal(...)` internally, since we would not usually wrap that in `@given` at all.  Making this change to the seven slowest cases cuts over a third from the total runtime of our Numpy tests.
- Retry [this (non-Numpy) test](https://dev.azure.com/HypothesisWorks/Hypothesis/_build/results?buildId=1953&view=logs&jobId=c3892b1c-72e7-59d5-9c14-67f44ff795dc&taskId=0686734f-5249-5de7-9548-d2ddac0a108a&lineStart=272&lineEnd=273&colStart=1&colEnd=1) if we happened to get a (very rare) hash collision while shrinking.

I had a separate PR for non-Numpy tests, but then that build failed with this flaky test, so:

- Allows a retry for `test_finds_multiple_failures_in_generation` if NaN is not generated.
