### PR TITLE
Preclude .jpg, .png, .gif being rewritten on git push

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 *    text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary


### PR DESCRIPTION
This was an incidental finding from PR #2018, and is intended so that image files (binary files) are not rewritten during `git push`.