### PR TITLE
Make stateful assign to multiple variables when printing steps that return MultipleResults

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -226,6 +226,7 @@ their individual contributions.
 * `J.J. Green <http://soliton.vm.bytemark.co.uk/pub/jjg/>`_
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)
 * `Jochen Müller <https://github.com/jomuel>`_
+* `Joseph Weston <https://github.com/jbweston>`_
 * `Joey Tuong <https://github.com/tetrapus>`_
 * `Jonathan Gayvallet <https://github.com/Meallia>`_ (jonathan.gayvallet@orange.com)
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch makes stateful step printing expand the result of a step into
+multiple variables when a MultipleResult is returned (:issue:`2139`).
+Thanks to Joseph Weston for reporting and fixing this bug!


### PR DESCRIPTION
If a rule returns MultipleResults then when a step using that rule
is printed the return value should be expanded into multiple
variables. Currently this is not the case

Fixes #2139.