### PR TITLE
Suport platforms where `__file__` is not defined

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch allows Hypothesis to run in environments that do not specify
+a ``__file__``, such as a :mod:`python:zipapp` (:issue:`2196`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -24,7 +24,6 @@ import base64
 import contextlib
 import datetime
 import inspect
-import os
 import random as rnd_module
 import traceback
 import warnings
@@ -483,11 +482,6 @@ def new_given_argspec(original_argspec, generator_kwargs):
     return original_argspec._replace(
         args=new_args, kwonlyargs=new_kwonlyargs, annotations=annots
     )
-
-
-ROOT = os.path.dirname(__file__)
-
-STDLIB = os.path.dirname(os.__file__)
 
 
 class StateForActualGivenExecution(object):

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -37,6 +37,9 @@ if False:
 
 
 def belongs_to(package):
+    if not hasattr(package, "__file__"):  # pragma: no cover
+        return lambda filepath: False
+
     root = os.path.dirname(package.__file__)
     cache = {text_type: {}, binary_type: {}}
 

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -45,13 +45,18 @@ URL_SAFE_CHARACTERS = frozenset(string.ascii_letters + string.digits + "$-_.+!*'
 
 # This file is sourced from http://data.iana.org/TLD/tlds-alpha-by-domain.txt
 # The file contains additional information about the date that it was last updated.
-with open(
-    os.path.join(os.path.dirname(__file__), "vendor", "tlds-alpha-by-domain.txt")
-) as tld_file:
-    __header = next(tld_file)
-    assert __header.startswith("#")
-    TOP_LEVEL_DOMAINS = sorted((line.rstrip() for line in tld_file), key=len)
-TOP_LEVEL_DOMAINS.insert(0, "COM")
+try:
+    from importlib.resources import read_text  # type: ignore
+except ImportError:
+    # If we don't have importlib.resources (Python 3.7+) or the importlib_resources
+    # backport available, fall back to __file__ and hope we're on a filesystem.
+    f = os.path.join(os.path.dirname(__file__), "vendor", "tlds-alpha-by-domain.txt")
+    with open(f) as tld_file:
+        _tlds = tld_file.read().splitlines()
+else:  # pragma: no cover  # new in Python 3.7
+    _tlds = read_text("hypothesis.vendor", "tlds-alpha-by-domain.txt").splitlines()
+assert _tlds[0].startswith("#")
+TOP_LEVEL_DOMAINS = ["COM"] + sorted(_tlds[1:], key=len)
 
 
 class DomainNameStrategy(SearchStrategy):


### PR DESCRIPTION
such as `zipapp` or `PyOxidizer`.

- `is_hypothesis_file` will always return `False`, because `hypothesis.__file__` is not defined.  This weakens our traceback elision somewhat; it's clearly better than a crash but if we get a non-trivial user base on these platforms it's probably possible to do better.
- Provisional strategies require one of Python 3.7+, `__file__`, or the `importlib_resources` backport to load the list of TLDs.  Anyone in the third category is encouraged to contact us, because I'm *not* adding a conditional dependency without any evidence that it would actually be useful.

Closes #2196.