### PR TITLE
Fix #2106. Defer directory creation to DirectoryBasedExampleDatabase

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch defers creation of the `.hypothesis` directory until we have 
+something to store in it, meaning that it will appear when Hypothesis is
+used rather than simply installed.
+
+Thanks to Peter C Kroon for the Hacktoberfest patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch defers creation of the `.hypothesis` directory until we have 
+This patch defers creation of the ``.hypothesis`` directory until we have
 something to store in it, meaning that it will appear when Hypothesis is
 used rather than simply installed.
 

--- a/hypothesis-python/src/hypothesis/configuration.py
+++ b/hypothesis-python/src/hypothesis/configuration.py
@@ -42,7 +42,6 @@ def hypothesis_home_dir():
         __hypothesis_home_directory = os.getenv("HYPOTHESIS_STORAGE_DIRECTORY")
     if not __hypothesis_home_directory:
         __hypothesis_home_directory = __hypothesis_home_directory_default
-        mkdir_p(__hypothesis_home_directory)
     return __hypothesis_home_directory
 
 

--- a/hypothesis-python/src/hypothesis/configuration.py
+++ b/hypothesis-python/src/hypothesis/configuration.py
@@ -47,9 +47,4 @@ def hypothesis_home_dir():
 
 def storage_directory(*names):
     path = os.path.join(hypothesis_home_dir(), *names)
-    mkdir_p(path)
     return path
-
-
-def tmpdir():
-    return storage_directory("tmp")

--- a/hypothesis-python/src/hypothesis/configuration.py
+++ b/hypothesis-python/src/hypothesis/configuration.py
@@ -36,15 +36,10 @@ def mkdir_p(path):
         pass
 
 
-def hypothesis_home_dir():
+def storage_directory(*names):
     global __hypothesis_home_directory
     if not __hypothesis_home_directory:
         __hypothesis_home_directory = os.getenv("HYPOTHESIS_STORAGE_DIRECTORY")
     if not __hypothesis_home_directory:
         __hypothesis_home_directory = __hypothesis_home_directory_default
-    return __hypothesis_home_directory
-
-
-def storage_directory(*names):
-    path = os.path.join(hypothesis_home_dir(), *names)
-    return path
+    return os.path.join(__hypothesis_home_directory, *names)

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -38,7 +38,9 @@ def _usable_dir(path):
         # This loop terminates because the topmost dir ('/' on unix) will always
         # exist.
         if os.path.exists(path):
-            usable = os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK)
+            usable = os.path.isdir(path) and os.access(
+                path, os.R_OK | os.W_OK | os.X_OK
+            )
             return usable
         else:
             path = os.path.dirname(path)

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -22,10 +22,26 @@ import os
 import warnings
 from hashlib import sha1
 
-from hypothesis.configuration import storage_directory
+from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.errors import HypothesisException, HypothesisWarning
 from hypothesis.internal.compat import hbytes
 from hypothesis.utils.conventions import not_set
+
+
+def _usable_dir(path):
+    """
+    Returns True iff the desired path can be used as database path because
+    either the directory exists and can be used, or its root directory can
+    be used and we can make the directory as needed.
+    """
+    while True:
+        # This loop terminates because the topmost dir ('/' on unix) will always
+        # exist.
+        if os.path.exists(path):
+            usable = os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK)
+            return usable
+        else:
+            path = os.path.dirname(path)
 
 
 def _db_for_path(path=None):
@@ -36,12 +52,9 @@ def _db_for_path(path=None):
                 "effect.  Configure your database location via a settings profile instead.\n"
                 "https://hypothesis.readthedocs.io/en/latest/settings.html#settings-profiles"
             )
