### PR TITLE
Implement targeted PBT

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+This release adds the :func:`hypothesis.target` function, which implements
+**experimental** support for :ref:`targeted property-based testing <targeted-search>`
+(:issue:`1779`).
+
+By calling :func:`~hypothesis.target` in your test function, Hypothesis can
+do a hill-climbing search for bugs.  If you can calculate a suitable metric
+such as the load factor or length of a queue, this can help you find bugs with
+inputs that are highly improbably from unguided generation - however good our
+heuristics, example diversity, and deduplication logic might be.  After all,
+those features are at work in targeted PBT too!

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -382,6 +382,34 @@ Check :ref:`the notes on framework compatibility <framework-compatibility>`
 to see how this affects other testing libraries you may be using.
 
 
+.. _targeted-search:
+
+---------------------------
+Targeted example generation
+---------------------------
+
+Targeted property-based testing combines the advantages of both search-based
+and property-based testing.  Instead of being completely random, T-PBT uses
+a search-based component to guide the input generation towards values that
+have a higher probability of falsifying a property.  This explores the input
+space more effectively and requires fewer tests to find a bug or achieve a
+high confidence in the system being tested than random PBT.
+(`Löscher and Sagonas <http://proper.softlab.ntua.gr/Publications.html>`__)
+
+This is not *always* a good idea - for example calculating the search metric
+might take time better spent running more uniformly-random test cases - but
+Hypothesis has **experimental** support for targeted PBT you may wish to try.
+
+.. autofunction:: hypothesis.target
+
+We recommend that users also skim the papers introducing targeted PBT;
+from `ISSTA 2017 <http://proper.softlab.ntua.gr/papers/issta2017.pdf>`__
+and `ICST 2018 <http://proper.softlab.ntua.gr/papers/icst2018.pdf>`__.
+For the curious, the initial implementation in Hypothesis uses hill-climbing
+search via a mutating fuzzer, with some tactics inspired by simulated
+annealing to avoid getting stuck and endlessly mutating a local maximum.
+
+
 .. _custom-function-execution:
 
 -------------------------

--- a/hypothesis-python/src/hypothesis/__init__.py
+++ b/hypothesis-python/src/hypothesis/__init__.py
@@ -32,7 +32,7 @@ from hypothesis._settings import (
     settings,
     unlimited,
 )
-from hypothesis.control import assume, event, note, reject
+from hypothesis.control import assume, event, note, reject, target
 from hypothesis.core import example, find, given, reproduce_failure, seed
 from hypothesis.internal.entropy import register_random
 from hypothesis.utils.conventions import infer
@@ -56,6 +56,7 @@ __all__ = [
     "event",
     "infer",
     "register_random",
+    "target",
     "__version__",
     "__version_info__",
 ]

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -150,13 +150,8 @@ def target(observation, label=""):
 
     The optional ``label`` argument can be used to distinguish between
     and therefore separately optimise distinct observations, such as the
-    mean and standard deviation of a dataset.
-
-    If ``hypothesis.target`` is called multiple times within a single test
-    case with a specific label, this is treated as if you only called it once
-    with the best result for that label.  For example, calling
-    ``target(high_score, "highest score")`` on every frame of an arcade game
-    would tag that test case with the highest score reached in that session.
+    mean and standard deviation of a dataset.  It is an error to call
+    ``target()`` with any label more than once per test case.
 
     .. note::
         **The more examples you run, the better this technique works.**
@@ -182,5 +177,10 @@ def target(observation, label=""):
     verbose_report("Saw target(observation=%r, label=%r)" % (observation, label))
 
     if context.data is not None:
-        if observation > context.data.target_observations.get(label, float("-inf")):
+        if label in context.data.target_observations:
+            raise InvalidArgument(
+                "Calling target(%r, label=%r) would overwrite target(%r, label=%r)"
+                % (observation, label, context.data.target_observations[label], label)
+            )
+        else:
             context.data.target_observations[label] = observation

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -24,7 +24,7 @@ from hypothesis import Verbosity, settings
 from hypothesis.errors import CleanupFailed, InvalidArgument, UnsatisfiedAssumption
 from hypothesis.internal.compat import string_types
 from hypothesis.internal.validation import check_type
-from hypothesis.reporting import report
+from hypothesis.reporting import report, verbose_report
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
 if False:
@@ -175,3 +175,12 @@ def target(observation, label=""):
     if math.isinf(observation) or math.isnan(observation):
         raise InvalidArgument("observation=%r must be a finite float." % observation)
     check_type(string_types, label, "label")
+
+    context = _current_build_context.value
+    if context is None:
+        raise InvalidArgument("Calling target() outside of a test is invalid.")
+    verbose_report("Saw target(observation=%r, label=%r)" % (observation, label))
+
+    if context.data is not None:
+        if observation > context.data.target_observations.get(label, float("-inf")):
+            context.data.target_observations[label] = observation

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -42,6 +42,22 @@ try:
 except ImportError:
     import collections as abc  # type: ignore
 
