### PR TITLE
Update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,1 +1,16 @@
-requirements_file: .rtfd-reqs.txt
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - path: hypothesis-python/
+        extra_requirements:
+           - all

--- a/.rtfd-reqs.txt
+++ b/.rtfd-reqs.txt
@@ -1,1 +1,0 @@
-hypothesis-python/[all]


### PR DESCRIPTION
This PR updates our readthedocs configuration to build using Python 3 rather than Python 2.

As well as getting ahead of the game for January 2020, we can inline the "install hypothesis[all]" requirements file, and users might appreciate seeing the `*` indicating a keyword-only argument over the `__reserved` argument that we convert.  ([before](https://hypothesis.readthedocs.io/en/latest/numpy.html#hypothesis.extra.numpy.mutually_broadcastable_shapes), [after](https://hypothesis.readthedocs.io/en/py3-for-rtfd/numpy.html#hypothesis.extra.numpy.mutually_broadcastable_shapes))

[config file schema](https://docs.readthedocs.io/en/stable/config-file/v2.html), [build logs](https://readthedocs.org/projects/hypothesis/builds/9917470/)