### PR TITLE
Pass alphabet through to characters()

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch improves the behaviour of the :func:`~hypothesis.strategies.text`
+strategy when passed an ``alphabet`` which is not a strategy.  The value is
+now interpreted as ``whitelist_characters`` to :func:`~hypothesis.strategies.characters`
+instead of a sequence for :func:`~hypothesis.strategies.sampled_from`, which
+standardises the distribution of examples and the shrinking behaviour.
+
+You can get the previous behaviour by using
+``lists(sampled_from(alphabet)).map("".map)`` instead.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -38,7 +38,6 @@ from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.cathetus import cathetus
 from hypothesis.internal.charmap import as_general_categories
 from hypothesis.internal.compat import (
-    abc,
     ceil,
     floor,
     gcd,
@@ -1071,28 +1070,24 @@ def text(
     elif isinstance(alphabet, SearchStrategy):
         char_strategy = alphabet
     else:
-        char_strategy = sampled_from(list(alphabet)) if alphabet else nothing()
-        if not isinstance(alphabet, abc.Sequence):
-            raise InvalidArgument(
-                "alphabet must be an ordered sequence, or tests may be "
-                "flaky and shrinking weaker, but a %r is not a type of "
-                "sequence." % (type(alphabet),)
-            )
         non_string = [c for c in alphabet if not isinstance(c, string_types)]
         if non_string:
             raise InvalidArgument(
                 "The following elements in alphabet are not unicode "
                 "strings:  %r" % (non_string,)
             )
-        not_one_char = [
-            c for c in alphabet if isinstance(c, string_types) and len(c) != 1
-        ]
+        not_one_char = [c for c in alphabet if len(c) != 1]
         if not_one_char:
             raise InvalidArgument(
                 "The following elements in alphabet are not of length "
                 "one, which leads to violation of size constraints:  %r"
                 % (not_one_char,)
             )
+        char_strategy = (
+            characters(whitelist_categories=(), whitelist_characters=alphabet)
+            if alphabet
+            else nothing()
+        )
     if (max_size == 0 or char_strategy.is_empty) and not min_size:
         return just(u"")
     return StringStrategy(lists(char_strategy, min_size=min_size, max_size=max_size))

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -230,6 +230,7 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.fixed_dictionaries, {"mapping": {1: ds.integers()}}),
     (ds.dictionaries, {"keys": ds.booleans(), "values": ds.integers()}),
     (ds.text, {"alphabet": "abc"}),
+    (ds.text, {"alphabet": set("abc")}),
     (ds.text, {"alphabet": ""}),
     (ds.text, {"alphabet": ds.sampled_from("abc")}),
     (ds.characters, {"whitelist_categories": ["N"]}),
@@ -278,11 +279,6 @@ def test_builds_raises_if_non_callable_as_first_arg(non_callable):
     # callable) must be specified as the first one.
     with pytest.raises(InvalidArgument):
         ds.builds(non_callable, target=lambda x: x).example()
-
-
-def test_text_raises_error_on_non_sequence_alphabet():
-    with pytest.raises(InvalidArgument):
-        ds.text(set("abc")).validate()
 
 
 def test_tuples_raise_error_on_bad_kwargs():

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -54,6 +54,11 @@ def test_will_find_ascii_examples_given_the_chance():
     assert u"0" in s
 
 
+def test_minimisation_consistent_with_characters():
+    s = minimal(text("FEDCBA", min_size=3))
+    assert s == "AAA"
+
+
 def test_finds_single_element_strings():
     assert minimal(text(), bool) == u"0"
 


### PR DESCRIPTION
We can treat `text("abc")` as `text(characters(whitelist_characters="abc"))` instead of `text(sampled_from("abc"))`.  This allows for non-sequence alphabets such as sets, as well as allowing common strategies like `text(string.printable)` to share the distribution and shrinking behaviour of the more advanced `characters()` strategy.

I've split this out from my WIP refresh of #1621, because it's independently useful and the smaller that gnarly PR gets the better :smile: 