### PR TITLE
Make @given raise "Missing required kwarg" errors lazily

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This release fixes :func:`@given <hypothesis.given>` to only complain about
+missing keyword-only arguments if the associated test function is actually
+called.
+
+This matches the behaviour of other ``InvalidArgument`` errors produced by
+``@given``.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -284,7 +284,7 @@ def is_invalid_test(name, original_argspec, generator_arguments, generator_kwarg
         repr(kw) for kw in original_argspec.kwonlyargs if kw not in generator_kwargs
     ]
     if missing:
-        raise InvalidArgument(
+        return invalid(
             "Missing required kwarg{}: {}".format(
                 "s" if len(missing) > 1 else "", ", ".join(missing)
             )

--- a/hypothesis-python/tests/py3/test_annotations.py
+++ b/hypothesis-python/tests/py3/test_annotations.py
@@ -75,11 +75,12 @@ def test_py3only_lambda_formatting(lam, source):
 
 
 def test_given_notices_missing_kwonly_args():
-    with pytest.raises(InvalidArgument):
+    @given(a=st.none())
+    def reqs_kwonly(*, a, b):
+        pass
 
-        @given(a=st.none())
-        def reqs_kwonly(*, a, b):
-            pass
+    with pytest.raises(InvalidArgument):
+        reqs_kwonly()
 
 
 def test_converter_handles_kwonly_args():


### PR DESCRIPTION
While looking into `is_invalid_test` for #2199, I noticed that most `@given` usage errors are reported lazily, but "Missing required kwarg" is reported eagerly.

After investigating #625, I couldn't find any reason to think that this was a deliberate choice, so it's probably just a minor oversight that slipped through.

I've therefore switched those errors over to use lazy reporting, to match the other argument usage errors.