### PR TITLE
Port `minimal()` test helper from `find()` to `@given`

### DIFF
--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -17,8 +17,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-from hypothesis import assume, find, given, reject, settings as Settings
+from hypothesis import HealthCheck, Verbosity, given, settings as Settings
 from hypothesis.errors import NoSuchExample, Unsatisfiable
+from hypothesis.internal.reflection import get_pretty_function_description
 from tests.common.utils import no_shrink
 
 TIME_INCREMENT = 0.01
@@ -28,10 +29,9 @@ class Timeout(BaseException):
     pass
 
 
-def minimal(definition, condition=None, settings=None, timeout_after=10):
-    settings = Settings(settings, max_examples=50000, database=None)
-
-    runtime = []
+def minimal(definition, condition=lambda x: True, settings=None, timeout_after=10):
+    class Found(Exception):
+        """Signal that the example matches condition."""
 
     def wrapped_condition(x):
         if timeout_after is not None:
@@ -39,15 +39,35 @@ def minimal(definition, condition=None, settings=None, timeout_after=10):
                 runtime[0] += TIME_INCREMENT
                 if runtime[0] >= timeout_after:
                     raise Timeout()
-        if condition is None:
-            result = True
-        else:
-            result = condition(x)
+        result = condition(x)
         if result and not runtime:
             runtime.append(0.0)
         return result
 
-    return find(definition, wrapped_condition, settings=settings)
+    @given(definition)
+    @Settings(
+        parent=settings or Settings(max_examples=50000, verbosity=Verbosity.quiet),
+        suppress_health_check=HealthCheck.all(),
+        report_multiple_bugs=False,
+        derandomize=True,
+        database=None,
+    )
+    def inner(x):
+        if wrapped_condition(x):
+            result[:] = [x]
+            raise Found
+
+    definition.validate()
+    runtime = []
+    result = []
+    try:
+        inner()
+    except Found:
+        return result[0]
+    raise Unsatisfiable(
+        "Could not find any examples from %r that satisfied %s"
+        % (definition, get_pretty_function_description(condition))
+    )
 
 
 def find_any(definition, condition=lambda _: True, settings=None):

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -21,7 +21,7 @@ import datetime as dt
 
 import pytest
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.internal.compat import hrange
 from hypothesis.strategies import dates, datetimes, timedeltas, times
 from tests.common.debug import find_any, minimal
@@ -96,7 +96,7 @@ def test_can_find_before_the_year_2000():
 
 @pytest.mark.parametrize("month", hrange(1, 13))
 def test_can_find_each_month(month):
-    find_any(dates(), lambda x: x.month == month)
+    find_any(dates(), lambda x: x.month == month, settings(max_examples=10 ** 6))
 
 
 def test_min_year_is_respected():

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -21,7 +21,7 @@ import decimal
 
 import pytest
 
-from hypothesis import assume, given, reject
+from hypothesis import assume, given, reject, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import data, decimals, fractions, integers, none, tuples
 from tests.common.debug import find_any
@@ -88,7 +88,7 @@ def test_decimals_include_nan():
 
 
 def test_decimals_include_inf():
-    find_any(decimals(), lambda x: x.is_infinite())
+    find_any(decimals(), lambda x: x.is_infinite(), settings(max_examples=10 ** 6))
 
 
 @given(decimals(allow_nan=False))

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -24,7 +24,7 @@ import unicodedata
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import PY3, hrange, hunichr
 from hypothesis.searchstrategy.regex import (
@@ -189,12 +189,16 @@ def test_any_doesnt_generate_newline():
 
 @pytest.mark.parametrize("pattern", [re.compile(u"\\A.\\Z", re.DOTALL), u"(?s)\\A.\\Z"])
 def test_any_with_dotall_generate_newline(pattern):
-    find_any(st.from_regex(pattern), lambda s: s == u"\n")
+    find_any(
+        st.from_regex(pattern), lambda s: s == u"\n", settings(max_examples=10 ** 6)
+    )
 
 
 @pytest.mark.parametrize("pattern", [re.compile(b"\\A.\\Z", re.DOTALL), b"(?s)\\A.\\Z"])
 def test_any_with_dotall_generate_newline_binary(pattern):
-    find_any(st.from_regex(pattern), lambda s: s == b"\n")
+    find_any(
+        st.from_regex(pattern), lambda s: s == b"\n", settings(max_examples=10 ** 6)
+    )
 
 
 @pytest.mark.parametrize(
@@ -437,7 +441,11 @@ def test_issue_992_regression(data):
     ],
 )
 def test_fullmatch_generates_example(pattern, matching_str):
-    find_any(st.from_regex(pattern, fullmatch=True), lambda s: s == matching_str)
+    find_any(
+        st.from_regex(pattern, fullmatch=True),
+        lambda s: s == matching_str,
+        settings(max_examples=10 ** 6),
+    )
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -17,8 +17,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from random import Random
-
 from hypothesis import given
 from hypothesis.strategies import binary, characters, text, tuples
 from tests.common.debug import minimal