+try:
+    from itertools import accumulate
+except ImportError:
+
+    def accumulate(iterable, func=lambda a, b: a + b):
+        it = iter(iterable)
+        try:
+            total = next(it)
+        except StopIteration:
+            return
+        yield total
+        for element in it:
+            total = func(total, element)
+            yield total
+
+
 if False:
     from typing import Type, Tuple  # noqa
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -756,6 +756,10 @@ class ConjectureData(object):
 
         self.__result = None
 
+        # Observations used for targeted search.  They'll be aggregated in
+        # ConjectureRunner.generate_new_examples and fed to TargetSelector.
+        self.target_observations = {}
+
         # Normally unpopulated but we need this in the niche case
         # that self.as_result() is Overrun but we still want the
         # examples for reporting purposes.

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -17,6 +17,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from operator import itemgetter
+
 import pytest
 
 from hypothesis import example, given, strategies as st, target
@@ -45,11 +47,9 @@ def test_target_without_label(observation):
 
 @given(
     st.lists(
-        st.tuples(
-            st.floats(allow_nan=False, allow_infinity=False),
-            st.sampled_from(["a", "few", "labels"]) | st.text(),
-        ),
+        st.tuples(st.floats(allow_nan=False, allow_infinity=False), st.text()),
         min_size=1,
+        unique_by=itemgetter(1),
     )
 )
 def test_multiple_target_calls(args):
@@ -94,3 +94,17 @@ def test_disallowed_inputs_to_target(observation, label):
 def test_cannot_target_outside_test():
     with pytest.raises(InvalidArgument):
         target(1.0, "example label")
+
+
+@given(st.none())
+def test_cannot_target_same_label_twice(_):
+    target(0.0, label="label")
+    with pytest.raises(InvalidArgument):
+        target(1.0, label="label")
+
+
+@given(st.none())
+def test_cannot_target_default_label_twice(_):
+    target(0.0)
+    with pytest.raises(InvalidArgument):
+        target(1.0)

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -57,6 +57,17 @@ def test_multiple_target_calls(args):
         target(observation, label)
 
 
+@given(
+    st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=11, max_size=20)
+)
+def test_respects_max_pool_size(observations):
+    """Using many examples of several labels like this stresses the
+    pool-size logic and internal assertions in TargetSelector.
+    """
+    for i, obs in enumerate(observations):
+        target(obs, label=str(i))
+
+
 def everything_except(type_):
     # Note: we would usually stick to fater traditional or parametrized
     # tests to check that invalid inputs are rejected, but for `target()`
@@ -78,3 +89,8 @@ def everything_except(type_):
 def test_disallowed_inputs_to_target(observation, label):
     with pytest.raises(InvalidArgument):
         target(observation, label)
+
+
+def test_cannot_target_outside_test():
+    with pytest.raises(InvalidArgument):
+        target(1.0, "example label")

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from hypothesis import example, given, strategies as st, target
+from hypothesis.errors import InvalidArgument
+from hypothesis.internal.compat import string_types
+
+
+@example(0.0, "this covers the branch where context.data is None")
+@given(observation=st.floats(allow_nan=False, allow_infinity=False), label=st.text())
+def test_allowed_inputs_to_target(observation, label):
+    target(observation, label)
+
+
+@given(
+    observation=st.floats(min_value=1, allow_nan=False, allow_infinity=False),
+    label=st.sampled_from(["a", "few", "labels"]),
+)
+def test_allowed_inputs_to_target_fewer_labels(observation, label):
+    target(observation, label)
+
+
+@given(st.floats(min_value=1, max_value=10))
+def test_target_without_label(observation):
+    target(observation)
+
+
+@given(
+    st.lists(
+        st.tuples(
+            st.floats(allow_nan=False, allow_infinity=False),
+            st.sampled_from(["a", "few", "labels"]) | st.text(),
+        ),
+        min_size=1,
+    )
+)
+def test_multiple_target_calls(args):
+    for observation, label in args:
+        target(observation, label)
+
+
+def everything_except(type_):
+    # Note: we would usually stick to fater traditional or parametrized
+    # tests to check that invalid inputs are rejected, but for `target()`
+    # we need to use `@given` (to validate arguments instead of context)
+    # so we might as well apply this neat recipe.
+    return (
+        st.from_type(type)
+        .flatmap(st.from_type)
+        .filter(lambda x: not isinstance(x, type_))
+    )
+
+
+@example(float("nan"), "")
+@example(float("inf"), "")
+@example(float("-inf"), "")
+@example("1", "Non-float observations are invalid")
+@example(0.0, ["a list of strings is not a valid label"])
+@given(observation=everything_except(float), label=everything_except(string_types))
+def test_disallowed_inputs_to_target(observation, label):
+    with pytest.raises(InvalidArgument):
+        target(observation, label)


### PR DESCRIPTION
This is the minimum releasable implementation that closes #1779:

- One new user-facing API (the `hypothesis.target()` function)
- Engine upgrades, mainly around `TargetSelector`.
- Plenty of documentation warning that this is experimental.

I've also been careful to leave as much flexibility as possible for future changes, where that didn't prematurely complicate the code.  

Thoughts?  Feedback on the implementation and API would be great, but I'm especially interested in how we could evaluate and tune the various constants for better performance :smile: 