### PR TITLE
Improved handling of typevars

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,9 @@ jobs:
     - script: ./build.sh
       displayName: Run tests
 
-  - job: windows
+  # prefix `a_` because jobs start running in roughly alphabetical order,
+  # and starting these longer-running jobs early improves utilisation.
+  - job: a_windows
     pool:
       vmImage: 'windows-2019'
     strategy:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This release fixes :func:`~hypothesis.strategies.from_type` when used with
+bounded or constrained :obj:`python:typing.TypeVar` objects (:issue:`2094`).
+
+Previously, distinct typevars with the same constraints would be treated as all
+single typevar, and in cases where a typevar bound was resolved to a union of
+subclasses this could result in mixed types being generated for that typevar.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -1437,7 +1437,7 @@ def from_type(thing):
     # not included because bool is a subclass of int as well as Number.
     strategies = [
         as_strategy(v, thing)
-        for k, v in types._global_type_lookup.items()
+        for k, v in sorted(types._global_type_lookup.items(), key=repr)
         if isinstance(k, type)
         and issubclass(k, thing)
         and sum(types.try_issubclass(k, typ) for typ in types._global_type_lookup) == 1

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -38,6 +38,8 @@ from hypothesis.internal.compat import (
     text_type,
     typing_root_type,
 )
+from hypothesis.searchstrategy.lazy import unwrap_strategies
+from hypothesis.searchstrategy.strategies import OneOfStrategy
 
 
 def type_sorting_key(t):
@@ -117,10 +119,17 @@ def from_typing_type(thing):
         return st.tuples(*map(st.from_type, elem_types))
     if isinstance(thing, typing.TypeVar):
         if getattr(thing, "__bound__", None) is not None:
-            return st.from_type(thing.__bound__)
+            strat = unwrap_strategies(st.from_type(thing.__bound__))
+            if not isinstance(strat, OneOfStrategy):
+                return strat
+            # The bound was a union, or we resolved it as a union of subtypes,
+            # so we need to unpack the strategy to ensure consistency across uses.
+            return st.shared(
+                st.sampled_from(strat.original_strategies), key="typevar=%r" % (thing,)
+            ).flatmap(lambda s: s)
         if getattr(thing, "__constraints__", None):
             return st.shared(
-                st.sampled_from(thing.__constraints__), key="typevar-with-constraint"
+                st.sampled_from(thing.__constraints__), key="typevar=%r" % (thing,)
             ).flatmap(st.from_type)
         # Constraints may be None or () on various Python versions.
         return st.text()  # An arbitrary type for the typevar

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -124,6 +124,9 @@ def from_typing_type(thing):
                 return strat
             # The bound was a union, or we resolved it as a union of subtypes,
             # so we need to unpack the strategy to ensure consistency across uses.
+            # This incantation runs a sampled_from over the strategies inferred for
+            # each part of the union, wraps that in shared so that we only generate
+            # from one type per testcase, and flatmaps that back to instances.
             return st.shared(
                 st.sampled_from(strat.original_strategies), key="typevar=%r" % (thing,)
             ).flatmap(lambda s: s)


### PR DESCRIPTION
If your `TypeVar` has a bound that is treated as a union, it wasn't actually treated as a typevar... *until now*.  If you had two typevars with the same constraints, they werent' distinguished... *until now*.  (if you wanted bare typevars not to always be text, uh, that's a lot harder than it sounds)

Closes #2094.