-        # Note: storage_directory attempts to create the dir in question, so
-        # if os.access fails there *must* be a fatal permissions issue.
-        path = storage_directory("examples")
-        if os.access(path, os.R_OK | os.W_OK | os.X_OK):
-            return _db_for_path(path)
-        else:  # pragma: no cover
+
+        path = os.path.join(hypothesis_home_dir(), "examples")
+        if not _usable_dir(path):  # pragma: no cover
             warnings.warn(
                 HypothesisWarning(
                     "The database setting is not configured, and the default "
@@ -158,7 +171,6 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         except KeyError:
             pass
         directory = os.path.join(self.path, _hash(key))
-        mkdirp(directory)
         self.keypaths[key] = directory
         return directory
 
@@ -167,6 +179,8 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
 
     def fetch(self, key):
         kp = self._key_path(key)
+        if not os.path.exists(kp):
+            return
         for path in os.listdir(kp):
             try:
                 with open(os.path.join(kp, path), "rb") as i:
@@ -175,6 +189,10 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
                 pass
 
     def save(self, key, value):
+        # Note: we attempt to create the dir in question now. We
+        # already checked for permissions, but there can still be other issues,
+        # e.g. the disk is full
+        mkdirp(self._key_path(key))
         path = self._value_path(key, value)
         if not os.path.exists(path):
             suffix = binascii.hexlify(os.urandom(16))

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 import unicodedata
 
-from hypothesis.configuration import storage_directory, tmpdir
+from hypothesis.configuration import hypothesis_home_dir, tmpdir
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import hunichr
 
@@ -37,7 +37,10 @@ if False:
 
 def charmap_file():
     return os.path.join(
-        storage_directory("unicodedata", unicodedata.unidata_version), "charmap.json.gz"
+        hypothesis_home_dir(),
+        "unicodedata",
+        unicodedata.unidata_version,
+        "charmap.json.gz",
     )
 
 
@@ -73,6 +76,8 @@ def charmap():
 
             try:
                 # Write the Unicode table atomically
+                # The call to tmpdir creates the directory (if it doesn't exist
+                # yet). This is fine, since we'll be writing to it anyway.
                 fd, tmpfile = tempfile.mkstemp(dir=tmpdir())
                 os.close(fd)
                 # Explicitly set the mtime to get reproducible output
@@ -80,7 +85,7 @@ def charmap():
                     result = json.dumps(sorted(tmp_charmap.items()))
                     o.write(result.encode())
 
-                os.rename(tmpfile, f)
+                os.renames(tmpfile, f)
             except Exception:
                 pass
 

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 import unicodedata
 
-from hypothesis.configuration import hypothesis_home_dir, tmpdir
+from hypothesis.configuration import mkdir_p, storage_directory
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import hunichr
 
@@ -36,11 +36,8 @@ if False:
 
 
 def charmap_file():
-    return os.path.join(
-        hypothesis_home_dir(),
-        "unicodedata",
-        unicodedata.unidata_version,
-        "charmap.json.gz",
+    return storage_directory(
+        "unicode_data", unicodedata.unidata_version, "charmap.json.gz"
     )
 
 
@@ -76,9 +73,9 @@ def charmap():
 
             try:
                 # Write the Unicode table atomically
-                # The call to tmpdir creates the directory (if it doesn't exist
-                # yet). This is fine, since we'll be writing to it anyway.
-                fd, tmpfile = tempfile.mkstemp(dir=tmpdir())
+                tmpdir = storage_directory("tmp")
+                mkdir_p(tmpdir)
+                fd, tmpfile = tempfile.mkstemp(dir=tmpdir)
                 os.close(fd)
                 # Explicitly set the mtime to get reproducible output
                 with gzip.GzipFile(tmpfile, "wb", mtime=1) as o:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import, division, print_function
 import ast
 import hashlib
 import inspect
-import os.path
 import re
 import tokenize
 import types
@@ -32,7 +31,6 @@ import uuid
 from functools import wraps
 from types import ModuleType
 
-from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.internal.compat import (
     ARG_NAME_ATTRIBUTE,
     getfullargspec,

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, division, print_function
 import ast
 import hashlib
 import inspect
+import os.path
 import re
 import tokenize
 import types
@@ -31,7 +32,7 @@ import uuid
 from functools import wraps
 from types import ModuleType
 
-from hypothesis.configuration import storage_directory
+from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.internal.compat import (
     ARG_NAME_ATTRIBUTE,
     getfullargspec,
@@ -474,7 +475,7 @@ def check_valid_identifier(identifier):
 
 
 def eval_directory():
-    return storage_directory("eval_source")
+    return os.path.join(hypothesis_home_dir(), "eval_source")
 
 
 eval_cache = {}  # type: dict

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -474,10 +474,6 @@ def check_valid_identifier(identifier):
         raise ValueError("%r is not a valid python identifier" % (identifier,))
 
 
-def eval_directory():
-    return os.path.join(hypothesis_home_dir(), "eval_source")
-
-
 eval_cache = {}  # type: dict
 
 

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -53,6 +53,6 @@ def test_will_pick_up_location_from_env(monkeypatch, tmpdir):
     assert fs.hypothesis_home_dir() == tmpdir
 
 
-def test_storage_directories_are_created_automatically(tmpdir):
+def test_storage_directories_are_not_created_automatically(tmpdir):
     fs.set_hypothesis_home_dir(str(tmpdir))
-    assert os.path.exists(fs.storage_directory(u"badgers"))
+    assert not os.path.exists(fs.storage_directory(u"badgers"))

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -26,7 +26,7 @@ previous_home_dir = None
 
 def setup_function(function):
     global previous_home_dir
-    previous_home_dir = fs.hypothesis_home_dir()
+    previous_home_dir = fs.storage_directory()
     fs.set_hypothesis_home_dir(None)
 
 
@@ -37,12 +37,12 @@ def teardown_function(function):
 
 
 def test_defaults_to_the_default():
-    assert fs.hypothesis_home_dir() == fs.__hypothesis_home_directory_default
+    assert fs.storage_directory() == fs.__hypothesis_home_directory_default
 
 
 def test_can_set_homedir_and_it_will_exist(tmpdir):
     fs.set_hypothesis_home_dir(str(tmpdir.mkdir(u"kittens")))
-    d = fs.hypothesis_home_dir()
+    d = fs.storage_directory()
     assert u"kittens" in d
     assert os.path.exists(d)
 
@@ -50,7 +50,7 @@ def test_can_set_homedir_and_it_will_exist(tmpdir):
 def test_will_pick_up_location_from_env(monkeypatch, tmpdir):
     tmpdir = str(tmpdir)
     monkeypatch.setattr(os, "environ", {"HYPOTHESIS_STORAGE_DIRECTORY": tmpdir})
-    assert fs.hypothesis_home_dir() == tmpdir
+    assert fs.storage_directory() == tmpdir
 
 
 def test_storage_directories_are_not_created_automatically(tmpdir):

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -29,7 +29,6 @@ from hypothesis.internal.reflection import (
     convert_keyword_arguments,
     convert_positional_arguments,
     define_function_signature,
-    eval_directory,
     fully_qualified_name,
     function_digest,
     get_pretty_function_description,
@@ -633,11 +632,6 @@ if not PY3:
 
         assert arg_string(foo, [BittySnowman()], {}) == "x=☃"
         assert arg_string(foo, [], {"x": BittySnowman()}) == "x=☃"
-
-
-def test_does_not_put_eval_directory_on_path():
-    source_exec_as_module("hello = 'world'")
-    assert eval_directory() not in sys.path
 
 
 def test_kwargs_appear_in_arg_string():

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -21,7 +21,7 @@ import os.path
 
 import hypothesis.strategies as st
 from hypothesis import assume, core, find, given, settings
-from hypothesis.database import InMemoryExampleDatabase, ExampleDatabase
+from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from hypothesis.internal.compat import hbytes
 from tests.common.utils import (
@@ -151,11 +151,11 @@ def test_does_not_use_database_when_seed_is_forced(monkeypatch):
 
 @given(st.binary(), st.binary())
 def test_database_not_created_when_not_used(tmp_path_factory, key, value):
-    path = tmp_path_factory.mktemp('hypothesis') / 'examples'
-    assert not os.path.exists(path)
+    path = tmp_path_factory.mktemp("hypothesis") / "examples"
+    assert not os.path.exists(str(path))
     database = ExampleDatabase(path)
     assert not list(database.fetch(key))
-    assert not os.path.exists(path)
+    assert not os.path.exists(str(path))
     database.save(key, value)
-    assert os.path.exists(path)
+    assert os.path.exists(str(path))
     assert list(database.fetch(key)) == [value]

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -17,9 +17,11 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os.path
+
 import hypothesis.strategies as st
 from hypothesis import assume, core, find, given, settings
-from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.database import InMemoryExampleDatabase, ExampleDatabase
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from hypothesis.internal.compat import hbytes
 from tests.common.utils import (
@@ -145,3 +147,15 @@ def test_does_not_use_database_when_seed_is_forced(monkeypatch):
         pass
 
     test()
+
+
+@given(st.binary(), st.binary())
+def test_database_not_created_when_not_used(tmp_path_factory, key, value):
+    path = tmp_path_factory.mktemp('hypothesis') / 'examples'
+    assert not os.path.exists(path)
+    database = ExampleDatabase(path)
+    assert not list(database.fetch(key))
+    assert not os.path.exists(path)
+    database.save(key, value)
+    assert os.path.exists(path)
+    assert list(database.fetch(key)) == [value]


### PR DESCRIPTION
This PR aims to delay creation of the `.hypothesis/examples` directory until it is actually needed. This is done by shifting responsibility for creation from `configuration.py` to `DirectoryBasedExampleDatabase.save`.

Be sure to let me know if anything else is needed from my side :)
And please point me to another issue I could pick up so I can keep working towards my hacktoberfest t-shirt!

Fixes #2106