### PR TITLE
Explain why launching "python -Werror" might mysteriously fail

### DIFF
--- a/guides/testing-hypothesis.rst
+++ b/guides/testing-hypothesis.rst
@@ -70,7 +70,7 @@ The following will give you a working virtualenv for running tests in:
   pip install -e .
 
   # Test specific dependencies.
-  pip install pytest-xdist flaky mock
+  pip install pytest-xdist flaky mock pexpect
 
 Now whenever you want to run tests you can just activate the virtualenv
 using ``source testing-venv/bin/activate`` or ``testing-venv\Scripts\activate``

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -88,6 +88,10 @@ def test_non_interactive_example_emits_warning():
 @pytest.mark.skipif(WINDOWS, reason="pexpect.spawn not supported on Windows")
 def test_interactive_example_does_not_emit_warning():
     child = pexpect.spawn("%s -Werror" % (sys.executable,))
+    # If this test mysteriously fails here, it might be that your python
+    # can't launch cleanly with "-Werror". If you are running tests manually
+    # from a virtualenv, you might need to update your copy of virtualenv
+    # and create a fresh environment.
     child.expect(">>> ", timeout=1)
     child.sendline("from hypothesis.strategies import none")
     child.sendline("none().example()")


### PR DESCRIPTION
Closes #2167, by adding a comment to explain why this test might mysteriously fail, with advice on how to fix it.