### PR TITLE
Remove many of our Travis build tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,24 +30,16 @@ env:
 
 jobs:
   include:
-    # Prechecks that we want to run first.
+    # Prechecks that we want to run to make sure the deploy is good.
     - stage: precheck
       env: TASK=check-whole-repo-tests
     - env: TASK=lint
     - env: TASK=lint-ruby
-    - env: TASK=check-format
     - env: TASK=check-rust-tests
-
-    - stage: main
-      env: TASK=check-coverage
-    - env: TASK=check-py27
+    - env: TASK=check-ruby-tests
     - env: TASK=check-py36
       sudo: required
       dist: xenial
-    - env: TASK=check-ruby-tests
-    - env: TASK=check-django111
-    - env: TASK=check-pandas24
-
     - stage: deploy
       env: TASK=deploy
 
@@ -59,8 +51,7 @@ matrix:
 
 stages:
     - precheck
-    - main
-    - extras
+      if: type = push
     - name: deploy
       if: type = push
 


### PR DESCRIPTION
Travis is now very much the bottleneck on our pull requests, and all of its tasks are also runnning on Azure. Currently we only really care about it because it still manages our releases.

This PR guts our Travis build in two ways:

* It removes a bunch of tasks we don't really need to run on Travis (and unifies the main and precheck stages as a result)
* It restricts the rest to only run on master builds rather than pull requests. 

This should significantly speed up our PR workflows.