### PR TITLE
Handle `floats()` width further down the stack

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch refactors ``width`` handling in :func:`~hypothesis.strategies.floats`;
+you may notice small performance improvements but the main purpose is to
+enable work on :issue:`1704` (improving shrinking of bounded floats).

--- a/hypothesis-python/src/hypothesis/searchstrategy/numbers.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/numbers.py
@@ -129,9 +129,10 @@ class FloatStrategy(SearchStrategy):
             else:
                 result = self.nasty_floats[i - 1]
                 flt.write_float(data, result)
-            data.stop_example()
             if self.permitted(result):
+                data.stop_example()
                 return result
+            data.stop_example(discard=True)
 
 
 def float_order_key(k):

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -478,3 +478,13 @@ class Sneaky(object):
 def test_data_explicitly_rejects_non_strategies(data, value, label):
     with pytest.raises(InvalidArgument):
         data.draw(value, label=label)
+
+
+@given(ds.integers().filter(bool).filter(lambda x: x % 3))
+def test_chained_filter(x):
+    assert x and x % 3
+
+
+def test_chained_filter_tracks_all_conditions():
+    s = ds.integers().filter(bool).filter(lambda x: x % 3)
+    assert len(s.flat_conditions) == 2


### PR DESCRIPTION
This reduces the number of recursive calls and of `.map()` and `.filter()` layers in many `floats()` strategies, which in many cases gives us a small but noticable performance improvement.

Once this is merged, I'll have a follow-up PR for #1704; I thought that this would be worth doing separately and much easier to review this way :smile: 