### PR TITLE
Warn on settings without given at pytest_runtest_call

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -276,6 +276,7 @@ their individual contributions.
 * `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Thomas Kluyver <https://www.github.com/takluyver>`_ (thomas@kluyver.me.uk)
 * `Tom McDermott <https://www.github.com/sponster-au>`_ (sponster@gmail.com)
+* `Tom Milligan <https://www.github.com/tommilligan>`_ (code@tommilligan.net)
 * `Tyler Gibbons <https://www.github.com/kavec>`_ (tyler.gibbons@flexport.com)
 * `Tyler Nickerson <https://www.github.com/nmbrgts>`_
 * `Vidya Rani <https://www.github.com/vidyarani-dg>`_ (vidyarani.d.g@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug (:issue:`2160`) where decorators applied after
+:func:`@settings <hypothesis.settings>` and before
+:func:`@given <hypothesis.given>` were ignored.
+
+Thanks to Tom Milligan for this bugfix!

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -38,7 +38,7 @@ from hypothesis.errors import (
     InvalidState,
 )
 from hypothesis.internal.compat import integer_types, quiet_raise, string_types
-from hypothesis.internal.reflection import get_pretty_function_description, proxies
+from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.internal.validation import check_type, try_convert
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.utils.dynamicvariables import DynamicVariable
@@ -238,25 +238,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
 
         test._hypothesis_internal_use_settings = self
         test._hypothesis_internal_settings_applied = True
-        if getattr(test, "is_hypothesis_test", False):
-            return test
-
-        @proxies(test)
-        def new_test(*args, **kwargs):
-            """@given has not been applied to `test`, so we replace it with this
-            wrapper so that using *only* @settings is an error.
-
-            We then attach the actual test as an attribute of this function, so
-            that we can unwrap it if @given is applied after the settings decorator.
-            """
-            raise InvalidArgument(
-                "Using `@settings` on a test without `@given` is completely pointless."
-            )
-
-        new_test._hypothesis_internal_test_function_without_warning = test
-        new_test._hypothesis_internal_use_settings = self
-        new_test._hypothesis_internal_settings_applied = True
-        return new_test
+        return test
 
     @classmethod
     def _define_setting(

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -804,10 +804,6 @@ def given(
     """
 
     def run_test_with_generator(test):
-        if hasattr(test, "_hypothesis_internal_test_function_without_warning"):
-            # Pull out the original test function to avoid the warning we
-            # stuck in about using @settings without @given.
-            test = test._hypothesis_internal_test_function_without_warning
         if inspect.isclass(test):
             # Provide a meaningful error to users, instead of exceptions from
             # internals that assume we're dealing with a function.

--- a/hypothesis-python/tests/cover/test_debug_information.py
+++ b/hypothesis-python/tests/cover/test_debug_information.py
@@ -28,7 +28,7 @@ from tests.common.utils import capture_out
 
 def test_reports_passes():
     @given(st.integers())
-    @settings(verbosity=Verbosity.debug)
+    @settings(verbosity=Verbosity.debug, max_examples=1000)
     def test(i):
         assert i < 10
 


### PR DESCRIPTION
Closes #2160 

In the case where `@settings` is applied before `@given`, we set up a shim test function in case `@given` is not called. We then update this shim with attributes created by other decorators. When `@given` is applied, we replace the shim test function with the real test function.

This PR also copies any `hypothesis` attributes from the shim test function onto the real test function, preserving settings that have been applied by other decorators.

The test case added specifically reflects #2160, and checks that the examples added via the `hypothesis_explicit_examples` attribute.
