### PR TITLE
Delete appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,1 +1,0 @@
-build: off


### PR DESCRIPTION
The service has been disabled - replaced by Windows tests on Pipelines - so we no longer need to disable building via their config file.  Small cleanup by number of lines, but still symbolic :smile: