### PR TITLE
Add support for positional only arguments

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -244,6 +244,7 @@ their individual contributions.
 * `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (maxim.kulkin@gmail.com)
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
+* `Paul Ganssle <https://ganssle.io>`_ (paul@ganssle.io)
 * `Paul Lorett Amazona <https://github.com/whatevergeek>`_
 * `Paul Stiverson <https://github.com/thismatters>`_
 * `Peadar Coyle <https://github.com/springcoil>`_ (peadarcoyle@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch makes Hypothesis compatible with the Python 3.8 alpha, which
+changed the representation of code objects to support positional-only
+arguments.  Note however that Hypothesis does not (yet) support such
+functions as e.g. arguments to :func:`~hypothesis.strategies.builds`
+or inputs to :func:`@given <hypothesis.given>`.
+
+Thanks to Paul Ganssle for identifying and fixing this bug.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -392,6 +392,10 @@ else:
         "co_cellvars",
     ]
 
+    if sys.version_info >= (3, 8, 0):
+        # PEP 570 added "positional only arguments"
+        CODE_FIELD_ORDER.insert(1, "co_posonlyargcount")
+
 
 def update_code_location(code, newfile, newlineno):
     """Take a code object and lie shamelessly about where it comes from.


### PR DESCRIPTION
PEP 570 adds "positional only" arguments to Python, which changes the
code object constructor. This adds support for Python 3.8.

I assume this is covered by existing tests, but it would be good to add a "nightly" build to the CI matrix.

Fixes #1943