### PR TITLE
Explicitly name deprecated methods in note

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -234,6 +234,7 @@ their individual contributions.
 * `Karthikeyan Singaravelan <https://www.github.com/tirkarthi>`_ (tir.karthi@gmail.com)
 * `Katrina Durance <https://github.com/kdurance>`_
 * `kbara <https://www.github.com/kbara>`_
+* `Kristian Glass <https://www.github.com/doismellburning>`_
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)
 * `Lee Begg <https://www.github.com/llnz2>`_
 * `Lisa Goeller <https://www.github.com/lgoeller>`_

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+Deprecation messages for functions in `hypothesis.extra.django.models` now explicitly name the deprecated function to make it easier to track down usages.
+Thanks to Kristian Glass for this contribution

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,3 +1,0 @@
-RELEASE_TYPE: patch
-Deprecation messages for functions in `hypothesis.extra.django.models` now explicitly name the deprecated function to make it easier to track down usages.
-Thanks to Kristian Glass for this contribution

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Deprecation messages for functions in :func:`hypothesis.extra.django.models` now 
+explicitly name the deprecated function to make it easier to track down usages.
+Thanks to Kristian Glass for this contribution!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-Deprecation messages for functions in :func:`hypothesis.extra.django.models` now 
+Deprecation messages for functions in ``hypothesis.extra.django.models`` now 
 explicitly name the deprecated function to make it easier to track down usages.
 Thanks to Kristian Glass for this contribution!

--- a/hypothesis-python/src/hypothesis/extra/django/models.py
+++ b/hypothesis-python/src/hypothesis/extra/django/models.py
@@ -34,7 +34,7 @@ if False:
 def add_default_field_mapping(field_type, strategy):
     # type: (Type[dm.Field], st.SearchStrategy[Any]) -> None
     note_deprecation(
-        "This function is deprecated; use `hypothesis.extra.django."
+        "`hypothesis.extra.django.models.add_default_field_mapping` is deprecated; use `hypothesis.extra.django."
         "register_field_strategy` instead.",
         since="2019-01-10",
     )
@@ -76,7 +76,7 @@ def models(
       shop_strategy = models(Shop, company=models(Company))
     """
     note_deprecation(
-        "This function is deprecated; use `hypothesis.extra.django."
+        "`hypothesis.extra.django.models.models` is deprecated; use `hypothesis.extra.django."
         "from_model` instead.",
         since="2019-01-10",
     )


### PR DESCRIPTION
Because otherwise, all I get by default is:

```
asauseriwant/tests/test_models.py::TestModels::test_userstory_str
  /home/circleci/.local/share/virtualenvs/project-zxI9dQ-Q/lib/python3.7/site-packages/hypothesis/extra/django/models.py:81: HypothesisDeprecationWarning: This function is deprecated; use `hypothesis.extra.django.from_model` instead.
    since="2019-01-10",
```

and I have to source-dive to find out what it is I'm using that I shouldn't