### PR TITLE
Fix day-of-month overflow in datetimes()

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch makes :func:`~hypothesis.strategies.datetimes` more efficient,
+as it now handles short months correctly by construction instead of filtering.

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -23,9 +23,7 @@ import pytest
 
 from hypothesis import given
 from hypothesis.internal.compat import hrange
-from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
-from hypothesis.searchstrategy.datetime import DatetimeStrategy
-from hypothesis.strategies import binary, dates, datetimes, none, timedeltas, times
+from hypothesis.strategies import dates, datetimes, timedeltas, times
 from tests.common.debug import find_any, minimal
 
 
@@ -88,21 +86,6 @@ def test_bordering_on_a_leap_year():
     assert x.year == 2004
 
 
-def test_DatetimeStrategy_draw_may_fail():
-    def is_failure_inducing(b):
-        try:
-            return strat._attempt_one_draw(ConjectureData.for_buffer(b)) is None
-        except StopTest:
-            return False
-
-    strat = DatetimeStrategy(dt.datetime.min, dt.datetime.max, none())
-    failure_inducing = minimal(binary(), is_failure_inducing, timeout_after=30)
-    data = ConjectureData.for_buffer(failure_inducing * 100)
-    with pytest.raises(StopTest):
-        data.draw(strat)
-    assert data.status == Status.INVALID
-
-
 def test_can_find_after_the_year_2000():
     assert minimal(dates(), lambda x: x.year > 2000).year == 2001
 
@@ -111,9 +94,9 @@ def test_can_find_before_the_year_2000():
     assert minimal(dates(), lambda x: x.year < 2000).year == 1999
 
 
-def test_can_find_each_month():
-    for month in hrange(1, 13):
-        find_any(dates(), lambda x: x.month == month)
+@pytest.mark.parametrize("month", hrange(1, 13))
+def test_can_find_each_month(month):
+    find_any(dates(), lambda x: x.month == month)
 
 
 def test_min_year_is_respected():

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -23,6 +23,7 @@ from hypothesis import find, given
 from hypothesis._settings import Verbosity, settings
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.strategies import booleans, integers, lists
+from tests.common.debug import minimal
 from tests.common.utils import capture_out, fails
 
 
@@ -60,16 +61,11 @@ def test_does_not_log_in_quiet_mode():
 
 def test_includes_progress_in_verbose_mode():
     with capture_verbosity() as o:
-
-        def foo():
-            find(
-                lists(integers()),
-                lambda x: sum(x) >= 100,
-                settings=settings(verbosity=Verbosity.verbose, database=None),
-            )
-
-        foo()
-
+        minimal(
+            lists(integers(), min_size=1),
+            lambda x: sum(x) >= 100,
+            settings(verbosity=Verbosity.verbose),
+        )
     out = o.getvalue()
     assert out
     assert u"Shrunk example" in out


### PR DESCRIPTION
Some months have fewer than 31 days!  And not trying to call datetime with an invalid month/day combination makes our can-overflow test impossible.