### PR TITLE
Remove unused flag data.can_reproduce_example_from_repr

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch removes an unused internal flag.
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -1203,7 +1203,6 @@ class RandomSeeder(object):
 
 class RandomModule(SearchStrategy):
     def do_draw(self, data):
-        data.can_reproduce_example_from_repr = False
         seed = data.draw(integers(0, 2 ** 32 - 1))
         seed_all, restore_all = get_seeder_and_restorer(seed)
         seed_all()
@@ -2151,8 +2150,6 @@ class DataStrategy(SearchStrategy):
     supports_find = False
 
     def do_draw(self, data):
-        data.can_reproduce_example_from_repr = False
-
         if not hasattr(data, "hypothesis_shared_data_strategy"):
             data.hypothesis_shared_data_strategy = DataObject(data)
         return data.hypothesis_shared_data_strategy

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -20,7 +20,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ast
 import base64
 import contextlib
 import datetime
@@ -534,8 +533,6 @@ class StateForActualGivenExecution(object):
                 return result
 
         def run(data):
-            if not hasattr(data, "can_reproduce_example_from_repr"):
-                data.can_reproduce_example_from_repr = True
             with local_settings(self.settings):
                 with deterministic_PRNG():
                     with BuildContext(data, is_final=is_final):
@@ -548,10 +545,6 @@ class StateForActualGivenExecution(object):
                                 test.__name__,
                                 arg_string(test, args, kwargs),
                             )
-                            try:
-                                ast.parse(example)
-                            except SyntaxError:
-                                data.can_reproduce_example_from_repr = False
                             report("Falsifying example: %s" % (example,))
                         elif current_verbosity() >= Verbosity.verbose:
                             report(

--- a/hypothesis-python/src/hypothesis/searchstrategy/functions.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/functions.py
@@ -42,7 +42,6 @@ class FunctionStrategy(SearchStrategy):
                     "This generated %s function can only be called within the "
                     "scope of the @given that created it." % (nicerepr(self.like),)
                 )
-            data.can_reproduce_example_from_repr = False
             val = data.draw(self.returns)
             note(
                 "Called function: %s(%s) -> %r"


### PR DESCRIPTION
This flag was previously used in the logic for deciding whether to print a `@reproduce_failure` blob, but that logic was simplified in #2054, and so the flag became unused.

This PR removes the remaining code that was creating or updating the unused flag.