### PR TITLE
Add Tidelift links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+tidelift: pypi/hypothesis
+custom: https://hypothesis.works/services/

--- a/hypothesis-python/README.rst
+++ b/hypothesis-python/README.rst
@@ -26,6 +26,23 @@ Hypothesis is extremely practical and advances the state of the art of
 unit testing by some way. It's easy to use, stable, and powerful. If
 you're not using Hypothesis to test your project then you're missing out.
 
+.. |tideliftlogo| image:: https://cdn2.hubspot.net/hubfs/4008838/website/logos/Tidelift_primary-shorthand-logo.png
+   :width: 75
+   :alt: Tidelift logo
+   :target: `Tidelift Subscription`_
+
+.. list-table::
+   :widths: 10 100
+
+   * - |tideliftlogo|
+     - Professional support for Hypothesis is available as part of the
+       `Tidelift Subscription`_.  Tidelift which gives software development
+       teams a single source for professional assurances about their
+       open-source dependencies.
+
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-hypothesis?utm_source=pypi-hypothesis&utm_medium=referral&utm_campaign=readme
+
+
 ------------------------
 Quick Start/Installation
 ------------------------
@@ -57,3 +74,6 @@ If you want to hear from people who are already using Hypothesis, some of them `
 about it <https://hypothesis.readthedocs.io/en/latest/endorsements.html>`_.
 
 If you want to create a downstream package of Hypothesis, please read `these guidelines for packagers <https://hypothesis.readthedocs.io/en/latest/packaging.html>`_.
+
+Hypothesis has never had a security vulnerability, but if you need to report the first
+you can do so via the `Tidelift security contact <https://tidelift.com/security>`_.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,14 @@
+RELEASE_TYPE: patch
+
+Professional support for Hypothesis is available as part of the
+`Tidelift Subscription`_, which gives software development teams
+a single source for professional assurances about the open-source
+software they use.  So if you're using Hypothesis at work,
+encourage your organisation to check it out!
+
+For non-business users - we love you too - this makes it easier to stay
+top of maintainence and that benefits everyone.  We also have a shiny new
+`Tidelift security contact <https://tidelift.com/security>`_, so please
+report any vulnerabilities there for a coordinated fix and disclosure.
+
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-hypothesis?utm_source=pypi-hypothesis&utm_medium=referral&utm_campaign=readme

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -91,6 +91,7 @@ setuptools.setup(
     project_urls={
         "Website": "https://hypothesis.works",
         "Documentation": "https://hypothesis.readthedocs.io",
+        "Funding": "https://tidelift.com/subscription/pkg/pypi-hypothesis?utm_source=pypi-hypothesis&utm_medium=referral&utm_campaign=pypi",
         "Issues": "https://github.com/HypothesisWorks/hypothesis/issues",
     },
     license="MPL v2",


### PR DESCRIPTION
Hypothesis is now [supported via Tidelift](https://tidelift.com/), which basically gives businesses a solid value proposition to pay open source projects for things which aren't covered by open source licenses *per se*.  Like confidence that it will continue to be maintained, that licence information is accurate, that there is a security contact, etc... basically, more than the traditional `THIS SOFTWARE IS PROVIDED AS-IS...`

@DRMacIver - as well as approving this for the public record, we'll need you to [check the 'Sponsorships' box](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) in the repo settings.  This PR creates the `FUNDING.yml` file, and I've already added the Tidelift API key to Travis vars so that's literally all 😄 