### PR TITLE
Support new-in-3.8 typing module types

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release supports :obj:`python:typing.Final` and :obj:`python:typing.TypedDict`
+in :func:`~hypothesis.strategies.from_type`.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -1369,6 +1369,20 @@ def from_type(thing):
     This is useful when writing tests which check that invalid input is
     rejected in a certain way.
     """
+    if (
+        hasattr(typing, "_TypedDictMeta")
+        and type(thing) is typing._TypedDictMeta  # type: ignore
+    ):  # pragma: no cover
+        # "helpfully", TypedDict raises an error on instance and subclass checks
+        # (at least in Python 3.8.0), so we have to check whether the type of its
+        # type is the expected metaclass.
+        # Then, we currently have no way to tell whether particular keys were
+        # defined on this or a parent class - nor what the parent classes were! -
+        # so we have to assume that nothing is optional.  Sorry.
+        return fixed_dictionaries(  # type: ignore
+            {k: from_type(v) for k, v in thing.__annotations__.items()}
+        )
+
     # TODO: We would like to move this to the top level, but pending some major
     # refactoring it's hard to do without creating circular imports.
     from hypothesis.searchstrategy import types

--- a/hypothesis-python/src/hypothesis/searchstrategy/types.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/types.py
@@ -125,6 +125,10 @@ def from_typing_type(thing):
         elif len(elem_types) == 1 and elem_types[0] == ():
             return st.tuples()  # Empty tuple; see issue #1583
         return st.tuples(*map(st.from_type, elem_types))
+    if (
+        hasattr(typing, "Final") and getattr(thing, "__origin__", None) == typing.Final
+    ):  # pragma: no cover  # new in Python 3.8
+        return st.one_of([st.from_type(t) for t in thing.__args__])
     if is_typing_literal(thing):  # pragma: no cover  # new in Python 3.8
         args_dfs_stack = list(thing.__args__)
         literals = []

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -33,6 +33,8 @@ run()
 # Skip collection of tests which require the Django test runner,
 # or that don't work on the current major version of Python.
 collect_ignore_glob = ["django/*", "py3/*" if sys.version_info[0] == 2 else "py2/*"]
+if sys.version_info < (3, 8):
+    collect_ignore_glob.append("py3/*py38*")
 
 
 def pytest_configure(config):

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -126,7 +126,7 @@ def test_exact_timing():
         time.sleep(0.5)
 
     stats = call_for_statistics(test)
-    assert re.match(r"~ [56]\d\dms", stats.runtimes) is not None, stats.runtimes
+    assert re.match(r"(~ |\d+-)5\d\dms", stats.runtimes) is not None, stats.runtimes
 
 
 def test_apparently_instantaneous_tests():

--- a/hypothesis-python/tests/py3/test_async_def.py
+++ b/hypothesis-python/tests/py3/test_async_def.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import asyncio
+import sys
+from unittest import TestCase
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import assume, given
+
+
+class TestAsyncioRun(TestCase):
+
+    timeout = 5
+
+    def execute_example(self, f):
+        asyncio.run(f())
+
+    @pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="asyncio.run() is new")
+    @given(st.text())
+    async def test_foo(self, x):
+        assume(x)
+        await asyncio.sleep(0.001)
+        assert x

--- a/hypothesis-python/tests/py3/test_asyncio.py
+++ b/hypothesis-python/tests/py3/test_asyncio.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import, division, print_function
 
 import asyncio
 import sys
-import unittest
 from unittest import TestCase
 
 import pytest
@@ -27,6 +26,11 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import assume, given
 from hypothesis.internal.compat import PYPY
+
+if sys.version_info < (3, 8):
+    coro_decorator = asyncio.coroutine
+else:
+    coro_decorator = pytest.mark.skip
 
 
 class TestAsyncio(TestCase):
@@ -59,9 +63,8 @@ class TestAsyncio(TestCase):
             raise error
 
     @pytest.mark.skipif(PYPY, reason="Error in asyncio.new_event_loop()")
-    @pytest.mark.skipif(sys.version_info[:2] >= (3, 8), reason="deprecated @coroutine")
     @given(st.text())
-    @asyncio.coroutine
+    @coro_decorator
     def test_foo(self, x):
         assume(x)
         yield from asyncio.sleep(0.001)
@@ -77,12 +80,8 @@ class TestAsyncioRun(TestCase):
 
     @pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="asyncio.run() is new")
     @given(st.text())
-    @asyncio.coroutine
+    @coro_decorator
     def test_foo(self, x):
         assume(x)
         yield from asyncio.sleep(0.001)
         assert x
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -305,32 +305,6 @@ def test_distinct_typevars_same_constraint():
     )
 
 
-@pytest.mark.skipif(
-    not hasattr(typing, "Literal"), reason="`typing.Literal` is not available."
-)
-@pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])
-def test_typing_Literal(value):
-    assert from_type(typing.Literal[value]).example() == value
-
-
-@pytest.mark.skipif(
-    not hasattr(typing, "Literal"), reason="`typing.Literal` is not available."
-)
-@given(st.data())
-def test_typing_Literal_nested(data):
-    lit = typing.Literal
-    values = [
-        (lit["hamster", 0], ("hamster", 0)),
-        (lit[26, False, "bunny", 130], (26, False, "bunny", 130)),
-        (lit[lit[1]], {1}),
-        (lit[lit[1], 2], {1, 2}),
-        (lit[1, lit[2], 3], {1, 2, 3}),
-        (lit[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
-    ]
-    literal_type, flattened_literals = data.draw(st.sampled_from(values))
-    assert data.draw(st.from_type(literal_type)) in flattened_literals
-
-
 def annotated_func(a: int, b: int = 2, *, c: int, d: int = 4):
     return a + b + c + d
 

--- a/hypothesis-python/tests/py3/test_lookup_py38.py
+++ b/hypothesis-python/tests/py3/test_lookup_py38.py
@@ -1,0 +1,107 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import typing
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import given
+from hypothesis.errors import Unsatisfiable
+from hypothesis.strategies import from_type
+from tests.common.debug import find_any
+from tests.common.utils import fails_with
+
+
+@given(st.data())
+def test_typing_Final(data):
+    value = data.draw(from_type(typing.Final[int]))
+    assert isinstance(value, int)
+
+
+@pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])
+def test_typing_Literal(value):
+    assert from_type(typing.Literal[value]).example() == value
+
+
+@given(st.data())
+def test_typing_Literal_nested(data):
+    lit = typing.Literal
+    values = [
+        (lit["hamster", 0], ("hamster", 0)),
+        (lit[26, False, "bunny", 130], (26, False, "bunny", 130)),
+        (lit[lit[1]], {1}),
+        (lit[lit[1], 2], {1, 2}),
+        (lit[1, lit[2], 3], {1, 2, 3}),
+        (lit[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
+    ]
+    literal_type, flattened_literals = data.draw(st.sampled_from(values))
+    assert data.draw(st.from_type(literal_type)) in flattened_literals
+
+
+class A(typing.TypedDict):
+    a: int
+
+
+@given(from_type(A))
+def test_simple_typeddict(value):
+    assert type(value) == dict
+    assert set(value) == {"a"}
+    assert isinstance(value["a"], int)
+
+
+class B(A, total=False):
+    # a is required, b is optional
+    b: bool
+
+
+@given(from_type(B))
+def test_typeddict_with_optional(value):
+    assert type(value) == dict
+    assert set(value).issubset({"a", "b"})
+    assert isinstance(value["a"], int)
+    if "b" in value:
+        assert isinstance(value["b"], bool)
+
+
+@fails_with(Unsatisfiable)
+def test_simple_optional_key_is_optional():
+    # Optional keys are not currently supported, as PEP-589 leaves no traces
+    # at runtime... there are ongoing discussions upstream.
+    find_any(from_type(B), lambda d: "b" not in d)
+
+
+class C(B):
+    # a is required, b is optional, c is required again
+    c: str
+
+
+@given(from_type(C))
+def test_typeddict_with_optional_then_required_again(value):
+    assert type(value) == dict
+    assert set(value).issubset({"a", "b", "c"})
+    assert isinstance(value["a"], int)
+    if "b" in value:
+        assert isinstance(value["b"], bool)
+    assert isinstance(value["c"], str)
+
+
+@fails_with(Unsatisfiable)
+def test_layered_optional_key_is_optional():
+    find_any(from_type(C), lambda d: "b" not in d)

--- a/hypothesis-python/tests/py3/test_lookup_py38.py
+++ b/hypothesis-python/tests/py3/test_lookup_py38.py
@@ -23,10 +23,8 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import given
-from hypothesis.errors import Unsatisfiable
 from hypothesis.strategies import from_type
 from tests.common.debug import find_any
-from tests.common.utils import fails_with
 
 
 @given(st.data())
@@ -80,10 +78,10 @@ def test_typeddict_with_optional(value):
         assert isinstance(value["b"], bool)
 
 
-@fails_with(Unsatisfiable)
+@pytest.mark.xfail
 def test_simple_optional_key_is_optional():
     # Optional keys are not currently supported, as PEP-589 leaves no traces
-    # at runtime... there are ongoing discussions upstream.
+    # at runtime.  See https://github.com/python/cpython/pull/17214
     find_any(from_type(B), lambda d: "b" not in d)
 
 
@@ -102,6 +100,8 @@ def test_typeddict_with_optional_then_required_again(value):
     assert isinstance(value["c"], str)
 
 
-@fails_with(Unsatisfiable)
+@pytest.mark.xfail
 def test_layered_optional_key_is_optional():
+    # Optional keys are not currently supported, as PEP-589 leaves no traces
+    # at runtime.  See https://github.com/python/cpython/pull/17214
     find_any(from_type(C), lambda d: "b" not in d)


### PR DESCRIPTION
i.e. `typing.Final` and `typing.TypedDict`, closing #2116, and fixes a new asyncio warning.

The support for optional keys in `typing.TypedDict` won't do anything until python/cpython#17214 is released, but until then it's valid to just assume that everything is required.