### PR TITLE
Disable pytest plugin if pytest is too old

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch disables our :pypi:`pytest` plugin when running on versions
+of :pypi:`pytest` before 4.3, the oldest our plugin supports.
+Note that at time of writing the Pytest developers only support 4.6 and later!
+
+Hypothesis *tests* using :func:`@given() <hypothesis.given>` work on any
+test runner, but our integrations to e.g. avoid example database collisions
+when combined with ``@pytest.mark.parametrize`` eventually drop support
+for obsolete versions.

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -24,7 +24,7 @@ import pytest
 from hypothesis import Verbosity, core, settings
 from hypothesis._settings import Verbosity, note_deprecation
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import OrderedDict, text_type
+from hypothesis.internal.compat import text_type
 from hypothesis.internal.detection import is_hypothesis_test
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.statistics import collector
@@ -48,168 +48,157 @@ class StoringReporter(object):
         self.results.append(msg)
 
 
-def pytest_addoption(parser):
-    group = parser.getgroup("hypothesis", "Hypothesis")
-    group.addoption(
-        LOAD_PROFILE_OPTION,
-        action="store",
-        help="Load in a registered hypothesis.settings profile",
-    )
-    group.addoption(
-        VERBOSITY_OPTION,
-        action="store",
-        choices=[opt.name for opt in Verbosity],
-        help="Override profile with verbosity setting specified",
-    )
-    group.addoption(
-        PRINT_STATISTICS_OPTION,
-        action="store_true",
-        help="Configure when statistics are printed",
-        default=False,
-    )
-    group.addoption(
-        SEED_OPTION, action="store", help="Set a seed to use for all Hypothesis tests"
-    )
+if LooseVersion(pytest.__version__) < "4.3":  # pragma: no cover
+    import warnings
+    from hypothesis.errors import HypothesisWarning
 
+    PYTEST_TOO_OLD_MESSAGE = """
+        You are using Pytest version %s.  Hypothesis tests work with any test
+        runner, but our Pytest plugin requires Pytest  4.3 or newer.
+        Note that the Pytest developers no longer support this version either!
+        Disabling the Hypothesis pytest plugin...
+    """
+    warnings.warn(PYTEST_TOO_OLD_MESSAGE % (pytest.__version__,), HypothesisWarning)
 
-def pytest_report_header(config):
-    profile = config.getoption(LOAD_PROFILE_OPTION)
-    if not profile:
-        profile = settings._current_profile
-    settings_str = settings.get_profile(profile).show_changed()
-    if settings_str != "":
-        settings_str = " -> %s" % (settings_str)
-    if config.option.verbose >= 1 or settings.default.verbosity >= Verbosity.verbose:
-        return "hypothesis profile %r%s" % (profile, settings_str)
+else:
 
