### PR TITLE
Remove ConjectureRunner.__rewrite

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release slightly simplifies a small part of the core engine.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -503,9 +503,6 @@ class ConjectureRunner(object):
 
         return mutate_from
 
-    def __rewrite(self, data, result):
-        return self.__zero_bound(data, result)
-
     def __zero_bound(self, data, result):
         """This tries to get the size of the generated data under control by
         replacing the result with zero if we are too deep or have already
@@ -741,7 +738,7 @@ class ConjectureRunner(object):
                     result = buffer[data.index : data.index + n]
                     if len(result) < n:
                         result += hbytes(n - len(result))
-                    return self.__rewrite(data, result)
+                    return self.__zero_bound(data, result)
 
                 data = self.new_conjecture_data(draw_bytes=draw_bytes)
                 self.test_function(data)


### PR DESCRIPTION
This internal method presumably served a useful purpose at some point.

But ever since #1052 overhauled novelty-generation, it has just delegated directly to `__zero_bound`.