### PR TITLE
More precise strategy type-hints

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch improves our type hints on the :func:`~hypothesis.strategies.emails`,
+:func:`~hypothesis.strategies.functions`, :func:`~hypothesis.strategies.integers`,
+:func:`~hypothesis.strategies.iterables`, and :func:`~hypothesis.strategies.slices`
+strategies, as well as the ``.filter()`` method.
+
+There is no runtime change, but if you use :pypi:`mypy` or a similar
+type-checker on your tests the results will be a bit more precise.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -137,7 +137,7 @@ if False:
     import random  # noqa
     from types import ModuleType  # noqa
     from typing import Any, Dict, Union, Sequence, Callable, Pattern  # noqa
-    from typing import TypeVar, Tuple, List, Set, FrozenSet, overload  # noqa
+    from typing import TypeVar, Tuple, Iterable, List, Set, FrozenSet, overload  # noqa
     from typing import Type, Text, AnyStr, Optional  # noqa
 
     from hypothesis.utils.conventions import InferType  # noqa
@@ -345,7 +345,7 @@ def one_of(*args):
 @cacheable
 @defines_strategy_with_reusable_values
 def integers(min_value=None, max_value=None):
-    # type: (Real, Real) -> SearchStrategy[int]
+    # type: (int, int) -> SearchStrategy[int]
     """Returns a strategy which generates integers; in Python 2 these may be
     ints or longs.
 
@@ -854,7 +854,14 @@ class PrettyIter(object):
 
 
 @defines_strategy
-def iterables(elements, min_size=0, max_size=None, unique_by=None, unique=False):
+def iterables(
+    elements,  # type: SearchStrategy[Ex]
+    min_size=0,  # type: int
+    max_size=None,  # type: int
+    unique_by=None,  # type: Union[Callable, Tuple[Callable, ...]]
+    unique=False,  # type: bool
+):
+    # type: (...) -> SearchStrategy[Iterable[Ex]]
     """This has the same behaviour as lists, but returns iterables instead.
 
     Some iterables cannot be indexed (e.g. sets) and some do not have a
@@ -2085,6 +2092,7 @@ class RunnerStrategy(SearchStrategy):
 
 @defines_strategy_with_reusable_values
 def runner(default=not_set):
+    # type: (Any) -> SearchStrategy[Any]
     """A strategy for getting "the current test runner", whatever that may be.
     The exact meaning depends on the entry point, but it will usually be the
     associated 'self' value for it.
@@ -2243,6 +2251,7 @@ def deferred(definition):
 
 @defines_strategy_with_reusable_values
 def emails():
+    # type: () -> SearchStrategy[Text]
     """A strategy for generating email addresses as unicode strings. The
     address format is specified in :rfc:`5322#section-3.4.1`. Values shrink
     towards shorter local-parts and host domains.
@@ -2260,14 +2269,14 @@ def emails():
     )
 
 
-# Mypy can't yet handle default values with generic types or typevars, but the
-# @overload workaround from https://github.com/python/mypy/issues/3737 doesn't
-# work with @composite functions - Mypy can't see that the function implements
-# `(Any, Callable[..., T], SearchStrategy[T]) -> Callable[..., T]`
-
-
 @defines_strategy
-def functions(like=lambda: None, returns=none()):
+def functions(
+    like=lambda: None,  # type: Callable[..., Any]
+    returns=none(),  # type: SearchStrategy[Any]
+):
+    # type: (...) -> SearchStrategy[Callable[..., Any]]
+    # The proper type signature of `functions()` would have T instead of Any, but mypy
+    # disallows default args for generics: https://github.com/python/mypy/issues/3737
     """A strategy for functions, which can be used in callbacks.
 
     The generated functions will mimic the interface of ``like``, which must
@@ -2292,6 +2301,7 @@ def functions(like=lambda: None, returns=none()):
 
 @composite
 def slices(draw, size):
+    # type: (Any, int) -> slice
     """Generates slices that will select indices up to the supplied size
 
     Generated slices will have start and stop indices that range from 0 to size - 1

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -40,7 +40,7 @@ from hypothesis.strategies import emails
 
 if False:
     from datetime import tzinfo  # noqa
