### PR TITLE
Support `from_type` for abstract classes with unknown concrete subclasses

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+The :func:`~hypothesis.strategies.from_type` strategy now knows to look up
+the subclasses of abstract types, which cannot be instantiated directly.
+
+This is very useful for :pypi:`hypothesmith` to support :pypi:`libCST`.

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import abc
 import collections
 import enum
 import io
@@ -37,6 +38,7 @@ from hypothesis.internal.compat import (
 from hypothesis.searchstrategy import types
 from hypothesis.strategies import from_type
 from tests.common.debug import minimal
+from tests.common.utils import fails_with
 
 typing = pytest.importorskip("typing")
 sentinel = object()
@@ -496,3 +498,32 @@ def test_resolves_ellipses_callable_to_function(f):
     f(1)
     f(1, 2, 3)
     f(accepts_kwargs_too=1)
+
+
+class AbstractFoo(abc.ABC):
+    @abc.abstractmethod
+    def foo(self):
+        pass
+
+
+class ConcreteFoo(AbstractFoo):
+    def foo(self):
+        pass
+
+
+@given(st.from_type(AbstractFoo))
+def test_can_resolve_abstract_class(instance):
+    assert isinstance(instance, ConcreteFoo)
+    instance.foo()
+
+
+class AbstractBar(abc.ABC):
+    @abc.abstractmethod
+    def bar(self):
+        pass
+
+
+@fails_with(ResolutionFailed)
+@given(st.from_type(AbstractBar))
+def test_cannot_resolve_abstract_class_with_no_concrete_subclass(instance):
+    assert False, "test body unreachable as strategy cannot resolve"


### PR DESCRIPTION
Another enhancement PR prompted by my [Hypothesmith](https://github.com/Zac-HD/hypothesmith/) project, this time to support the lovely [libCST](https://libcst.readthedocs.io/en/latest/why_libcst.html).

Concrete syntax tree?  Just what I wanted... and every node is a dataclass with type annotations, so it only takes a little massaging for `from_type` to cheerfully construct a whole tree for me.  Well, once it handles abstract base classes anyway!

(I don't actually *need* this for Hypothesmith since I'm going to register a strategy for every concrete node type anyway, but it's a small enough change and the only downside I can see is that we might end up walking down a tree that doesn't have any concrete subclasses after all.)