### PR TITLE
Add support for `SupportsIndex` in Python 3.8

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+Python 3.8's new :class:`python:typing.SupportsIndex` type - see :pep:`357`
+for details - is now  supported in :func:`~hypothesis.strategies.from_type`.
+
+Thanks to Grigorios Giannakopoulos for the patch!

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -238,6 +238,9 @@ try:  # pragma: no cover
         array_shapes,
         scalar_dtypes,
         nested_dtypes,
+        from_dtype,
+        integer_dtypes,
+        unsigned_integer_dtypes,
     )
 
     _global_type_lookup.update(
@@ -247,7 +250,7 @@ try:  # pragma: no cover
         }
     )
 except ImportError:  # pragma: no cover
-    pass
+    np = None
 
 try:
     import typing
@@ -276,9 +279,10 @@ else:
     except AttributeError:  # pragma: no cover
         pass
     try:
-        _global_type_lookup[typing.SupportsIndex] = st.one_of(
-            st.integers(), st.booleans()
-        )
+        strat = st.integers() | st.booleans()
+        if np is not None:  # pragma: no branch
+            strat |= (unsigned_integer_dtypes() | integer_dtypes()).flatmap(from_dtype)
+        _global_type_lookup[typing.SupportsIndex] = strat  # type: ignore
     except AttributeError:  # pragma: no cover
         pass
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -275,6 +275,12 @@ else:
         _global_type_lookup[typing.SupportsRound] = st.complex_numbers()
     except AttributeError:  # pragma: no cover
         pass
+    try:
+        _global_type_lookup[typing.SupportsIndex] = st.one_of(
+            st.integers(), st.booleans()
+        )
+    except AttributeError:  # pragma: no cover
+        pass
 
     def register(type_, fallback=None):
         if isinstance(type_, str):

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -245,6 +245,15 @@ def test_register_generic_typing_strats():
         typing.SupportsFloat,
         typing.SupportsInt,
         typing.SupportsRound,
+        pytest.param(
+            typing.SupportsIndex if sys.version_info >= (3, 8) else None,
+            marks=[
+                pytest.mark.skipif(
+                    sys.version_info < (3, 8),
+                    reason="SupportsIndex was added in Python 3.8",
+                )
+            ],
+        ),
     ],
 )
 def test_resolves_weird_types(typ):

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -232,6 +232,13 @@ def test_register_generic_typing_strats():
         st.from_type.__clear_cache()
 
 
+def if_available(name):
+    try:
+        return getattr(typing, name)
+    except AttributeError:
+        return pytest.param(name, marks=[pytest.mark.skip])
+
+
 @pytest.mark.parametrize(
     "typ",
     [
@@ -245,15 +252,7 @@ def test_register_generic_typing_strats():
         typing.SupportsFloat,
         typing.SupportsInt,
         typing.SupportsRound,
-        pytest.param(
-            typing.SupportsIndex if sys.version_info >= (3, 8) else None,
-            marks=[
-                pytest.mark.skipif(
-                    sys.version_info < (3, 8),
-                    reason="SupportsIndex was added in Python 3.8",
-                )
-            ],
-        ),
+        if_available("SupportsIndex"),
     ],
 )
 def test_resolves_weird_types(typ):


### PR DESCRIPTION
Relates to #2116