### PR TITLE
Don't run apt-get commands from the whole repo test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,3 +75,4 @@ addons:
   apt:
     packages:
       - libgmp-dev
+      - shellcheck

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
         check-pandas24:
           TASK: check-pandas24
     steps:
-    - script: sudo apt-get update && sudo apt-get install libreadline-dev libsqlite3-dev
+    - script: sudo apt-get update && sudo apt-get install libreadline-dev libsqlite3-dev shellcheck
       displayName: Install apt dependencies
     - script: ./build.sh check-installed
       displayName: Install Python

--- a/tooling/src/hypothesistooling/installers.py
+++ b/tooling/src/hypothesistooling/installers.py
@@ -93,13 +93,9 @@ def ensure_ghc():
 def ensure_shellcheck():
     if os.path.exists(SHELLCHECK):
         return
-    if shutil.which("apt-get") is not None:
-        subprocess.check_call(["apt-get", "update"])
-        subprocess.check_call(["apt-get", "install", "shellcheck"])
-    else:
-        update_stack()
-        ensure_ghc()
-        subprocess.check_call([STACK, "install", "ShellCheck"])
+    update_stack()
+    ensure_ghc()
+    subprocess.check_call([STACK, "install", "ShellCheck"])
 
 
 @once


### PR DESCRIPTION
The recent changes to how we install shellcheck in #2026 mean that the whole repo tests can only be run as root (and attempt to install things globally), which isn't ideal in general and prevents local usage. This PR changes it so that the build will still use the old method to install shellcheck if it's not found, but will use a system one if present, and updates our build config to install shellcheck before the tests are run.