### PR TITLE
Fix biased_coin doc

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch corrects some internal documentation.  There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -167,7 +167,7 @@ def boolean(data):
 
 
 def biased_coin(data, p):
-    """Return False with probability p (assuming a uniform generator),
+    """Return True with probability p (assuming a uniform generator),
     shrinking towards False."""
     data.start_example(BIASED_COIN_LABEL)
     while True:

--- a/hypothesis-python/tests/pandas/test_indexes.py
+++ b/hypothesis-python/tests/pandas/test_indexes.py
@@ -50,6 +50,12 @@ def test_unique_indexes_of_small_values(ix):
     assert len(set(ix)) == len(ix)
 
 
+@given(pdst.indexes(dtype=bool, min_size=2, unique=True))
+def test_unique_indexes_of_many_small_values(ix):
+    assert len(ix) == 2
+    assert len(set(ix)) == len(ix)
+
+
 # Sizes that fit into an int64 without overflow
 range_sizes = st.integers(0, 2 ** 63 - 1)
 


### PR DESCRIPTION
Originally - I think - a typo in 5df039ff, this caused @rsokl and I some confusion as we worked on #2153; it's a separate PR because I don't want to inflict *that* review on anyone else.