### PR TITLE
README: Fix a typo in code example

### DIFF
--- a/hypothesis-ruby/README.markdown
+++ b/hypothesis-ruby/README.markdown
@@ -32,7 +32,7 @@ RSpec.describe "removing an element from a list" do
 
       values.delete_at(values.index(to_remove))
 
-      # Will fail if the value ws duplicated in the list.
+      # Will fail if the value was duplicated in the list.
       expect(values.include?(to_remove)).to be false
       
     end


### PR DESCRIPTION
This PR fixes a misspelled word in the initial code example.

Thanks for putting this preview out here.