### PR TITLE
Fix for newest Lark parser

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,3 +3,6 @@ RELEASE_TYPE: patch
 This patch tidies up the repr of several ``settings``-related objects,
 at runtime and in the documentation, and deprecates the undocumented
 edge case that ``phases=None`` was treated like ``phases=tuple(Phase)``.
+
+It *also* fixes :func:`~hypothesis.extra.lark.from_lark` with
+:pypi:`lark 0.7.2 <lark-parser>` and later.

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -33,6 +33,8 @@ pip uninstall -y dpcontracts
 
 pip install ".[lark]"
 $PYTEST tests/lark/
+pip install lark-parser==0.7.1
+$PYTEST tests/lark/
 pip uninstall -y lark-parser
 
 if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6)))')" = "False" ] ; then

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -85,7 +85,8 @@ class LarkStrategy(SearchStrategy):
 
         if "start" in getfullargspec(grammar.grammar.compile).args:
             terminals, rules, ignore_names = grammar.grammar.compile(start)
-        else:
+        else:  # pragma: no cover
+            # This branch is to support lark <= 0.7.1, without the start argument.
             terminals, rules, ignore_names = grammar.grammar.compile()
 
         self.names_to_symbols = {}

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements/coverage.txt requirements/coverage.in
 #
 coverage==4.5.4
-lark-parser==0.7.1
+lark-parser==0.7.2
 numpy==1.17.0
 pandas==0.25.0
 python-dateutil==2.8.0    # via pandas


### PR DESCRIPTION
Turns out that Lark added [a required argument in the latest patch version](https://github.com/lark-parser/lark/compare/0.7.1..0.7.2), which made the tests fail for our in-progress release :sob: 

So this PR makes the fix, and ensures that we test against both the old and the new versions.