### PR TITLE
Switch from pytest.org to pytest.readthedocs.io to work around site issues

### DIFF
--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -67,7 +67,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "pytest": ("https://docs.pytest.org/en/stable/", None),
+    "pytest": ("https://pytest.readthedocs.io/en/stable/", None),
     "django": ("https://django.readthedocs.io/en/stable/", None),
     "attrs": ("https://www.attrs.org/en/stable/", None),
 }


### PR DESCRIPTION
pytest.org is currently down due an SSL issue. Due to the fragility of everything, this breaks our build. This PR fixes that by switching over to their readthedocs version which is still up.