### PR TITLE
Reliably cover the handling of stale example identifiers while shrinking

### DIFF
--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -46,7 +46,7 @@ from hypothesis.internal.conjecture.shrinking import Float
 from hypothesis.internal.conjecture.utils import Sampler, calc_label_from_name
 from hypothesis.internal.entropy import deterministic_PRNG
 from tests.common.strategies import SLOW, HardToShrink
-from tests.common.utils import no_shrink
+from tests.common.utils import counts_calls, no_shrink
 
 SOME_LABEL = calc_label_from_name("some label")
 
@@ -1615,3 +1615,48 @@ def test_exhaust_space():
         runner.run()
         assert runner.tree.is_exhausted
         assert runner.valid_examples == 2
+
+
+@pytest.mark.parametrize(
+    "pass_name",
+    [
+        "pass_to_descendant",
+        "adaptive_example_deletion",
+        "zero_examples",
+        "minimize_floats",
+        "example_deletion_with_block_lowering",
+        "reorder_examples",
+    ],
+)
+def test_shrinker_skips_stale_examples(monkeypatch, pass_name):
+    # Pretend that all example identifiers are stale, to test that this case
+    # is handled cleanly.
+    monkeypatch.setattr(
+        Shrinker, "example_for_stable_identifier", counts_calls(lambda self, x: None)
+    )
+
+    # For "example_deletion_with_block_lowering", also pretend that all blocks
+    # are shrinking blocks, so that steps can be generated.
+    monkeypatch.setattr(
+        Shrinker, "is_shrinking_block", counts_calls(lambda self, i: True)
+    )
+
+    # Declare a test function that should satisfy step generation for all of
+    # the relevant shrink passes.
+    @shrinking_from([255] * 5)
+    def shrinker(data):
+        total = 0
+        data.start_example(0)
+        for _ in range(5):
+            data.start_example(0)
+            total += data.draw_bits(8)
+            data.stop_example(0)
+        data.stop_example(0)
+
+        data.mark_interesting()
+
+    # Run the shrink pass; this should not throw.
+    shrinker.fixate_shrink_passes([pass_name])
+
+    # Confirm that the pass had to deal with stale examples.
+    assert Shrinker.example_for_stable_identifier.calls > 0


### PR DESCRIPTION
As seen in https://github.com/HypothesisWorks/hypothesis/pull/2000#issuecomment-498007405, we apparently don't have reliable coverage of the branch in `reorder_examples` that rejects example identifiers that are no longer valid (due to intervening shrinks).

This PR aims to remove that flakiness by explicitly triggering that path, and similar paths in other shrink passes.