### PR TITLE
Upgrade `mutually_broadcastable_shapes()` to handle gufunc signatures

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release adds a ``gufunc`` argument to
+:func:`~hypothesis.extra.numpy.mutually_broadcastable_shapes` (:issue:`2174`),
+which allows us to generate shapes which are valid for functions like
+:obj:`numpy:numpy.matmul` that require shapes which are not simply broadcastable.
+
+Thanks to everyone who has contributed to this feature over the last year,
+and a particular shout-out to Zac Hatfield-Dodds and Ryan Soklaski for
+:func:`~hypothesis.extra.numpy.mutually_broadcastable_shapes` and to
+Ryan Turner for the downstream :pypi:`hypothesis-gufunc` project.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -86,6 +86,7 @@ extlinks = {
     "pull": (_repo + "pull/%s", "pull request #"),
     "pypi": ("https://pypi.org/project/%s", ""),
     "bpo": ("https://bugs.python.org/issue%s", "bpo-"),
+    "np-ref": ("https://docs.scipy.org/doc/numpy/reference/%s", ""),
 }
 
 # -- Options for HTML output ----------------------------------------------

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1037,6 +1037,31 @@ def mutually_broadcastable_shapes(
         BroadcastableShapes(input_shapes=((3,), (1, 3), (2, 3)), result_shape=(2, 3))
         BroadcastableShapes(input_shapes=((), (), ()), result_shape=(2, 3))
         BroadcastableShapes(input_shapes=((3,), (), (3,)), result_shape=(2, 3))
+
+    **Use with Generalised Universal Function signatures**
+
+    A :np-ref:`universal function <ufuncs.html>` (or ufunc for short) is a function
+    that operates on ndarrays in an element-by-element fashion, supporting array
+    broadcasting, type casting, and several other standard features.
+    A :np-ref:`generalised ufunc <c-api.generalized-ufuncs.html>` operates on
+    sub-arrays rather than elements, based on the "signature" of the function.
+    Compare e.g. :obj:`numpy:numpy.add` (ufunc) to :obj:`numpy:numpy.matmul` (gufunc).
+
+    To generate shapes for a gufunc, you can pass the ``gufunc`` argument *instead of*
+    ``num_shapes``.  This may be a gufunc signature string, or a gufunc object.
+
+    In this case, the ``side`` arguments are applied to the 'core dimensions' as well,
+    ignoring any frozen dimensions.  ``base_shape``  and the ``dims`` arguments are
+    applied to the 'loop dimensions'.  If necessary, the dimensionality of each shape
+    is silently capped to respect the 32-dimension limit.
+
+    .. code-block:: pycon
+
+        >>> # np.matmul.signature == "(m?,n),(n,p?)->(m?,p?)"
+        >>> mutually_broadcastable_shapes(gufunc=np.matmul).example()
+        BroadcastableShapes(input_shapes=((2,), (2,)), result_shape=())
+        BroadcastableShapes(input_shapes=((3, 4, 2), (1, 2)), result_shape=(3, 4))
+        BroadcastableShapes(input_shapes=((4, 2), (1, 2, 3)), result_shape=(4, 3))
     """
     if __reserved is not not_set:
         raise InvalidArgument("Do not pass the __reserved argument.")

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -228,6 +228,14 @@ def e(a, **kwargs):
             gufunc="()->(),()",
         ),
         e(
+            nps.mutually_broadcastable_shapes,  # output has dimension not in inputs
+            gufunc="()->(i)",
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # frozen-optional is ambiguous & banned
+            gufunc="(2?)->()",
+        ),
+        e(
             nps.mutually_broadcastable_shapes,  # signature must be in string format
             gufunc=([(), ()], [()]),
         ),

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -213,48 +213,44 @@ def e(a, **kwargs):
         e(
             nps.mutually_broadcastable_shapes,  # valid to pass num_shapes xor gufunc
             num_shapes=2,
-            gufunc="()->()",
+            signature="()->()",
         ),
         e(
-            nps.mutually_broadcastable_shapes,  # non-ufunc callables are not valid
-            gufunc=sum,
-        ),
-        e(
-            nps.mutually_broadcastable_shapes,  # element-wise ufunc has no signature
-            gufunc=numpy.add,
+            nps.mutually_broadcastable_shapes,  # element-wise ufunc has signature=None
+            signature=numpy.add.signature,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # multiple outputs not yet supported
-            gufunc="()->(),()",
+            signature="()->(),()",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # output has dimension not in inputs
-            gufunc="()->(i)",
+            signature="()->(i)",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # frozen-optional is ambiguous & banned
-            gufunc="(2?)->()",
+            signature="(2?)->()",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # signature must be in string format
-            gufunc=([(), ()], [()]),
+            signature=([(), ()], [()]),
         ),
         e(
             nps.mutually_broadcastable_shapes,  # string must match signature regex
-            gufunc="this string isn't a valid signature",
+            signature="this string isn't a valid signature",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # shape with too many dimensions
-            gufunc="(" + ",".join("d{}".format(n) for n in range(33)) + ")->()",
+            signature="(" + ",".join("d{}".format(n) for n in range(33)) + ")->()",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # max_dims too large given ufunc
-            gufunc=numpy.matmul,
+            signature=numpy.matmul.signature,
             max_dims=32,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # least valid max_dims is < min_dims
-            gufunc=numpy.matmul,
+            signature=numpy.matmul.signature,
             min_dims=32,
         ),
         e(nps.basic_indices, shape=0),

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -28,7 +28,8 @@ from tests.common.utils import checks_deprecated_behaviour
 
 
 def e(a, **kwargs):
-    return (a, kwargs)
+    rep = "%s(%s)" % (a.__name__, ", ".join("%s=%r" % it for it in kwargs.items()))
+    return pytest.param(a, kwargs, id=rep)
 
 
 @pytest.mark.parametrize(
@@ -117,70 +118,59 @@ def e(a, **kwargs):
             min_side=2,
             max_side=3,
         ),
+        e(nps.mutually_broadcastable_shapes),
         e(nps.mutually_broadcastable_shapes, num_shapes=0),
         e(nps.mutually_broadcastable_shapes, num_shapes="a"),
         e(nps.mutually_broadcastable_shapes, num_shapes=2, base_shape="a"),
         e(
             nps.mutually_broadcastable_shapes,  # min_side is invalid type
             num_shapes=2,
-            base_shape=(2, 2),
             min_side="a",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # min_dims is invalid type
             num_shapes=2,
-            base_shape=(2, 2),
             min_dims="a",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # max_side is invalid type
             num_shapes=2,
-            base_shape=(2, 2),
             max_side="a",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # max_side is invalid type
             num_shapes=2,
-            base_shape=(2, 2),
             max_dims="a",
         ),
         e(
             nps.mutually_broadcastable_shapes,  # min_side is out of domain
             num_shapes=2,
-            base_shape=(2, 2),
             min_side=-1,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # min_dims is out of domain
             num_shapes=2,
-            base_shape=(2, 2),
             min_dims=-1,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # min_dims is out of domain
             num_shapes=2,
-            base_shape=(2, 2),
             min_dims=33,
-            max_dims=None,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # max_dims is out of domain
             num_shapes=2,
-            base_shape=(2, 2),
-            min_dims=1,
             max_dims=33,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # max_side < min_side
             num_shapes=2,
-            base_shape=(2, 2),
             min_side=1,
             max_side=0,
         ),
         e(
             nps.mutually_broadcastable_shapes,  # max_dims < min_dims
             num_shapes=2,
-            base_shape=(2, 2),
             min_dims=1,
             max_dims=0,
         ),
@@ -219,6 +209,35 @@ def e(a, **kwargs):
             max_dims=4,
             min_side=2,
             max_side=3,
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # valid to pass num_shapes xor gufunc
+            num_shapes=2,
+            gufunc="()->()",
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # non-ufunc callables are not valid
+            gufunc=sum,
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # element-wise ufunc has no signature
+            gufunc=numpy.add,
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # multiple outputs not yet supported
+            gufunc="()->(),()",
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # signature must be in string format
+            gufunc=([(), ()], [()]),
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # string must match signature regex
+            gufunc="this string isn't a valid signature",
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # shape with too many dimensions
+            gufunc="(" + ",".join("d{}".format(n) for n in range(33)) + ")->()",
         ),
         e(nps.basic_indices, shape=0),
         e(nps.basic_indices, shape=("1", "2")),

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -247,6 +247,16 @@ def e(a, **kwargs):
             nps.mutually_broadcastable_shapes,  # shape with too many dimensions
             gufunc="(" + ",".join("d{}".format(n) for n in range(33)) + ")->()",
         ),
+        e(
+            nps.mutually_broadcastable_shapes,  # max_dims too large given ufunc
+            gufunc=numpy.matmul,
+            max_dims=32,
+        ),
+        e(
+            nps.mutually_broadcastable_shapes,  # least valid max_dims is < min_dims
+            gufunc=numpy.matmul,
+            min_dims=32,
+        ),
         e(nps.basic_indices, shape=0),
         e(nps.basic_indices, shape=("1", "2")),
         e(nps.basic_indices, shape=(0, -1)),

--- a/hypothesis-python/tests/numpy/test_gufunc.py
+++ b/hypothesis-python/tests/numpy/test_gufunc.py
@@ -86,3 +86,7 @@ def test_hypothesis_signature_parses(sig):
         hy_sig = nps._hypothesis_parse_gufunc_signature(sig, all_checks=False)
         np_sig = np.lib.function_base._parse_gufunc_signature(sig)
         assert np_sig == hy_sig_2_np_sig(hy_sig)
+
+
+def test_frozen_dims_signature():
+    nps._hypothesis_parse_gufunc_signature("(2),(3)->(4)")

--- a/hypothesis-python/tests/numpy/test_gufunc.py
+++ b/hypothesis-python/tests/numpy/test_gufunc.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+import hypothesis.extra.numpy as nps
+import hypothesis.strategies as st
+from hypothesis import example, given
+from hypothesis.errors import InvalidArgument
+
+
+def use_signature_examples(func):
+    for sig in [
+        "(),()->()",
+        "(i)->()",
+        "(i),(i)->()",
+        "(m,n),(n,p)->(m,p)",
+        "(n),(n,p)->(p)",
+        "(m,n),(n)->(m)",
+        "(m?,n),(n,p?)->(m?,p?)",
+        "(3),(3)->(3)",
+    ]:
+        func = example(sig)(func)
+    return func
+
+
+def hy_sig_2_np_sig(hy_sig):
+    return (
+        [tuple(d.strip("?") for d in shape) for shape in hy_sig.input_shapes],
+        [tuple(d.strip("?") for d in hy_sig.result_shape)],
+    )
+
+
+@use_signature_examples
+@example("()->(%s),()" % ",".join(33 * "0"))
+@given(st.from_regex(np.lib.function_base._SIGNATURE))
+def test_numpy_signature_parses(sig):
+    if sig == "(m?,n),(n,p?)->(m?,p?)":  # matmul example
+        return
+
+    np_sig = np.lib.function_base._parse_gufunc_signature(sig)
+    try:
+        hy_sig = nps._hypothesis_parse_gufunc_signature(sig, all_checks=False)
+        assert np_sig == hy_sig_2_np_sig(hy_sig)
+    except InvalidArgument:
+        shape_too_long = any(len(s) > 32 for s in np_sig[0] + np_sig[1])
+        multiple_outputs = len(np_sig[1]) > 1
+        assert shape_too_long or multiple_outputs
+
+        # Now, if we can fix this up does it validate?
+        in_, out = sig.split("->")
+        sig = in_ + "->" + out.split(",(")[0]
+        np_sig = np.lib.function_base._parse_gufunc_signature(sig)
+        if all(len(s) <= 32 for s in np_sig[0] + np_sig[1]):
+            hy_sig = nps._hypothesis_parse_gufunc_signature(sig, all_checks=False)
+            assert np_sig == hy_sig_2_np_sig(hy_sig)
+
+
+@use_signature_examples
+@given(st.from_regex(nps._SIGNATURE))
+def test_hypothesis_signature_parses(sig):
+    hy_sig = nps._hypothesis_parse_gufunc_signature(sig, all_checks=False)
+    try:
+        np_sig = np.lib.function_base._parse_gufunc_signature(sig)
+        assert np_sig == hy_sig_2_np_sig(hy_sig)
+    except ValueError:
+        assert "?" in sig
+        # We can always fix this up, and it should then always validate.
+        sig = sig.replace("?", "")
+        hy_sig = nps._hypothesis_parse_gufunc_signature(sig, all_checks=False)
+        np_sig = np.lib.function_base._parse_gufunc_signature(sig)
+        assert np_sig == hy_sig_2_np_sig(hy_sig)


### PR DESCRIPTION
Closes #2174.  

This is a smaller API than [`hypothesis-gufunc`](https://github.com/uber/hypothesis-gufunc), but should have significantly better shrinking performance.  @rdturnermtl, you might want to port over to use this!

I'm implicitly pushing advanced users onto `@st.composite` to define their own gufunc-arrays strategy, as everyone will want something a little different - and Hypothesis is a library full of things for them to compose, not a my-way-or-highway framework.