### PR TITLE
Warn on non-interactive `s.example()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release emits a warning if you use the ``.example()`` method of
+a strategy in a non-interactive context.
+
+:func:`~hypothesis.given` is a much better choice for writing tests,
+whether you care about performance, minimal examples, reproducing
+failures, or even just the variety of inputs that will be tested!

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -112,6 +112,12 @@ class FailedHealthCheck(HypothesisWarning):
         self.health_check = check
 
 
+class NonInteractiveExampleWarning(HypothesisWarning):
+    """SearchStrategy.example() is designed for interactive use,
+    but should never be used in the body of a test.
+    """
+
+
 class HypothesisDeprecationWarning(HypothesisWarning, FutureWarning):
     """A deprecation warning issued by Hypothesis.
 

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -24,6 +24,7 @@ from warnings import filterwarnings
 from hypothesis import Verbosity, settings
 from hypothesis._settings import not_set
 from hypothesis.configuration import set_hypothesis_home_dir
+from hypothesis.errors import NonInteractiveExampleWarning
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
@@ -57,6 +58,9 @@ def run():
     filterwarnings(
         "ignore", message="Importing from numpy.testing.nosetester is deprecated"
     )
+
+    # User-facing warning which does not apply to our own tests
+    filterwarnings("ignore", category=NonInteractiveExampleWarning)
 
     new_home = mkdtemp()
     set_hypothesis_home_dir(new_home)

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -12,7 +12,9 @@ mock==3.0.5
 more-itertools==5.0.0
 numpy==1.16.4             # last compatible with Python 2
 packaging==19.0           # via pytest
+pexpect==4.7.0
 pluggy==0.12.0            # via pytest
+ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest
 pyparsing==2.4.0          # via packaging
 pytest-forked==1.0.2      # via pytest-xdist

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,3 +1,4 @@
 attrs
+pexpect
 pytest
 pytest-xdist

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,9 @@ execnet==1.7.1            # via pytest-xdist
 importlib-metadata==0.23  # via pluggy, pytest
 more-itertools==7.2.0     # via pytest, zipp
 packaging==19.2           # via pytest
+pexpect==4.7.0
 pluggy==0.13.0            # via pytest
+ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest
 pyparsing==2.4.2          # via packaging
 pytest-forked==1.0.2      # via pytest-xdist


### PR DESCRIPTION
The `.example()` method on strategies is great for interactive exploration.

Unfortunately, it's not (yet) as clear as it should be that `.example()` should not be used in tests - it's built on top of `@given`, but: slower, more prone to duplicates, less configurable, doesn't support minimal examples, and *doesn't save or replay failures*.

So this PR adds a warning, which will only trigger if the code is not running in an interactive session.