### PR TITLE
Count `charmap()` towards `text()` drawtime

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2108`, where the first test using
+:func:`~hypothesis.strategies.data` to draw from :func:`~hypothesis.strategies.characters`
+or :func:`~hypothesis.strategies.text` would be flaky due to unreliable test timings.
+
+Time taken by lazy instantiation of strategies is now counted towards drawing from
+the strategy, rather than towards the deadline for the test function.


### PR DESCRIPTION
Closes #2108.