### PR TITLE
Work around a bug in pandas's repr handling

### DIFF
--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -171,7 +171,9 @@ def test_arbitrary_data_frames(data):
     )
 
     try:
-        df = data.draw(pdst.data_frames(columns))
+        # Use raw data to work around pandas bug in repr. See
+        # https://github.com/pandas-dev/pandas/issues/27484
+        df = data.conjecture_data.draw(pdst.data_frames(columns))
     except Exception as e:
         if type(e).__name__ == "OutOfBoundsDatetime":
             # See https://github.com/HypothesisWorks/hypothesis-python/pull/826

--- a/hypothesis-python/tests/pandas/test_series.py
+++ b/hypothesis-python/tests/pandas/test_series.py
@@ -32,7 +32,9 @@ from tests.pandas.helpers import supported_by_pandas
 def test_can_create_a_series_of_any_dtype(data):
     dtype = np.dtype(data.draw(npst.scalar_dtypes()))
     assume(supported_by_pandas(dtype))
-    series = data.draw(pdst.series(dtype=dtype))
+    # Use raw data to work around pandas bug in repr. See
+    # https://github.com/pandas-dev/pandas/issues/27484
+    series = data.conjecture_data.draw(pdst.series(dtype=dtype))
     assert series.dtype == pandas.Series([], dtype=dtype).dtype
 
 


### PR DESCRIPTION
Our build is currently failing (most of the time) due to https://github.com/pandas-dev/pandas/issues/27484 causing an error when it tries to display the data frame generated.

This works around that bug by suppressing printing of the repr in the test for now.