-
-def pytest_configure(config):
-    core.running_under_pytest = True
-    profile = config.getoption(LOAD_PROFILE_OPTION)
-    if profile:
-        settings.load_profile(profile)
-    verbosity_name = config.getoption(VERBOSITY_OPTION)
-    if verbosity_name:
-        verbosity_value = Verbosity[verbosity_name]
-        profile_name = "%s-with-%s-verbosity" % (
-            settings._current_profile,
-            verbosity_name,
+    def pytest_addoption(parser):
+        group = parser.getgroup("hypothesis", "Hypothesis")
+        group.addoption(
+            LOAD_PROFILE_OPTION,
+            action="store",
+            help="Load in a registered hypothesis.settings profile",
         )
-        # register_profile creates a new profile, exactly like the current one,
-        # with the extra values given (in this case 'verbosity')
-        settings.register_profile(profile_name, verbosity=verbosity_value)
-        settings.load_profile(profile_name)
-    seed = config.getoption(SEED_OPTION)
-    if seed is not None:
-        try:
-            seed = int(seed)
-        except ValueError:
-            pass
-        core.global_force_seed = seed
-    config.addinivalue_line("markers", "hypothesis: Tests which use hypothesis.")
-
-
-gathered_statistics = OrderedDict()  # type: dict
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item):
-    if not hasattr(item, "obj"):
-        yield
-    elif not is_hypothesis_test(item.obj):
-        # If @given was not applied, check whether other hypothesis decorators
-        # were applied, and fail if so
-        if getattr(item.obj, "_hypothesis_internal_settings_applied", False):
-            raise InvalidArgument(
-                "Using `@settings` on a test without `@given` is completely pointless."
-            )
-        yield
-    else:
-        if item.get_closest_marker("parametrize") is not None:
-            # Give every parametrized test invocation a unique database key
-            item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = item.nodeid.encode(
-                "utf-8"
-            )
-
-        store = StoringReporter(item.config)
-
-        def note_statistics(stats):
-            lines = [item.nodeid + ":", ""] + stats.get_description() + [""]
-            gathered_statistics[item.nodeid] = lines
-            item.hypothesis_statistics = lines
-
-        with collector.with_value(note_statistics):
-            with with_reporter(store):
-                yield
-        if store.results:
-            item.hypothesis_report_information = list(store.results)
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    report = (yield).get_result()
-    if hasattr(item, "hypothesis_report_information"):
-        report.sections.append(
-            ("Hypothesis", "\n".join(item.hypothesis_report_information))
+        group.addoption(
+            VERBOSITY_OPTION,
+            action="store",
+            choices=[opt.name for opt in Verbosity],
+            help="Override profile with verbosity setting specified",
         )
-    if hasattr(item, "hypothesis_statistics") and report.when == "teardown":
-        # Running on pytest < 3.5 where user_properties doesn't exist, fall
-        # back on the global gathered_statistics (which breaks under xdist)
-        if hasattr(report, "user_properties"):  # pragma: no branch
-            val = ("hypothesis-stats", item.hypothesis_statistics)
-            # Workaround for https://github.com/pytest-dev/pytest/issues/4034
-            if isinstance(report.user_properties, tuple):
-                report.user_properties += (val,)
-            else:
-                report.user_properties.append(val)
+        group.addoption(
+            PRINT_STATISTICS_OPTION,
+            action="store_true",
+            help="Configure when statistics are printed",
+            default=False,
+        )
+        group.addoption(
+            SEED_OPTION,
+            action="store",
+            help="Set a seed to use for all Hypothesis tests",
+        )
 
+    def pytest_report_header(config):
+        profile = config.getoption(LOAD_PROFILE_OPTION)
+        if not profile:
+            profile = settings._current_profile
+        settings_str = settings.get_profile(profile).show_changed()
+        if settings_str != "":
+            settings_str = " -> %s" % (settings_str)
+        if (
+            config.option.verbose >= 1
+            or settings.default.verbosity >= Verbosity.verbose
+        ):
+            return "hypothesis profile %r%s" % (profile, settings_str)
 
-def pytest_terminal_summary(terminalreporter):
-    if not terminalreporter.config.getoption(PRINT_STATISTICS_OPTION):
-        return
-    terminalreporter.section("Hypothesis Statistics")
-
-    if LooseVersion(pytest.__version__) < "3.5":  # pragma: no cover
-        if not gathered_statistics:
-            terminalreporter.write_line(
-                "Reporting Hypothesis statistics with pytest-xdist enabled "
-                "requires pytest >= 3.5"
+    def pytest_configure(config):
+        core.running_under_pytest = True
+        profile = config.getoption(LOAD_PROFILE_OPTION)
+        if profile:
+            settings.load_profile(profile)
+        verbosity_name = config.getoption(VERBOSITY_OPTION)
+        if verbosity_name:
+            verbosity_value = Verbosity[verbosity_name]
+            profile_name = "%s-with-%s-verbosity" % (
+                settings._current_profile,
+                verbosity_name,
             )
-        for lines in gathered_statistics.values():
-            for li in lines:
-                terminalreporter.write_line(li)
-        return
+            # register_profile creates a new profile, exactly like the current one,
+            # with the extra values given (in this case 'verbosity')
+            settings.register_profile(profile_name, verbosity=verbosity_value)
+            settings.load_profile(profile_name)
+        seed = config.getoption(SEED_OPTION)
+        if seed is not None:
+            try:
+                seed = int(seed)
+            except ValueError:
+                pass
+            core.global_force_seed = seed
+        config.addinivalue_line("markers", "hypothesis: Tests which use hypothesis.")
 
-    # terminalreporter.stats is a dict, where the empty string appears to
-    # always be the key for a list of _pytest.reports.TestReport objects
-    # (where we stored the statistics data in pytest_runtest_makereport above)
-    for test_report in terminalreporter.stats.get("", []):
-        for name, lines in test_report.user_properties:
-            if name == "hypothesis-stats" and test_report.when == "teardown":
-                for li in lines:
-                    terminalreporter.write_line(li)
-
-
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if not isinstance(item, pytest.Function):
-            continue
-        if is_hypothesis_test(item.obj):
-            item.add_marker("hypothesis")
-        if getattr(item.obj, "is_hypothesis_strategy_function", False):
-
-            def note_strategy_is_not_test(*args, **kwargs):
-                note_deprecation(
-                    "%s is a function that returns a Hypothesis strategy, "
-                    "but pytest has collected it as a test function.  This "
-                    "is useless as the function body will never be executed.  "
-                    "To define a test function, use @given instead of "
-                    "@composite." % (item.nodeid,),
-                    since="2018-11-02",
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(item):
+        if not hasattr(item, "obj"):
+            yield
+        elif not is_hypothesis_test(item.obj):
+            # If @given was not applied, check whether other hypothesis
+            # decorators were applied, and raise an error if they were.
+            if getattr(item.obj, "_hypothesis_internal_settings_applied", False):
+                raise InvalidArgument(
+                    "Using `@settings` on a test without `@given` is completely pointless."
                 )
+            yield
+        else:
+            if item.get_closest_marker("parametrize") is not None:
+                # Give every parametrized test invocation a unique database key
+                key = item.nodeid.encode("utf-8")
+                item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = key
 
-            item.obj = note_strategy_is_not_test
+            store = StoringReporter(item.config)
+
+            def note_statistics(stats):
+                lines = [item.nodeid + ":", ""] + stats.get_description() + [""]
+                item.hypothesis_statistics = lines
+
+            with collector.with_value(note_statistics):
+                with with_reporter(store):
+                    yield
+            if store.results:
+                item.hypothesis_report_information = list(store.results)
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(item, call):
+        report = (yield).get_result()
+        if hasattr(item, "hypothesis_report_information"):
+            report.sections.append(
+                ("Hypothesis", "\n".join(item.hypothesis_report_information))
+            )
+        if hasattr(item, "hypothesis_statistics") and report.when == "teardown":
+            val = ("hypothesis-stats", item.hypothesis_statistics)
+            report.user_properties.append(val)
+
+    def pytest_terminal_summary(terminalreporter):
+        if not terminalreporter.config.getoption(PRINT_STATISTICS_OPTION):
+            return
+        terminalreporter.section("Hypothesis Statistics")
+        # terminalreporter.stats is a dict, where the empty string appears to
+        # always be the key for a list of _pytest.reports.TestReport objects
+        # (where we stored the statistics data in pytest_runtest_makereport above)
+        for test_report in terminalreporter.stats.get("", []):
+            for name, lines in test_report.user_properties:
+                if name == "hypothesis-stats" and test_report.when == "teardown":
+                    for li in lines:
+                        terminalreporter.write_line(li)
+
+    def pytest_collection_modifyitems(items):
+        for item in items:
+            if not isinstance(item, pytest.Function):
+                continue
+            if is_hypothesis_test(item.obj):
+                item.add_marker("hypothesis")
+            if getattr(item.obj, "is_hypothesis_strategy_function", False):
+
+                def note_strategy_is_not_test(*args, **kwargs):
+                    note_deprecation(
+                        "%s is a function that returns a Hypothesis strategy, "
+                        "but pytest has collected it as a test function.  This "
+                        "is useless as the function body will never be executed.  "
+                        "To define a test function, use @given instead of "
+                        "@composite." % (item.nodeid,),
+                        since="2018-11-02",
+                    )
+
+                item.obj = note_strategy_is_not_test
 
 
 def load():
-    pass
+    """Required for `pluggy` to load a plugin from setuptools entrypoints."""


### PR DESCRIPTION
This ensures that, if you're using a version of pytest which is older than our plugin supports - which is itself older than the pytest developers support - we just disable the plugin instead of throwing an internal error.  You won't get e.g. statistics support, but can still run the tests!

This means you get a warning and graceful degredation in old environments, and in particular that being unable to upgrade pytest won't stop you upgrading Hypothesis.