### PR TITLE
Only add profile info to pytest header if in verbose mode

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch ensures that we only add profile information to the pytest header
+if running either pytest or Hypothesis in verbose mode, matching the
+`builtin cache plugin <https://docs.pytest.org/en/latest/cache.html>`__
+(:issue:`2155`).

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -22,7 +22,7 @@ from distutils.version import LooseVersion
 import pytest
 
 from hypothesis import Verbosity, core, settings
-from hypothesis._settings import note_deprecation
+from hypothesis._settings import Verbosity, note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import OrderedDict, text_type
 from hypothesis.internal.detection import is_hypothesis_test
@@ -79,7 +79,8 @@ def pytest_report_header(config):
     settings_str = settings.get_profile(profile).show_changed()
     if settings_str != "":
         settings_str = " -> %s" % (settings_str)
-    return "hypothesis profile %r%s" % (profile, settings_str)
+    if config.option.verbose >= 1 or settings.default.verbosity >= Verbosity.verbose:
+        return "hypothesis profile %r%s" % (profile, settings_str)
 
 
 def pytest_configure(config):

--- a/hypothesis-python/tests/cover/test_setup_teardown.py
+++ b/hypothesis-python/tests/cover/test_setup_teardown.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 from hypothesis.strategies import integers, text
 
 
@@ -45,6 +45,7 @@ class SomeGivens(object):
         pass
 
     @given(integers())
+    @settings(max_examples=1000)
     def give_me_a_positive_int(self, x):
         assert x >= 0
 

--- a/hypothesis-python/tests/pytest/test_profiles.py
+++ b/hypothesis-python/tests/pytest/test_profiles.py
@@ -17,6 +17,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 from hypothesis.extra.pytestplugin import LOAD_PROFILE_OPTION
 from hypothesis.version import __version__
 
@@ -37,11 +39,23 @@ def test_this_one_is_ok():
 """
 
 
-def test_runs_reporting_hook(testdir):
+def test_does_not_run_reporting_hook_by_default(testdir):
     script = testdir.makepyfile(TESTSUITE)
     testdir.makeconftest(CONFTEST)
     result = testdir.runpytest(script, LOAD_PROFILE_OPTION, "test")
     out = "\n".join(result.stdout.lines)
     assert "1 passed" in out
+    assert "hypothesis profile" not in out
+    assert __version__ in out
+
+
+@pytest.mark.parametrize("option", ["-v", "--hypothesis-verbosity=verbose"])
+def test_runs_reporting_hook_in_any_verbose_mode(testdir, option):
+    script = testdir.makepyfile(TESTSUITE)
+    testdir.makeconftest(CONFTEST)
+    result = testdir.runpytest(script, LOAD_PROFILE_OPTION, "test", option)
+    out = "\n".join(result.stdout.lines)
+    assert "1 passed" in out
     assert "max_examples=1" in out
+    assert "hypothesis profile" in out
     assert __version__ in out


### PR DESCRIPTION
Currently, we unconditionally add profile information to the pytest report header.  This PR changes to only adding the information if pytest (*or* Hypothesis) is in verbose mode, which matches the behaviour of pytest's builtin cache plugin.  

Closes #2155.