### PR TITLE
Remove if check on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ matrix:
 
 stages:
     - precheck
-      if: type = push
     - name: deploy
       if: type = push
 


### PR DESCRIPTION
Apparently #2140 broke master builds (or Travis is being flaky): https://github.com/HypothesisWorks/hypothesis/pull/2140#discussion_r335457825

This PR removes the condition on our prechecks so they always run. This *shouldn't* be necessary, but maybe it will help? I've already unmarked Travis as required for merge so we'll still get most of the benefits.