### PR TITLE
Add test for numpy indices (#1930)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -236,6 +236,7 @@ their individual contributions.
 * `kbara <https://www.github.com/kbara>`_
 * `Kristian Glass <https://www.github.com/doismellburning>`_
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)
+* `Lampros Mountrakis <https://www.github.com/lmount>`_
 * `Lee Begg <https://www.github.com/llnz2>`_
 * `Lisa Goeller <https://www.github.com/lgoeller>`_
 * `Louis Taylor <https://github.com/kragniz>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,20 @@
+RELEASE_TYPE: minor
+
+
+This release implements :func:`~hypothesis.extra.numpy.basic_indices`, generating valid indices for numpy arrays (:issue:`1930`).
+
+It returns a tuple for each dimension, as per ``numpy`` [indexing](https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html) documentation:
+    
+    In Python, `x[(exp1, exp2, ..., expN)]`` is equivalent to `x[exp1, exp2, ..., expN]`; the latter is just syntactic sugar for the former.
+
+Each  `exprN` can be:
+    - an integers, positive or negative, 
+    - a slice object, as generated from `st.slices(s)`,
+    - an `Ellipsis` object,
+    - a `numpy.newaxis`.
+
+`Ellipsis` and `numpy.newaxis` are optional and can be adjusted with the arguments.
+
+
+
+

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -917,15 +917,9 @@ def integer_array_indices(shape, result_shape=array_shapes(), dtype="int"):
 
 @st.defines_strategy
 def basic_indices(shape, allow_ellipsis=True, allow_newaxis=False, max_dims=None):
-    # type: (Shape, bool, bool, int) -> st.SearchStrategy
+    # type: (Shape, bool, bool, int) -> st.SearchStrategy[Any]
+    """Return a search strategy for numpy indices.
 
-    """Return a search strategy for tuples of integer-arrays that, when used
-    to index into an array of shape ``shape``, given an array whose shape
-    was drawn from ``result_shape``.
-
-    Examples from this strategy shrink towards the tuple of index-arrays::
-
-        len(shape) * (np.zeros(drawn_result_shape, dtype), )
 
     * ``shape`` a tuple of integers that indicates the shape of the array,
       whose indices are being generated.
@@ -958,11 +952,12 @@ def basic_indices(shape, allow_ellipsis=True, allow_newaxis=False, max_dims=None
         add_to_index_list.append(st.just(np.newaxis))
 
     # Strategy for each individual dimension
-    one_dim_index = lambda size: st.one_of(
-        [st.integers(-size, size - 1)]
-        + [st.slices(size)]  # integer index
-        + add_to_index_list  # slice  # ellipsis and/or np.newaxis
-    )
+    def one_dim_index(size):
+        return st.one_of(
+            [st.integers(-size, size - 1)]
+            + [st.slices(size)]  # integer index
+            + add_to_index_list  # slice  # ellipsis and/or np.newaxis
+        )
 
     if max_dims is None:
         strategy = st.tuples(*(one_dim_index(s) for s in shape))

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -800,3 +800,26 @@ def test_advanced_integer_index_can_generate_any_pattern(shape, data):
         lambda index: np.all(target == x[index]),
         settings(max_examples=10 ** 6),
     )
+
+
+@settings(deadline=None)
+@given(
+    numpy_array=nps.arrays(dtype=nps.array_dtypes(), shape=nps.array_shapes()),
+    allow_ellipsis=st.booleans(),
+    allow_newaxis=st.booleans(),
+    data=st.data(),
+)
+def test_basic_indices_can_generate_valid_patterns(
+    numpy_array, allow_ellipsis, allow_newaxis, data
+):
+    # ensures that generated index-arrays can be used to yield any pattern of elements from an array
+    max_dims = data.draw(st.one_of(st.integers(0, len(numpy_array.shape)), st.none()))
+    target = data.draw(
+        nps.basic_indices(
+            shape=numpy_array.shape,
+            allow_ellipsis=allow_ellipsis,
+            allow_newaxis=allow_newaxis,
+            max_dims=max_dims,
+        )
+    )
+    numpy_array[target]


### PR DESCRIPTION
Addresses #1930, generating valid indices for numpy arrays.

It returns a tuple for each dimension, as per ``numpy`` [indexing](https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html) documentation:
    
    Note
    In Python, `x[(exp1, exp2, ..., expN)]`` is equivalent to `x[exp1, exp2, ..., expN]`; the latter is just syntactic sugar for the former.

Each  `exprN` can be:
    - an integers, positive or negative, 
    - a slice object, as generated from `st.slices(s)`,
    - an `Ellipsis` object,
    - a `numpy.newaxis`.

`Ellipsis` and `numpy.newaxis` are optional and can be adjusted with the arguments.

The test checks if `basic_indices` can generate valid patters.

-----

SciPy2019 Sprint