@@ -57,7 +55,7 @@ def test_will_find_ascii_examples_given_the_chance():
 
 
 def test_finds_single_element_strings():
-    assert minimal(text(), bool, random=Random(4)) == u"0"
+    assert minimal(text(), bool) == u"0"
 
 
 @fails_with(AssertionError)

--- a/hypothesis-python/tests/cover/test_slices.py
+++ b/hypothesis-python/tests/cover/test_slices.py
@@ -80,16 +80,16 @@ def test_step_will_be_positive(size):
     find_any(st.slices(size), lambda x: x.step > 0)
 
 
-@given(st.integers(1, 10))
-@settings(deadline=None)
+@pytest.mark.parametrize("size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 def test_stop_will_equal_size(size):
-    find_any(st.slices(size), lambda x: x.stop == size)
+    find_any(st.slices(size), lambda x: x.stop == size, settings(max_examples=10 ** 6))
 
 
-@given(st.integers(1, 10))
-@settings(deadline=None)
+@pytest.mark.parametrize("size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 def test_start_will_equal_size(size):
-    find_any(st.slices(size), lambda x: x.start == size - 1)
+    find_any(
+        st.slices(size), lambda x: x.start == size - 1, settings(max_examples=10 ** 6)
+    )
 
 
 @given(st.integers(1, 1000))

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -68,8 +68,8 @@ def test_includes_progress_in_verbose_mode():
         )
     out = o.getvalue()
     assert out
-    assert u"Shrunk example" in out
-    assert u"Found satisfying example" in out
+    assert u"Trying example: " in out
+    assert u"Falsifying example: " in out
 
 
 def test_prints_initial_attempts_on_find():

--- a/hypothesis-python/tests/nocover/test_collective_minimization.py
+++ b/hypothesis-python/tests/nocover/test_collective_minimization.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from hypothesis import settings
-from hypothesis.errors import NoSuchExample
+from hypothesis.errors import Unsatisfiable
 from hypothesis.strategies import lists
 from tests.common import standard_types
 from tests.common.debug import minimal
@@ -35,21 +35,13 @@ def test_can_collectively_minimize(spec):
     answer fast enough."""
     n = 10
 
-    def distinct_reprs(x):
-        result = set()
-        for t in x:
-            result.add(repr(t))
-            if len(result) >= 2:
-                return True
-        return False
-
     try:
         xs = minimal(
             lists(spec, min_size=n, max_size=n),
-            distinct_reprs,
-            settings=settings(max_examples=2000),
+            lambda x: len(set(map(repr, x))) >= 2,
+            settings(max_examples=2000),
         )
         assert len(xs) == n
         assert 2 <= len(set(map(repr, xs))) <= 3
-    except NoSuchExample:
+    except Unsatisfiable:
         pass

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -107,8 +107,7 @@ def test_can_shrink_through_a_binding(n):
     bool_lists = integers(0, 100).flatmap(
         lambda k: lists(booleans(), min_size=k, max_size=k)
     )
-
-    assert minimal(bool_lists, lambda x: len(list(filter(bool, x))) >= n) == [True] * n
+    assert minimal(bool_lists, lambda x: x.count(True) >= n) == [True] * n
 
 
 @pytest.mark.parametrize("n", range(1, 10))
@@ -116,7 +115,5 @@ def test_can_delete_in_middle_of_a_binding(n):
     bool_lists = integers(1, 100).flatmap(
         lambda k: lists(booleans(), min_size=k, max_size=k)
     )
-
-    assert minimal(bool_lists, lambda x: x[0] and x[-1] and x.count(False) >= n) == [
-        True
-    ] + [False] * n + [True]
+    result = minimal(bool_lists, lambda x: x[0] and x[-1] and x.count(False) >= n)
+    assert result == [True] + [False] * n + [True]

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -18,9 +18,9 @@
 from __future__ import absolute_import, division, print_function
 
 import hypothesis.strategies as st
-from hypothesis import HealthCheck, given, settings
+from hypothesis import settings
 from tests.common.debug import find_any, minimal
-from tests.common.utils import flaky, no_shrink
+from tests.common.utils import flaky
 
 
 def test_can_generate_with_large_branching():
@@ -96,16 +96,9 @@ def test_drawing_many_near_boundary():
     assert len(ls) == target
 
 
-@given(st.randoms())
-@settings(
-    max_examples=50,
-    phases=no_shrink,
-    suppress_health_check=HealthCheck.all(),
-    deadline=None,
-)
-def test_can_use_recursive_data_in_sets(rnd):
+def test_can_use_recursive_data_in_sets():
     nested_sets = st.recursive(st.booleans(), st.frozensets, max_leaves=3)
-    find_any(nested_sets, random=rnd)
+    find_any(nested_sets, settings=settings(deadline=None))
 
     def flatten(x):
         if isinstance(x, bool):
@@ -118,8 +111,7 @@ def test_can_use_recursive_data_in_sets(rnd):
                     break
             return result
 
-    assert rnd is not None
-    x = minimal(nested_sets, lambda x: len(flatten(x)) == 2, random=rnd)
+    x = find_any(nested_sets, lambda x: len(flatten(x)) == 2, settings(deadline=None))
     assert x in (
         frozenset((False, True)),
         frozenset((False, frozenset((True,)))),

--- a/hypothesis-python/tests/nocover/test_sets.py
+++ b/hypothesis-python/tests/nocover/test_sets.py
@@ -18,20 +18,13 @@
 from __future__ import absolute_import, division, print_function
 
 from hypothesis import given, settings
-from hypothesis.strategies import floats, integers, randoms, sets
+from hypothesis.strategies import floats, integers, sets
 from tests.common.debug import find_any
 
 
-@given(randoms())
-@settings(max_examples=5, deadline=None)
-def test_can_draw_sets_of_hard_to_find_elements(rnd):
+def test_can_draw_sets_of_hard_to_find_elements():
     rarebool = floats(0, 1).map(lambda x: x <= 0.05)
-    find_any(
-        sets(rarebool, min_size=2),
-        lambda x: True,
-        random=rnd,
-        settings=settings(database=None),
-    )
+    find_any(sets(rarebool, min_size=2), settings=settings(deadline=None))
 
 
 @given(sets(integers(), max_size=0))

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -687,4 +687,5 @@ def test_broadcastable_shape_can_generate_arbitrary_ndims(shape, max_dims, data)
     find_any(
         nps.broadcastable_shapes(shape, min_side=0, max_dims=max_dims, **args),
         lambda x: len(x) == desired_ndim,
+        settings(max_examples=10 ** 6),
     )

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -220,10 +220,10 @@ def test_uniqueness_does_not_affect_other_rows_1():
 def test_uniqueness_does_not_affect_other_rows_2():
     data_frames = pdst.data_frames(
         [
-            pdst.column("A", dtype=int, unique=False),
+            pdst.column("A", dtype=bool, unique=False),
             pdst.column("B", dtype=int, unique=True),
         ],
-        rows=st.tuples(st.integers(0, 10), st.integers(0, 10)),
+        rows=st.tuples(st.booleans(), st.integers(0, 10)),
         index=pdst.range_indexes(2, 2),
     )
     find_any(data_frames, lambda x: x["A"][0] == x["A"][1])

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -17,8 +17,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from random import Random
-
 import pytest
 
 import hypothesis.strategies as st
@@ -45,12 +43,7 @@ def test_can_shrink_in_variable_sized_context(n):
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
 @settings(deadline=None, suppress_health_check=HealthCheck.all())
 def test_shrinks_downwards_to_integers(f):
-    g = minimal(
-        st.floats(),
-        lambda x: x >= f,
-        random=Random(0),
-        settings=settings(verbosity=Verbosity.quiet),
-    )
+    g = minimal(st.floats(), lambda x: x >= f, settings(verbosity=Verbosity.quiet))
     assert g == ceil(f)
 
 
@@ -61,7 +54,6 @@ def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats(),
         lambda x: assume((0 < x < (2 ** 53)) and int(x) != x) and x >= b,
-        random=Random(0),
         settings=settings(verbosity=Verbosity.quiet),
     )
     assert g == b + 0.5

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -54,6 +54,6 @@ def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats(),
         lambda x: assume((0 < x < (2 ** 53)) and int(x) != x) and x >= b,
-        settings=settings(verbosity=Verbosity.quiet),
+        settings=settings(verbosity=Verbosity.quiet, max_examples=10 ** 6),
     )
     assert g == b + 0.5

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 from collections import namedtuple
 from fractions import Fraction
 from functools import reduce
-from random import Random
 
 import pytest
 
@@ -220,7 +219,6 @@ def test_containment(n, seed):
         tuples(lists(integers()), integers()),
         lambda x: x[1] in x[0] and x[1] >= n,
         timeout_after=60,
-        random=Random(seed),
     )
     assert iv == ([n], n)
 
@@ -237,10 +235,7 @@ def test_duplicate_containment():
 
 @pytest.mark.parametrize("seed", [11, 28, 37])
 def test_reordering_bytes(seed):
-    ls = minimal(
-        lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3, random=Random(seed)
-    )
-
+    ls = minimal(lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
     assert ls == sorted(ls)
 
 

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -145,7 +145,7 @@ commands =
     rm -f branch-check
     python -m coverage --version
     python -m coverage debug sys
-    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas tests/lark --maxfail=1 --ff {posargs}
+    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas tests/lark --ff {posargs}
     python -m coverage report -m --fail-under=100 --show-missing
     python scripts/validate_branch_check.py
 


### PR DESCRIPTION
This PR reduces our internal use of `find()`, to make it easier to deprecate it in future (#1694), by re-implementing `minimal()` and associated test helpers on top of `@given` instead.

~~This is pretty easy to do, with one exception: `test_can_shrink_through_a_binding` and `test_can_delete_in_middle_of_a_binding` are now failing.  @DRMacIver - it looks like this shrinking logic doesn't work properly under `@given`??~~