### PR TITLE
Deprecate find()

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+This release deprecates ``find()``.  The ``.example()`` method is a better
+replacement if you want *an* example, and for the rare occasions where you
+want the *minimal* example you can get it from :func:`@given <hypothesis.given>`.
+
+:func:`@given <hypothesis.given>` has steadily outstripped ``find()`` in both
+features and performance over recent years, and as we do not have the resources
+to maintain and test both we think it is better to focus on just one.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -1576,7 +1576,7 @@ is only recorded internally and has no user-visible effect.
 -------------------
 
 This release changes the stateful testing backend from
-:func:`~hypothesis.find` to use :func:`@given <hypothesis.given>`
+``find()`` to use :func:`@given <hypothesis.given>`
 (:issue:`1300`).  This doesn't change how you create stateful tests,
 but does make them run more like other Hypothesis tests.
 
@@ -3140,7 +3140,7 @@ knowledge of our internals (:issue:`535`).
   and poor interaction with :obj:`~hypothesis.settings.max_examples`.
 - ``HYPOTHESIS_VERBOSITY_LEVEL`` is now deprecated.  Set
   :obj:`~hypothesis.settings.verbosity` through the profile system instead.
-- Examples tried by :func:`~hypothesis.find` are now reported at ``debug``
+- Examples tried by ``find()`` are now reported at ``debug``
   verbosity level (as well as ``verbose`` level).
 
 .. _v3.55.6:
@@ -3257,7 +3257,7 @@ This patch fixes the ``min_satisfying_examples`` settings
 documentation, by explaining that example shrinking is tracked at the level
 of the underlying bytestream rather than the output value.
 
-The output from :func:`~hypothesis.find` in verbose mode has also been
+The output from ``find()`` in verbose mode has also been
 adjusted - see :ref:`the example session <verbose-output>` - to avoid
 duplicating lines when the example repr is constant, even if the underlying
 representation has been shrunken.
@@ -5694,7 +5694,7 @@ Minor bug fix release.
 * Remove duplicated __all__ exports from hypothesis.strategies (thanks to
   Piët Delport).
 * Update headers to point to new repository location.
-* Allow use of strategies that can't be used in :func:`~hypothesis.find`
+* Allow use of strategies that can't be used in ``find()``
   (e.g. ``choices()``) in stateful testing.
 
 
@@ -5817,7 +5817,7 @@ New features:
 New limitations:
 
 * ``choices()`` and ``streaming()``
-  strategies may no longer be used with :func:`~hypothesis.find`. Neither may
+  strategies may no longer be used with ``find()``. Neither may
   :func:`~hypothesis.strategies.data` (this is the change that necessitated a major version bump).
 
 Feature removal:

--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -98,7 +98,7 @@ hard to satisfy then this can fail:
     >>> integers().filter(lambda x: False).example()
     Traceback (most recent call last):
         ...
-    hypothesis.errors.NoExamples: Could not find any valid examples in 20 tries
+    hypothesis.errors.Unsatisfiable: Could not find any valid examples in 20 tries
 
 In general you should try to use ``filter`` only to avoid corner cases that you
 don't want rather than attempting to cut out a large chunk of the search space.
@@ -133,13 +133,13 @@ length:
 
     >>> rectangle_lists = integers(min_value=0, max_value=10).flatmap(
     ... lambda n: lists(lists(integers(), min_size=n, max_size=n)))
-    >>> find(rectangle_lists, lambda x: True)
+    >>> rectangle_lists.example()
     []
-    >>> find(rectangle_lists, lambda x: len(x) >= 10)
+    >>> rectangle_lists.filter(lambda x: len(x) >= 10).example()
     [[], [], [], [], [], [], [], [], [], []]
