### PR TITLE
Test and fix attrs type inference when using the typing module

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -227,6 +227,7 @@ their individual contributions.
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)
 * `Jochen Müller <https://github.com/jomuel>`_
 * `Joey Tuong <https://github.com/tetrapus>`_
+* `Jonathan Gayvallet <https://github.com/Meallia>`_ (jonathan.gayvallet@orange.com)
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)
 * `Joshua Boone <https://www.github.com/patchedwork>`_ (joshuaboone4190@gmail.com)
 * `jmhsi <https://www.github.com/jmhsi>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,7 @@
 RELEASE_TYPE: patch
 
-This patch fixes a bug in the :pypi:`attrs` search strategy that made Hypothesis fail to infer types from the :mod:`typing` module such as `Union[int, str]`, `Dict[str,int]` or `List[int]` (:issue:`2091`).
+This patch fixes a bug in strategy inference for :pypi:`attrs` classes where
+Hypothesis would fail to infer a strategy for attributes of a generic type
+such as ``Union[int, str]`` or ``List[bool]`` (:issue:`2091`).
 
-Hypothesis will now use :func:`~hypothesis.strategies.from_type` when encountering a generic type in an `attrs` attribute.
+Thanks to Jonathan Gayvallet for the bug report and this patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug in the :pypi:`attrs` search strategy that made Hypothesis fail to infer types from the :mod:`typing` module such as `Union[int, str]`, `Dict[str,int]` or `List[int]` (:issue:`2091`).
+
+Hypothesis will now use :func:`~hypothesis.strategies.from_type` when encountering a generic type in an `attrs` attribute.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -508,14 +508,7 @@ class StateForActualGivenExecution(object):
 
         self.used_examples_from_database = False
 
-    def execute(
-        self,
-        data,
-        print_example=False,
-        is_final=False,
-        expected_failure=None,
-        collect=False,
-    ):
+    def execute(self, data, print_example=False, is_final=False, expected_failure=None):
         text_repr = [None]
         if self.settings.deadline is None:
             test = self.test

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -304,7 +304,11 @@ else:
         typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
         ForwardRef = typing.ForwardRef  # type: ignore
     except AttributeError:
-        typing_root_type = (typing.TypingMeta, typing.TypeVar)  # type: ignore
+        typing_root_type = (
+            typing.TypingMeta,
+            typing.TypeVar,
+            typing._FinalTypingBase,
+        )  # type: ignore
         ForwardRef = typing._ForwardRef  # type: ignore
 
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -307,7 +307,7 @@ else:
         typing_root_type = (
             typing.TypingMeta,
             typing.TypeVar,
-            typing._FinalTypingBase,
+            typing._Union,
         )  # type: ignore
         ForwardRef = typing._ForwardRef  # type: ignore
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
@@ -25,7 +25,7 @@ import attr
 import hypothesis.strategies as st
 from hypothesis.errors import ResolutionFailed
 from hypothesis.internal.compat import get_type_hints, string_types
-from hypothesis.searchstrategy.types import type_sorting_key
+from hypothesis.searchstrategy.types import is_a_type, type_sorting_key
 from hypothesis.utils.conventions import infer
 
 
@@ -124,7 +124,7 @@ def types_to_strategy(attrib, types):
 
     # Otherwise, try the `type` attribute as a fallback, and finally try
     # the type hints on a converter (desperate!) before giving up.
-    if isinstance(getattr(attrib, "type", None), type):
+    if is_a_type(getattr(attrib, "type", None)):
         # The convoluted test is because variable annotations may be stored
         # in string form; attrs doesn't evaluate them and we don't handle them.
         # See PEP 526, PEP 563, and Hypothesis issue #1004 for details.

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -17,8 +17,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import typing
-
 import attr
 import pytest
 
@@ -26,16 +24,15 @@ import hypothesis.strategies as st
 from hypothesis import given, infer
 from hypothesis.errors import ResolutionFailed
 
+try:
+    import typing
+except ImportError:
+    typing = None
+
 
 @attr.s
 class Inferrables(object):
     type_ = attr.ib(type=int)
-
-    type_typing_list = attr.ib(type=typing.List[int])
-    type_typing_list_of_list = attr.ib(type=typing.List[typing.List[int]])
-    type_typing_dict = attr.ib(type=typing.Dict[str, int])
-    type_typing_union = attr.ib(type=typing.Union[str, int])
-
     type_converter = attr.ib(converter=bool)
     validator_type = attr.ib(validator=attr.validators.instance_of(str))
     validator_type_tuple = attr.ib(validator=attr.validators.instance_of((str, int)))
@@ -62,6 +59,14 @@ class Inferrables(object):
     validator_in_multiple_strings = attr.ib(
         validator=[attr.validators.in_("abcd"), attr.validators.in_(["ab", "cd"])]
     )
+
+    if typing is not None:
+        typing_list = attr.ib(type=typing.List[int])
+        typing_list_of_list = attr.ib(type=typing.List[typing.List[int]])
+        typing_dict = attr.ib(type=typing.Dict[str, int])
+        typing_union = attr.ib(type=typing.Optional[bool])
+        typing_union = attr.ib(type=typing.Union[str, int])
+
     has_default = attr.ib(default=0)
     has_default_factory = attr.ib(default=attr.Factory(list))
     has_default_factory_takes_self = attr.ib(  # uninferrable but has default

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -17,6 +17,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import typing
+
 import attr
 import pytest
 
@@ -28,6 +30,12 @@ from hypothesis.errors import ResolutionFailed
 @attr.s
 class Inferrables(object):
     type_ = attr.ib(type=int)
+
+    type_typing_list = attr.ib(type=typing.List[int])
+    type_typing_list_of_list = attr.ib(type=typing.List[typing.List[int]])
+    type_typing_dict = attr.ib(type=typing.Dict[str, int])
+    type_typing_union = attr.ib(type=typing.Union[str, int])
+
     type_converter = attr.ib(converter=bool)
     validator_type = attr.ib(validator=attr.validators.instance_of(str))
     validator_type_tuple = attr.ib(validator=attr.validators.instance_of((str, int)))

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -21,4 +21,3 @@ pytest==4.6.4
 six==1.12.0               # via mock, more-itertools, packaging, pytest-xdist
 wcwidth==0.1.7            # via pytest
 zipp==0.5.1               # via importlib-metadata
-typing==3.7.4.1

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -21,3 +21,4 @@ pytest==4.6.4
 six==1.12.0               # via mock, more-itertools, packaging, pytest-xdist
 wcwidth==0.1.7            # via pytest
 zipp==0.5.1               # via importlib-metadata
+typing==3.7.4.1


### PR DESCRIPTION
Fix for #2091 

Changed the attrs strategy to fallback to `from_type` if the attribute type if from `typing`

in python < 3.6 (including 2.7), `typing.Union` is a subclass of `typing._FinalTypingBase`