### PR TITLE
Delete cu.getrandbits

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch has a minor cleanup of the internal engine.
+There is no user-visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -154,25 +154,12 @@ def choice(data, values):
     return values[integer_range(data, 0, len(values) - 1)]
 
 
-def getrandbits(data, n):
-    # This method is equivalent to data.draw_bits(n) except that it fails
-    # to set the mask. This method should die but is currently maintaining
-    # bugwards compatibility with some oddities of behaviour that we've
-    # not yet fully debugged. See
-    # https://github.com/HypothesisWorks/hypothesis/issues/1827
-    # for details.
-    n_bytes = n // 8
-    if n % 8 != 0:
-        n_bytes += 1
-    return data.draw_bits(n_bytes * 8) & ((1 << n) - 1)
-
-
 FLOAT_PREFIX = 0b1111111111 << 52
 FULL_FLOAT = int_to_float(FLOAT_PREFIX | ((2 << 53) - 1)) - 1
 
 
 def fractional_float(data):
-    return (int_to_float(FLOAT_PREFIX | getrandbits(data, 52)) - 1) / FULL_FLOAT
+    return (int_to_float(FLOAT_PREFIX | data.draw_bits(52)) - 1) / FULL_FLOAT
 
 
 def boolean(data):

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -26,7 +26,6 @@ from hypothesis import HealthCheck, Phase, assume, example, given, settings
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
-from tests.cover.test_conjecture_engine import run_to_buffer
 
 
 def test_does_draw_data_for_empty_range():
@@ -147,12 +146,3 @@ def test_sampler_distribution(weights):
         calculated[base] += (1 - p_alternate) / n
         calculated[alternate] += p_alternate / n
     assert probabilities == calculated
-
-
-def test_get_randbits_can_set_high_bit():
-    @run_to_buffer
-    def x(data):
-        if cu.getrandbits(data, 8) >> 7:
-            data.mark_interesting()
-
-    assert x == hbytes([1 << 7])


### PR DESCRIPTION
`cu.getrandbits(data, n)` is replaced by `data.draw_bits(n)`, and whatever was making the tests fail for the last few changes no longer does so.  Closes #1827.