### PR TITLE
Explicit terminal strategies for Lark

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release improves the :func:`~hypothesis.extra.lark.from_lark` strategy,
+tightening argument validation and adding the ``explicit`` argument to allow use
+with terminals that use ``@declare`` instead of a string or regular expression.
+
+This feature is required to handle features such as indent and dedent tokens
+in Python code, which can be generated with the :pypi:`hypothesmith` package.


### PR DESCRIPTION
Closes #1806, in that it turns out to make supporting `@declare`d indents possible for [hypothesmith](https://github.com/Zac-HD/hypothesmith) *without* weird hacks, and handling of identifiers a *lot* more efficient.