### PR TITLE
Warn on tests that pollute global PRNG

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,20 @@
+RELEASE_TYPE: minor
+
+This release adds a warning for tests that set the global PRNG state, for example
+by using :func:`python:random.seed` without appropriate cleanup (:issue:`1919`).
+While convenient, this creates significant cross-test state and can substantially
+reduce Hypothesis' chances of finding new bugs over multiple runs!
+
+If you want deterministic Hypothesis tests - though we strongly recommend varied
+generation and :doc:`reproducing` instead - you can use the
+:obj:`~hypothesis.settings.derandomize` setting.  For other tests, the following
+idiom may be useful in a decorator, fixture, or context manager:
+
+.. code:: python
+
+    state = random.getstate()
+    random.seed(your_seed_here)
+    try:
+        yield
+    finally:
+        random.setstate(state)

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -36,6 +36,8 @@ VERBOSITY_OPTION = "--hypothesis-verbosity"
 PRINT_STATISTICS_OPTION = "--hypothesis-show-statistics"
 SEED_OPTION = "--hypothesis-seed"
 
+SOURCE_OF_GOOD_SEEDS = random.Random()
+
 
 class StoringReporter(object):
     def __init__(self, config):
@@ -132,8 +134,10 @@ def pytest_runtest_call(item):
             gathered_statistics[item.nodeid] = lines
             item.hypothesis_statistics = lines
 
-        # Peturb PRNG so that we can detect e.g. everything calling seed(0)
-        random.seed(random.randrange(2 ** 32))
+        # We start by peturbing the state of the PRNG, using a module-local Random
+        # instance.  Without this, repeatedly seeding shows as "no use of random"
+        # because the state before and after are always the same!
+        random.seed(SOURCE_OF_GOOD_SEEDS.randrange(2 ** 32))
         before = random.getstate()
 
         with collector.with_value(note_statistics):


### PR DESCRIPTION
We've accidentally done this twice now!  The warning here would have caught both those cases, and I expect it to warn about some similar user code downstream.

Note that this cannot detect a single seeded test or tests with unique seeds, but IMO that's an acceptable tradeoff for not needing to deal with persistent (e.g. cross-version) state issues.  Again, this detects our historical problems!

Closes #1919.