### PR TITLE
Check for PRNG state leaks in our test suite

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,18 @@
+RELEASE_TYPE: minor
+
+This release adds a check for tests that set the global PRNG state, for example
+by using :func:`python:random.seed` without appropriate cleanup (:issue:`1919`).
+
+If you want deterministic Hypothesis tests - though we strongly recommend varied
+generation and :doc:`reproducing` instead - you can use the
+:obj:`~hypothesis.settings.derandomize` setting.  For other tests, the following
+idiom may be useful in a decorator or context manager:
+
+.. code:: python
+
+    state = random.getstate()
+    random.seed(your_seed_here)
+    try:
+        yield
+    finally:
+        random.setstate(state)

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -90,7 +90,7 @@ def get_seeder_and_restorer(seed=0):
 
 
 @contextlib.contextmanager
-def deterministic_PRNG():
+def deterministic_PRNG(seed=0):
     """Context manager that handles random.seed without polluting global state.
 
     See issue #1255 and PR #1295 for details and motivation - in short,
@@ -98,7 +98,7 @@ def deterministic_PRNG():
     bad idea in principle, and breaks all kinds of independence assumptions
     in practice.
     """
-    seed_all, restore_all = get_seeder_and_restorer()
+    seed_all, restore_all = get_seeder_and_restorer(seed)
     seed_all()
     try:
         yield


### PR DESCRIPTION
*Update: I'm going to try doing this as a warning upstream; please review something else instead 😄*

Closes #1919.  This trick only works if multiple tests leak the *same* state, but that's been the case in our previous problems.  

Distinguishing a leaking test from a test that just uses some randomness requires multiple runs, to observe that b1->a1 and also b2->a1 (ie sets output state rather than advancing from input state).  I didn't bother, since we've never needed it and we would have to maintain a bunch of fiddly and version-dependent state.