### PR TITLE
Fix some flaky tests and fix a longstanding bug in recursive

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug in :func:`~hypothesis.strategies.recursive` which would
+have meant that in practice ``max_leaves`` was treated as if it was lower than
+it actually is - specifically it would be capped at the largest power of two
+smaller than it. It is now handled correctly.

--- a/hypothesis-python/src/hypothesis/searchstrategy/recursive.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/recursive.py
@@ -36,6 +36,9 @@ class LimitedStrategy(SearchStrategy):
         self.marker = 0
         self.currently_capped = False
 
+    def __repr__(self):
+        return "LimitedStrategy(%r)" % (self.base_strategy,)
+
     def do_validate(self):
         self.base_strategy.validate()
 
@@ -65,7 +68,7 @@ class RecursiveStrategy(SearchStrategy):
         self.extend = extend
 
         strategies = [self.limited_base, self.extend(self.limited_base)]
-        while 2 ** len(strategies) <= max_leaves:
+        while 2 ** (len(strategies) - 1) <= max_leaves:
             strategies.append(extend(OneOfStrategy(tuple(strategies))))
         self.strategy = OneOfStrategy(strategies)
 

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -63,6 +63,12 @@ def test_decoding_may_fail(t):
         assert False, "decoding failed with %r, not InvalidArgument" % (e,)
 
 
+def test_invalid_base_64_gives_invalid_argument():
+    with pytest.raises(InvalidArgument) as exc_info:
+        decode_failure(b"/")
+    assert "Invalid base64 encoded" in exc_info.value.args[0]
+
+
 def test_reproduces_the_failure():
     b = b"hello world"
     n = len(b)

--- a/hypothesis-python/tests/quality/test_integers.py
+++ b/hypothesis-python/tests/quality/test_integers.py
@@ -46,10 +46,11 @@ def problems(draw):
             d = ConjectureData.for_buffer(buf)
             k = d.draw(st.integers())
             stop = d.draw_bits(8)
-            if stop > 0 and k > 0:
-                return (draw(st.integers(0, k - 1)), hbytes(d.buffer))
         except (StopTest, IndexError):
             pass
+        else:
+            if stop > 0 and k > 0:
+                return (draw(st.integers(0, k - 1)), hbytes(d.buffer))
 
 
 @example((2, b"\x00\x00\n\x01"))


### PR DESCRIPTION
Some flaky tests are blocking #2153. Initially I thought these were caused by #2137 but apparently not! Possibly they were exposed by it, but they're actually two latent longstanding bugs in our test suite:

* We genuinely don't have any examples that guarantee covering invalid base 64, because (on Python 3?) whitespace is stripped from decode
* We were potentially catching a `StopTest` that we shouldn't.

Additionally in investigating and improving the testing of the `recursive` strategy to improve some missing coverage that I got there when I pushed the first set of changes, I discovered that our logic for how many branches we needed in `recursive` was wrong and we were stopping adding child strategies too soon, so I fixed that while I was there.