### PR TITLE
Implement pytest.mark.parametrize detection. Fix #1996

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,8 +46,8 @@ jobs:
           TASK: check-py27-typing
         check-nose:
           TASK: check-nose
-        check-pytest30:
-          TASK: check-pytest30
+        check-pytest43:
+          TASK: check-pytest43
         check-django22:
           TASK: check-django22
         check-django21:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds a unique ID to the database key used for pytest parametrized tests. 
+
+Thanks to Peter C Kroon for the Hacktoberfest patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,12 @@
 RELEASE_TYPE: minor
 
-This patch adds a unique ID to the database key used for pytest parametrized tests. This also increases the minimum supported pytest version to 4.3.
+This release fixes a bug where our example database logic did not distinguish 
+between failing examples based on arguments from a ``@pytest.mark.parametrize(...)``.
+This could in theory cause data loss if a common failure overwrote a rare one, and
+in practice caused occasional file-access collisions in highly concurrent workloads
+(e.g. during a 300-way parametrize on 16 cores).
+
+For internal reasons this also involves bumping the minimum supported version of
+:pypi:`pytest` to 4.3
 
 Thanks to Peter C Kroon for the Hacktoberfest patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch adds a unique ID to the database key used for pytest parametrized tests. 
+This patch adds a unique ID to the database key used for pytest parametrized tests. This also increases the minimum supported pytest version to 4.3.
 
 Thanks to Peter C Kroon for the Hacktoberfest patch!

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -58,7 +58,7 @@ extras = {
     "lark": ["lark-parser>=0.6.5"],
     "numpy": ["numpy>=1.9.0"],
     "pandas": ["pandas>=0.19"],
-    "pytest": ["pytest>=3.0"],
+    "pytest": ["pytest>=4.3"],
     "dpcontracts": ["dpcontracts>=0.4"],
     # We only support Django versions with upstream support - see
     # https://www.djangoproject.com/download/#supported-versions

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -180,6 +180,10 @@ def pytest_collection_modifyitems(items):
             continue
         if is_hypothesis_test(item.obj):
             item.add_marker("hypothesis")
+            if item.get_closest_marker("parametrize") is not None:
+                item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = item.nodeid.encode(
+                    "utf-8"
+                )
         if getattr(item.obj, "is_hypothesis_strategy_function", False):
 
             def note_strategy_is_not_test(*args, **kwargs):

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -115,6 +115,12 @@ def pytest_runtest_call(item):
     if not (hasattr(item, "obj") and is_hypothesis_test(item.obj)):
         yield
     else:
+        if item.get_closest_marker("parametrize") is not None:
+            # Give every parametrized test invocation a unique database key
+            item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = item.nodeid.encode(
+                "utf-8"
+            )
+
         store = StoringReporter(item.config)
 
         def note_statistics(stats):
@@ -180,10 +186,6 @@ def pytest_collection_modifyitems(items):
             continue
         if is_hypothesis_test(item.obj):
             item.add_marker("hypothesis")
-            if item.get_closest_marker("parametrize") is not None:
-                item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = item.nodeid.encode(
-                    "utf-8"
-                )
         if getattr(item.obj, "is_hypothesis_strategy_function", False):
 
             def note_strategy_is_not_test(*args, **kwargs):

--- a/hypothesis-python/tests/pytest/test_compat.py
+++ b/hypothesis-python/tests/pytest/test_compat.py
@@ -19,8 +19,8 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from hypothesis.database import InMemoryExampleDatabase
 from hypothesis import given, settings
+from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.strategies import booleans
 
 
@@ -38,7 +38,8 @@ DB = InMemoryExampleDatabase()
 @pytest.mark.parametrize("hi", (1, 2, 3))
 @pytest.mark.xfail()
 def test_dummy_for_parametrized_db_keys(hi, i):
-    assert False  # Test *must* fail for it to end up the database anyway
+    assert i  # Test *must* fail for it to end up the database anyway
+    print(DB.data)
 
 
 def test_DB_keys_for_parametrized_test():

--- a/hypothesis-python/tests/pytest/test_compat.py
+++ b/hypothesis-python/tests/pytest/test_compat.py
@@ -19,7 +19,8 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from hypothesis import given
+from hypothesis.database import InMemoryExampleDatabase
+from hypothesis import given, settings
 from hypothesis.strategies import booleans
 
 
@@ -27,3 +28,19 @@ from hypothesis.strategies import booleans
 @pytest.mark.parametrize("hi", (1, 2, 3))
 def test_parametrize_after_given(hi, i):
     pass
+
+
+DB = InMemoryExampleDatabase()
+
+
+@settings(database=DB)
+@given(booleans())
+@pytest.mark.parametrize("hi", (1, 2, 3))
+@pytest.mark.xfail()
+def test_dummy_for_parametrized_db_keys(hi, i):
+    assert False  # Test *must* fail for it to end up the database anyway
+
+
+def test_DB_keys_for_parametrized_test():
+    print(DB.data)
+    assert len(DB.data) > 1

--- a/hypothesis-python/tests/pytest/test_parametrized_db_keys.py
+++ b/hypothesis-python/tests/pytest/test_parametrized_db_keys.py
@@ -15,6 +15,8 @@
 #
 # END HEADER
 
+from __future__ import absolute_import, division, print_function
+
 DB_KEY_TESTCASE = """
 from hypothesis import settings, given
 from hypothesis.database import InMemoryExampleDatabase

--- a/hypothesis-python/tests/pytest/test_parametrized_db_keys.py
+++ b/hypothesis-python/tests/pytest/test_parametrized_db_keys.py
@@ -15,15 +15,28 @@
 #
 # END HEADER
 
-from __future__ import absolute_import, division, print_function
-
+DB_KEY_TESTCASE = """
+from hypothesis import settings, given
+from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.strategies import booleans
 import pytest
 
-from hypothesis import given
-from hypothesis.strategies import booleans
+DB = InMemoryExampleDatabase()
 
 
+@settings(database=DB)
 @given(booleans())
 @pytest.mark.parametrize("hi", (1, 2, 3))
-def test_parametrize_after_given(hi, i):
-    pass
+@pytest.mark.xfail()
+def test_dummy_for_parametrized_db_keys(hi, i):
+    assert Fail  # Test *must* fail for it to end up the database anyway
+
+
+def test_DB_keys_for_parametrized_test():
+    assert len(DB.data) == 3
+"""
+
+
+def test_db_keys_for_parametrized_tests_are_unique(testdir):
+    script = testdir.makepyfile(DB_KEY_TESTCASE)
+    testdir.runpytest(script).assert_outcomes(xfailed=3, passed=1)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -148,11 +148,11 @@ deps =
 commands=
     nosetests tests/cover/test_testdecorators.py
 
-[testenv:pytest30]
+[testenv:pytest43]
 deps =
     -r../requirements/test.txt
 commands=
-    pip install pytest==3.0 pytest-xdist==1.24 pytest-forked==0.2
+    pip install pytest==4.3 pytest-xdist==1.25 pytest-forked==0.2
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -460,7 +460,7 @@ def standard_tox_task(name):
 
 
 standard_tox_task("nose")
-standard_tox_task("pytest30")
+standard_tox_task("pytest43")
 
 for n in [20, 21, 22, 111]:
     standard_tox_task("django%d" % (n,))


### PR DESCRIPTION
Detecting whether a pytest Item is parametrized turned out to be deceptively simple. However, I have trouble figuring out how to test this code. I can make a (parametrized) test that uses an InMemoryExampleDatabase, and look into it's state in a different test, but this does not seem to be a nice way forward.
Secondly, doing `item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = item.nodeid.encode("utf-8")` as proposed in the issue doesn't seem to produce the desired behaviour for some reason. 
I'll dig a bit further through the internals tomorrow.

Fixes #1996