### PR TITLE
Deprecate the buffer_size setting

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release deprecates and disables the ``buffer_size`` setting,
+which should have been treated as a private implementation detail
+all along.  We recommend simply deleting this settings argument.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -599,7 +599,7 @@ Thanks to Ryan Soklaski for this strategy.
 ------------------
 
 This release significantly tightens validation in :class:`hypothesis.settings`.
-:obj:`~hypothesis.settings.max_examples`, :obj:`~hypothesis.settings.buffer_size`,
+:obj:`~hypothesis.settings.max_examples`, ``buffer_size``,
 and :obj:`~hypothesis.settings.stateful_step_count` must be positive integers;
 :obj:`~hypothesis.settings.deadline` must be a positive number or ``None``; and
 :obj:`~hypothesis.settings.derandomize` must be either ``True`` or ``False``.

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -42,7 +42,7 @@ Available settings
 
 .. autoclass:: hypothesis.settings
     :members:
-    :exclude-members: register_profile, get_profile, load_profile
+    :exclude-members: register_profile, get_profile, load_profile, buffer_size
 
 .. _phases:
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -456,14 +456,11 @@ For very complex code, we have observed Hypothesis finding novel bugs after
 
 settings._define_setting(
     "buffer_size",
-    default=8 * 1024,
+    default=not_set,
     validator=lambda x: _ensure_positive_int(x, "buffer_size", since="2019-03-06"),
-    show_default=False,
-    description="""
-The size of the underlying data used to generate examples. If you need to
-generate really large examples you may want to increase this, but it will make
-your tests slower.
-""",
+    description="The buffer_size setting has been deprecated and no longer does anything.",
+    deprecation_message="The buffer_size setting can safely be removed with no effect.",
+    deprecated_since="RELEASEDAY",
 )
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -57,6 +57,7 @@ MAX_SHRINKS = 500
 CACHE_SIZE = 10000
 MUTATION_POOL_SIZE = 100
 MIN_TEST_CALLS = 10
+BUFFER_SIZE = 8 * 1024
 
 
 @attr.s
@@ -237,7 +238,7 @@ class ConjectureRunner(object):
 
     @property
     def cap(self):
-        return self.settings.buffer_size // 2
+        return BUFFER_SIZE // 2
 
     def record_for_health_check(self, data):
         # Once we've actually found a bug, there's no point in trying to run
@@ -602,13 +603,12 @@ class ConjectureRunner(object):
             # the time to look for additional failures.
             return
 
-        zero_data = self.cached_test_function(hbytes(self.settings.buffer_size))
+        zero_data = self.cached_test_function(hbytes(BUFFER_SIZE))
         if zero_data.status > Status.OVERRUN:
             self.__data_cache.pin(zero_data.buffer)
 
         if zero_data.status == Status.OVERRUN or (
-            zero_data.status == Status.VALID
-            and len(zero_data.buffer) * 2 > self.settings.buffer_size
+            zero_data.status == Status.VALID and len(zero_data.buffer) * 2 > BUFFER_SIZE
         ):
             fail_health_check(
                 self.settings,
@@ -770,7 +770,7 @@ class ConjectureRunner(object):
     def new_conjecture_data(self, draw_bytes):
         return ConjectureData(
             draw_bytes=draw_bytes,
-            max_length=self.settings.buffer_size,
+            max_length=BUFFER_SIZE,
             observer=self.tree.new_observer(),
         )
 

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -117,8 +117,8 @@ def test_filtering_most_things_fails_a_health_check():
 
 
 def test_large_data_will_fail_a_health_check():
-    @given(st.none() | st.binary(min_size=1024))
-    @settings(database=None, buffer_size=1000)
+    @given(st.none() | st.binary(min_size=10 ** 5))
+    @settings(database=None)
     def test(x):
         pass
 

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -480,6 +480,11 @@ def test_dubious_settings_deprecations(name):
 
 
 @checks_deprecated_behaviour
+def test_buffer_size_deprecated():
+    assert settings(buffer_size=100).buffer_size == 100
+
+
+@checks_deprecated_behaviour
 def test_max_example_eq_0_warns_and_disables_generation():
     # Terrible way to disable generation, but did predate the phases setting
     # and existed in our test suite so it's not an error *just* yet.

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -100,7 +100,6 @@ def run_language_test_for(root, data, seed):
         test,
         settings=settings(
             max_examples=1,
-            buffer_size=512,
             database=None,
             suppress_health_check=HealthCheck.all(),
             verbosity=Verbosity.quiet,

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -199,7 +199,7 @@ def test_can_generate_compound_dtypes(dtype):
     assert isinstance(dtype, np.dtype)
 
 
-@given(nps.nested_dtypes(max_itemsize=settings.default.buffer_size // 10), st.data())
+@given(nps.nested_dtypes(max_itemsize=400), st.data())
 def test_infer_strategy_from_dtype(dtype, data):
     # Given a dtype
     assert isinstance(dtype, np.dtype)
@@ -226,7 +226,7 @@ def test_minimise_nested_types():
 def test_minimise_array_strategy():
     smallest = minimal(
         nps.arrays(
-            nps.nested_dtypes(max_itemsize=settings.default.buffer_size // 3 ** 3),
+            nps.nested_dtypes(max_itemsize=200),
             nps.array_shapes(max_dims=3, max_side=3),
         )
     )

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -94,9 +94,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
         if len(v) >= size:
             data.mark_interesting()
 
-    runner = ConjectureRunner(
-        test_function, random=random, settings=settings(TEST_SETTINGS, buffer_size=LOTS)
-    )
+    runner = ConjectureRunner(test_function, random=random, settings=TEST_SETTINGS)
 
     while not runner.interesting_examples:
         runner.test_function(


### PR DESCRIPTION
From the vaguely-on-the-todo-list-for-ages department, we expose the `buffer_size` setting to users... even though it's deeply entwined with implementation details and basically impossible to set beyond "more than the default" (and doing so is *usually* unhelpful).

So this PR closes #1233 by deprecating the setting and ignoring it in favour of an internal constant.