### PR TITLE
Add `flake8-bugbear` to our CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
     test_imports.py,
     hypothesis-python/tests/py2/*,
     test_lambda_formatting.py
-ignore = F811,D1,D205,D209,D213,D400,D401,D412,D413,D999,D202,E203,E501,W503
+ignore = F811,D1,D205,D209,D213,D400,D401,D412,D413,D999,D202,E203,E501,W503,B008,B011
 
 # Use flake8-alfred to forbid builtins that require compatibility wrappers.
 warn-symbols=

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+We've adopted :pypi:`flake8-bugbear` to check for a few more style issues,
+and this patch implements the minor internal cleanups it suggested.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -239,7 +239,7 @@ class Nothing(SearchStrategy):
     def do_draw(self, data):
         # This method should never be called because draw() will mark the
         # data as invalid immediately because is_empty is True.
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError("This should never happen")  # pragma: no cover
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -239,7 +239,7 @@ class Nothing(SearchStrategy):
     def do_draw(self, data):
         # This method should never be called because draw() will mark the
         # data as invalid immediately because is_empty is True.
-        assert False  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def calc_has_reusable_values(self, recur):
         return True
@@ -1498,14 +1498,9 @@ def fractions(
     """
     min_value = try_convert(Fraction, min_value, "min_value")
     max_value = try_convert(Fraction, max_value, "max_value")
-
-    if (
-        min_value is not None
-        and not isinstance(min_value, Fraction)
-        or max_value is not None
-        and not isinstance(max_value, Fraction)
-    ):
-        assert False, "Unreachable for Mypy"  # pragma: no cover
+    # These assertions tell Mypy what happened in try_convert
+    assert min_value is None or isinstance(min_value, Fraction)
+    assert max_value is None or isinstance(max_value, Fraction)
 
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     check_valid_integer(max_denominator)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -956,10 +956,10 @@ def given(
                 if isinstance(runner, TestCase) and hasattr(runner, "subTest"):
                     subTest = runner.subTest
                     try:
-                        setattr(runner, "subTest", fake_subTest)
+                        runner.subTest = fake_subTest
                         state.run()
                     finally:
-                        setattr(runner, "subTest", subTest)
+                        runner.subTest = subTest
                 else:
                     state.run()
             except BaseException as e:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -548,7 +548,7 @@ class ConjectureRunner(object):
         """If the data or result object is suitable for hill climbing, run hill
         climbing on all of its target observations."""
         if data.status == Status.VALID:
-            for target, score in data.target_observations.items():
+            for target in data.target_observations:
                 self.new_optimiser(data, target).run()
 
     def _run(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -71,7 +71,7 @@ class IntList(object):
             except OverflowError:
                 pass
         else:  # pragma: no cover
-            assert False, "Could not create storage for %r" % (values,)
+            raise AssertionError("Could not create storage for %r" % (values,))
         if isinstance(self.__underlying, list):
             for v in self.__underlying:
                 if v < 0 or not isinstance(v, integer_types):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -102,7 +102,7 @@ class Optimiser(object):
             """Select any non-empty example, uniformly at random."""
             while True:
                 i = self.random.randrange(0, len(d.examples))
-                if d.examples[i].length > 0:
+                if d.examples[i].length > 0:  # pragma: no branch  # flaky coverage :/
                     return i
 
         self.do_hill_climbing(last_example)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -100,7 +100,7 @@ def defines_shrink_pass():
         ShrinkPassDefinition(run_with_chooser=run_step)
 
         def run(self):  # pragma: no cover
-            assert False, "Shrink passes should not be run directly"
+            raise AssertionError("Shrink passes should not be run directly")
 
         run.__name__ = run_step.__name__
         run.is_shrink_pass = True
@@ -1377,7 +1377,7 @@ class Shrinker(object):
                 elif d == "X":
                     del attempt[u:v]
                 else:  # pragma: no cover
-                    assert False, "Unrecognised command %r" % (d,)
+                    raise AssertionError("Unrecognised command %r" % (d,))
         return self.incorporate_new_buffer(attempt)
 
 

--- a/hypothesis-python/src/hypothesis/searchstrategy/lazy.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/lazy.py
@@ -144,7 +144,7 @@ class LazyStrategy(SearchStrategy):
                 )
             kwargs_for_repr = dict(_kwargs)
             for k, v in defaults.items():
-                if k in kwargs_for_repr and kwargs_for_repr[k] is defaults[k]:
+                if k in kwargs_for_repr and kwargs_for_repr[k] is v:
                     del kwargs_for_repr[k]
             self.__representation = "%s(%s)" % (
                 self.function.__name__,

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -712,7 +712,7 @@ class RuleBasedStateMachine(GenericStateMachine):
         except KeyError:
             pass
 
-        for k, v in inspect.getmembers(cls):
+        for _, v in inspect.getmembers(cls):
             r = getattr(v, INITIALIZE_RULE_MARKER, None)
             if r is not None:
                 cls.define_initialize_rule(
@@ -728,7 +728,7 @@ class RuleBasedStateMachine(GenericStateMachine):
         except KeyError:
             pass
 
-        for k, v in inspect.getmembers(cls):
+        for _, v in inspect.getmembers(cls):
             r = getattr(v, RULE_MARKER, None)
             if r is not None:
                 cls.define_rule(r.targets, r.function, r.arguments, r.precondition)
@@ -743,7 +743,7 @@ class RuleBasedStateMachine(GenericStateMachine):
             pass
 
         target = []
-        for k, v in inspect.getmembers(cls):
+        for _, v in inspect.getmembers(cls):
             i = getattr(v, INVARIANT_MARKER, None)
             if i is not None:
                 target.append(i)

--- a/hypothesis-python/src/hypothesis/utils/dynamicvariables.py
+++ b/hypothesis-python/src/hypothesis/utils/dynamicvariables.py
@@ -32,7 +32,7 @@ class DynamicVariable(object):
 
     @value.setter
     def value(self, value):
-        setattr(self.data, "value", value)
+        self.data.value = value
 
     @contextmanager
     def with_value(self, value):

--- a/hypothesis-python/tests/cover/test_conjecture_utils.py
+++ b/hypothesis-python/tests/cover/test_conjecture_utils.py
@@ -110,16 +110,6 @@ def test_drawing_an_exact_fraction_coin():
     assert count == 3
 
 
-@st.composite
-def weights(draw):
-    parts = draw(st.lists(st.integers()))
-    parts.reverse()
-    base = Fraction(1, 1)
-    for p in parts:
-        base = Fraction(1) / (1 + base)
-    return base
-
-
 @example([Fraction(1, 3), Fraction(1, 3), Fraction(1, 3)])
 @example([Fraction(1, 1), Fraction(1, 2)])
 @example([Fraction(1, 2), Fraction(4, 10)])
@@ -130,7 +120,7 @@ def weights(draw):
     suppress_health_check=HealthCheck.all(),
     phases=[Phase.explicit] if IN_COVERAGE_TESTS else tuple(Phase),
 )
-@given(st.lists(weights(), min_size=1))
+@given(st.lists(st.fractions(min_value=0, max_value=1), min_size=1))
 def test_sampler_distribution(weights):
     total = sum(weights)
     n = len(weights)

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -498,7 +498,7 @@ def test_fail_gracefully_on_bogus__qualname__and__name__():
         __name__ = 5
 
     class Type(object):
-        __metaclass__ = Meta
+        __metaclass__ = Meta  # noqa
         __qualname__ = 5
 
     stream = StringIO()

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -327,7 +327,7 @@ def test_can_find_sets_unique_by_incomplete_data():
     assert len(ls) == size
     values = sorted(list(map(max, ls)))
     assert values[-1] - values[0] == size - 1
-    for u, v in ls:
+    for u, _ in ls:
         assert u <= 0
 
 

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -8,6 +8,7 @@ django
 dpcontracts
 flake8
 flake8-alfred
+flake8-bugbear
 flake8-docstrings
 ipython
 isort

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -29,6 +29,7 @@ dpcontracts==0.6.0
 entrypoints==0.3          # via flake8
 filelock==3.0.12          # via tox
 flake8-alfred==1.1.1
+flake8-bugbear==19.8.0
 flake8-docstrings==1.5.0
 flake8==3.7.9
 gitdb2==2.0.6             # via gitpython

--- a/tooling/src/hypothesistooling/releasemanagement.py
+++ b/tooling/src/hypothesistooling/releasemanagement.py
@@ -61,7 +61,7 @@ def extract_assignment_from_string(contents, name):
 
     matcher = assignment_matcher(name)
 
-    for i, l in enumerate(lines):
+    for l in lines:
         match = matcher.match(l)
         if match is not None:
             return match[2].strip()


### PR DESCRIPTION
https://pypi.org/project/flake8-bugbear/ adds a useful set of more-subjective style warnings to `flake8`.  The main ones of interest to us are checks for unused loop variables, use of `setattr()` with a static name, and constant `assert False` where an exception is always expected.

Since the checks are easy, why not use them?  In particular this found some over-elaborate code relating to fractions, so it definitely catches a few things that nothing else did.

(plus some fixes for documentation formatting, because there's no change in behaviour there either)