### PR TITLE
Skip the interactive test if -Werror fails

### DIFF
--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
 import sys
 import warnings
 from decimal import Decimal
@@ -95,7 +96,12 @@ def test_interactive_example_does_not_emit_warning():
         # and create a fresh environment.
         child.expect(">>> ", timeout=1)
     except pexpect.exceptions.EOF:
-        pytest.skip("Unable to run python with -Werror, this may be the result of having a very old virtualenv")
+        # See https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables
+        assert "Build.ArtifactStagingDirectory" not in os.environ
+        pytest.skip(
+            "Unable to run python with -Werror, this may be the result of "
+            "having a very old virtualenv"
+        )
     child.sendline("from hypothesis.strategies import none")
     child.sendline("none().example()")
     child.sendline("quit(code=0)")

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -90,17 +90,14 @@ def test_non_interactive_example_emits_warning():
 def test_interactive_example_does_not_emit_warning():
     try:
         child = pexpect.spawn("%s -Werror" % (sys.executable,))
-        # If this test mysteriously fails here, it might be that your python
-        # can't launch cleanly with "-Werror". If you are running tests manually
-        # from a virtualenv, you might need to update your copy of virtualenv
-        # and create a fresh environment.
         child.expect(">>> ", timeout=1)
     except pexpect.exceptions.EOF:
         # See https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables
         assert "Build.ArtifactStagingDirectory" not in os.environ
         pytest.skip(
-            "Unable to run python with -Werror, this may be the result of "
-            "having a very old virtualenv"
+            "Unable to run python with -Werror.  This may be because you are "
+            "running from an old virtual environment - update your installed "
+            "copy of `virtualenv` and then create a fresh environment."
         )
     child.sendline("from hypothesis.strategies import none")
     child.sendline("none().example()")

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -87,12 +87,15 @@ def test_non_interactive_example_emits_warning():
 
 @pytest.mark.skipif(WINDOWS, reason="pexpect.spawn not supported on Windows")
 def test_interactive_example_does_not_emit_warning():
-    child = pexpect.spawn("%s -Werror" % (sys.executable,))
-    # If this test mysteriously fails here, it might be that your python
-    # can't launch cleanly with "-Werror". If you are running tests manually
-    # from a virtualenv, you might need to update your copy of virtualenv
-    # and create a fresh environment.
-    child.expect(">>> ", timeout=1)
+    try:
+        child = pexpect.spawn("%s -Werror" % (sys.executable,))
+        # If this test mysteriously fails here, it might be that your python
+        # can't launch cleanly with "-Werror". If you are running tests manually
+        # from a virtualenv, you might need to update your copy of virtualenv
+        # and create a fresh environment.
+        child.expect(">>> ", timeout=1)
+    except pexpect.exceptions.EOF:
+        pytest.skip("Unable to run python with -Werror, this may be the result of having a very old virtualenv")
     child.sendline("from hypothesis.strategies import none")
     child.sendline("none().example()")
     child.sendline("quit(code=0)")


### PR DESCRIPTION
If you do a clean install of hypothesis with an older version of virtualenv, `tests/cover/test_example.py::test_interactive_example_does_not_emit_warning` will fail because `python -Werror` fails in `site.py`. With this PR, this condition is detected - that is, if `python -Werror` itself fails for some reason - the test is simply skipped. If just running python succeeds, then the actual test code is run (through `pexpect`) and the test will succeed or fail as per normal.