### PR TITLE
Widen caught exception in rare database collision

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes a very rare example database issue with file permissions.
+
+When running a test that uses both :func:`@given <hypothesis.given>`
+and ``pytest.mark.parametrize``, using :pypi:`pytest-xdist` on Windows,
+with failing examples in the database, two attempts to read a file could
+overlap and we caught ``FileNotFound`` but not other ``OSError``\ s.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -24,7 +24,7 @@ from hashlib import sha1
 
 from hypothesis.configuration import storage_directory
 from hypothesis.errors import HypothesisException, HypothesisWarning
-from hypothesis.internal.compat import FileNotFoundError, hbytes
+from hypothesis.internal.compat import hbytes
 from hypothesis.utils.conventions import not_set
 
 
@@ -171,7 +171,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
             try:
                 with open(os.path.join(kp, path), "rb") as i:
                     yield hbytes(i.read())
-            except FileNotFoundError:
+            except EnvironmentError:
                 pass
 
     def save(self, key, value):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -525,27 +525,6 @@ def implements_iterator(it):
     return it
 
 
-if PY3:
-    FileNotFoundError = FileNotFoundError  # type: Type[IOError]
-else:
-    FileNotFoundError = IOError
-
-# We need to know what sort of exception gets thrown when you try to write over
-# an existing file where you're not allowed to. This is rather less consistent
-# between versions than might be hoped.
-if PY3:
-    FileExistsError = FileExistsError  # type: Type[IOError]
-
-elif WINDOWS:
-    FileExistsError = WindowsError
-
-else:
-    # This doesn't happen in this case: We're not on windows and don't support
-    # the x flag because it's Python 2, so there are no places where this can
-    # be thrown.
-    FileExistsError = None
-
-
 # Under Python 2, math.floor and math.ceil return floats, which cannot
 # represent large integers - eg `float(2**53) == float(2**53 + 1)`.
 # We therefore implement them entirely in (long) integer operations.


### PR DESCRIPTION
This patch fixes a very rare example database issue with file permissions.

When running a test that uses both `@given` and `pytest.mark.parametrize`, using `pytest-xdist` on Windows, with failing examples in the database, two attempts to read a file could
overlap and we caught `FileNotFound` but not other `PermissionError` or other `OSError`s.

This is obviously a pretty niche case due to the timing, but I've seen it twice in a \~month while working on hypothesis-jsonschema... which has a 269-way parametrize over the entire upstream test suite and ``-n 16`` on a nice desktop 😄

(for "we should have distinct DB keys for different parametrize items", see #1996)