### PR TITLE
Consistently use dict/set literals and comprehensions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release adds the :pypi:`pyupgrade` fixer to our code style,
+for consistent use of dict and set literals and comprehensions.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -1236,7 +1236,7 @@ def builds(
             "builds(), but is only allowed as a keyword arg"
         )
     required = required_args(target, args, kwargs) or set()
-    to_infer = set(k for k, v in kwargs.items() if v is infer)
+    to_infer = {k for k, v in kwargs.items() if v is infer}
     if required or to_infer:
         if isclass(target) and attr.has(target):
             # Use our custom introspection for attrs classes

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -424,7 +424,7 @@ def skip_exceptions_to_reraise():
     import unittest
 
     # This is a set because nose may simply re-export unittest.SkipTest
-    exceptions = set([unittest.SkipTest])
+    exceptions = {unittest.SkipTest}
 
     try:  # pragma: no cover
         from unittest2 import SkipTest

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -93,7 +93,7 @@ def models(
     if missed:
         raise InvalidArgument(
             u"Missing arguments for mandatory field%s %s for model %s"
-            % (u"s" if missed else u"", u", ".join(missed), model.__name__)
+            % (u"s" if len(missed) > 1 else u"", u", ".join(missed), model.__name__)
         )
 
     for field in result:

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -493,7 +493,7 @@ def dtype_factory(kind, sizes, valid_sizes, endianness):
             valid_sizes,
         )
         if all(isinstance(s, int) for s in sizes):
