### PR TITLE
Don't attempt to mess with tokenize.detect_encoding

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes some minor internal changes in support of improving the
+Hypothesis test suite. It should not have any user visible impact.

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -23,6 +23,7 @@ from functools import partial
 
 import pytest
 
+import hypothesis.internal.reflection as reflection
 from hypothesis.internal.compat import PY2, PY3, FullArgSpec, getfullargspec
 from hypothesis.internal.reflection import (
     arg_string,
@@ -693,32 +694,22 @@ def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
 
 
 @pytest.mark.skipif(PY2, reason="detect_encoding does not exist in Python 2")
-def test_can_render_lambda_with_no_encoding():
+def test_can_render_lambda_with_no_encoding(monkeypatch):
     is_positive = lambda x: x > 0
 
-    # Monkey-patching out the `tokenize.detect_encoding` method here means
+    # Monkey-patching out the `detect_encoding` method here means
     # that our reflection can't detect the encoding of the source file, and
     # has to fall back to assuming it's ASCII.
-    import tokenize
 
-    old_detect_encoding = tokenize.detect_encoding
-    try:
-        del tokenize.detect_encoding
-        assert get_pretty_function_description(is_positive) == "lambda x: x > 0"
-    finally:
-        tokenize.detect_encoding = old_detect_encoding
+    monkeypatch.setattr(reflection, "detect_encoding", None)
+    assert get_pretty_function_description(is_positive) == "lambda x: x > 0"
 
 
 @pytest.mark.skipif(PY2, reason="detect_encoding does not exist in Python 2")
-def test_does_not_crash_on_utf8_lambda_without_encoding():
-    # Monkey-patching out the `tokenize.detect_encoding` method here means
+def test_does_not_crash_on_utf8_lambda_without_encoding(monkeypatch):
+    # Monkey-patching out the `detect_encoding` method here means
     # that our reflection can't detect the encoding of the source file, and
     # has to fall back to assuming it's ASCII.
-    import tokenize
 
-    old_detect_encoding = tokenize.detect_encoding
-    try:
-        del tokenize.detect_encoding
-        assert get_pretty_function_description(is_str_pi) == "lambda x: <unknown>"
-    finally:
-        tokenize.detect_encoding = old_detect_encoding
+    monkeypatch.setattr(reflection, "detect_encoding", None)
+    assert get_pretty_function_description(is_str_pi) == "lambda x: <unknown>"


### PR DESCRIPTION
Turns out some of our reflection tests fail if you run them first. Why? Because we mess with `tokenize.detect_encoding` for our own sakes, but it turns out that the standard library *most unreasonably* expects to be able to call that function too. If the tests run later then the line cache is already populated and it's not needed, but if the tests run first then the `inspect` module needs to be able to `detect_encoding` and we can't.

This fixes that by giving us a copy of `detect_encoding` local to the reflection module that we can mess with without stepping on the standard library's toes.

(The things you find when you run the Hypothesis build with `-n40`...)