### PR TITLE
Properly validate strategies used with test methods

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This release ensures that the strategies passed to
+:func:`@given <hypothesis.given>` are properly validated when applied to a test
+method inside a test class.
+
+This should result in clearer error messages when some of those strategies are
+invalid.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -223,6 +223,9 @@ class WithRunner(SearchStrategy):
         data.hypothesis_runner = self.runner
         return self.base.do_draw(data)
 
+    def do_validate(self):
+        self.base.validate()
+
 
 def is_invalid_test(name, original_argspec, generator_arguments, generator_kwargs):
     def invalid(message):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -90,7 +90,7 @@ from hypothesis.internal.reflection import (
 )
 from hypothesis.reporting import current_verbosity, report, verbose_report
 from hypothesis.searchstrategy.collections import TupleStrategy
-from hypothesis.searchstrategy.strategies import SearchStrategy
+from hypothesis.searchstrategy.strategies import MappedSearchStrategy, SearchStrategy
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.utils.conventions import infer
 from hypothesis.version import __version__
@@ -213,18 +213,18 @@ def decode_failure(blob):
         )
 
 
-class WithRunner(SearchStrategy):
+class WithRunner(MappedSearchStrategy):
     def __init__(self, base, runner):
         assert runner is not None
-        self.base = base
+        MappedSearchStrategy.__init__(self, base)
         self.runner = runner
 
     def do_draw(self, data):
         data.hypothesis_runner = self.runner
-        return self.base.do_draw(data)
+        return self.mapped_strategy.do_draw(data)
 
-    def do_validate(self):
-        self.base.validate()
+    def __repr__(self):
+        return "WithRunner(%r, runner=%r)" % (self.mapped_strategy, self.runner)
 
 
 def is_invalid_test(name, original_argspec, generator_arguments, generator_kwargs):

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -22,7 +22,7 @@ from _pytest.outcomes import Failed, Skipped
 
 import hypothesis.strategies as s
 from hypothesis import find, given, reject, settings
-from hypothesis.errors import NoSuchExample, Unsatisfiable
+from hypothesis.errors import InvalidArgument, NoSuchExample, Unsatisfiable
 from tests.common.utils import checks_deprecated_behaviour
 
 
@@ -113,3 +113,16 @@ def test_can_find_with_db_eq_none():
 def test_no_such_example():
     with pytest.raises(NoSuchExample):
         find(s.none(), bool, database_key=b"no such example")
+
+
+def test_validates_strategies_for_test_method():
+    invalid_strategy = s.lists(s.nothing(), min_size=1)
+
+    class TestStrategyValidation(object):
+        @given(invalid_strategy)
+        def test_method_with_bad_strategy(self, x):
+            pass
+
+    instance = TestStrategyValidation()
+    with pytest.raises(InvalidArgument):
+        instance.test_method_with_bad_strategy()


### PR DESCRIPTION
Due to the absence of a pass-through implementation of `WithRunner.do_validate`, strategies supplied to a test method (in a test class) were not being properly validated before running the test.