-    >>> find(rectangle_lists, lambda t: len(t) >= 3 and len(t[0]) >= 3)
+    >>> rectangle_lists.filter(lambda t: len(t) >= 3 and len(t[0]) >= 3).example()
     [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
-    >>> find(rectangle_lists, lambda t: sum(len(s) for s in t) >= 10)
+    >>> rectangle_lists.filter(lambda t: sum(len(s) for s in t) >= 10).example()
     [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
 
 In this example we first choose a length for our tuples, then we build a

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -495,47 +495,6 @@ random number generators for you, and you can register others:
 .. autofunction:: hypothesis.register_random
 
 
--------------------------------
-Using Hypothesis to find values
--------------------------------
-
-You can use Hypothesis's data exploration features to find values satisfying
-some predicate.  This is generally useful for exploring custom strategies
-defined with :func:`@composite <hypothesis.strategies.composite>`, or
-experimenting with conditions for filtering data.
-
-.. autofunction:: hypothesis.find
-
-.. code-block:: pycon
-
-    >>> from hypothesis import find
-    >>> from hypothesis.strategies import sets, lists, integers
-    >>> find(lists(integers()), lambda x: sum(x) >= 10)
-    [10]
-    >>> find(lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
-    [0, 0, 10]
-    >>> find(sets(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
-    {0, 1, 9}
-
-The first argument to :func:`~hypothesis.find` describes data in the usual way for an argument to
-:func:`~hypothesis.given`, and supports :doc:`all the same data types <data>`. The second is a
-predicate it must satisfy.
-
-Of course not all conditions are satisfiable. If you ask Hypothesis for an
-example to a condition that is always false it will raise an error:
-
-.. code-block:: pycon
-
-    >>> find(integers(), lambda x: False)
-    Traceback (most recent call last):
-        ...
-    hypothesis.errors.NoSuchExample: No examples of condition lambda x: <unknown>
-
-(The ``lambda x: unknown`` is because Hypothesis can't retrieve the source code
-of lambdas from the interactive python console. It gives a better error message
-most of the time which contains the actual condition)
-
-
 .. _type-inference:
 
 -------------------

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -81,16 +81,18 @@ Seeing intermediate result
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To see what's going on while Hypothesis runs your tests, you can turn
-up the verbosity setting. This works with both :func:`~hypothesis.find`
-and :func:`@given <hypothesis.given>`.
+up the verbosity setting.
 
 .. code-block:: pycon
 
     >>> from hypothesis import find, settings, Verbosity
     >>> from hypothesis.strategies import lists, integers
-    >>> find(lists(integers()), any, settings=settings(verbosity=Verbosity.verbose))
-    Tried non-satisfying example []
-    Found satisfying example [-1198601713, -67, 116, -29578]
+    >>> @given(lists(integers())
+    ... @settings(verbosity=Verbosity.verbose))
+    ... def f(x): assert not any(x)
+    ... f()
+    Trying example: []
+    Falsifying example: [-1198601713, -67, 116, -29578]
     Shrunk example to [-1198601713]
     Shrunk example to [-1198601600]
     Shrunk example to [-1191228800]

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -2154,10 +2154,6 @@ def data():
     """This isn't really a normal strategy, but instead gives you an object
     which can be used to draw data interactively from other strategies.
 
-    It can only be used within :func:`@given <hypothesis.given>`, not
-    :func:`find() <hypothesis.find>`. This is because the lifetime
-    of the object cannot outlast the test body.
-
     See :ref:`the rest of the documentation <interactive-draw>` for more
     complete information.
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -42,6 +42,7 @@ from hypothesis._settings import (
     PrintSettings,
     Verbosity,
     local_settings,
+    note_deprecation,
     settings as Settings,
 )
 from hypothesis.control import BuildContext
@@ -1054,6 +1055,11 @@ def find(
     # type: (...) -> Any
     """Returns the minimal example from the given strategy ``specifier`` that
     matches the predicate function ``condition``."""
+    note_deprecation(
+        "`find(s, f)` is deprecated, because it is rarely used but takes "
+        "ongoing work to maintain as we upgrade other parts of Hypothesis.",
+        since="RELEASEDAY",
+    )
     if settings is None:
         settings = Settings(max_examples=2000)
     settings = Settings(settings, suppress_health_check=HealthCheck.all())

--- a/hypothesis-python/tests/cover/test_arbitrary_data.py
+++ b/hypothesis-python/tests/cover/test_arbitrary_data.py
@@ -21,7 +21,7 @@ import pytest
 
 from hypothesis import find, given, reporting, strategies as st
 from hypothesis.errors import InvalidArgument
-from tests.common.utils import capture_out, raises
+from tests.common.utils import capture_out, checks_deprecated_behaviour, raises
 
 
 @given(st.integers(), st.data())
@@ -82,6 +82,7 @@ def test_given_twice_is_same():
     assert "Draw 2: 0" in result
 
 
+@checks_deprecated_behaviour
 def test_errors_when_used_in_find():
     with raises(InvalidArgument):
         find(st.data(), lambda x: x.draw(st.booleans()))

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -23,8 +23,10 @@ from _pytest.outcomes import Failed, Skipped
 import hypothesis.strategies as s
 from hypothesis import find, given, reject, settings
 from hypothesis.errors import NoSuchExample, Unsatisfiable
+from tests.common.utils import checks_deprecated_behaviour
 
 
+@checks_deprecated_behaviour
 def test_stops_after_max_examples_if_satisfying():
     tracker = []
 
@@ -40,6 +42,7 @@ def test_stops_after_max_examples_if_satisfying():
     assert len(tracker) == max_examples
 
 
+@checks_deprecated_behaviour
 def test_stops_after_ten_times_max_examples_if_not_satisfying():
     count = [0]
 
@@ -98,5 +101,12 @@ def test_pytest_skip_skips_shrinking():
     assert len([x for x in values if x > 100]) == 1
 
 
+@checks_deprecated_behaviour
 def test_can_find_with_db_eq_none():
     find(s.integers(), bool, settings(database=None))
+
+
+@checks_deprecated_behaviour
+def test_no_such_example():
+    with pytest.raises(NoSuchExample):
+        find(s.none(), bool, database_key=b"no such example")

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -26,7 +26,7 @@ from hypothesis import find, given, register_random, reporting
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import entropy
 from hypothesis.internal.entropy import deterministic_PRNG
-from tests.common.utils import capture_out
+from tests.common.utils import capture_out, checks_deprecated_behaviour
 
 
 def test_can_seed_random():
@@ -131,6 +131,7 @@ def test_given_does_not_pollute_state():
         assert state_a != state_b
 
 
+@checks_deprecated_behaviour
 def test_find_does_not_pollute_state():
     with deterministic_PRNG():
 

--- a/hypothesis-python/tests/cover/test_runner_strategy.py
+++ b/hypothesis-python/tests/cover/test_runner_strategy.py
@@ -24,6 +24,7 @@ import pytest
 from hypothesis import find, given, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.stateful import RuleBasedStateMachine, rule
+from tests.common.utils import checks_deprecated_behaviour
 
 
 def test_cannot_use_without_a_runner():
@@ -35,11 +36,13 @@ def test_cannot_use_without_a_runner():
         f()
 
 
+@checks_deprecated_behaviour
 def test_cannot_use_in_find_without_default():
     with pytest.raises(InvalidArgument):
         find(st.runner(), lambda x: True)
 
 
+@checks_deprecated_behaviour
 def test_is_default_in_find():
     t = object()
     assert find(st.runner(t), lambda x: True) == t

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -224,6 +224,7 @@ def test_given_warns_when_mixing_positional_with_keyword():
         test()
 
 
+@checks_deprecated_behaviour
 def test_cannot_find_non_strategies():
     with pytest.raises(InvalidArgument):
         find(bool, bool)

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -24,7 +24,7 @@ from hypothesis._settings import Verbosity, settings
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.strategies import booleans, integers, lists
 from tests.common.debug import minimal
-from tests.common.utils import capture_out, fails
+from tests.common.utils import capture_out, checks_deprecated_behaviour, fails
 
 
 @contextmanager
@@ -72,6 +72,7 @@ def test_includes_progress_in_verbose_mode():
     assert u"Falsifying example: " in out
 
 
+@checks_deprecated_behaviour
 def test_prints_initial_attempts_on_find():
 
     with capture_verbosity() as o:

--- a/hypothesis-python/tests/nocover/test_boundary_exploration.py
+++ b/hypothesis-python/tests/nocover/test_boundary_exploration.py
@@ -20,8 +20,9 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import HealthCheck, Verbosity, find, given, reject, settings
-from hypothesis.errors import NoSuchExample
+from hypothesis import HealthCheck, Verbosity, given, reject, settings
+from hypothesis.errors import Unsatisfiable
+from tests.common.debug import minimal
 from tests.common.utils import no_shrink
 
 
@@ -38,12 +39,12 @@ def test_explore_arbitrary_function(strat, data):
             return cache.setdefault(x, data.draw(st.booleans(), label=repr(x)))
 
     try:
-        find(
+        minimal(
             strat,
             predicate,
             settings=settings(
                 max_examples=10, database=None, verbosity=Verbosity.quiet
             ),
         )
-    except NoSuchExample:
+    except Unsatisfiable:
         reject()

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -22,13 +22,18 @@ from hypothesis import assume, core, find, given, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from hypothesis.internal.compat import hbytes
-from tests.common.utils import all_values, non_covering_examples
+from tests.common.utils import (
+    all_values,
+    checks_deprecated_behaviour,
+    non_covering_examples,
+)
 
 
 def has_a_non_zero_byte(x):
     return any(hbytes(x))
 
 
+@checks_deprecated_behaviour
 def test_saves_incremental_steps_in_database():
     key = b"a database key"
     database = InMemoryExampleDatabase()
@@ -41,6 +46,7 @@ def test_saves_incremental_steps_in_database():
     assert len(all_values(database)) > 1
 
 
+@checks_deprecated_behaviour
 def test_clears_out_database_as_things_get_boring():
     key = b"a database key"
     database = InMemoryExampleDatabase()
@@ -73,6 +79,7 @@ def test_clears_out_database_as_things_get_boring():
         assert False
 
 
+@checks_deprecated_behaviour
 def test_trashes_invalid_examples():
     key = b"a database key"
     database = InMemoryExampleDatabase()
@@ -97,6 +104,7 @@ def test_trashes_invalid_examples():
     assert len(all_values(database)) < original
 
 
+@checks_deprecated_behaviour
 def test_respects_max_examples_in_database_usage():
     key = b"a database key"
     database = InMemoryExampleDatabase()

--- a/hypothesis-python/tests/nocover/test_deferred_errors.py
+++ b/hypothesis-python/tests/nocover/test_deferred_errors.py
@@ -23,6 +23,7 @@ import hypothesis.strategies as st
 from hypothesis import find, given
 from hypothesis._strategies import defines_strategy
 from hypothesis.errors import InvalidArgument
+from tests.common.utils import checks_deprecated_behaviour
 
 
 def test_does_not_error_on_initial_calculation():
@@ -49,6 +50,7 @@ def test_errors_on_test_invocation():
         test()
 
 
+@checks_deprecated_behaviour
 def test_errors_on_find():
     s = st.lists(st.integers(), min_size=5, max_size=2)
     with pytest.raises(InvalidArgument):

--- a/hypothesis-python/tests/nocover/test_find.py
+++ b/hypothesis-python/tests/nocover/test_find.py
@@ -25,6 +25,7 @@ from hypothesis import find, settings as Settings
 from hypothesis.errors import NoSuchExample
 from hypothesis.strategies import booleans, dictionaries, floats, integers, lists
 from tests.common.debug import minimal
+from tests.common.utils import checks_deprecated_behaviour
 
 
 def test_can_find_an_int():
@@ -49,6 +50,7 @@ def test_can_find_nans():
         assert 2 <= len(x) <= 3
 
 
+@checks_deprecated_behaviour
 def test_condition_is_name():
     settings = Settings(max_examples=20)
     with pytest.raises(NoSuchExample) as e:

--- a/hypothesis-python/tests/nocover/test_imports.py
+++ b/hypothesis-python/tests/nocover/test_imports.py
@@ -22,8 +22,9 @@ from hypothesis.strategies import *
 
 
 def test_can_star_import_from_hypothesis():
-    find(
-        lists(integers()),
-        lambda x: sum(x) > 1,
-        settings=settings(max_examples=10000, verbosity=Verbosity.quiet),
-    )
+    @given(lists(integers()))
+    @settings(max_examples=10000, verbosity=Verbosity.quiet)
+    def f(x):
+        pass
+
+    f()

--- a/hypothesis-python/tests/nocover/test_randomization.py
+++ b/hypothesis-python/tests/nocover/test_randomization.py
@@ -23,9 +23,10 @@ from pytest import raises
 
 import hypothesis.strategies as st
 from hypothesis import Verbosity, find, given, settings
-from tests.common.utils import no_shrink
+from tests.common.utils import checks_deprecated_behaviour, no_shrink
 
 
+@checks_deprecated_behaviour
 def test_seeds_off_random():
     s = settings(phases=no_shrink, database=None)
     r = random.getstate()

--- a/hypothesis-python/tests/py2/test_generate_ints.py
+++ b/hypothesis-python/tests/py2/test_generate_ints.py
@@ -20,10 +20,10 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import find
+from tests.common.debug import minimal
 
 
 @pytest.mark.parametrize("kwargs", [{}, {"min_value": 0}, {"max_value": 0}])
 def test_generates_an_int_as_the_min_value(kwargs):
-    n = find(st.integers(**kwargs), lambda x: True)
+    n = minimal(st.integers(**kwargs))
     assert isinstance(n, int)


### PR DESCRIPTION
This PR *finally* closes #1694, after other PRs ported our internal uses of `find()` over to `@given`.

In particular, this consists mostly of documentation changes and our `@checks_deprecated_behaviour` test helper - there were only a few tests left using `find()` without specifically existing *to* test `find()`.  And one important call to `note_deprecation`, of course!