### PR TITLE
New representation of shrink steps

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release changes how the shrinker represents its progress internally. For large generated test cases
+this should result in significantly less memory usage and possibly faster shrinking. Small generated
+test cases may be slightly slower to shrink but this shouldn't be very noticeable.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -39,11 +39,11 @@ class Chooser(object):
         """
         assert not self.__finished
         node = self.__node_trail[-1]
-        if node.size is None:
-            node.size = len(values)
+        if node.live_child_count is None:
+            node.live_child_count = len(values)
             node.n = len(values)
 
-        assert node.size > 0 or len(values) == 0
+        assert node.live_child_count > 0 or len(values) == 0
 
         depth = len(self.__choices)
 
@@ -55,7 +55,7 @@ class Chooser(object):
             i = 0
 
         count = 0
-        while node.size > 0:
+        while node.live_child_count > 0:
             count += 1
             assert count <= len(values)
             if not node.children[i].exhausted:
@@ -66,7 +66,7 @@ class Chooser(object):
                     return v
                 else:
                     node.children[i] = DeadNode
-                    node.size -= 1
+                    node.live_child_count -= 1
             i = (i + 1) % len(values)
         raise DeadBranch()
 
@@ -87,14 +87,14 @@ class Chooser(object):
                 else:
                     break
 
-        self.__node_trail[-1].size = 0
+        self.__node_trail[-1].live_child_count = 0
         while len(self.__node_trail) > 1 and self.__node_trail[-1].exhausted:
             self.__node_trail.pop()
             assert len(self.__node_trail) == len(self.__choices)
             i = self.__choices.pop()
             target = self.__node_trail[-1]
             target.children[i] = DeadNode
-            target.size -= 1
+            target.live_child_count -= 1
 
         while len(next_value) > 0 and next_value[-1] == 0:
             next_value.pop()
@@ -129,16 +129,16 @@ class ChoiceTree(object):
 class TreeNode(object):
     def __init__(self):
         self.children = defaultdict(TreeNode)
-        self.size = None
+        self.live_child_count = None
         self.n = None
 
     @property
     def exhausted(self):
-        return self.size == 0
+        return self.live_child_count == 0
 
 
 DeadNode = TreeNode()
-DeadNode.size = 0
+DeadNode.live_child_count = 0
 
 
 class DeadBranch(Exception):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -1,0 +1,146 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from collections import defaultdict
+
+from hypothesis.internal.compat import hrange
+
+
+class Chooser(object):
+    """A source of nondeterminism for use in shrink passes."""
+
+    def __init__(self, tree, prefix):
+        self.__prefix = prefix
+        self.__tree = tree
+        self.__node_trail = [tree.root]
+        self.__choices = []
+        self.__finished = False
+        self.__depth = 0
+
+    def choose(self, values, condition=lambda x: True):
+        """Return some element of values satisfying the condition
+        that will not lead to an exhausted branch, or raise DeadBranch
+        if no such element exist".
+        """
+        assert not self.__finished
+        node = self.__node_trail[-1]
+        if node.size is None:
+            node.size = len(values)
+            node.n = len(values)
+
+        assert node.size > 0 or len(values) == 0
+
+        if self.__depth < len(self.__prefix):
+            i = self.__prefix[self.__depth]
+            if i >= len(values):
+                i = 0
+            self.__depth += 1
+        else:
+            i = 0
+
+        count = 0
+        while node.size > 0:
+            count += 1
+            assert count <= len(values)
+            child_size = node.children[i].size
+            if child_size != 0:
+                v = values[i]
+                if condition(v):
+                    self.__choices.append(i)
+                    self.__node_trail.append(node.children[i])
+                    return v
+                else:
+                    node.children[i] = DeadNode
+                    node.size -= 1
+            i = (i + 1) % len(values)
+        raise DeadBranch()
+
+    def finish(self):
+        """Record the decisions made in the underlying tree and return
+        a prefix that can be used for the next Chooser to be used."""
+        self.__finished = True
+        assert len(self.__node_trail) == len(self.__choices) + 1
+
+        next_value = list(self.__choices)
+        if next_value:
+            next_value[-1] += 1
+            for i in hrange(len(next_value) - 1, -1, -1):
+                if next_value[i] >= self.__node_trail[i].n:
+                    next_value[i] = 0
+                    if i > 0:
+                        next_value[i - 1] += 1
+                else:
+                    break
+
+        self.__node_trail[-1].size = 0
+        while len(self.__node_trail) > 1 and self.__node_trail[-1].exhausted:
+            self.__node_trail.pop()
+            assert len(self.__node_trail) == len(self.__choices)
+            i = self.__choices.pop()
+            target = self.__node_trail[-1]
+            target.children[i] = DeadNode
+            target.size -= 1
+
+        while len(next_value) > 0 and next_value[-1] == 0:
+            next_value.pop()
+
+        return next_value
+
+
+class ChoiceTree(object):
+    """Records sequences of choices made during shrinking so that we
+    can track what parts of a pass has run. Used to create Chooser
+    objects that are the main interface that a pass uses to make
+    decisions about what to do.
+    """
+
+    def __init__(self):
+        self.root = TreeNode()
+
+    @property
+    def exhausted(self):
+        return self.root.exhausted
+
+    def step(self, prefix, f):
+        assert not self.exhausted
+        chooser = Chooser(self, prefix)
+        try:
+            f(chooser)
+        except DeadBranch:
+            pass
+        return chooser.finish()
+
+
+class TreeNode(object):
+    def __init__(self):
+        self.children = defaultdict(TreeNode)
+        self.size = None
+        self.n = None
+
+    @property
+    def exhausted(self):
+        return self.size == 0
+
+
+DeadNode = TreeNode()
+DeadNode.size = 0
+
+
+class DeadBranch(Exception):
+    pass

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -100,7 +100,7 @@ class Chooser(object):
         while len(next_value) > 0 and next_value[-1] == 0:
             next_value.pop()
 
-        return next_value
+        return tuple(next_value)
 
 
 class ChoiceTree(object):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -31,7 +31,6 @@ class Chooser(object):
         self.__node_trail = [tree.root]
         self.__choices = []
         self.__finished = False
-        self.__depth = 0
 
     def choose(self, values, condition=lambda x: True):
         """Return some element of values satisfying the condition
