### PR TITLE
Run all of our builds with whatever parallelism level is good for the local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ docs/_build
 *.egg-info
 _build
 .tox
-.coverage
+.coverage*
+branch-check
 .pypirc
 htmlcov
 build

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release is a minor change in support of some internal Hypothesis testing
+functionality. It will have no user visible impact.

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -13,7 +13,7 @@ for k, v in sorted(dict(os.environ).items()):
 pip install .
 
 
-PYTEST="python -m pytest -n2"
+PYTEST="python -m pytest"
 
 # Run all the no-extra-dependency tests for this version (except slow nocover tests)
 if [ "$(python -c 'import sys; print(sys.version_info[0] == 2)')" = "True" ] ; then

--- a/hypothesis-python/scripts/validate_branch_check.py
+++ b/hypothesis-python/scripts/validate_branch_check.py
@@ -20,15 +20,17 @@ from __future__ import absolute_import, division, print_function
 import json
 import sys
 from collections import defaultdict
+from glob import glob
 
 if __name__ == "__main__":
-    with open("branch-check") as i:
-        data = [json.loads(l) for l in i]
-
     checks = defaultdict(set)
 
-    for d in data:
-        checks[d["name"]].add(d["value"])
+    for f in glob("branch-check/*"):
+        with open(f) as i:
+            data = [json.loads(l) for l in i]
+
+        for d in data:
+            checks[d["name"]].add(d["value"])
 
     always_true = []
     always_false = []

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -66,12 +66,14 @@ if IN_COVERAGE_TESTS:
 
     written = set()  # type: Set[Tuple[str, bool]]
 
+    branch_file = os.path.join("branch-check", str(os.getpid()))
+
     def record_branch(name, value):
         key = (name, value)
         if key in written:
             return
         written.add(key)
-        with open("branch-check", "a") as log:
+        with open(branch_file, "a") as log:
             log.write(json.dumps({"name": name, "value": value}) + "\n")
 
     description_stack = []

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -165,10 +165,11 @@ whitelist_externals=
 setenv=
     HYPOTHESIS_INTERNAL_COVERAGE=true
 commands =
-    rm -f branch-check
+    rm -rf branch-check
+    mkdir branch-check
     python -m coverage --version
     python -m coverage debug sys
-    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas tests/lark --ff {posargs}
+    python -m coverage run -p --rcfile=.coveragerc -m pytest -n=auto --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas tests/lark --ff {posargs}
     python -m coverage report -m --fail-under=100 --show-missing --skip-covered
     python scripts/validate_branch_check.py
 

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -169,7 +169,7 @@ commands =
     mkdir branch-check
     python -m coverage --version
     python -m coverage debug sys
-    python -m coverage run -p --rcfile=.coveragerc -m pytest -n=auto --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas tests/lark --ff {posargs}
+    python -m coverage run -p --rcfile=.coveragerc -m pytest -n=0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas tests/lark --ff {posargs}
     python -m coverage report -m --fail-under=100 --show-missing --skip-covered
     python scripts/validate_branch_check.py
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 
-addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20
+addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20 -n=auto

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -17,6 +17,7 @@ numpy
 pip-tools
 pylint
 pytest
+pytest-xdist
 python-dateutil
 pyupgrade
 pyupio

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file=requirements/tools.txt requirements/tools.in
 #
 alabaster==0.7.12         # via sphinx
+apipkg==1.5               # via execnet
 appdirs==1.4.3            # via black
 astroid==2.3.2            # via pylint
 atomicwrites==1.3.0       # via pytest
@@ -27,6 +28,7 @@ docutils==0.15.2          # via readme-renderer, restructuredtext-lint, sphinx
 dparse==0.4.1             # via pyupio, safety
 dpcontracts==0.6.0
 entrypoints==0.3          # via flake8
+execnet==1.7.1            # via pytest-xdist
 filelock==3.0.12          # via tox
 flake8-alfred==1.1.1
 flake8-docstrings==1.5.0
@@ -68,6 +70,8 @@ pygments==2.4.2           # via ipython, readme-renderer, sphinx
 pyjwt==1.7.1              # via pygithub
 pylint==2.4.3
 pyparsing==2.4.2          # via packaging
+pytest-forked==1.1.3      # via pytest-xdist
+pytest-xdist==1.30.0
 pytest==5.2.1
 python-dateutil==2.8.0
 python-gitlab==1.12.1     # via pyupio
@@ -80,7 +84,7 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.22.0
 restructuredtext-lint==1.3.0
 safety==1.8.5             # via pyupio
-six==1.12.0               # via astroid, bandit, bleach, dparse, packaging, pip-tools, prompt-toolkit, pygithub, python-dateutil, python-gitlab, pyupio, readme-renderer, stevedore, tox, traitlets
+six==1.12.0               # via astroid, bandit, bleach, dparse, packaging, pip-tools, prompt-toolkit, pygithub, pytest-xdist, python-dateutil, python-gitlab, pyupio, readme-renderer, stevedore, tox, traitlets
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-rtd-theme==0.4.3

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -504,7 +504,7 @@ def check_unicode():
 @task()
 def check_whole_repo_tests():
     install.ensure_shellcheck()
-    subprocess.check_call([sys.executable, "-m", "pytest", tools.REPO_TESTS])
+    subprocess.check_call([sys.executable, "-m", "pytest", "-n0", tools.REPO_TESTS])
 
 
 @task()


### PR DESCRIPTION
I've been doing a lot of Hypothesis development on a 64 core machine recently and it has been *painful* waiting for our builds to run single-threaded when I know that they can run 64 times as fast. This moves all of our build config over to use `-n=auto`, so it will detect the number of cores available and set the parallelism appropriately.

This requires some minor changes to our coverage tests but otherwise is mostly just a question of setting some flags.