-            sizes = sorted(set(s // 8 for s in sizes))
+            sizes = sorted({s // 8 for s in sizes})
     strat = st.sampled_from(sizes)
     if "{}" not in kind:
         kind += "{}"

--- a/hypothesis-python/src/hypothesis/searchstrategy/collections.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/collections.py
@@ -188,7 +188,7 @@ class FixedKeysDictStrategy(MappedSearchStrategy):
             except TypeError:
                 self.keys = tuple(sorted(strategy_dict.keys(), key=repr))
         super(FixedKeysDictStrategy, self).__init__(
-            strategy=TupleStrategy((strategy_dict[k] for k in self.keys))
+            strategy=TupleStrategy(strategy_dict[k] for k in self.keys)
         )
 
     def calc_is_empty(self, recur):

--- a/hypothesis-python/src/hypothesis/searchstrategy/regex.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/regex.py
@@ -36,16 +36,16 @@ UNICODE_CATEGORIES = set(categories())
 
 SPACE_CHARS = set(u" \t\n\r\f\v")
 UNICODE_SPACE_CHARS = SPACE_CHARS | set(u"\x1c\x1d\x1e\x1f\x85")
-UNICODE_DIGIT_CATEGORIES = set(["Nd"])
+UNICODE_DIGIT_CATEGORIES = {"Nd"}
 UNICODE_SPACE_CATEGORIES = set(as_general_categories("Z"))
 UNICODE_LETTER_CATEGORIES = set(as_general_categories("L"))
 UNICODE_WORD_CATEGORIES = set(as_general_categories(["L", "N"]))
 
 # This is verbose, but correct on all versions of Python
-BYTES_ALL = set(int_to_byte(i) for i in range(256))
-BYTES_DIGIT = set(b for b in BYTES_ALL if re.match(b"\\d", b))
-BYTES_SPACE = set(b for b in BYTES_ALL if re.match(b"\\s", b))
-BYTES_WORD = set(b for b in BYTES_ALL if re.match(b"\\w", b))
+BYTES_ALL = {int_to_byte(i) for i in range(256)}
+BYTES_DIGIT = {b for b in BYTES_ALL if re.match(b"\\d", b)}
+BYTES_SPACE = {b for b in BYTES_ALL if re.match(b"\\s", b)}
+BYTES_WORD = {b for b in BYTES_ALL if re.match(b"\\w", b)}
 BYTES_LOOKUP = {
     sre.CATEGORY_DIGIT: BYTES_DIGIT,
     sre.CATEGORY_SPACE: BYTES_SPACE,

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -130,7 +130,7 @@ def checks_deprecated_behaviour(func):
 
 
 def all_values(db):
-    return set(v for vs in db.data.values() for v in vs)
+    return {v for vs in db.data.values() for v in vs}
 
 
 def non_covering_examples(database):

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -161,8 +161,8 @@ def test_example_depth_marking():
 
     assert len(d.examples) == 6
 
-    depths = set((ex.length, ex.depth) for ex in d.examples)
-    assert depths == set([(2, 1), (3, 2), (6, 2), (9, 1), (12, 1), (23, 0)])
+    depths = {(ex.length, ex.depth) for ex in d.examples}
+    assert depths == {(2, 1), (3, 2), (6, 2), (9, 1), (12, 1), (23, 0)}
 
 
 def test_has_examples_even_when_empty():

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -48,7 +48,7 @@ def test_exception_in_compare_can_still_have_example():
 
 def test_does_not_always_give_the_same_example():
     s = st.integers()
-    assert len(set(s.example() for _ in range(100))) >= 10
+    assert len({s.example() for _ in range(100)}) >= 10
 
 
 def test_raises_on_no_examples():

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -112,7 +112,7 @@ def test_can_use_examples_around_given():
         seen.append(x)
 
     test_not_long_str()
-    assert set(seen[:2]) == set((long_str, short_str))
+    assert set(seen[:2]) == {long_str, short_str}
 
 
 @pytest.mark.parametrize((u"x", u"y"), [(1, False), (2, True)])

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -249,11 +249,11 @@ def test_sets():
     objects = [
         set(),
         frozenset(),
-        set([1]),
+        {1},
         frozenset([1]),
-        set([1, 2]),
+        {1, 2},
         frozenset([1, 2]),
-        set([-1, -2, -3]),
+        {-1, -2, -3},
     ]
     expected = [
         "set()",
@@ -270,14 +270,14 @@ def test_sets():
 
 
 def test_unsortable_set():
-    xs = set([1, 2, 3, "foo", "bar", "baz", object()])
+    xs = {1, 2, 3, "foo", "bar", "baz", object()}
     p = pretty.pretty(xs)
     for x in xs:
         assert pretty.pretty(x) in p
 
 
 def test_unsortable_dict():
-    xs = dict((k, 1) for k in [1, 2, 3, "foo", "bar", "baz", object()])
+    xs = {k: 1 for k in [1, 2, 3, "foo", "bar", "baz", object()]}
     p = pretty.pretty(xs)
     for x in xs:
         assert pretty.pretty(x) in p
@@ -389,7 +389,7 @@ def test_long_tuple():
 
 
 def test_long_dict():
-    d = dict((n, n) for n in range(10000))
+    d = {n: n for n in range(10000)}
     p = pretty.pretty(d)
     last2 = p.rsplit("\n", 2)[-2:]
     assert_equal(last2, [" 999: 999,", " ...}"])

--- a/hypothesis-python/tests/cover/test_regressions.py
+++ b/hypothesis-python/tests/cover/test_regressions.py
@@ -82,7 +82,7 @@ def test_mock_injection():
 
 def test_regression_issue_1230():
     strategy = st.builds(
-        lambda x, y: dict((list(x.items()) + list(y.items()))),
+        lambda x, y: dict(list(x.items()) + list(y.items())),
         st.fixed_dictionaries({"0": st.text()}),
         st.builds(
             lambda dictionary, keys: {key: dictionary[key] for key in keys},

--- a/hypothesis-python/tests/nocover/test_collective_minimization.py
+++ b/hypothesis-python/tests/nocover/test_collective_minimization.py
@@ -50,6 +50,6 @@ def test_can_collectively_minimize(spec):
             settings=settings(max_examples=2000),
         )
         assert len(xs) == n
-        assert 2 <= len(set((map(repr, xs)))) <= 3
+        assert 2 <= len(set(map(repr, xs))) <= 3
     except NoSuchExample:
         pass

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -99,7 +99,7 @@ def test_mixed_list_flatmap():
 
     result = minimal(s, criterion)
     assert len(result) == 6
-    assert set(result) == set([False, u""])
+    assert set(result) == {False, u""}
 
 
 @pytest.mark.parametrize("n", range(1, 10))

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -94,7 +94,7 @@ Strategies = st.recursive(
 )
 
 
-strategy_globals = dict((k, getattr(st, k)) for k in dir(st))
+strategy_globals = {k: getattr(st, k) for k in dir(st)}
 
 strategy_globals["OrderedDict"] = OrderedDict
 strategy_globals["inf"] = float("inf")

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -466,7 +466,7 @@ def test_mapped_positive_axes_are_unique(ndim, data):
     min_size = data.draw(st.integers(0, ndim), label="min_size")
     max_size = data.draw(st.integers(min_size, ndim), label="max_size")
     axes = data.draw(nps.valid_tuple_axes(ndim, min_size, max_size), label="axes")
-    assert len(set(axes)) == len(set([i if 0 < i else ndim + i for i in axes]))
+    assert len(set(axes)) == len({i if 0 < i else ndim + i for i in axes})
 
 
 @given(ndim=st.integers(0, 5), data=st.data())

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -73,7 +73,7 @@ def test_minimize_one_of():
 
 def test_minimize_mixed_list():
     mixed = minimal(lists(integers() | text()), lambda x: len(x) >= 10)
-    assert set(mixed).issubset(set((0, u"")))
+    assert set(mixed).issubset({0, u""})
 
 
 def test_minimize_longer_string():
@@ -85,14 +85,11 @@ def test_minimize_longer_list_of_strings():
 
 
 def test_minimize_3_set():
-    assert minimal(sets(integers()), lambda x: len(x) >= 3) in (
-        set((0, 1, 2)),
-        set((-1, 0, 1)),
-    )
+    assert minimal(sets(integers()), lambda x: len(x) >= 3) in ({0, 1, 2}, {-1, 0, 1})
 
 
 def test_minimize_3_set_of_tuples():
-    assert minimal(sets(tuples(integers())), lambda x: len(x) >= 2) == set(((0,), (1,)))
+    assert minimal(sets(tuples(integers())), lambda x: len(x) >= 2) == {(0,), (1,)}
 
 
 def test_minimize_sets_of_sets():
@@ -163,7 +160,7 @@ def test_dictionary(dict_class):
         lambda t: len(t) >= 3,
     )
     assert isinstance(x, dict_class)
-    assert set(x.values()) == set((u"",))
+    assert set(x.values()) == {u""}
     for k in x:
         if k < 0:
             assert k + 1 in x
@@ -301,7 +298,7 @@ def test_minimize_dict():
 def test_minimize_list_of_sets():
     assert minimal(
         lists(sets(booleans())), lambda x: len(list(filter(None, x))) >= 3
-    ) == ([set((False,))] * 3)
+    ) == ([{False}] * 3)
 
 
 def test_minimize_list_of_lists():

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -19,6 +19,7 @@ pip-tools
 pylint
 pytest
 python-dateutil
+pyupgrade
 pyupio
 requests
 restructuredtext-lint

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -72,6 +72,7 @@ pytest==4.5.0
 python-dateutil==2.8.0
 python-gitlab==1.8.0      # via pyupio
 pytz==2019.1              # via babel, django
+pyupgrade==1.17.0
 pyupio==1.0.2
 pyyaml==5.1               # via bandit, dparse, pyupio
 readme-renderer==24.0     # via twine
@@ -92,6 +93,7 @@ sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 sqlparse==0.3.0           # via django
 stevedore==1.30.1         # via bandit
+tokenize-rt==2.2.0        # via pyupgrade
 toml==0.10.0
 tox==3.10.0
 tqdm==4.31.1              # via pyupio, twine

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -232,6 +232,7 @@ def format():
         "--remove-unused-variables",
         *files_to_format,
     )
+    pip_tool("pyupgrade", "--keep-percent-format", *files_to_format)
     pip_tool("isort", *files_to_format)
     pip_tool("black", *files_to_format)
 


### PR DESCRIPTION
They're slightly more efficient than creating and converting an intermediate structure.

More importantly, this is another thing where we can enforce (and automatically convert to) a canonical form for our code - this time with https://github.com/asottile/pyupgrade

(and I fixed a logic bug where "fields" was always plural in an error message)