### PR TITLE
Deprecate generating string dtypes with unspecified length

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -270,6 +270,7 @@ their individual contributions.
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
 * `Tessa Bradbury <https://www.github.com/tessereth>`_
 * `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
+* `Thomas Kluyver <https://www.github.com/takluyver>`_ (thomas@kluyver.me.uk)
 * `Tom McDermott <https://www.github.com/sponster-au>`_ (sponster@gmail.com)
 * `Tyler Gibbons <https://www.github.com/kavec>`_ (tyler.gibbons@flexport.com)
 * `Tyler Nickerson <https://www.github.com/nmbrgts>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This patch deprecates ``min_len`` or ``max_len`` of 0 in
+:func:`~hypothesis.extra.numpy.byte_string_dtypes` and
+:func:`~hypothesis.extra.numpy.unicode_string_dtypes`.
+The lower limit is now 1.
+
+Numpy uses a length of 0 in these dtypes to indicate an undetermined size,
+chosen from the data at array creation.
+However, as the :func:`~hypothesis.extra.numpy.arrays` strategy creates arrays
+before filling them, strings were truncated to 1 byte.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -600,14 +600,14 @@ def byte_string_dtypes(endianness="?", min_len=1, max_len=16):
         note_deprecation(
             "generating byte string dtypes for unspecified length ('S0') "
             "is deprecated. min_len will be 1 instead.",
-            since="RELEASEDAY"
+            since="RELEASEDAY",
         )
         min_len = 1
     if max_len == 0:
         note_deprecation(
             "generating byte string dtypes for unspecified length ('S0') "
             "is deprecated. max_len will be 1 instead.",
-            since="RELEASEDAY"
+            since="RELEASEDAY",
         )
         max_len = 1
 
@@ -629,14 +629,14 @@ def unicode_string_dtypes(endianness="?", min_len=1, max_len=16):
         note_deprecation(
             "generating unicode string dtypes for unspecified length ('U0') "
             "is deprecated. min_len will be 1 instead.",
-            since="RELEASEDAY"
+            since="RELEASEDAY",
         )
         min_len = 1
     if max_len == 0:
         note_deprecation(
             "generating unicode string dtypes for unspecified length ('U0') "
             "is deprecated. max_len will be 1 instead.",
-            since="RELEASEDAY"
+            since="RELEASEDAY",
         )
         max_len = 1
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -587,20 +587,48 @@ def timedelta64_dtypes(max_period="Y", min_period="ns", endianness="?"):
 
 
 @defines_dtype_strategy
-def byte_string_dtypes(endianness="?", min_len=0, max_len=16):
+def byte_string_dtypes(endianness="?", min_len=1, max_len=16):
     # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating bytestring dtypes, of various lengths
     and byteorder."""
     order_check("len", 0, min_len, max_len)
+    if min_len == 0:
+        note_deprecation(
+            "generating byte string dtypes for unspecified length ('S0') "
+            "is deprecated. min_len will be 1 instead.",
+            since="RELEASEDAY"
+        )
+        min_len = 1
+    if max_len == 0:
+        note_deprecation(
+            "generating byte string dtypes for unspecified length ('S0') "
+            "is deprecated. max_len will be 1 instead.",
+            since="RELEASEDAY"
+        )
+        max_len = 1
     return dtype_factory("S", list(range(min_len, max_len + 1)), None, endianness)
 
 
 @defines_dtype_strategy
-def unicode_string_dtypes(endianness="?", min_len=0, max_len=16):
+def unicode_string_dtypes(endianness="?", min_len=1, max_len=16):
     # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating unicode string dtypes, of various
     lengths and byteorder."""
     order_check("len", 0, min_len, max_len)
+    if min_len == 0:
+        note_deprecation(
+            "generating unicode string dtypes for unspecified length ('U0') "
+            "is deprecated. min_len will be 1 instead.",
+            since="RELEASEDAY"
+        )
+        min_len = 1
+    if max_len == 0:
+        note_deprecation(
+            "generating unicode string dtypes for unspecified length ('U0') "
+            "is deprecated. max_len will be 1 instead.",
+            since="RELEASEDAY"
+        )
+        max_len = 1
     return dtype_factory("U", list(range(min_len, max_len + 1)), None, endianness)
 
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -590,7 +590,12 @@ def timedelta64_dtypes(max_period="Y", min_period="ns", endianness="?"):
 def byte_string_dtypes(endianness="?", min_len=1, max_len=16):
     # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating bytestring dtypes, of various lengths
-    and byteorder."""
+    and byteorder.
+
+    While Hypothesis' string strategies can generate empty strings, string
+    dtypes with length 0 indicate that size is still to be determined, so
+    the minimum length for string dtypes is 1.
+    """
     if min_len == 0:
         note_deprecation(
             "generating byte string dtypes for unspecified length ('S0') "
@@ -614,7 +619,12 @@ def byte_string_dtypes(endianness="?", min_len=1, max_len=16):
 def unicode_string_dtypes(endianness="?", min_len=1, max_len=16):
     # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating unicode string dtypes, of various
-    lengths and byteorder."""
+    lengths and byteorder.
+
+    While Hypothesis' string strategies can generate empty strings, string
+    dtypes with length 0 indicate that size is still to be determined, so
+    the minimum length for string dtypes is 1.
+    """
     if min_len == 0:
         note_deprecation(
             "generating unicode string dtypes for unspecified length ('U0') "

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -591,7 +591,6 @@ def byte_string_dtypes(endianness="?", min_len=1, max_len=16):
     # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating bytestring dtypes, of various lengths
     and byteorder."""
-    order_check("len", 0, min_len, max_len)
     if min_len == 0:
         note_deprecation(
             "generating byte string dtypes for unspecified length ('S0') "
@@ -606,6 +605,8 @@ def byte_string_dtypes(endianness="?", min_len=1, max_len=16):
             since="RELEASEDAY"
         )
         max_len = 1
+
+    order_check("len", 1, min_len, max_len)
     return dtype_factory("S", list(range(min_len, max_len + 1)), None, endianness)
 
 
@@ -614,7 +615,6 @@ def unicode_string_dtypes(endianness="?", min_len=1, max_len=16):
     # type: (str, int, int) -> st.SearchStrategy[np.dtype]
     """Return a strategy for generating unicode string dtypes, of various
     lengths and byteorder."""
-    order_check("len", 0, min_len, max_len)
     if min_len == 0:
         note_deprecation(
             "generating unicode string dtypes for unspecified length ('U0') "
@@ -629,6 +629,8 @@ def unicode_string_dtypes(endianness="?", min_len=1, max_len=16):
             since="RELEASEDAY"
         )
         max_len = 1
+
+    order_check("len", 1, min_len, max_len)
     return dtype_factory("U", list(range(min_len, max_len + 1)), None, endianness)
 
 

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -24,6 +24,7 @@ import hypothesis.extra.numpy as nps
 import hypothesis.strategies as st
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
+from tests.common.utils import checks_deprecated_behaviour
 
 
 def e(a, **kwargs):
@@ -142,3 +143,17 @@ def test_bad_dtype_strategy(capsys, data):
     assert capsys.readouterr().out.startswith(
         "Got invalid dtype value=%r from strategy=just(%r), function=" % (val, val)
     )
+
+
+@checks_deprecated_behaviour
+@given(st.data())
+def test_byte_string_dtype_len_0(data):
+    s = nps.byte_string_dtypes(min_len=0, max_len=0)
+    assert data.draw(s).itemsize == 1
+
+
+@checks_deprecated_behaviour
+@given(st.data())
+def test_unicode_string_dtype_len_0(data):
+    s = nps.unicode_string_dtypes(min_len=0, max_len=0)
+    assert data.draw(s).itemsize == 4

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -194,9 +194,27 @@ def test_can_generate_scalar_dtypes(dtype):
     assert isinstance(dtype, np.dtype)
 
 
-@given(nps.nested_dtypes())
+@given(
+    nps.nested_dtypes(
+        subtype_strategy=st.one_of(
+            nps.scalar_dtypes(), nps.byte_string_dtypes(), nps.unicode_string_dtypes()
+        )
+    )
+)
 def test_can_generate_compound_dtypes(dtype):
     assert isinstance(dtype, np.dtype)
+
+
+@given(
+    nps.nested_dtypes(
+        subtype_strategy=st.one_of(
+            nps.scalar_dtypes(), nps.byte_string_dtypes(), nps.unicode_string_dtypes()
+        )
+    ).flatmap(lambda dt: nps.arrays(dtype=dt, shape=1))
+)
+def test_can_generate_data_compound_dtypes(arr):
+    # This is meant to catch the class of errors which prompted PR #2085
+    assert isinstance(arr, np.ndarray)
 
 
 @given(nps.nested_dtypes(max_itemsize=400), st.data())


### PR DESCRIPTION
From discussion with @Zac-HD at Euroscipy. Generating arrays with string dtypes with `min_len=0` issues warnings like:

> properties/test_pandas_roundtrip.py::test_roundtrip_pandas_dataframe
>  /home/takluyver/miniconda3/envs/hypothesise-xarray/lib/python3.7/site-packages/hypothesis/extra/numpy.py:147: HypothesisDeprecationWarning: Generated array element b'\xff\xc00\xff\xc8\xff\xb2\xff)\x00\xd6\xff\xff\xcb\xff' from binary().filter(lambda b: b[-1:] != b"\0").map(bytes_).map(convert_element) cannot be represented as dtype dtype('S') - instead it becomes b'\xff' (type <class 'numpy.bytes_'>).  Consider using a more precise strategy, for example passing the `width` argument to `floats()`, as this will be an error in a future version.

This is because the value generation from `from_dtype` interprets 'S0' as meaning "strings of arbitrary length", whereas creating the empty array (like `np.zeros(dtype='S0', shape=10)`) sets the length of each string to 1.

An alternative way to work around this would be to generate the necessary values first, and then create an array with them. But arrays are currently created before their values, and it appears there's quite a bit of complexity in how arrays are filled, so it's not trivial to reorder that operation.