### PR TITLE
Add test to reliably cover handling of collisions in unique arrays

### DIFF
--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -313,6 +313,19 @@ def test_array_values_are_unique(arr):
     assert len(set(arr)) == len(arr)
 
 
+@given(
+    nps.arrays(
+        elements=st.just(0.0),
+        dtype=float,
+        fill=st.just(float("nan")),
+        shape=st.integers(0, 20),
+        unique=True,
+    )
+)
+def test_array_values_are_unique_high_collision(arr):
+    assert (arr == 0.0).sum() <= 1
+
+
 def test_may_fill_with_nan_when_unique_is_set():
     find_any(
         nps.arrays(


### PR DESCRIPTION
The coverage job is currently flaky because https://github.com/HypothesisWorks/hypothesis/blob/c3c28220d6b4ca53957a63979665d1d9d6d3b685/hypothesis-python/src/hypothesis/extra/numpy.py#L241-L242 are not being reliably covered. This PR adds a test that reliably hits them.