### PR TITLE
Avoid being the first to import large packages

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch avoids importing test runners such as :pypi`pytest`, :pypi`unittest2`,
+or :pypi`nose` solely to access their special "skip test" exception types -
+if the module is not in ``sys.modules``, the exception can't be raised anyway.
+
+This fixes a problem where importing an otherwise unused module could cause
+spurious errors due to import-time side effects (and possibly ``-Werror``).

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -126,11 +126,6 @@ try:
 except ImportError:
     pass
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 if False:
     import random  # noqa
     from types import ModuleType  # noqa
@@ -485,7 +480,7 @@ def floats(
             "Got width=%r, but the only valid values are the integers 16, "
             "32, and 64." % (width,)
         )
-    if width == 16 and sys.version_info[:2] < (3, 6) and numpy is None:
+    if width == 16 and sys.version_info[:2] < (3, 6) and "numpy" not in sys.modules:
         raise InvalidArgument(  # pragma: no cover
             "width=16 requires either Numpy, or Python >= 3.6"
         )

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -403,7 +403,8 @@ def skip_exceptions_to_reraise():
     """Return a tuple of exceptions meaning 'skip this test', to re-raise.
 
     This is intended to cover most common test runners; if you would
-    like another to be added please open an issue or pull request.
+    like another to be added please open an issue or pull request adding
+    it to this function and to tests/cover/test_lazy_import.py
     """
     # This is a set because nose may simply re-export unittest.SkipTest
     exceptions = set()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 import enum
 import hashlib
 import heapq
+import sys
 from collections import OrderedDict
 from fractions import Fraction
 
@@ -114,14 +115,8 @@ def integer_range(data, lower, upper, center=None):
     return int(result)
 
 
-try:
-    from numpy import ndarray
-except ImportError:  # pragma: no cover
-    ndarray = ()
-
-
 def check_sample(values, strategy_name):
-    if isinstance(values, ndarray):
+    if "numpy" in sys.modules and isinstance(values, sys.modules["numpy"].ndarray):
         if values.ndim != 1:
             raise InvalidArgument(
                 (

--- a/hypothesis-python/tests/cover/test_lazy_import.py
+++ b/hypothesis-python/tests/cover/test_lazy_import.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import subprocess
+import sys
+
+SHOULD_NOT_IMPORT_TEST_RUNNERS = """
+import sys
+import unittest
+from hypothesis import given, strategies as st
+
+class TestDoesNotImportRunners(unittest.TestCase):
+    strat = st.integers() | st.floats() | st.sampled_from(["a", "b"])
+
+    @given(strat)
+    def test_does_not_import_unittest2(self, x):
+        assert "unittest2" not in sys.modules
+
+    @given(strat)
+    def test_does_not_import_nose(self, x):
+        assert "nose" not in sys.modules
+
+    @given(strat)
+    def test_does_not_import_pytest(self, x):
+        assert "pytest" not in sys.modules
+
+if __name__ == '__main__':
+    unittest.main()
+"""
+
+
+def test_hypothesis_does_not_import_test_runners(tmp_path):
+    # We obviously can't use pytest to check that pytest is not imported,
+    # so for consistency we use unittest for all three non-stdlib test runners.
+    # It's unclear which of our dependencies is importing unittest, but
+    # since I doubt it's causing any spurious failures I don't really care.
+    # See https://github.com/HypothesisWorks/hypothesis/pull/2204
+    fname = str(tmp_path / "test.py")
+    with open(fname, "w") as f:
+        f.write(SHOULD_NOT_IMPORT_TEST_RUNNERS)
+    subprocess.check_call([sys.executable, fname])

--- a/hypothesis-python/tests/nocover/test_skipping.py
+++ b/hypothesis-python/tests/nocover/test_skipping.py
@@ -46,7 +46,3 @@ def test_no_falsifying_example_if_unittest_skip(skip_exception):
         unittest.TextTestRunner().run(suite)
 
     assert "Falsifying example" not in o.getvalue()
-
-
-def test_skipping_is_cached():
-    assert skip_exceptions_to_reraise() is skip_exceptions_to_reraise()

--- a/hypothesis-python/tests/numpy/test_lazy_import.py
+++ b/hypothesis-python/tests/numpy/test_lazy_import.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from hypothesis.internal.compat import CAN_PACK_HALF_FLOAT
+
+SHOULD_NOT_IMPORT_NUMPY = """
+import sys
+from hypothesis import given, strategies as st
+
+@given(st.integers() | st.floats() | st.sampled_from(["a", "b"]))
+def test_no_numpy_import(x):
+    assert "numpy" not in sys.modules
+"""
+
+
+def test_hypothesis_is_not_the_first_to_import_numpy(testdir):
+    result = testdir.runpytest(testdir.makepyfile(SHOULD_NOT_IMPORT_NUMPY))
+    # OK, we import numpy on Python < 3.6 to get 16-bit float support.
+    # But otherwise we only import it if the user did so first.
+    if CAN_PACK_HALF_FLOAT:
+        result.assert_outcomes(passed=1, failed=0)
+    else:
+        result.assert_outcomes(passed=0, failed=1)


### PR DESCRIPTION
Via https://github.com/astropy/astropy/pull/9532#issuecomment-552346683, our attempted import of `nose` (to get its `SkipTest` exception) can cause problems in some setups.

So I've adapted [this trick](https://twitter.com/jakevdp/status/1130987263301627904) to ensure that we only import test runner packages (and numpy) if someone else did so first.  If it's never imported, we don't need to integrate with it!

Caveats: `st.from_type()` still does optimistic imports, and if you're on Python <= 3.5 `numpy` will be imported to support 16-bit floats.  Otherwise we should be a bit lighter than before 😄 