### PR TITLE
Improve performance of generate_novel_prefix

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes  :issue:`2027`, by changing the way Hypothesis tries to generate distinct examples to be more efficient.
+
+This may result in slightly different data distribution, and should improve generation performance in general,
+but should otherwise have minimal user impact.

--- a/hypothesis-python/tests/cover/test_conjecture_data_tree.py
+++ b/hypothesis-python/tests/cover/test_conjecture_data_tree.py
@@ -341,20 +341,6 @@ def test_child_becomes_exhausted_after_split():
     assert tree.root.transition.children[0].is_exhausted
 
 
-def test_will_avoid_exhausted_branches_for_necessary_prefix():
-    tree = DataTree()
-    data = ConjectureData.for_buffer([0], observer=tree.new_observer())
-    data.draw_bits(1)
-    data.freeze()
-
-    data = ConjectureData.for_buffer([1, 1], observer=tree.new_observer())
-    data.draw_bits(1)
-    data.draw_bits(8)
-    data.freeze()
-
-    assert list(tree.find_necessary_prefix_for_novelty()) == [1]
-
-
 def test_will_generate_novel_prefix_to_avoid_exhausted_branches():
     tree = DataTree()
     data = ConjectureData.for_buffer([1], observer=tree.new_observer())

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -167,7 +167,7 @@ def test_shrinks_both_failures():
     duds = set()
     second_target = [None]
 
-    @settings(database=None)
+    @settings(database=None, max_examples=1000)
     @given(st.integers(min_value=0).map(int))
     def test(i):
         if i >= 10000:

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -26,7 +26,7 @@ from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
 from hypothesis.strategies import datetimes, sampled_from, times
-from tests.common.debug import minimal
+from tests.common.debug import assert_can_trigger_event, minimal
 
 
 def test_utc_is_minimal():
@@ -97,3 +97,12 @@ def test_can_generate_non_utc():
 def test_time_bounds_must_be_naive(name, val):
     with pytest.raises(InvalidArgument):
         times(**{name: val}).validate()
+
+
+def test_can_trigger_error_in_draw_near_max_date():
+    assert_can_trigger_event(
+        datetimes(
+            min_value=dt.datetime.max - dt.timedelta(days=3), timezones=timezones()
+        ),
+        lambda event: "Failed to draw a datetime" in event,
+    )

--- a/hypothesis-python/tests/nocover/test_regressions.py
+++ b/hypothesis-python/tests/nocover/test_regressions.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import, division, print_function
 
 import warnings
 
+import hypothesis.strategies as st
+from hypothesis import given
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.strategies import composite, integers
@@ -42,3 +44,11 @@ def test_note_deprecation_blames_right_code_issue_652():
     assert isinstance(record.message, HypothesisDeprecationWarning)
     assert record.message.args == (msg,)
     assert record.filename == __file__
+
+
+@given(
+    x=st.one_of(st.just(0) | st.just(1)),
+    y=st.one_of(st.just(0) | st.just(1) | st.just(2)),
+)
+def test_performance_issue_2027(x, y):
+    pass


### PR DESCRIPTION
Fixes #2027 

This is the performance patch I pulled from #2030 because it didn't seem necessary and changes the data distribution for some reason caused us to lose coverage.

I decided that the reason we lost coverage was mostly accidental - the previous tests couldn't reliably guarantee that coverage, they just happened to work - so I also added some tests for datetimes in this PR in order to get back to 100% coverage. I've also upped the `max_examples` count on one test that had become flaky, so I think there's some chance that this has made the data distribution slightly worse, but I think it's worth it for the performance gain.