### PR TITLE
Remove one final use of md5

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -255,6 +255,7 @@ their individual contributions.
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Paul Ganssle <https://ganssle.io>`_ (paul@ganssle.io)
+* `Paul Kehrer <https://github.com/reaperhulk>`_
 * `Paul Lorett Amazona <https://github.com/whatevergeek>`_
 * `Paul Stiverson <https://github.com/thismatters>`_
 * `Peadar Coyle <https://github.com/springcoil>`_ (peadarcoyle@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch changes a final internal use of MD5 to SHA384 hashes, to better
-support users subject to FIPS-140. There is no user-visible or API change.
+This patch changes some internal hashes to SHA384, to better support
+users subject to FIPS-140. There is no user-visible API change.
+
+Thanks to Paul Kehrer for this contribution!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch changes a final internal use of MD5 to SHA384 hashes, to better
+support users subject to FIPS-140. There is no user-visible or API change.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, division, print_function
 import binascii
 import os
 import warnings
-from hashlib import sha1
+from hashlib import sha384
 
 from hypothesis.configuration import mkdir_p, storage_directory
 from hypothesis.errors import HypothesisException, HypothesisWarning
@@ -139,7 +139,7 @@ class InMemoryExampleDatabase(ExampleDatabase):
 
 
 def _hash(key):
-    return sha1(key).hexdigest()[:16]
+    return sha384(key).hexdigest()[:16]
 
 
 class DirectoryBasedExampleDatabase(ExampleDatabase):
@@ -163,7 +163,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         return directory
 
     def _value_path(self, key, value):
-        return os.path.join(self._key_path(key), sha1(value).hexdigest()[:16])
+        return os.path.join(self._key_path(key), sha384(value).hexdigest()[:16])
 
     def fetch(self, key):
         kp = self._key_path(key)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -490,7 +490,7 @@ def source_exec_as_module(source):
 
     result = ModuleType(
         "hypothesis_temporary_module_%s"
-        % (hashlib.sha1(str_to_bytes(source)).hexdigest(),)
+        % (hashlib.sha384(str_to_bytes(source)).hexdigest(),)
     )
     assert isinstance(source, str)
     exec(source, result.__dict__)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -82,7 +82,7 @@ def function_digest(function):
 
     No guarantee of uniqueness though it usually will be.
     """
-    hasher = hashlib.md5()
+    hasher = hashlib.sha384()
     try:
         hasher.update(to_unicode(inspect.getsource(function)).encode("utf-8"))
     # Different errors on different versions of python. What fun.

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -848,6 +848,12 @@ def test_test_basic_indices_can_generate_long_ellipsis():
     )
 
 
+@given(nps.basic_indices(shape=(0, 0, 0, 0, 0)).filter(lambda idx: Ellipsis in idx))
+def test_test_basic_indices_replaces_whole_axis_slices_with_ellipsis(idx):
+    # If ... is in the slice, it replaces all ,:, entries for this shape.
+    assert slice(None) not in idx
+
+
 @given(
     shape=nps.array_shapes(min_dims=0, max_side=4)
     | nps.array_shapes(min_dims=0, min_side=0, max_side=10),

--- a/whole-repo-tests/test_security.py
+++ b/whole-repo-tests/test_security.py
@@ -23,4 +23,5 @@ from hypothesistooling.scripts import pip_tool
 
 def test_bandit_passes_on_hypothesis():
     # pypi.org/project/bandit has the table of error codes, or `bandit --help`
-    pip_tool("bandit", "--skip", "B101,B102,B110,B303,B311", "--recursive", PYTHON_SRC)
+    # Note that e.g. the hash type is important for users subject to FIPS-140.
+    pip_tool("bandit", "--skip=B101,B102,B110,B311", "--recursive", PYTHON_SRC)


### PR DESCRIPTION
FIPS 140-2 is an obnoxious mistress, but SHA384 is a fine replacement for an MD5 even in circumstances where you don't hugely care about cryptographic security.