### PR TITLE
Optimize character map generation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release reduces the delay when generating text for the first time in
+a test run if no Unicode character map cache exists (:issue:`2170`), which could
+lead to timeouts with the default ``deadline`` setting.
+
+Thanks to Robert Knight for this patch!


### PR DESCRIPTION
Optimize generation of the charmap returned by `internal.charmap.charmap()` if there is no cached data.

Optimize the hot loop over `range(0, sys.maxunicode)` (~1M iterations)
by reducing work when the current character has the same category as the
previous character.

This makes charmap generation about ~2x as fast (~0.80s => ~0.36s on my
system) and reduces the risk of the initial cache generation causing
a deadline failure in the test that triggers it.

Original context: https://github.com/HypothesisWorks/hypothesis/pull/2166#issuecomment-548773250