### PR TITLE
Update attrs dependency to >= 19.2

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch bumps our dependency on :pypi:`attrs` to ``>=19.2.0``;
+but there are no user-visible changes to Hypothesis.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -68,7 +68,7 @@ extras = {
 extras["all"] = sorted(sum(extras.values(), []))
 
 
-install_requires = ["attrs>=16.0.0"]
+install_requires = ["attrs>=19.2.0"]
 # Using an environment marker on enum34 makes the dependency condition
 # independent of the build environemnt, which is important for wheels.
 # https://www.python.org/dev/peps/pep-0345/#environment-markers

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1442,7 +1442,7 @@ def block_program(description):
     return name
 
 
-@attr.s(slots=True, cmp=False)
+@attr.s(slots=True, eq=False)
 class ShrinkPass(object):
     run_with_chooser = attr.ib()
     index = attr.ib()

--- a/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/attrs.py
@@ -45,12 +45,12 @@ def from_attrs(target, args, kwargs, to_infer):
 
 def from_attrs_attribute(attrib, target):
     """Infer a strategy from the metadata on an attr.Attribute object."""
-    # Try inferring from the default argument.  Note that this will only help
+    # Try inferring from the default argument.  Note that this will only help if
     # the user passed `infer` to builds() for this attribute, but in that case
     # we use it as the minimal example.
     default = st.nothing()
     if isinstance(attrib.default, attr.Factory):
-        if not getattr(attrib.default, "takes_self", False):  # new in 17.1
+        if not attrib.default.takes_self:
             default = st.builds(attrib.default.factory)
     elif attrib.default is not attr.NOTHING:
         default = st.just(attrib.default)

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -4,7 +4,7 @@
 #
 apipkg==1.5               # via execnet
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0
+attrs==19.2.0
 colorama==0.4.1           # via pytest
 execnet==1.6.0            # via pytest-xdist
 importlib-metadata==0.18  # via pluggy, pytest


### PR DESCRIPTION
Use of `cmp=` is deprecated, and the workaround is a lot clumsier than our one-line `getattr` for pre-17 attr versions.  So given `attrs` excellent compatibility policy, I thought that the best option was to simply increase the minimum version.

Closes #2110.