### PR TITLE
Fix flaky tests in cover suite

### DIFF
--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -98,7 +98,7 @@ def test_composite_of_lists():
     def f(draw):
         return draw(st.integers()) + draw(st.integers())
 
-    assert minimal(st.lists(f()), lambda x: len(x) >= 10) == [0] * 10
+    assert minimal(st.lists(f()), lambda x: len(x) >= 5) == [0] * 5
 
 
 @flaky(min_passes=3, max_runs=5)

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -24,7 +24,7 @@ from hypothesis import Phase, given, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import Flaky, MultipleFailures
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
-from tests.common.utils import capture_out, non_covering_examples
+from tests.common.utils import capture_out, flaky, non_covering_examples
 
 
 def test_raises_multiple_failures_with_varying_type():
@@ -242,7 +242,10 @@ def test_can_disable_multiple_error_reporting(allow_multi):
     assert seen == {TypeError, ValueError}
 
 
+@flaky(max_runs=3, min_passes=2)
 def test_finds_multiple_failures_in_generation():
+    # Very rarely, this raises ZeroDivisionError instead of MultipleFailure,
+    # because we never generated NaN.  We therefore allow one additional run.
     @settings(phases=[Phase.generate])
     @given(st.lists(st.floats()))
     def test(x):


### PR DESCRIPTION
Each commit de-flakes a flaky test, ready for the PyCon sprints.  CC @alexwlchan for review?