### PR TITLE
Detect and warn on float truncation in arrays

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release makes :func:`~hypothesis.extra.numpy.arrays` more pedantic about
+``elements`` strategies that cannot be exactly represented as array elements.
+
+In practice, you will see new warnings if you were using a ``float16`` or
+``float32`` dtype without passing :func:`~hypothesis.strategies.floats` the
+``width=16`` or ``width=32`` arguments respectively.
+
+The previous behaviour could lead to silent truncation, and thus some elements
+being equal to an explicitly excluded bound (:issue:`1899`).

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -268,7 +268,7 @@ def test_can_cast_for_scalars(data):
     # combinations will result in an error if numpy is not able to cast them.
     dt_elements = np.dtype(data.draw(st.sampled_from(["bool", "<i2", ">i2"])))
     dt_desired = np.dtype(
-        data.draw(st.sampled_from(["<i2", ">i2", "float16", "float32", "float64"]))
+        data.draw(st.sampled_from(["<i2", ">i2", "float32", "float64"]))
     )
     result = data.draw(
         nps.arrays(dtype=dt_desired, elements=nps.from_dtype(dt_elements), shape=())
@@ -283,7 +283,7 @@ def test_can_cast_for_arrays(data):
     # combinations will result in an error if numpy is not able to cast them.
     dt_elements = np.dtype(data.draw(st.sampled_from(["bool", "<i2", ">i2"])))
     dt_desired = np.dtype(
-        data.draw(st.sampled_from(["<i2", ">i2", "float16", "float32", "float64"]))
+        data.draw(st.sampled_from(["<i2", ">i2", "float32", "float64"]))
     )
     result = data.draw(
         nps.arrays(

--- a/hypothesis-python/tests/numpy/test_narrow_floats.py
+++ b/hypothesis-python/tests/numpy/test_narrow_floats.py
@@ -18,10 +18,22 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import pytest
 
 from hypothesis import given
-from hypothesis.extra.numpy import from_dtype, integer_dtypes
+from hypothesis.extra.numpy import arrays, from_dtype, integer_dtypes
 from hypothesis.strategies import data, floats, integers
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize("low", [-2.0, -1.0, 0.0, 1.0])
+@given(data())
+def test_bad_float_exclude_min_in_array(dtype, low, data):
+    elements = floats(
+        low, low + 1, exclude_min=True, width=np.dtype(dtype).itemsize * 8
+    )
+    x = data.draw(arrays(dtype, shape=(1,), elements=elements), label="x")
+    assert np.all(low < x)
 
 
 @given(floats(width=32))


### PR DESCRIPTION
Closes #1899.  Some users will probably find this pretty annoying, but we *do* have a `width` argument to `floats()` for exactly this reason, and it's used by our inferred strategies.  Unfortunately - and to my surprise - `numpy.can_cast(..., "safe")` does allow lossy downcasting.  So now we just compare exactly.