### PR TITLE
Use CodeType.replace in Python 3.8

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch improves the implementation of an internal wrapper on Python 3.8
+beta1 (and will break on the alphas; but they're not meant to be stable).
+On other versions, there is no change at all.
+
+Thanks to Daniel Hahler for the patch, and Victor Stinner for his work
+on :bpo:`37032` that made it possible.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -407,6 +407,13 @@ def update_code_location(code, newfile, newlineno):
     code you're probably here because it's broken something and now
     you're angry at me. Sorry.
     """
+    if hasattr(code, "replace"):
+        # Python 3.8.
+        return code.replace(
+            co_filename=newfile,
+            co_firstlineno=newlineno
+        )
+
     unpacked = [getattr(code, name) for name in CODE_FIELD_ORDER]
     unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile
     unpacked[CODE_FIELD_ORDER.index("co_firstlineno")] = newlineno

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -374,6 +374,9 @@ if PY2:
         "co_cellvars",
     ]
 else:
+    # This field order is accurate for 3.5 - 3.7, but not 3.8 when a new field
+    # was added for positional-only arguments.  However it also added a .replace()
+    # method that we use instead of field indices, so they're fine as-is.
     CODE_FIELD_ORDER = [
         "co_argcount",
         "co_kwonlyargcount",
@@ -392,10 +395,6 @@ else:
         "co_cellvars",
     ]
 
-    if sys.version_info >= (3, 8, 0):
-        # PEP 570 added "positional only arguments"
-        CODE_FIELD_ORDER.insert(1, "co_posonlyargcount")
-
 
 def update_code_location(code, newfile, newlineno):
     """Take a code object and lie shamelessly about where it comes from.
@@ -408,11 +407,10 @@ def update_code_location(code, newfile, newlineno):
     you're angry at me. Sorry.
     """
     if hasattr(code, "replace"):
-        # Python 3.8.
-        return code.replace(
-            co_filename=newfile,
-            co_firstlineno=newlineno
-        )
+        # Python 3.8 added positional-only params (PEP 570), and thus changed
+        # the layout of code objects.  In beta1, the `.replace()` method was
+        # added to facilitate future-proof code.  See BPO-37032 for details.
+        return code.replace(co_filename=newfile, co_firstlineno=newlineno)
 
     unpacked = [getattr(code, name) for name in CODE_FIELD_ORDER]
     unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile


### PR DESCRIPTION
Added via https://bugs.python.org/issue37032.