### PR TITLE
Fix various typos in docstrings & comments

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch fixes typos in docstrings and comments.
+This patch fixes several typos in our docstrings and comments,
+with no change in behaviour.  Thanks to  Dmitry Dygalo for
+identifying and fixing them!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes typos in docstrings and comments.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -36,7 +36,7 @@ a ``__file__``, such as a :mod:`python:zipapp` (:issue:`2196`).
 4.44.0 - 2019-11-11
 -------------------
 
-This release adds a ``gufunc`` argument to
+This release adds a ``signature`` argument to
 :func:`~hypothesis.extra.numpy.mutually_broadcastable_shapes` (:issue:`2174`),
 which allows us to generate shapes which are valid for functions like
 :obj:`numpy:numpy.matmul` that require shapes which are not simply broadcastable.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -310,7 +310,7 @@ def one_of(*args):
 
 
 def one_of(*args):
-    # Mypy workaround alert:  Any is too loose above; the return paramater
+    # Mypy workaround alert:  Any is too loose above; the return parameter
     # should be the union of the input parameters.  Unfortunately, Mypy <=0.600
     # raises errors due to incompatible inputs instead.  See #1270 for links.
     # v0.610 doesn't error; it gets inference wrong for 2+ arguments instead.
@@ -964,8 +964,8 @@ def characters(
     """Generates unicode text type (unicode on python 2, str on python 3)
     characters following specified filtering rules.
 
-    - When no filtering rules are specifed, any character can be produced.
-    - If ``min_codepoint`` or ``max_codepoint`` is specifed, then only
+    - When no filtering rules are specified, any character can be produced.
+    - If ``min_codepoint`` or ``max_codepoint`` is specified, then only
       characters having a codepoint in that range will be produced.
     - If ``whitelist_categories`` is specified, then only characters from those
       Unicode categories will be produced. This is a further restriction,
@@ -1806,7 +1806,7 @@ def datetimes(
     there.
 
     Alternatively, you can create a list of the timezones you wish to allow
-    (e.g. from the standard library, ``datetutil``, or ``pytz``) and use
+    (e.g. from the standard library, :pypi:`dateutil`, or :pypi:`pytz`) and use
     :py:func:`sampled_from`.  Ensure that simple values such as None or UTC
     are at the beginning of the list for proper minimisation.
 
@@ -1814,7 +1814,7 @@ def datetimes(
     """
     # Why must bounds be naive?  In principle, we could also write a strategy
     # that took aware bounds, but the API and validation is much harder.
-    # If you want to generate datetimes between two particular momements in
+    # If you want to generate datetimes between two particular moments in
     # time I suggest (a) just filtering out-of-bounds values; (b) if bounds
     # are very close, draw a value and subtract its UTC offset, handling
     # overflows and nonexistent times; or (c) do something customised to

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -157,7 +157,7 @@ def target(observation, label=""):
         **The more examples you run, the better this technique works.**
 
         As a rule of thumb, the targeting effect is noticeable above
-        :obj:`max_exmples=1000 <hypothesis.settings.max_examples>`,
+        :obj:`max_examples=1000 <hypothesis.settings.max_examples>`,
         and immediately obvious by around ten thousand examples
         *per label* used by your test.
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -749,7 +749,7 @@ def fake_subTest(self, msg=None, **__):
     """Monkeypatch for `unittest.TestCase.subTest` during `@given`.
 
     If we don't patch this out, each failing example is reported as a
-    seperate failing test by the unittest test runner, which is
+    separate failing test by the unittest test runner, which is
     obviously incorrect. We therefore replace it for the duration with
     this version.
     """
@@ -983,7 +983,7 @@ def given(
                         raise
                     # On Python 3, we swap out the real traceback for our
                     # trimmed version.  Using a variable ensures that the line
-                    # which will actually appear in trackbacks is as clear as
+                    # which will actually appear in tracebacks is as clear as
                     # possible - "raise the_error_hypothesis_found".
                     the_error_hypothesis_found = e.with_traceback(
                         get_trimmed_traceback()

--- a/hypothesis-python/src/hypothesis/extra/dpcontracts.py
+++ b/hypothesis-python/src/hypothesis/extra/dpcontracts.py
@@ -41,7 +41,7 @@ def fulfill(contract_func):
     and retry them with different arguments.
 
     This is a convenience function for testing internal code that uses
-    :pypi:dpcontracts`, to automatically filter out arguments that would be
+    :pypi:`dpcontracts`, to automatically filter out arguments that would be
     rejected by the public interface before triggering a contract error.
 
     This can be used as ``builds(fulfill(func), ...)`` or in the body of the

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -179,7 +179,7 @@ class Example(object):
 
 class ExampleProperty(object):
     """There are many properties of examples that we calculate by
-    essentially rerunning that test case multiple times based on the
+    essentially rerunning the test case multiple times based on the
     calls which we record in ExampleRecord.
 
     This class defines a visitor, subclasses of which can be used

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -179,7 +179,7 @@ class Example(object):
 
 class ExampleProperty(object):
     """There are many properties of examples that we calculate by
-    essentially rerunning thet test case multiple times based on the
+    essentially rerunning that test case multiple times based on the
     calls which we record in ExampleRecord.
 
     This class defines a visitor, subclasses of which can be used
@@ -238,7 +238,7 @@ class ExampleProperty(object):
 
     def block(self, i):
         """Called with each ``draw_bits`` call, with ``i`` the index of the
-        corresonding block in ``self.examples.blocks``"""
+        corresponding block in ``self.examples.blocks``"""
 
     def stop_example(self, i, discarded):
         """Called at the end of each example, with ``i`` the

--- a/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
@@ -42,7 +42,7 @@ float (there is some redundancy here, as 7 * 8 = 56, which is larger than the
 largest integer that floating point numbers can represent exactly, so multiple
 encodings may map to the same float).
 
-If the tag bit is 1, we instead use somemthing that is closer to the normal
+If the tag bit is 1, we instead use something that is closer to the normal
 representation of floats (and can represent every non-negative float exactly)
 but has a better ordering:
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -64,7 +64,7 @@ ONE_FROM_MANY_LABEL = calc_label_from_name("one more from many()")
 def integer_range(data, lower, upper, center=None):
     assert lower <= upper
     if lower == upper:
-        # Write a value even when this is trival so that when a bound depends
+        # Write a value even when this is trivial so that when a bound depends
         # on other values we don't suddenly disappear when the gap shrinks to
         # zero - if that happens then often the data stream becomes misaligned
         # and we fail to shrink in cases where we really should be able to.

--- a/hypothesis-python/tests/django/toystore/forms.py
+++ b/hypothesis-python/tests/django/toystore/forms.py
@@ -82,7 +82,7 @@ class BasicFieldForm(ReprForm):
     _boolean_required = forms.BooleanField()
     _boolean = forms.BooleanField(required=False)
     # This took me too long to figure out... The BooleanField will actually
-    # raise a ValidationError when it recieves a value of False. Why they
+    # raise a ValidationError when it receives a value of False. Why they
     # didn't call it a TrueOnlyField escapes me, but *if* you actually want
     # to accept both True and False in your BooleanField, make sure you set
     # `required=False`. This behavior has been hotly contested in the bug


### PR DESCRIPTION
Hej, I was reading docs on the targeted PBT and noticed a typo, so I looked for some more typos as well