### PR TITLE
Removed usage of MD5 from calc_label_from_name

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -185,6 +185,7 @@ their individual contributions.
 
 * `Adam Johnson <https://github.com/adamchainz>`_
 * `Adam Sven Johnson <https://www.github.com/pkqk>`_
+* `Alex Gaynor <https://github.com/alex>`_
 * `Alex Stapleton <https://www.github.com/public>`_
 * `Alex Willmer <https://github.com/moreati>`_ (alex@moreati.org.uk)
 * `Ben Peterson <https://github.com/killthrush>`_ (killthrush@hotmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Changes the hash algorithm used in an internal function to avoid using MD5. This should not impact users.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,6 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-Changes the hash algorithm used in an internal function to avoid using MD5. This should not impact users.
+This patch changes an internal use of MD5 to SHA hashes, to better support
+users subject to FIPS-140.  There is no user-visible or API change.
+
+Thanks to Alex Gaynor for this patch.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -1697,7 +1697,7 @@ cause errors on Python 3 due to internal rounding.
 -------------------
 
 Hypothesis now seeds and resets the global state of
-:class:`np.random <numpy:numpy.random.RandomState>` for each
+:mod:`np.random <numpy:numpy.random>` for each
 test case, to ensure that tests are reproducible.
 
 This matches and complements the existing handling of the

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -39,7 +39,7 @@ LABEL_MASK = 2 ** 64 - 1
 
 
 def calc_label_from_name(name):
-    hashed = hashlib.md5(str_to_bytes(name)).digest()
+    hashed = hashlib.sha384(str_to_bytes(name)).digest()
     return int_from_bytes(hashed[:8])
 
 


### PR DESCRIPTION
MD5 is cryptographically broken. Of course, this function doesn't really need cryptographic strength (it's slicing down to 8 bytes, so it hardly matters). However, when OpenSSL is used in FIPS mode (conforming to the US Government's FIPS-140 standard), MD5 is entirely disabled. While I generally have a pretty low opinion of FIPS, and I'm loath to ask projects to do actual work to support FIPS deployments, in this case I think the balance of equities is in favor:

- The match is tiny, and should not bring any ongoing maintenance burden
- FIPS's efforts to burn MD5 with fire are legitimately useful
- I'd expect the performance difference to be minimal, on my machine it's ~0.5 usecs per MD5 (of a 12 byte string) vs. ~0.6 usecs per SHA384 (same string)