### PR TITLE
Check for PRNG state leaks

### DIFF
--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -18,11 +18,13 @@
 from __future__ import absolute_import, division, print_function
 
 import gc
+import random
 import sys
 import time as time_module
 
 import pytest
 
+from hypothesis.internal.detection import is_hypothesis_test
 from tests.common import TIME_INCREMENT
 from tests.common.setup import run
 
@@ -76,3 +78,30 @@ def consistently_increment_time(monkeypatch):
         assert sys.version_info[0] == 2
     monkeypatch.setattr(time_module, "sleep", sleep)
     monkeypatch.setattr(time_module, "freeze", freeze, raising=False)
+
+
+random_states_after_tests = {}
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    # This hookwrapper checks for PRNG state leaks from Hypothesis tests.
+    # See: https://github.com/HypothesisWorks/hypothesis/issues/1919
+    if not (hasattr(item, "obj") and is_hypothesis_test(item.obj)):
+        yield
+    else:
+        # We start by peturbing the state of the PRNG, because repeatedly
+        # leaking PRNG state resets state_after to the (previously leaked)
+        # state_before, and that just shows as "no use of random".
+        random.seed(random.randrange(2 ** 32))
+        before = random.getstate()
+        yield
+        after = random.getstate()
+        if before != after:
+            if after in random_states_after_tests:
+                raise Exception(
+                    "%r and %r both used the `random` module, and finished with the "
+                    "same global `random.getstate()`; this is probably a nasty bug!"
+                    % (item.nodeid, random_states_after_tests[after])
+                )
+            random_states_after_tests[after] = item.nodeid

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -81,6 +81,7 @@ def consistently_increment_time(monkeypatch):
 
 
 random_states_after_tests = {}
+independent_random = random.Random()
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -93,7 +94,7 @@ def pytest_runtest_call(item):
         # We start by peturbing the state of the PRNG, because repeatedly
         # leaking PRNG state resets state_after to the (previously leaked)
         # state_before, and that just shows as "no use of random".
-        random.seed(random.randrange(2 ** 32))
+        random.seed(independent_random.randrange(2 ** 32))
         before = random.getstate()
         yield
         after = random.getstate()


### PR DESCRIPTION
Closes #1919, by adding a pytest hook to our test suite derived from #2129.