### PR TITLE
Minor tweaks to contributor/maintainer guides

### DIFF
--- a/guides/README.rst
+++ b/guides/README.rst
@@ -7,7 +7,7 @@ working on Hypothesis.
 
 It is separate from the main documentation because it is not much
 use if you are merely *using* Hypothesis. It's purely for working
-on it.
+on it, and aimed more at maintainers than casual contributors.
 
 Most of these are currently written with the Python version of
 Hypothesis in mind, but will evolve over time to be more multilingual.

--- a/guides/internals.rst
+++ b/guides/internals.rst
@@ -207,34 +207,23 @@ The Shrinker
 ------------
 
 The shrinking part of Hypothesis is organised into a single class called ``Shrinker``
-that lives in ``engine.py``.
+that lives in ``hypothesis/internal/conjecture/shrinker.py``.
 
 Its job is to take an initial ``ConjectureData`` object and some predicate that
 it satisfies, and to try to produce a simpler ``ConjectureData`` object that
 also satisfies that predicate.
 
-~~~~~~~~~~~~~~
-Search Process
-~~~~~~~~~~~~~~
-
-The search process mostly happens in the ``shrink`` method. It is split into
-two parts: ``greedy_shrink`` and ``escape_local_minimum``. The former is a
-greedy algorithm, meaning that it will only ever call the predicate with values
-that are strictly smaller than our current best. This mostly works very well,
-but sometimes it gets stuck. So what we do is after we have run that we try
-restarting the process from something like our final state but a bit fuzzed and
-run the greedy shrink again. We keep doing this as long as it results in a
-smaller value than our previous best.
-
-The greedy shrinker is where almost all of the work happens. It is organised
-into a large number of search passes, and is designed to run until all of those
-passes fail to make any improvements.
+The search process mostly happens in the ``shrink`` method, which tries various
+shrink passes in the ``greedy_shrink`` method and then reports on the outcome.
+For details, you are strongly encouraged to read the source code.  It is very
+well commented, and as the subject of active research often has newer techniques
+than are documented here.
 
 ~~~~~~~~~~~~~
 Search Passes
 ~~~~~~~~~~~~~
 
-Search passes are methods on the ``Shrinker`` class in ``engine.py``. They are
+Search passes are methods on the ``Shrinker`` class. They are
 designed to take the current shrink target and try a number of things that might
 be sensible shrinks of it.
 

--- a/guides/review.rst
+++ b/guides/review.rst
@@ -224,9 +224,16 @@ New settings should:
    have more than one value for a setting across any of its runs, it should be
    some sort of global configuration, not a setting.
 
-Removing settings is not something we have done so far, so the exact process
-is still up in the air, but it should involve a careful deprecation path where
-the default behaviour does not change without first introducing warnings.
+When deprecating a setting for later removal, we prefer to change the default
+value of the setting to a private singleton (``not_set``), and implement the
+future behaviour immediately.  Passing any other value triggers a deprecation
+warning, but is otherwise a no-op (i.e. we still use the future behaviour).
+
+For settings where this would be especially disruptive, we have also prefixed
+that deprecation process with a process where we emit a warning, add a special
+value that can be passed to opt-in to the future behaviour, and then in the
+following major release we deprecate *that*, make it an no-op, and make it an
+error to pass any other value.
 
 ~~~~~~~~~~~~~~
 Engine Changes

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -31,7 +31,7 @@ The :func:`~hypothesis.strategies.from_type` strategy now supports
 :class:`python:slice` objects.
 
 Thanks to Charlie El. Awbery for writing this feature at the
-`PyCon 2019 Mentored Sprints <https://uspycon.org/2019/hatchery/mentoredsprints/>`__.
+`PyCon 2019 Mentored Sprints <https://us.pycon.org/2019/hatchery/mentoredsprints/>`__.
 
 .. _v4.20.0:
 


### PR DESCRIPTION
With the PyCon sprints increasingly close, I did a last pass through the docs and found a few places where the guide was out of date and one where the behaviour of `lists()` was mis-described (this is relevant if you have a bunch of equal numbers of different types!).