### PR TITLE
Faster build on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,9 @@ jobs:
         check-pandas24:
           TASK: check-pandas24
     steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.6'
     - script: sudo apt-get update && sudo apt-get install libreadline-dev libsqlite3-dev shellcheck
       displayName: Install apt dependencies
     - script: ./build.sh check-installed
@@ -130,6 +133,9 @@ jobs:
         check-py36:
           TASK: check-py36
     steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.6'
     - script: |
         brew update
         brew install readline xz ncurses

--- a/build.sh
+++ b/build.sh
@@ -17,9 +17,14 @@ SCRIPTS="$ROOT/tooling/scripts"
 # shellcheck source=tooling/scripts/common.sh
 source "$SCRIPTS/common.sh"
 
-"$SCRIPTS/ensure-python.sh" 3.6.5
-
-PYTHON=$(pythonloc 3.6.5)/bin/python
+if [ -n "${PIPELINE_WORKSPACE-}" ] ; then
+    # We're on Azure Pipelines and already set up a suitable Python
+    PYTHON=$(command -v python)
+else
+    # Otherwise, we install it from scratch
+    "$SCRIPTS/ensure-python.sh" 3.6.8
+    PYTHON=$(pythonloc 3.6.8)/bin/python
+fi
 
 TOOL_REQUIREMENTS="$ROOT/requirements/tools.txt"
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -377,7 +377,7 @@ def run_tox(task, version):
 
 PY27 = "2.7.14"
 PY35 = "3.5.5"
-PY36 = "3.6.5"
+PY36 = "3.6.8"
 PY37 = "3.7.0"
 PYPY2 = "pypy2.7-5.10.0"
 PYPY3 = "pypy3.5-5.10.1"

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -477,7 +477,7 @@ def check_examples2():
 
 @examples_task
 def check_examples3():
-    run_tox("examples2", PY36)
+    run_tox("examples3", PY36)
 
 
 @python_tests


### PR DESCRIPTION
We can skip install of our "tool Python" by having Pipelines supply that, which makes the install step of _every_ task take one instead of three minutes.  That's pretty handy when the rest of a slow task takes ~6 minutes, and a fast one takes 20 seconds!