### PR TITLE
Fix loading of charmap from cache file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -261,6 +261,7 @@ their individual contributions.
 * `Peadar Coyle <https://github.com/springcoil>`_ (peadarcoyle@gmail.com)
 * `Pierre-Jean Campigotto <https://github.com/PJCampi>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
+* `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
 * `Ryan Soklaski <https://www.github.com/rsokl>`_ (rsoklaski@gmail.com)
 * `Ryan Turner <https://github.com/rdturnermtl>`_ (ryan.turner@uber.com)
 * `Sam Bishop (TechDragon) <https://github.com/techdragon>`_ (sam@techdragon.io)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug (:issue:`2166`) where a Unicode character info
+cache file was generated but never used on subsequent test runs, causing tests
+to run more slowly than they should have.
+
+Thanks to Robert Knight for this bugfix!

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -59,7 +59,7 @@ def charmap():
         f = charmap_file()
         try:
             with gzip.GzipFile(f, "rb") as i:
-                tmp_charmap = dict(json.loads(i))
+                tmp_charmap = dict(json.load(i))
 
         except Exception:
             tmp_charmap = {}

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -59,7 +59,10 @@ def charmap():
         f = charmap_file()
         try:
             with gzip.GzipFile(f, "rb") as i:
-                tmp_charmap = dict(json.load(i))
+                # When the minimum Python 3 version becomes 3.6, this can be
+                # simplified to `json.load(i)` without needing to decode first.
+                data = i.read().decode()
+                tmp_charmap = dict(json.loads(data))
 
         except Exception:
             tmp_charmap = {}

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import tempfile
+import time
 import unicodedata
 
 import hypothesis.internal.charmap as cm
@@ -107,6 +108,20 @@ def test_recreate_charmap():
     y = cm.charmap()
     assert x is not y
     assert x == y
+
+
+def test_uses_cached_charmap():
+    cm.charmap()
+    atime = time.time() - 1000
+    mtime = atime
+    os.utime(cm.charmap_file(), (atime, mtime))
+
+    # Force reload of charmap from cache file.
+    cm._charmap = None
+    cm.charmap()
+    statinfo = os.stat(cm.charmap_file())
+    assert statinfo.st_atime == atime
+    assert statinfo.st_mtime == mtime
 
 
 def test_union_empty():

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -112,15 +112,17 @@ def test_recreate_charmap():
 
 def test_uses_cached_charmap():
     cm.charmap()
-    atime = time.time() - 1000
-    mtime = atime
-    os.utime(cm.charmap_file(), (atime, mtime))
 
-    # Force reload of charmap from cache file.
+    # Reset the last-modified time of the cache file to a point in the past.
+    mtime = int(time.time() - 1000)
+    os.utime(cm.charmap_file(), (mtime, mtime))
+    statinfo = os.stat(cm.charmap_file())
+    assert statinfo.st_mtime == mtime
+
+    # Force reload of charmap from cache file and check that mtime is unchanged.
     cm._charmap = None
     cm.charmap()
     statinfo = os.stat(cm.charmap_file())
-    assert statinfo.st_atime == atime
     assert statinfo.st_mtime == mtime
 
 

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -69,7 +69,7 @@ def test_raises_flaky_if_a_test_becomes_fast_on_rerun():
 
 
 def test_deadlines_participate_in_shrinking():
-    @settings(deadline=500)
+    @settings(deadline=500, max_examples=1000)
     @given(st.integers(min_value=0))
     def slow_if_large(i):
         if i >= 1000:


### PR DESCRIPTION
Loading the cached charmap from disk always failed because the
`GzipFile` was passed to `json.loads`, which expects a string. Use
`json.load` instead, which accepts a file.

This fixes an issue where the first test in a test run that used the
charmap would be unexpectedly slow.

For context, see https://github.com/HypothesisWorks/hypothesis/issues/2108#issuecomment-548579704.