### PR TITLE
Attempt to unbreak build by using latest pip and pip-tools

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ export PYTHONPATH="$ROOT/tooling/src"
 
 if ! "$TOOL_PYTHON" -m hypothesistooling check-installed ; then
   rm -rf "$TOOL_VIRTUALENV"
+  "$PYTHON" -m pip install --upgrade pip
   "$PYTHON" -m pip install --upgrade virtualenv
   "$PYTHON" -m virtualenv "$TOOL_VIRTUALENV"
   "$TOOL_PYTHON" -m pip install --no-warn-script-location -r requirements/tools.txt

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -53,7 +53,7 @@ parso==0.5.1              # via jedi
 pbr==5.4.3                # via stevedore
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==4.1.0
+pip-tools==4.2.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.0            # via pytest, tox
 prompt-toolkit==2.0.10    # via ipython


### PR DESCRIPTION
The build on master is currently broken: https://travis-ci.org/HypothesisWorks/hypothesis/jobs/597671659#L649

This appears to be a mismatch between pip-tools (which uses internal pip APIs) and pip.

This PR does two things:

1. Manually bump the pip-tools to the latest version
2. Ensure when building our tools virtualenv we always use the latest pip

Hopefully that should both fix this mismatch and make them less likely in future.