### PR TITLE
Stop `floats(max_value=0.0, exclude_max=True)` generating `-0.0`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,16 @@
+RELEASE_TYPE: minor
+
+This release changes the behaviour of :func:`~hypothesis.strategies.floats`
+when excluding signed zeros - ``floats(max_value=0.0, exclude_max=True)``
+can no longer generate ``-0.0`` nor the much rarer
+``floats(min_value=-0.0, exclude_min=True)`` generate ``+0.0``.
+
+The correct interaction between signed zeros and exclusive endpoints was unclear;
+we now enforce the invariant that :func:`~hypothesis.strategies.floats` will
+never generate a value equal to an excluded endpoint (:issue:`2201`).
+
+If you prefer the old behaviour, you can pass ``floats(max_value=-0.0)`` or
+``floats(min_value=0.0)`` which is exactly equivalent and has not changed.
+If you had *two* endpoints equal to zero, we recommend clarifying your tests by using
+:func:`~hypothesis.strategies.just` or :func:`~hypothesis.strategies.sampled_from`
+instead of :func:`~hypothesis.strategies.floats`.

--- a/hypothesis-python/tests/cover/test_float_nastiness.py
+++ b/hypothesis-python/tests/cover/test_float_nastiness.py
@@ -294,16 +294,23 @@ def test_exclude_entire_interval(lo, hi, bound):
         st.floats(bound, bound, exclude_min=lo, exclude_max=hi).validate()
 
 
-def test_exclude_zero_interval():
+def test_zero_intervals_are_OK():
+    st.floats(0.0, 0.0).validate()
     st.floats(-0.0, 0.0).validate()
-    st.floats(-0.0, 0.0, exclude_min=True).validate()
-    st.floats(-0.0, 0.0, exclude_max=True).validate()
+    st.floats(-0.0, -0.0).validate()
 
 
 @checks_deprecated_behaviour
 def test_inverse_zero_interval_is_deprecated():
     st.floats(0.0, -0.0).validate()
-    st.floats(-0.0, 0.0, exclude_min=True, exclude_max=True).validate()
+
+
+@pytest.mark.parametrize("lo", [0.0, -0.0])
+@pytest.mark.parametrize("hi", [0.0, -0.0])
+@pytest.mark.parametrize("exmin,exmax", [(True, False), (False, True), (True, True)])
+def test_cannot_exclude_endpoint_with_zero_interval(lo, hi, exmin, exmax):
+    with pytest.raises(InvalidArgument):
+        st.floats(lo, hi, exclude_min=exmin, exclude_max=exmax).validate()
 
 
 WIDTHS = (64, 32)


### PR DESCRIPTION
Closes #2201.  

This does technically break `floats(min_value=-0.0, max_value=0.0, exclude_max=True)` (i.e. `just(-0.0)`) and `floats(min_value=-0.0, max_value=0.0, exclude_min=True)` (i.e. `just(0.0)`).  I sincerely doubt that anyone at all was doing this, but could turn it into a deprecation warning if requested.