### PR TITLE
Write a JOSS paper for Hypothesis

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -170,4 +170,37 @@ Bdsk-Url-1 = {https://doi.org/10.3847/1538-3881/aabc4f}}
   bibsource = {dblp computer science bibliography, https://dblp.org}
 }
 
+@inproceedings{DBLP:conf/issta/LoscherS17,
+  author    = {Andreas L{\"{o}}scher and
+               Konstantinos Sagonas},
+  title     = {Targeted property-based testing},
+  booktitle = {Proceedings of the 26th {ACM} {SIGSOFT} International Symposium on
+               Software Testing and Analysis, Santa Barbara, CA, USA, July 10 - 14,
+               2017},
+  pages     = {46--56},
+  year      = {2017},
+  crossref  = {DBLP:conf/issta/2017},
+  url       = {https://doi.org/10.1145/3092703.3092711},
+  doi       = {10.1145/3092703.3092711},
+  timestamp = {Wed, 25 Sep 2019 18:08:21 +0200},
+  biburl    = {https://dblp.org/rec/bib/conf/issta/LoscherS17},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@proceedings{DBLP:conf/issta/2017,
+  editor    = {Tevfik Bultan and
+               Koushik Sen},
+  title     = {Proceedings of the 26th {ACM} {SIGSOFT} International Symposium on
+               Software Testing and Analysis, Santa Barbara, CA, USA, July 10 - 14,
+               2017},
+  publisher = {{ACM}},
+  year      = {2017},
+  url       = {https://doi.org/10.1145/3092703},
+  doi       = {10.1145/3092703},
+  isbn      = {978-1-4503-5076-1},
+  timestamp = {Tue, 06 Nov 2018 16:57:30 +0100},
+  biburl    = {https://dblp.org/rec/bib/conf/issta/2017},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
 

--- a/paper.bib
+++ b/paper.bib
@@ -1,0 +1,173 @@
+@inproceedings{DBLP:conf/icfp/ClaessenH00,
+  author    = {Koen Claessen and
+               John Hughes},
+  title     = {QuickCheck: a lightweight tool for random testing of Haskell programs},
+  booktitle = {Proceedings of the Fifth {ACM} {SIGPLAN} International Conference
+               on Functional Programming {(ICFP} '00), Montreal, Canada, September
+               18-21, 2000.},
+  pages     = {268--279},
+  year      = {2000},
+  crossref  = {DBLP:conf/icfp/2000},
+  url       = {https://doi.org/10.1145/351240.351266},
+  doi       = {10.1145/351240.351266},
+  timestamp = {Tue, 06 Nov 2018 16:59:25 +0100},
+  biburl    = {https://dblp.org/rec/bib/conf/icfp/ClaessenH00},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@proceedings{DBLP:conf/icfp/2000,
+  editor    = {Martin Odersky and
+               Philip Wadler},
+  title     = {Proceedings of the Fifth {ACM} {SIGPLAN} International Conference
+               on Functional Programming {(ICFP} '00), Montreal, Canada, September
+               18-21, 2000},
+  publisher = {{ACM}},
+  year      = {2000},
+  isbn      = {1-58113-202-6},
+  timestamp = {Tue, 11 Jun 2013 13:51:25 +0200},
+  biburl    = {https://dblp.org/rec/bib/conf/icfp/2000},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@inproceedings{DBLP:conf/erlang/ArtsHJW06,
+  author    = {Thomas Arts and
+               John Hughes and
+               Joakim Johansson and
+               Ulf T. Wiger},
+  title     = {Testing telecoms software with quviq QuickCheck},
+  booktitle = {Proceedings of the 2006 {ACM} {SIGPLAN} Workshop on Erlang, Portland,
+               Oregon, USA, September 16, 2006},
+  pages     = {2--10},
+  year      = {2006},
+  crossref  = {DBLP:conf/erlang/2006},
+  url       = {https://doi.org/10.1145/1159789.1159792},
+  doi       = {10.1145/1159789.1159792},
+  timestamp = {Tue, 06 Nov 2018 16:59:37 +0100},
+  biburl    = {https://dblp.org/rec/bib/conf/erlang/ArtsHJW06},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@proceedings{DBLP:conf/erlang/2006,
+  editor    = {Marc Feeley and
+               Philip W. Trinder},
+  title     = {Proceedings of the 2006 {ACM} {SIGPLAN} Workshop on Erlang, Portland,
+               Oregon, USA, September 16, 2006},
+  publisher = {{ACM}},
+  year      = {2006},
+  isbn      = {1-59593-490-1},
+  timestamp = {Wed, 02 Apr 2008 10:59:25 +0200},
+  biburl    = {https://dblp.org/rec/bib/conf/erlang/2006},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@misc{PraiseOfPBT,
+  title = {In Praise of Property-Bsed Testing},
+  howpublished = {\url{https://increment.com/testing/in-praise-of-property-based-testing/}},
+  year={2019},
+  author={David R. MacIver},
+}
+
+@article{DBLP:journals/tse/ZellerH02,
+  author    = {Andreas Zeller and
+               Ralf Hildebrandt},
+  title     = {Simplifying and Isolating Failure-Inducing Input},
+  journal   = {{IEEE} Trans. Software Eng.},
+  volume    = {28},
+  number    = {2},
+  pages     = {183--200},
+  year      = {2002},
+  url       = {https://doi.org/10.1109/32.988498},
+  doi       = {10.1109/32.988498},
+  timestamp = {Wed, 14 Nov 2018 10:49:20 +0100},
+  biburl    = {https://dblp.org/rec/bib/journals/tse/ZellerH02},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@inproceedings{DBLP:conf/pldi/RegehrCCEEY12,
+  author    = {John Regehr and
+               Yang Chen and
+               Pascal Cuoq and
+               Eric Eide and
+               Chucky Ellison and
+               Xuejun Yang},
+  title     = {Test-case reduction for {C} compiler bugs},
+  booktitle = {{ACM} {SIGPLAN} Conference on Programming Language Design and Implementation,
+               {PLDI} '12, Beijing, China - June 11 - 16, 2012},
+  pages     = {335--346},
+  year      = {2012},
+  crossref  = {DBLP:conf/pldi/2012},
+  url       = {https://doi.org/10.1145/2254064.2254104},
+  doi       = {10.1145/2254064.2254104},
+  timestamp = {Wed, 14 Nov 2018 10:54:59 +0100},
+  biburl    = {https://dblp.org/rec/bib/conf/pldi/RegehrCCEEY12},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+@proceedings{DBLP:conf/pldi/2012,
+  editor    = {Jan Vitek and
+               Haibo Lin and
+               Frank Tip},
+  title     = {{ACM} {SIGPLAN} Conference on Programming Language Design and Implementation,
+               {PLDI} '12, Beijing, China - June 11 - 16, 2012},
+  publisher = {{ACM}},
+  year      = {2012},
+  url       = {http://dl.acm.org/citation.cfm?id=2254064},
+  isbn      = {978-1-4503-1205-9},
+  timestamp = {Tue, 12 Jun 2012 19:17:55 +0200},
+  biburl    = {https://dblp.org/rec/bib/conf/pldi/2012},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+
+@article{astropy:2013,
+Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+Adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A},
+Archiveprefix = {arXiv},
+Author = {{Astropy Collaboration} and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Greenfield}, P. and {Droettboom}, M. and {Bray}, E. and {Aldcroft}, T. and {Davis}, M. and {Ginsburg}, A. and {Price-Whelan}, A.~M. and {Kerzendorf}, W.~E. and {Conley}, A. and {Crighton}, N. and {Barbary}, K. and {Muna}, D. and {Ferguson}, H. and {Grollier}, F. and {Parikh}, M.~M. and {Nair}, P.~H. and {Unther}, H.~M. and {Deil}, C. and {Woillez}, J. and {Conseil}, S. and {Kramer}, R. and {Turner}, J.~E.~H. and {Singer}, L. and {Fox}, R. and {Weaver}, B.~A. and {Zabalza}, V. and {Edwards}, Z.~I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and {Casey}, A.~R. and {Crawford}, S.~M. and {Dencheva}, N. and {Ely}, J. and {Jenness}, T. and {Labrie}, K. and {Lim}, P.~L. and {Pierfederici}, F. and {Pontzen}, A. and {Ptak}, A. and {Refsdal}, B. and {Servillat}, M. and {Streicher}, O.},
+Doi = {10.1051/0004-6361/201322068},
+Eid = {A33},
+Eprint = {1307.6212},
+Journal = {\aap},
+Keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+Month = oct,
+Pages = {A33},
+Primaryclass = {astro-ph.IM},
+Title = {{Astropy: A community Python package for astronomy}},
+Volume = 558,
+Year = 2013,
+Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}
+
+@article{astropy:2018,
+Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+Adsurl = {https://ui.adsabs.harvard.edu/#abs/2018AJ....156..123T},
+Author = {{Price-Whelan}, A.~M. and {Sip{\H{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and {de Val-Borro}, M. and {Paper Contributors}, (Primary and {Aldcroft}, T.~L. and {Cruz}, K.~L. and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Coordination Committee}, (Astropy and {Ardelean}, C. and {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and {Corrales}, L. and {Crichton}, D. and {D{\textquoteright}Avella}, D. and {Deil}, C. and {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and {Ma}, Z. and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and {Zabalza}, V. and {Contributors}, (Astropy},
+Doi = {10.3847/1538-3881/aabc4f},
+Eid = {123},
+Journal = {\aj},
+Keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
+Month = Sep,
+Pages = {123},
+Primaryclass = {astro-ph.IM},
+Title = {{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}},
+Volume = {156},
+Year = 2018,
+Bdsk-Url-1 = {https://doi.org/10.3847/1538-3881/aabc4f}}
+
+@article{DBLP:journals/cse/WaltCV11,
+  author    = {St{\'{e}}fan van der Walt and
+               S. Chris Colbert and
+               Ga{\"{e}}l Varoquaux},
+  title     = {The NumPy Array: {A} Structure for Efficient Numerical Computation},
+  journal   = {Computing in Science and Engineering},
+  volume    = {13},
+  number    = {2},
+  pages     = {22--30},
+  year      = {2011},
+  url       = {https://doi.org/10.1109/MCSE.2011.37},
+  doi       = {10.1109/MCSE.2011.37},
+  timestamp = {Wed, 14 Nov 2018 10:48:31 +0100},
+  biburl    = {https://dblp.org/rec/bib/journals/cse/WaltCV11},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+

--- a/paper.md
+++ b/paper.md
@@ -45,12 +45,9 @@ and to software testing researchers as a platform for research in its own right.
 # Hypothesis for Testing Scientific Software
 
 Python has a rich and thriving ecosystem of scientific software, and Hypothesis is helpful for ensuring its correctness.
-This is particularly useful for foundational libraries on which the scientific software ecosystem is built,
-but any researcher who tests their software in Python can benefit from these facilities. 
-
-For example, it has found bugs in astropy [@astropy:2018] and numpy [@DBLP:journals/cse/WaltCV11],
-both of which are foundational libraries on which a significant amount of research is based.
-In particular it has proven very effective at finding numerical stability issues in such software.
+Any researcher who tests their software in Python can benefit from these facilities,
+but it is particularly useful for improving the correctness foundational libraries on which the scientific software ecosystem is built.
+For example, it has found bugs in astropy [@astropy:2018]^[e.g. https://github.com/astropy/astropy/pull/9328, https://github.com/astropy/astropy/pull/9532] and numpy [@DBLP:journals/cse/WaltCV11]^[e.g. https://github.com/numpy/numpy/issues/10930, https://github.com/numpy/numpy/issues/13089, https://github.com/numpy/numpy/issues/14239].
 
 Additionally, Hypothesis is easily extensible, and has a number of user-provided exceptions for specific research applications.
 For example, hypothesis-networkx^[https://pypi.org/project/hypothesis-networkx/] generates graph data structures,

--- a/paper.md
+++ b/paper.md
@@ -37,8 +37,9 @@ tests specify properties that hold for a wide range of inputs,
 which the testing library then attempts to generate test cases to refute.
 For a general introduction to property-based testing, see [@PraiseOfPBT].
 
-Hypothesis is a mature and widely used^[It has over 100,000 downloads per week, over a thousand open source projects use it, and in 2018 more than 4% of Python users surveyed by the PSF reported using it.] property-based testing library for Python,
-and is one of very few widely used examples of such a library outside of functional programming languages.
+Hypothesis is a mature and widely used property-based testing library for Python.
+It has over 100,000 downloads per week^[https://pypistats.org/packages/hypothesis], thousands of open source projects use it^[https://github.com/HypothesisWorks/hypothesis/network/dependents],
+and in 2018 more than 4% of Python users surveyed by the PSF reported using it^[https://www.jetbrains.com/research/python-developers-survey-2018/].
 It will be of interest both to researchers using Python for developing scientific software,
 and to software testing researchers as a platform for research in its own right.
 

--- a/paper.md
+++ b/paper.md
@@ -21,7 +21,7 @@ authors:
 affiliations:
   - name: Imperial College London
     index: 1
-  - name: Australian National University: Canberra
+  - name: Australian National University
     index: 2
   - name: Various
     index: 3

--- a/paper.md
+++ b/paper.md
@@ -48,7 +48,7 @@ Python has a rich and thriving ecosystem of scientific software, and Hypothesis 
 This is particularly useful for foundational libraries on which the scientific software ecosystem is built,
 but any researcher who tests their software in Python can benefit from these facilities. 
 
-For example, it has found bugs in astropy ([@astropy:2018]) and numpy ([@DBLP:journals/cse/WaltCV11]),
+For example, it has found bugs in astropy [@astropy:2018] and numpy [@DBLP:journals/cse/WaltCV11],
 both of which are foundational libraries on which a significant amount of research is based.
 In particular it has proven very effective at finding numerical stability issues in such software.
 
@@ -76,7 +76,7 @@ Particular subproblems of this are:
 3. How do we generate human readable test cases?
  
 Traditionally property-based testing has adopted random test-case generation to find interesting test cases,
-followed by test-case reduction (see [@DBLP:conf/pldi/RegehrCCEEY12, DBLP:journals/tse/ZellerH02]) to turn them into human readable ones,
+followed by test-case reduction (see @DBLP:conf/pldi/RegehrCCEEY12, @DBLP:journals/tse/ZellerH02) to turn them into more human readable ones,
 requiring the users to manually specify a *validity oracle* (a predicate that identifies if an arbitrary test case is valid) to avoid invalid test cases.
 
 The chief limitations of this from a user's point of view are that writing correct validity oracles is difficult and annoying,
@@ -96,7 +96,7 @@ and improvements to the generation process can operate solely on this universal 
 Currently Hypothesis uses this format to support two major use cases:
 
 1. It is the basis of its approach to test-case reduction, allowing it to support more powerful test-case reduction than is found in most property-based testing libraries with no user intervention.
-2. It supports Targeted Property-Based Testing ([@DBLP:conf/issta/LoscherS17]), which uses a score to guide testing towards a particular goal (e.g. maximising an error term). Normally this would require custom mutation operators per test.
+2. It supports Targeted Property-Based Testing [@DBLP:conf/issta/LoscherS17], which uses a score to guide testing towards a particular goal (e.g. maximising an error term). Normally this would require custom mutation operators per test.
 
 The internal format is flexible and contains rich information about the structure of generated test cases,
 so it is likely future versions of the software will see other features built on top of it,

--- a/paper.md
+++ b/paper.md
@@ -13,6 +13,7 @@ authors:
     - name: David R. MacIver
       orcid: 0000-0002-8635-3223
     - name: Zac Hatfield Dodds
+      orcid: 0000-0002-8646-8362
 
 ---
 

--- a/paper.md
+++ b/paper.md
@@ -12,9 +12,19 @@ authors:
 
     - name: David R. MacIver
       orcid: 0000-0002-8635-3223
+      affiliation: 1
     - name: Zac Hatfield Dodds
       orcid: 0000-0002-8646-8362
+      affiliation: 2
     - name: many other contributors
+affiliations:
+  - name: Imperial College London
+    index: 1
+  - name: Australian National University: Canberra
+    index: 2
+date: 11 November 2019
+bibliography: paper.bib
+
 ---
 
 # Summary

--- a/paper.md
+++ b/paper.md
@@ -47,6 +47,9 @@ For example, hypothesis-networkx^[https://pypi.org/project/hypothesis-networkx/]
 and hypothesis-bio^[https://pypi.org/project/hypothesis-bio/] generates formats suitable for bioinformatics.
 As it is used by more researchers, the number of research applications will only increase.
 
+By lowering the barrier to effective testing significantly, Hypothesis makes testing of research software written in Python much more compelling,
+and has the potential to significantly improve the quality of the associated scientific research as a result.
+
 # Hypothesis for Software Testing Research
 
 This is true both because of the much wider array of software that can now easily be tested with property-based testing,

--- a/paper.md
+++ b/paper.md
@@ -27,7 +27,7 @@ tests specify properties that hold for a wide range of inputs,
 which the testing library then attempts to generate test cases to refute.
 For a general introduction to property-based testing, see [@PraiseOfPBT].
 
-Hypothesis is a mature and widely used^[It has over 100,000 downloads per week, over a thousands open source projects use it, and in 2018 the more than 4% of Python users surveyed by the PSF reported using it.] property-based testing library for Python,
+Hypothesis is a mature and widely used^[It has over 100,000 downloads per week, over a thousand open source projects use it, and in 2018 more than 4% of Python users surveyed by the PSF reported using it.] property-based testing library for Python,
 and is one of very few widely used examples of such a library outside of functional programming languages.
 It will be of interest both to researchers using Python for developing scientific software,
 and to software testing researchers as a platform for research in its own right.

--- a/paper.md
+++ b/paper.md
@@ -12,7 +12,7 @@ authors:
     - name: David R. MacIver
       orcid: 0000-0002-8635-3223
       affiliation: 1
-    - name: Zac Hatfield Dodds
+    - name: Zac Hatfield-Dodds
       orcid: 0000-0002-8646-8362
       affiliation: 2
     - name: many other contributors

--- a/paper.md
+++ b/paper.md
@@ -14,7 +14,7 @@ authors:
       orcid: 0000-0002-8635-3223
     - name: Zac Hatfield Dodds
       orcid: 0000-0002-8646-8362
-
+    - name: many other contributors
 ---
 
 # Summary

--- a/paper.md
+++ b/paper.md
@@ -27,7 +27,7 @@ which the testing library then attempts to generate test cases to refute.
 For a general introduction to property-based testing, see [@PraiseOfPBT].
 
 Hypothesis is a mature property-based testing library for Python,
-and is one of very few widely used examples of such a library outside of functional programming languages,
+and is one of very few widely used examples of such a library outside of functional programming languages.
 It will be of interest both to researchers using Python for developing scientific software,
 and to software testing researchers as a platform for research in its own right.
 

--- a/paper.md
+++ b/paper.md
@@ -66,7 +66,7 @@ Much of software testing research boils down to variants on the following proble
 Given some interestingness test (e.g. that it triggers a bug in some software),
 how do we generate a "good" test case that passes that interestingness test?
 
-Particular subproblems of this are:
+Particular sub-problems of this are:
 
 1. How do we generate test cases that satisfy difficult interestingness tests?
 2. How do we ensure we generate only valid test cases? (the *test-case validity problem* - see @DBLP:conf/pldi/RegehrCCEEY12)
@@ -76,10 +76,11 @@ Traditionally property-based testing has adopted random test-case generation to 
 followed by test-case reduction (see @DBLP:conf/pldi/RegehrCCEEY12, @DBLP:journals/tse/ZellerH02) to turn them into more human readable ones,
 requiring the users to manually specify a *validity oracle* (a predicate that identifies if an arbitrary test case is valid) to avoid invalid test cases.
 
-The chief limitations of this from a user's point of view are that writing correct validity oracles is difficult and annoying,
-and that random generation, while often much better than hand-written examples, is not especially good at satisfying difficult properties.
-Fortunately it is very easy to define correct random generators,
-and the users can then defer the rest of the work until their tests start finding bugs, when they are more likely to be willing to do the work.
+The chief limitations of this from a user's point of view are:
+
+* Writing correct validity oracles is difficult and annoying.
+* Random generation, while often much better than hand-written examples, is not especially good at satisfying difficult properties.
+* Writing test-case reducers that work well for your problem domain is a specialised skill that few people have or want to acquire.
 
 The chief limitation from a researcher's point of view is that trying to improve on random generation's ability to find bugs will typically require modification of existing tests to support new ways of generating data,
 and typically these modifications are significantly more complex than writing the random generator would have been.
@@ -87,13 +88,14 @@ Users are rarely going to be willing to undertake the work themselves,
 which leaves researchers in the unfortunate position of having to put in a significant amount of work per project to understand how to test it.
 
 Hypothesis avoids both of these problems by using a single universal representation for test cases.
-Ensuring that test cases produced from this format are valid is relatively easy, no more difficult than ensuring that randomly generated tests cases are valid at least,
+Ensuring that test cases produced from this format are valid is relatively easy, no more difficult than ensuring that randomly generated tests cases are valid,
 and improvements to the generation process can operate solely on this universal representation rather than requiring adapting to each test.
 
 Currently Hypothesis uses this format to support two major use cases:
 
 1. It is the basis of its approach to test-case reduction, allowing it to support more powerful test-case reduction than is found in most property-based testing libraries with no user intervention.
-2. It supports Targeted Property-Based Testing [@DBLP:conf/issta/LoscherS17], which uses a score to guide testing towards a particular goal (e.g. maximising an error term). Normally this would require custom mutation operators per test.
+2. It supports Targeted Property-Based Testing [@DBLP:conf/issta/LoscherS17], which uses a score to guide testing towards a particular goal (e.g. maximising an error term). In the original implementation this would require custom mutation operators per test,
+   but in Hypothesis this mutation is transparent to the user and they need only specify the goal.
 
 The internal format is flexible and contains rich information about the structure of generated test cases,
 so it is likely future versions of the software will see other features built on top of it,

--- a/paper.md
+++ b/paper.md
@@ -47,7 +47,7 @@ For example, hypothesis-networkx^[https://pypi.org/project/hypothesis-networkx/]
 and hypothesis-bio^[https://pypi.org/project/hypothesis-bio/] generates formats suitable for bioinformatics.
 As it is used by more researchers, the number of research applications will only increase.
 
-By lowering the barrier to effective testing significantly, Hypothesis makes testing of research software written in Python much more compelling,
+By lowering the barrier to effective testing, Hypothesis makes testing of research software written in Python much more compelling,
 and has the potential to significantly improve the quality of the associated scientific research as a result.
 
 # Hypothesis for Software Testing Research

--- a/paper.md
+++ b/paper.md
@@ -1,15 +1,14 @@
 ---
-
 title: 'Hypothesis: A new approach to property-based testing'
+date: 1 November 2019
+bibliography: paper.bib
 tags:
     - Python
     - testing
     - test-case reduction
     - test-case generation
     - property-based testing
-
 authors:
-
     - name: David R. MacIver
       orcid: 0000-0002-8635-3223
       affiliation: 1
@@ -19,15 +18,12 @@ authors:
     - name: many other contributors
       affiliation: 3
 affiliations:
-  - name: Imperial College London
-    index: 1
-  - name: Australian National University
-    index: 2
-  - name: Various
-    index: 3
-date: 11 November 2019
-bibliography: paper.bib
-
+    - name: Imperial College London
+      index: 1
+    - name: Australian National University
+      index: 2
+    - name: Various
+      index: 3
 ---
 
 # Summary

--- a/paper.md
+++ b/paper.md
@@ -17,11 +17,14 @@ authors:
       orcid: 0000-0002-8646-8362
       affiliation: 2
     - name: many other contributors
+      affiliation: 3
 affiliations:
   - name: Imperial College London
     index: 1
   - name: Australian National University: Canberra
     index: 2
+  - name: Various
+    index: 3
 date: 11 November 2019
 bibliography: paper.bib
 

--- a/paper.md
+++ b/paper.md
@@ -1,0 +1,91 @@
+---
+
+title: 'Hypothesis: A new approach to property-based testing'
+tags:
+    - Python
+    - testing
+    - test-case reduction
+    - test-case generation
+    - property-based testing
+
+authors:
+
+    - name: David R. MacIver
+      orcid: 0000-0002-8635-3223
+    - name: Zac Hatfield Dodds
+
+---
+
+# Summary
+
+*Property-based testing* is a style of testing popularised by the QuickCheck family of libraries,
+first in Haskell [@DBLP:conf/icfp/ClaessenH00] and later in Erlang [@DBLP:conf/erlang/ArtsHJW06],
+which integrates generated test cases into existing software testing workflows:
+Instead of tests which provide examples of a single concrete behaviour,
+tests specify properties that hold for a wide range of inputs,
+which the testing library then attempts to generate test cases to refute.
+For a general introduction to property-based testing, see [@PraiseOfPBT].
+
+Hypothesis is a mature property-based testing library for Python,
+and is one of very few widely used examples of such a library outside of functional programming languages,
+It will be of interest both to researchers using Python for developing scientific software,
+and to software testing researchers as a platform for research in its own right.
+
+# Hypothesis for Testing Scientific Software
+
+Python has a rich and thriving ecosystem of scientific software, and Hypothesis is helpful for ensuring its correctness.
+This is particularly useful for foundational libraries on which the scientific software ecosystem is built,
+but any researcher who tests their software in Python can benefit from these facilities. 
+
+For example, it has found bugs in astropy ([@astropy:2018]) and numpy ([@DBLP:journals/cse/WaltCV11]),
+both of which are foundational libraries on which a significant amount of research is based.
+In particular it has proven very effective at finding numerical stability issues in such software.
+
+Additionally, Hypothesis is easily extensible, and has a number of user-provided exceptions for specific research applications.
+For example, hypothesis-networkx^[https://pypi.org/project/hypothesis-networkx/] generates graph data structures,
+and hypothesis-bio^[https://pypi.org/project/hypothesis-bio/] generates formats suitable for bioinformatics.
+As it is used by more researchers, the number of research applications will only increase.
+
+# Hypothesis for Software Testing Research
+
+This is true both because of the much wider array of software that can now easily be tested with property-based testing,
+and because it has a novel implementation that lifts a major difficulty that prior research on software testing faces.
+
+Much of software testing research boils down to variants on the following problem:
+Given some interestingness test (e.g. that it triggers a bug in some software),
+how do we generate a "good" test case that passes that interestingness test?
+
+Particular subproblems of this are:
+
+1. How do we generate test cases that satisfy difficult interestingness tests?
+2. How do we ensure we generate only valid test cases? (the *test-case validity problem* - see @DBLP:conf/pldi/RegehrCCEEY12)
+3. How do we generate human readable test cases?
+ 
+Traditionally property-based testing has adopted random test-case generation to find interesting test cases,
+followed by test-case reduction (see [@DBLP:conf/pldi/RegehrCCEEY12, DBLP:journals/tse/ZellerH02]) to turn them into human readable ones,
+requiring the users to manually specify a *validity oracle* (a predicate that identifies if an arbitrary test case is valid) to avoid invalid test cases.
+
+The chief limitations of this from a user's point of view are that writing correct validity oracles is difficult and annoying,
+and that random generation, while often much better than hand-written examples, is not especially good at satisfying difficult properties.
+Fortunately it is very easy to define correct random generators,
+and the users can then defer the rest of the work until their tests start finding bugs, when they are more likely to be willing to do the work.
+
+The chief limitation from a researcher's point of view is that trying to improve on random generation's ability to find bugs will typically require modification of existing tests to support new ways of generating data,
+and typically these modifications are significantly more complex than writing the random generator would have been.
+Users are rarely going to be willing to undertake the work themselves,
+which leaves researchers in the unfortunate position of having to put in a significant amount of work per project to understand how to test it.
+
+Hypothesis avoids both of these problems by using a single universal representation for test cases.
+Ensuring that test cases produced from this format are valid is relatively easy, no more difficult than ensuring that randomly generated tests cases are valid at least,
+and improvements to the generation process can operate solely on this universal representation rather than requiring adapting to each test.
+
+Currently Hypothesis uses this format to support two major use cases:
+
+1. It is the basis of its approach to test-case reduction, allowing it to support more powerful test-case reduction than is found in most property-based testing libraries with no user intervention.
+2. It supports Targeted Property-Based Testing ([@DBLP:conf/issta/LoscherS17]), which uses a score to guide testing towards a particular goal (e.g. maximising an error term). Normally this would require custom mutation operators per test.
+
+The internal format is flexible and contains rich information about the structure of generated test cases,
+so it is likely future versions of the software will see other features built on top of it,
+and we hope researchers will use it as a vehicle to explore other interesting possibilities for test-case generation.
+
+# References

--- a/paper.md
+++ b/paper.md
@@ -27,7 +27,7 @@ tests specify properties that hold for a wide range of inputs,
 which the testing library then attempts to generate test cases to refute.
 For a general introduction to property-based testing, see [@PraiseOfPBT].
 
-Hypothesis is a mature property-based testing library for Python,
+Hypothesis is a mature and widely used^[It has over 100,000 downloads per week, over a thousands open source projects use it, and in 2018 the more than 4% of Python users surveyed by the PSF reported using it.] property-based testing library for Python,
 and is one of very few widely used examples of such a library outside of functional programming languages.
 It will be of interest both to researchers using Python for developing scientific software,
 and to software testing researchers as a platform for research in its own right.


### PR DESCRIPTION
[JOSS](https://joss.theoj.org/) is a journal specifically for advertising the research benefits of your open source project. @Zac-HD suggested ages ago that we should have a paper there and then, for reasons that are entirely my fault, we err didn't. This is is step one of my attempting to fix this.

Unfortunately we cannot currently easily preview the resulting paper without merging to master (see https://github.com/openjournals/joss/issues/617), but this pull request is an opportunity for people to comment on content, form, etc. Also @Zac-HD do you have an orcid I can include for you as the author?

Currently Zac and I are listed as the coauthors. This isn't due to any particular desire to exclude people so much as the result of there being a *lot* of contributors and having to cut it down somehow. We're the obvious candidates as the top contributors and we'd both find it academically useful to have the publication, butanyone in  @HypothesisWorks/hypothesis-python-contributors or otherwise, if you've contributed something you think interesting to Hypothesis and would find it useful to have the publication, please pipe up and we can add you to the list.