### PR TITLE
Work around weird behavior of np.dtype

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes the very rare :issue:`1798` in
+:func:`~hypothesis.extra.numpy.array_dtypes`,
+which caused an internal error in our tests.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -26,7 +26,7 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis import Verbosity
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange, integer_types, text_type
+from hypothesis.internal.compat import hrange, integer_types
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
 from hypothesis.internal.validation import check_type, check_valid_interval
@@ -636,9 +636,7 @@ def array_dtypes(
     """Return a strategy for generating array (compound) dtypes, with members
     drawn from the given subtype strategy."""
     order_check("size", 0, min_size, max_size)
-    native_strings = st.text()  # type: SearchStrategy[Any]
-    if text_type is not str:  # pragma: no cover
-        native_strings = st.binary()
+    native_strings = st.from_type(str).filter(bool)  # See issue #1798 re: filter!
     elements = st.tuples(native_strings, subtype_strategy)
     if allow_subarrays:
         elements |= st.tuples(


### PR DESCRIPTION
Fixes #1798.  Paraphrasing my comment there: it's triggered by a *weird* behaviour of `np.dtype` that can be rarely found by `npst.array_dtypes()`, where:

`np.dtype([("f1", int), ("", int)])` fails, as does anything where the name `"f{index}"` exists elsewhere but the name at the index is `""` (e.g. `dtype([('', int), ('f0', int)])`) - the empty name defaults to the `f{index}` name even if it exists elsewhere, but obviously the `unique_by` doesn't catch that.  We can ensuring that all field names are non-empty is a decent workaround until I can talk it over with upstream.