-    from typing import Any, Type, Optional, List, Text, Callable, Union  # noqa
+    from typing import Any, Dict, Type, Optional, List, Text, Callable, Union  # noqa
 
 
 # Mapping of field types, to strategy objects or functions of (type) -> strategy
@@ -66,7 +66,7 @@ _global_field_lookup = {
     df.NullBooleanField: st.one_of(st.none(), st.booleans()),
     df.URLField: urls(),
     df.UUIDField: st.uuids(),
-}
+}  # type: Dict[Any, Union[st.SearchStrategy, Callable[[Any], st.SearchStrategy]]]
 
 
 def register_for(field_type):
@@ -265,7 +265,7 @@ def from_field(field):
             if getattr(field, "null", False):
                 return st.none()
             raise InvalidArgument("Could not infer a strategy for %r", (field,))
-        strategy = _global_field_lookup[type(field)]
+        strategy = _global_field_lookup[type(field)]  # type: ignore
         if not isinstance(strategy, st.SearchStrategy):
             strategy = strategy(field)
     assert isinstance(strategy, st.SearchStrategy)

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
 
 
 if False:
-    from typing import Any, Union, Sequence, Set  # noqa
+    from typing import Any, List, Union, Sequence, Set  # noqa
     from hypothesis.searchstrategy.strategies import Ex  # noqa
 
 
@@ -341,6 +341,7 @@ def columns(
     fill=None,  # type: st.SearchStrategy[Ex]
     unique=False,  # type: bool
 ):
+    # type: (...) -> List[column]
     """A convenience function for producing a list of :class:`column` objects
     of the same general shape.
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/strategies.py
@@ -51,7 +51,7 @@ from hypothesis.internal.validation import check_type
 from hypothesis.utils.conventions import UniqueIdentifier
 
 try:
-    from typing import List, Callable, TypeVar, Generic, Optional  # noqa
+    from typing import Any, List, Callable, TypeVar, Generic, Optional  # noqa
 
     Ex = TypeVar("Ex", covariant=True)
     T = TypeVar("T")
@@ -348,7 +348,7 @@ class SearchStrategy(Generic[Ex]):
         return FlatMapStrategy(expand=expand, strategy=self)
 
     def filter(self, condition):
-        # type: (Callable[[Ex], bool]) -> SearchStrategy[Ex]
+        # type: (Callable[[Ex], Any]) -> SearchStrategy[Ex]
         """Returns a new strategy that generates values from this strategy
         which satisfy the provided condition. Note that if the condition is too
         hard to satisfy this might result in your tests failing with

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -37,7 +37,7 @@ def get_mypy_analysed_type(fname, val):
         encoding="utf-8",
         universal_newlines=True,
         # We set the MYPYPATH explicitly, because PEP561 discovery wasn't
-        # working in CI as of mypy==0.600 - hopefully a temporary workaround.
+        # working in CI as of mypy==0.730 - hopefully a temporary workaround.
         env=dict(os.environ, MYPYPATH=PYTHON_SRC),
     ).stdout.read()
     assert len(out.splitlines()) == 1
@@ -83,7 +83,7 @@ def test_revealed_types(tmpdir, val, expect):
 
 
 def test_data_object_type_tracing(tmpdir):
-    f = tmpdir.join("chech_mypy_on_st_data.py")
+    f = tmpdir.join("check_mypy_on_st_data.py")
     f.write(
         "from hypothesis.strategies import data, integers\n"
         "d = data().example()\n"


### PR DESCRIPTION
Closes #2071, with a slight change of plans - I've just gone through some manual inspection without writing automated tests, since it turns out that mypy still has trouble expressing Hypothesis' types.

So IMO this is patch is a nice improvement, but it's not worth doing much more with static typing at the moment.