### PR TITLE
Remove bias argument from OneOfStrategy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -238,6 +238,7 @@ their individual contributions.
 * `Lisa Goeller <https://www.github.com/lgoeller>`_
 * `Louis Taylor <https://github.com/kragniz>`_
 * `Luke Barone-Adesi <https://github.com/baluke>`_
+* `Marco Sirabella <https://www.github.com/mjsir911>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (marius@gedmin.as)
 * `Markus Unterwaditzer <https://github.com/untitaker>`_ (markus@unterwaditzer.net)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch cleans up the internals of :func:`~hypothesis.strategies.one_of`.
+You may see a slight change to the distribution of examples from this strategy
+but there is no change to the public API.
+
+Thanks to Marco Sirabella for writing this patch at the PyCon 2019 sprints!

--- a/hypothesis-python/src/hypothesis/searchstrategy/recursive.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/recursive.py
@@ -66,7 +66,7 @@ class RecursiveStrategy(SearchStrategy):
 
         strategies = [self.limited_base, self.extend(self.limited_base)]
         while 2 ** len(strategies) <= max_leaves:
-            strategies.append(extend(OneOfStrategy(tuple(strategies), bias=0.8)))
+            strategies.append(extend(OneOfStrategy(tuple(strategies))))
         self.strategy = OneOfStrategy(strategies)
 
     def __repr__(self):


### PR DESCRIPTION
Solves issue #1600 by removing `bias` and logic depending on it.

`bias` was removed in `recursive` and tests still seem to pass