### PR TITLE
Check that `strategy` argument to `data.draw()` is actually a strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch corrects the exception type and error message you get if you attempt
+to use :func:`~hypothesis.strategies.data` to draw from something which is not
+a strategy.  This never worked, but the error is more helpful now.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -2142,6 +2142,7 @@ class DataObject(object):
 
     def draw(self, strategy, label=None):
         # type: (SearchStrategy[Ex], Any) -> Ex
+        check_type(SearchStrategy, strategy, "strategy")
         result = self.conjecture_data.draw(strategy)
         self.count += 1
         if label is not None:

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -456,3 +456,25 @@ def test_no_nan_for_min_max_values(value, parameter_name):
         assert not math.isnan(xs)
 
     test_not_nan()
+
+
+class Sneaky(object):
+    """It's like a strategy, but it's not a strategy."""
+
+    is_empty = False
+    depth = 0
+    label = 0
+
+    def do_draw(self, data):
+        pass
+
+    def validate(self):
+        pass
+
+
+@pytest.mark.parametrize("value", [5, Sneaky()])
+@pytest.mark.parametrize("label", [None, "not a strategy"])
+@given(data=ds.data())
+def test_data_explicitly_rejects_non_strategies(data, value, label):
+    with pytest.raises(InvalidArgument):
+        data.draw(value, label=label)


### PR DESCRIPTION
This would almost always raise an internal error, though if you're carefully sneaky you could cause a silent failure instead.  Closes #2178.