### PR TITLE
Support newer typing backport too

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2014`, where our compatibility layer broke with version
+3.7.4 of the :pypi:`typing` module backport on PyPI.
+
+This issue only affects Python 2.  We remind users that Hypothesis, like many other
+packages, `will drop Python 2 support on 2020-01-01 <https://python3statement.org>`__
+and already has several features that are only available on Python 3.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -298,10 +298,12 @@ except ImportError:
     typing_root_type = ()  # type: Tuple[type, ...]
     ForwardRef = None
 else:
-    if hasattr(typing, "_Final"):  # new in Python 3.7
+    try:
+        # These types are new in Python 3.7, but also (partially) backported to the
+        # typing backport on PyPI.  Use if possible; or fall back to older names.
         typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
         ForwardRef = typing.ForwardRef  # type: ignore
-    else:
+    except AttributeError:
         typing_root_type = (typing.TypingMeta, typing.TypeVar)  # type: ignore
         ForwardRef = typing._ForwardRef  # type: ignore
 

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -4,4 +4,4 @@
 #
 #    pip-compile --output-file=requirements/typing.txt requirements/typing.in
 #
-typing==3.6.6
+typing==3.7.4


### PR DESCRIPTION
Closes #2014.

I have checked that this still works on the previous version of the `typing` backport, but did not add an "older backport" environment to our CI matrix - we explicitly document that we only support the latest version of the `typing` ecosystem, and will be dropping Python 2 support at the end of this year anyway.