### PR TITLE
Fix warnings in Pandas extra

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch ensures that the Pandas extra will keep working when Python 3.8
+removes abstract base classes from the top-level :obj:`python:collections`
+namespace.  This also fixes the relevant warning in Python 3.7, but there
+is no other difference in behaviour and you do not need to do anything.

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -17,7 +17,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterable, OrderedDict
 from copy import copy
 
 import attr
@@ -29,7 +28,7 @@ import hypothesis.extra.numpy as npst
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange
+from hypothesis.internal.compat import OrderedDict, abc, hrange
 from hypothesis.internal.coverage import check, check_function
 from hypothesis.internal.validation import (
     check_type,
@@ -489,7 +488,7 @@ def data_frames(
                 @check_function
                 def row():
                     result = draw(rows)
-                    check_type(Iterable, result, "draw(row)")
+                    check_type(abc.Iterable, result, "draw(row)")
                     return result
 
                 if len(index) > 0:


### PR DESCRIPTION
The [`collections` module will remove the top-level aliases](https://docs.python.org/3/library/collections.html#module-collections) for the classes that now belong in `collections.abc`.

We have a redirect in `compat.py`, and this PR simply uses it from our Pandas extra.

I also investigated enabling `-Werror` for the Pandas extra, but was quickly foiled by the volume of warnings about Numpy/Pandas/Cython versions and deprecation pathways etc.  It's certainly possible to make this work, but not across every version of Pandas we test against!