@@ -46,11 +45,12 @@ class Chooser(object):
 
         assert node.size > 0 or len(values) == 0
 
-        if self.__depth < len(self.__prefix):
-            i = self.__prefix[self.__depth]
+        depth = len(self.__choices)
+
+        if depth < len(self.__prefix):
+            i = self.__prefix[depth]
             if i >= len(values):
                 i = 0
-            self.__depth += 1
         else:
             i = 0
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -58,8 +58,7 @@ class Chooser(object):
         while node.size > 0:
             count += 1
             assert count <= len(values)
-            child_size = node.children[i].size
-            if child_size != 0:
+            if not node.children[i].exhausted:
                 v = values[i]
                 if condition(v):
                     self.__choices.append(i)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1200,19 +1200,23 @@ class Shrinker(object):
         # never have got here.
         assert attempt is not self.shrink_target
 
-        lo = 0
-        hi = len(self.examples)
-        while lo + 1 < hi:
-            mid = (lo + hi) // 2
-            ex = self.examples[mid]
-            if ex.start >= block.end:
-                hi = mid
-            else:
-                lo = mid
+        @self.cached(block.index)
+        def first_example_after_block():
+            lo = 0
+            hi = len(self.examples)
+            while lo + 1 < hi:
+                mid = (lo + hi) // 2
+                ex = self.examples[mid]
+                if ex.start >= block.end:
+                    hi = mid
+                else:
+                    lo = mid
+            return hi
 
         ex = self.examples[
             chooser.choose(
-                hrange(hi, len(self.examples)), lambda i: self.examples[i].length > 0
+                hrange(first_example_after_block, len(self.examples)),
+                lambda i: self.examples[i].length > 0,
             )
         ]
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -451,7 +451,7 @@ class Shrinker(object):
 
                         self.debug(
                             (
-                                "  * %s ran made %d call%s of which "
+                                "  * %s made %d call%s of which "
                                 "%d shrank, deleting %d byte%s."
                             )
                             % (

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1448,7 +1448,7 @@ class ShrinkPass(object):
     index = attr.ib()
     shrinker = attr.ib()
 
-    next_probe = attr.ib(default=())
+    next_prefix = attr.ib(default=())
     fixed_point_at = attr.ib(default=None)
     successes = attr.ib(default=0)
     calls = attr.ib(default=0)
@@ -1468,8 +1468,8 @@ class ShrinkPass(object):
         size = len(self.shrinker.shrink_target.buffer)
         self.shrinker.explain_next_call_as(self.name)
         try:
-            self.next_probe = tree.step(
-                self.next_probe,
+            self.next_prefix = tree.step(
+                self.next_prefix,
                 lambda chooser: self.run_with_chooser(self.shrinker, chooser),
             )
         finally:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -642,7 +642,7 @@ class Shrinker(object):
 
         ls = self.examples_by_label[label]
 
-        i = chooser.choose(hrange(len(ls)))
+        i = chooser.choose(hrange(len(ls) - 1))
 
         ancestor = ls[i]
         descendant = chooser.choose(

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1166,10 +1166,7 @@ class Shrinker(object):
         but it fails when there is data that has to stay in particular places
         in the list.
         """
-        block = chooser.choose(self.blocks)
-
-        if block.trivial:
-            return
+        block = chooser.choose(self.blocks, lambda b: not b.trivial)
 
         initial = self.shrink_target
         u, v = block.bounds

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -612,7 +612,7 @@ class Shrinker(object):
         """
 
         label = chooser.choose(
-            self.distinct_labels, lambda l: len(self.examples_by_label[l]) >= 1
+            self.distinct_labels, lambda l: len(self.examples_by_label[l]) >= 2
         )
 
         ls = self.examples_by_label[label]

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -53,7 +53,6 @@ def minimal(definition, condition=lambda x: True, settings=None, timeout_after=1
         report_multiple_bugs=False,
         derandomize=True,
         database=None,
-        # verbosity=Verbosity.debug
     )
     def inner(x):
         if wrapped_condition(x):

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -53,6 +53,7 @@ def minimal(definition, condition=lambda x: True, settings=None, timeout_after=1
         report_multiple_bugs=False,
         derandomize=True,
         database=None,
+        # verbosity=Verbosity.debug
     )
     def inner(x):
         if wrapped_condition(x):

--- a/hypothesis-python/tests/cover/test_conjecture_choice_tree.py
+++ b/hypothesis-python/tests/cover/test_conjecture_choice_tree.py
@@ -66,3 +66,33 @@ def test_all_filtered_child():
         chooser.choose(hrange(10), condition=lambda j: False)
 
     assert all_filtered == []
+
+
+def test_skips_over_exhausted_children():
+
+    results = []
+
+    def f(chooser):
+        results.append(
+            (
+                chooser.choose(hrange(3), condition=lambda x: x > 0),
+                chooser.choose(hrange(2)),
+            )
+        )
+
+    tree = ChoiceTree()
+
+    tree.step((1, 0), f)
+    tree.step((1, 1), f)
+    tree.step((0, 0), f)
+
+    assert results == [(1, 0), (1, 1), (2, 0)]
+
+
+def test_wraps_around_to_beginning():
+    def f(chooser):
+        chooser.choose(hrange(3))
+
+    tree = ChoiceTree()
+
+    assert tree.step((2,), f) == ()

--- a/hypothesis-python/tests/cover/test_conjecture_choice_tree.py
+++ b/hypothesis-python/tests/cover/test_conjecture_choice_tree.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import hypothesis.strategies as st
+from hypothesis import given
+from hypothesis.internal.compat import hrange
+from hypothesis.internal.conjecture.choicetree import ChoiceTree
+
+
+def exhaust(f):
+    tree = ChoiceTree()
+
+    results = []
+
+    prefix = ()
+
+    while not tree.exhausted:
+        prefix = tree.step(prefix, lambda chooser: results.append(f(chooser)))
+    return results
+
+
+@given(st.lists(st.integers()))
+def test_can_enumerate_a_shallow_set(ls):
+    results = exhaust(lambda chooser: chooser.choose(ls))
+
+    assert sorted(results) == sorted(ls)
+
+
+def test_can_enumerate_a_nested_set():
+    @exhaust
+    def nested(chooser):
+        i = chooser.choose(hrange(10))
+        j = chooser.choose(hrange(10), condition=lambda j: j > i)
+        return (i, j)
+
+    assert sorted(nested) == [(i, j) for i in hrange(10) for j in hrange(i + 1, 10)]
+
+
+def test_can_enumerate_empty():
+    @exhaust
+    def empty(chooser):
+        return 1
+
+    assert empty == [1]
+
+
+def test_all_filtered_child():
+    @exhaust
+    def all_filtered(chooser):
+        chooser.choose(hrange(10), condition=lambda j: False)
+
+    assert all_filtered == []

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -479,10 +479,7 @@ def test_can_shrink_variable_draws_with_just_deletion(n, monkeypatch):
         if any(b):
             data.mark_interesting()
 
-    # We normally would have populated this in minimize_individual_blocks
-    shrinker.is_shrinking_block = lambda x: True
-
-    shrinker.fixate_shrink_passes(["example_deletion_with_block_lowering"])
+    shrinker.fixate_shrink_passes(["minimize_individual_blocks"])
 
     assert list(shrinker.shrink_target.buffer) == [1, 1]
 
@@ -491,13 +488,8 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
     monkeypatch.setattr(
         Shrinker,
         "shrink",
-        lambda self: self.fixate_shrink_passes(
-            ["example_deletion_with_block_lowering"]
-        ),
+        lambda self: self.fixate_shrink_passes(["minimize_individual_blocks"]),
     )
-    # Would normally be added by minimize_individual_blocks, but we skip
-    # that phase in this test.
-    monkeypatch.setattr(Shrinker, "is_shrinking_block", lambda self, i: i == 0)
 
     def gen(self):
         self.cached_test_function(10)


### PR DESCRIPTION
TLDR version: Changes to the shrinker that a) Should dramatically reduce memory usage for large starting points and b) Will in the long run hopefully produce much faster shrinking but right now are merely not noticeably worse than the status qo.

## Details

This changes the logic of shrink passes so we don't have to calculate large collections of arguments which gradually go stale up front. Its main goal is that it should significantly improve the ability of the shrinker to handle larger test cases.

The basic core of the idea is that the thing we do for non-redundant random generation also works really well for defining shrink passes: We encode steps in shrink passes as the shrinker making a series of choices (e.g. pick an example, pick a block), and the indices corresponding to the sequence of choices made represents a single iteration of the shrink pass.

You can imagine a classic shrink pass looking like:

```python
def shrink_pass(self):
    i = 0
    while i < len(self.examples):
        # try deleting example i
        ...
        i += 1
```

which in this model turns into:


```python
def shrink_pass(self, chooser):
    example = chooser.choose(self.examples)
    # try deleting this example
```

With the iteration order fully abstracted away from the individual shrink pass. Currently we are using a depth first search iteration order that is roughly equivalent to the original loop. This somewhat walks back our general desire to use random order to minimize stalls, but seems to be what works best for the moment - I suspect it will require more experimentation to find something that works well on larger examples, but the stall prevention code I experimented with locally doesn't seem to help *at all* on our test suite, so I decided to investigate this later.

Having this tree representation lets us ditch the current code where we precalculate a bunch of arguments corresponding to each step and gradually exhaust them all. Instead, we mark parts of the tree explored as the shrink pass runs (resetting it each time the tree has changed). This has the advantage of saving us a lot of up front time and memory usage when the example is large.

Additional things that were enabled by this / had to change in order to support this:

* The logic for how shrink passes are run has changed a bit because we no longer have external definitions of the shrink steps
* We've stopped doing a bunch of expensive tracking of whether blocks are shrinking. This was eating up a lot of memory and created fragile dependencies between shrink passes.
* The logic for minimizing examples has been tinkered with a lot and merged together with the logic for doing so while deleting other examples in order to get it to play nice with this.