### PR TITLE
Make use of targets during shrinking to highlight more dramatic failures

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release changes how shrinking interacts with :ref:`targeted property-based testing <targeted-search>`,
+by changing the shrinking behaviour to try to ensure that targets remain large when it's for them to be.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -141,6 +141,12 @@ def target(observation, label=""):
     For example, ``-abs(error)`` is a metric that increases as ``error``
     approaches zero.
 
+    Additionally, targets may be used to control shrinking: If a target seems
+    to determine whether a test fails (e.g. this will happen if you have an
+    assertion that a target is below some value) then during shrinking
+    Hypothesis will try to ensure that the target scores remain large, even
+    if this results in larger falsifying examples.
+
     Example metrics:
 
     - Number of elements in a collection, or tasks in a queue

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1439,3 +1439,36 @@ def test_number_of_examples_in_integer_range_is_bounded(n):
 
         runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS)
         runner.run()
+
+
+def test_detect_threshold_as_relevant():
+    with deterministic_PRNG():
+
+        def test(data):
+            n = data.draw_bits(32)
+            data.target_observations["score"] = n
+            data.target_observations["irrelevant"] = data.draw_bits(32)
+            if n >= 1000:
+                data.mark_interesting()
+
+        runner = ConjectureRunner(test, settings=TEST_SETTINGS)
+        runner.run()
+
+        assert runner.thresholds(None) == ["score"]
+
+
+def test_does_not_use_erratic_as_threshold():
+    with deterministic_PRNG():
+
+        def test(data):
+            n = data.draw_bits(32)
+            data.target_observations["score"] = n
+            if data.draw_bits(1):
+                data.target_observations["irrelevant"] = data.draw_bits(32)
+            if n >= 1000:
+                data.mark_interesting()
+
+        runner = ConjectureRunner(test, settings=TEST_SETTINGS)
+        runner.run()
+
+        assert runner.thresholds(None) == ["score"]

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1455,6 +1455,7 @@ def test_detect_threshold_as_relevant():
         runner.run()
 
         assert runner.thresholds(None) == ["score"]
+        assert runner.shrinks > 0
 
 
 def test_does_not_use_erratic_as_threshold():
@@ -1472,6 +1473,7 @@ def test_does_not_use_erratic_as_threshold():
         runner.run()
 
         assert runner.thresholds(None) == ["score"]
+        assert runner.shrinks > 0
 
 
 def test_retains_lower_bound_on_score_when_reducing():
@@ -1489,6 +1491,7 @@ def test_retains_lower_bound_on_score_when_reducing():
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
         runner.run()
+        assert runner.shrinks > 0
 
     data = ConjectureData.for_buffer(runner.interesting_examples[None].buffer)
 
@@ -1516,6 +1519,7 @@ def test_will_minimize_scores_that_are_not_thresholds():
         assert runner.interesting_examples
 
         runner.shrink_interesting_examples()
+        assert runner.shrinks > 0
 
     data = ConjectureData.for_buffer(runner.interesting_examples[None].buffer)
 


### PR DESCRIPTION
Prompted by #2180, this changes the way targetting interacts with shrinking.

This comes in two parts:

1. We identify when a particular failure's value is determined by a target, by considering whether the value of the target is larger for every example with that failure than every uninteresting valid example. This lets us automatically detect things like `target(score); assert score <= threshold`.
2. When we find these thresholds, we require the shrinker to not lower those target scores.