### PR TITLE
Add autoflake fixer

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch uses :pypi:`autoflake` to remove some pointless ``pass`` statements,
+which improves our workflow but has no user-visible impact.

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -184,7 +184,6 @@ class GenericCache(object):
     def on_evict(self, key, value, score):
         """Called after a key has been evicted, with the score it had had at
         the point of eviction."""
-        pass
 
     def check_valid(self):
         """Debugging method for use in tests.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -235,18 +235,15 @@ class ExampleProperty(object):
         """Called at the start of each example, with ``i`` the
         index of the example and ``label_index`` the index of
         its label in ``self.examples.labels``."""
-        pass
 
     def block(self, i):
         """Called with each ``draw_bits`` call, with ``i`` the index of the
         corresonding block in ``self.examples.blocks``"""
-        pass
 
     def stop_example(self, i, discarded):
         """Called at the end of each example, with ``i`` the
         index of the example and ``discarded`` being ``True`` if ``stop_example``
         was called with ``discard=True``."""
-        pass
 
     def finish(self):
         return self.result
@@ -677,7 +674,6 @@ class DataObserver(object):
 
         Note that this is called after ``freeze`` has completed.
         """
-        pass
 
     def draw_bits(self, n_bits, forced, value):
         """Called when ``draw_bits`` is called on on the
@@ -687,7 +683,6 @@ class DataObserver(object):
            draw was forced or ``False`` otherwise.
         * ``value`` is the result that ``draw_bits`` returned.
         """
-        pass
 
 
 @attr.s(slots=True)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -98,7 +98,6 @@ class Shrinker(object):
         Convenience function for children that doesn't require messing
         with the signature of init.
         """
-        pass
 
     def delegate(self, other_class, convert_to, convert_from, **kwargs):
         """Delegates shrinking to another shrinker class, by converting the

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -206,11 +206,9 @@ class GenericStateMachine(
 
         Does nothing by default.
         """
-        pass
 
     def check_invariants(self):
         """Called after initializing and after executing each step."""
-        pass
 
     _test_case_cache = {}  # type: dict
 

--- a/hypothesis-python/tests/cover/test_unittest.py
+++ b/hypothesis-python/tests/cover/test_unittest.py
@@ -55,4 +55,3 @@ class test_given_on_setUp_fails_health_check(unittest.TestCase):
 
     def test(self):
         """Provide something to set up for, so the setUp method is called."""
-        pass

--- a/hypothesis-python/tests/nocover/test_modify_inner_test.py
+++ b/hypothesis-python/tests/nocover/test_modify_inner_test.py
@@ -30,7 +30,6 @@ def always_passes(*args, **kwargs):
     For example, pytest-trio would take the inner test, wrap it in an
     async-to-sync converter, and use the new func (not always_passes).
     """
-    pass
 
 
 @given(st.integers())

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -1,4 +1,5 @@
 attrs
+autoflake
 bandit
 black
 coverage

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -9,6 +9,7 @@ appdirs==1.4.3            # via black
 astroid==2.2.5            # via pylint
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0
+autoflake==1.3
 babel==2.6.0              # via sphinx
 backcall==0.1.0           # via ipython
 bandit==1.5.1
@@ -61,7 +62,7 @@ ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
 pydocstyle==3.0.0         # via flake8-docstrings
-pyflakes==2.1.1           # via flake8
+pyflakes==2.1.1           # via autoflake, flake8
 pygithub==1.43.7          # via pyupio
 pygments==2.3.1           # via ipython, readme-renderer, sphinx
 pyjwt==1.7.1              # via pygithub

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -221,8 +221,18 @@ def format():
                 o.write("\n\n")
                 o.write(source)
             o.write("\n")
-    pip_tool("isort", *files_to_format)
 
+    pip_tool(
+        "autoflake",
+        "--recursive",
+        "--in-place",
+        "--exclude=compat.py",
+        "--remove-all-unused-imports",
+        "--remove-duplicate-keys",
+        "--remove-unused-variables",
+        *files_to_format,
+    )
+    pip_tool("isort", *files_to_format)
     pip_tool("black", *files_to_format)
 
 


### PR DESCRIPTION
This patch adds [`autoflake`](https://pypi.org/project/autoflake/) to our formatting job, so that unused imports are removed automatically instead of causing a lint error.  It also handles unused variables, and - most relevantly as this actually causes a diff - removes pointless `pass` statements.  Hurrah for canonical forms!