### PR TITLE
Clarify settings reprs and refactor decoration logic

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch tidies up the repr of several ``settings``-related objects,
+at runtime and in the documentation, and deprecates the undocumented
+edge case that ``phases=None`` was treated like ``phases=tuple(Phase)``.

--- a/hypothesis-python/docs/healthchecks.rst
+++ b/hypothesis-python/docs/healthchecks.rst
@@ -27,6 +27,7 @@ Using a value of ``HealthCheck.all()`` will disable all health checks.
 .. autoclass:: HealthCheck
    :undoc-members:
    :inherited-members:
+   :exclude-members: all
 
 
 .. _deprecation-policy:

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -619,7 +619,7 @@ settings._define_setting(
 settings._define_setting(
     name="stateful_step_count",
     default=50,
-    validator=lambda x: _ensure_positive_int(x, "stateful_step_count", "RELEASEDAY"),
+    validator=lambda x: _ensure_positive_int(x, "stateful_step_count", "2019-03-06"),
     description="""
 Number of steps to run a stateful program for before giving up on it breaking.
 """,

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -578,13 +578,6 @@ class HealthCheck(Enum):
 
 
 @unique
-class Statistics(IntEnum):
-    never = 0
-    interesting = 1
-    always = 2
-
-
-@unique
 class Verbosity(IntEnum):
     quiet = 0
     normal = 1

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -602,7 +602,8 @@ settings._define_setting(
 
 def _validate_phases(phases):
     if phases is None:
-        return tuple(Phase)
+        phases = tuple(Phase)
+        note_deprecation("Use phases=%r, not None." % (phases,), since="RELEASEDAY")
     phases = tuple(phases)
     for a in phases:
         if not isinstance(a, Phase):

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -73,8 +73,10 @@ class Statistics(object):
             )
 
         self.events = [
-            "%.2f%%, %s" % (c / engine.call_count * 100, e)
-            for e, c in sorted(engine.event_call_counts.items(), key=lambda x: -x[1])
+            "%6.2f%%, %s" % (c / engine.call_count * 100, e)
+            for e, c in sorted(
+                engine.event_call_counts.items(), key=lambda x: (-x[1], x[0])
+            )
         ]
 
         total_runtime = math.fsum(engine.all_runtimes)

--- a/hypothesis-python/tests/cover/test_phases.py
+++ b/hypothesis-python/tests/cover/test_phases.py
@@ -45,6 +45,17 @@ def test_this_would_fail_if_you_ran_it(b):
     assert False
 
 
+@pytest.mark.parametrize(
+    "arg,expected",
+    [
+        (tuple(Phase)[::-1], tuple(Phase)),
+        ([Phase.explicit, Phase.explicit], (Phase.explicit,)),
+    ],
+)
+def test_sorts_and_dedupes_phases(arg, expected):
+    assert settings(phases=arg).phases == expected
+
+
 def test_phases_default_to_all():
     assert settings(phases=None).phases == tuple(Phase)
 

--- a/hypothesis-python/tests/cover/test_phases.py
+++ b/hypothesis-python/tests/cover/test_phases.py
@@ -23,6 +23,7 @@ import hypothesis.strategies as st
 from hypothesis import Phase, example, given, settings
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import InvalidArgument
+from tests.common.utils import checks_deprecated_behaviour
 
 
 @example(11)
@@ -57,6 +58,11 @@ def test_sorts_and_dedupes_phases(arg, expected):
 
 
 def test_phases_default_to_all():
+    assert settings().phases == tuple(Phase)
+
+
+@checks_deprecated_behaviour
+def test_phases_none_equals_all():
     assert settings(phases=None).phases == tuple(Phase)
 
 


### PR DESCRIPTION
I went to look something up in the settings docs, and ended up doing a bunch of minor refactoring, improved a few reprs and error messages, and added some better markup in a few places.

It's individually-minor stuff, but the little things add up for users - or for contributors!