### PR TITLE
Bias initial data generation towards small test cases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug introduced in :ref:`Hypothesis 4.42.0 <v4.42.0>` which would cause occasional 
+:obj:`~hypothesis.HealthCheck.too_slow` failures on some tests.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,6 @@
 RELEASE_TYPE: patch
 
-This release fixes a bug introduced in :ref:`Hypothesis 4.42.0 <v4.42.0>` which would cause occasional 
+This release adds some heuristics to test case generation that try to ensure that test cases generated early on will be relatively small.
+
+This fixes a bug introduced in :ref:`Hypothesis 4.42.0 <v4.42.0>` which would cause occasional
 :obj:`~hypothesis.HealthCheck.too_slow` failures on some tests.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -329,7 +329,7 @@ class TreeRecordingObserver(DataObserver):
         self.__current_node = tree.root
         self.__index_in_current_node = 0
         self.__trail = [self.__current_node]
-        self.__killed = False
+        self.killed = False
 
     def draw_bits(self, n_bits, forced, value):
         i = self.__index_in_current_node
@@ -381,10 +381,10 @@ class TreeRecordingObserver(DataObserver):
 
     def kill_branch(self):
         """Mark this part of the tree as not worth re-exploring."""
-        if self.__killed:
+        if self.killed:
             return
 
-        self.__killed = True
+        self.killed = True
 
         if self.__index_in_current_node < len(self.__current_node.values) or (
             self.__current_node.transition is not None
@@ -432,7 +432,7 @@ class TreeRecordingObserver(DataObserver):
         node.check_exhausted()
         assert len(node.values) > 0 or node.check_exhausted()
 
-        if not self.__killed:
+        if not self.killed:
             self.__update_exhausted()
 
     def __update_exhausted(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -417,7 +417,7 @@ class TreeRecordingObserver(DataObserver):
             # As an, I'm afraid, horrible bodge, we deliberately ignore flakiness
             # where tests go from interesting to valid, because it's much easier
             # to produce good error messages for these further up the stack.
-            if (
+            if isinstance(node.transition, Conclusion) and (
                 node.transition.status != Status.INTERESTING
                 or new_transition.status != Status.VALID
             ):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -368,7 +368,7 @@ class TreeRecordingObserver(DataObserver):
                 # stopped
                 inconsistent_generation()
             else:
-                assert isinstance(trans, Branch)
+                assert isinstance(trans, Branch), trans
                 if n_bits != trans.bit_length:
                     inconsistent_generation()
                 try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -315,6 +315,7 @@ class DataTree(object):
                         raise PreviouslyUnseenBehaviour()
                 else:
                     assert isinstance(node.transition, Killed)
+                    data.observer.kill_branch()
                     node = node.transition.next_node
         except StopTest:
             pass

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -594,9 +594,9 @@ class ConjectureRunner(object):
 
                 consecutive_zero_extend_is_invalid = 0
 
-                max_length = (len(minimal_example.buffer) - len(prefix)) * 10 + len(
-                    prefix
-                )
+                minimal_extension = len(minimal_example.buffer) - len(prefix)
+
+                max_length = min(len(prefix) + minimal_extension * 10, BUFFER_SIZE,)
 
                 # We could end up in a situation where even though the prefix was
                 # novel when we generated it, because we've now tried zero extending
@@ -619,8 +619,6 @@ class ConjectureRunner(object):
                 # we don't want to run this.
                 if trial_data.observer.killed:
                     continue
-
-                max_length = min(max_length, BUFFER_SIZE)
 
                 # We might have hit the cap on number of examples we should
                 # run when calculating the minimal example.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -596,7 +596,7 @@ class ConjectureRunner(object):
 
                 minimal_extension = len(minimal_example.buffer) - len(prefix)
 
-                max_length = min(len(prefix) + minimal_extension * 10, BUFFER_SIZE,)
+                max_length = min(len(prefix) + minimal_extension * 10, BUFFER_SIZE)
 
                 # We could end up in a situation where even though the prefix was
                 # novel when we generated it, because we've now tried zero extending

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -36,8 +36,12 @@ from hypothesis.internal.conjecture.data import (
     Status,
     StopTest,
 )
-from hypothesis.internal.conjecture.datatree import DataTree, TreeRecordingObserver
-from hypothesis.internal.conjecture.junkdrawer import uniform
+from hypothesis.internal.conjecture.datatree import (
+    DataTree,
+    PreviouslyUnseenBehaviour,
+    TreeRecordingObserver,
+)
+from hypothesis.internal.conjecture.junkdrawer import clamp, uniform
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report
@@ -534,10 +538,103 @@ class ConjectureRunner(object):
         parameter = GenerationParameters(self.random)
         count = 0
 
+        # We attempt to use the size of the minimal generated test case starting
+        # from a given novel prefix as a guideline to generate smaller test
+        # cases for an initial period, by restriscting ourselves to test cases
+        # that are not much larger than it.
+        #
+        # Calculating the actual minimal generated test case is hard, so we
+        # take a best guess that zero extending a prefix produces the minimal
+        # test case starting with that prefix (this is true for our built in
+        # strategies). This is only a reasonable thing to do if the resulting
+        # test case is valid. If we regularly run into situations where it is
+        # not valid then this strategy is a waste of time, so we want to
+        # abandon it early. In order to do this we track how many times in a
+        # row it has failed to work, and abort small test case generation when
+        # it has failed too many times in a row.
+        consecutive_zero_extend_is_invalid = 0
+
         while should_generate_more():
             prefix = self.generate_novel_prefix()
+            assert len(prefix) <= BUFFER_SIZE
 
-            data = self.new_conjecture_data(draw_bytes_with(prefix, parameter))
+            # We control growth during initial example generation, for two
+            # reasons:
+            #
+            # * It gives us an opportunity to find small examples early, which
+            #   gives us a fast path for easy to find bugs.
+            # * It avoids low probability events where we might end up
+            #   generating very large examples during health checks, which
+            #   on slower machines can trigger HealthCheck.too_slow.
+            #
+            # The heuristic we use is that we attempt to estimate the smallest
+            # extension of this prefix, and limit the size to no more than
+            # an order of magnitude larger than that. If we fail to estimate
+            # the size accurately, we skip over this prefix and try again.
+            #
+            # We need to tune the example size based on the initial prefix,
+            # because any fixed size might be too small, and any size based
+            # on the strategy in general can fall afoul of strategies that
+            # have very different sizes for different prefixes.
+            small_example_cap = clamp(10, self.settings.max_examples // 10, 50)
+
+            if (
+                self.valid_examples <= small_example_cap
+                and self.call_count <= 5 * small_example_cap
+                and not self.interesting_examples
+                and consecutive_zero_extend_is_invalid < 5
+            ):
+                minimal_example = self.cached_test_function(
+                    prefix + hbytes(BUFFER_SIZE - len(prefix))
+                )
+
+                if minimal_example.status < Status.VALID:
+                    consecutive_zero_extend_is_invalid += 1
+                    continue
+
+                consecutive_zero_extend_is_invalid = 0
+
+                max_length = (len(minimal_example.buffer) - len(prefix)) * 10 + len(
+                    prefix
+                )
+
+                # We could end up in a situation where even though the prefix was
+                # novel when we generated it, because we've now tried zero extending
+                # it not all possible continuations of it will be novel. In order to
+                # avoid making redundant test calls, we rerun it in simulation mode
+                # first. If this has a predictable result, then we don't bother
+                # running the test function for real here. If however we encounter
+                # some novel behaviour, we try again with the real test function,
+                # starting from the new novel prefix that has discovered.
+                try:
+                    trial_data = self.new_conjecture_data(
+                        draw_bytes_with(prefix, parameter), max_length=max_length
+                    )
+                    self.tree.simulate_test_function(trial_data)
+                    continue
+                except PreviouslyUnseenBehaviour:
+                    pass
+
+                # If the simulation entered part of the tree that has been killed,
+                # we don't want to run this.
+                if trial_data.observer.killed:
+                    continue
+
+                max_length = min(max_length, BUFFER_SIZE)
+
+                # We might have hit the cap on number of examples we should
+                # run when calculating the minimal example.
+                if not should_generate_more():
+                    break
+
+                prefix = trial_data.buffer
+            else:
+                max_length = BUFFER_SIZE
+
+            data = self.new_conjecture_data(
+                draw_bytes_with(prefix, parameter), max_length=max_length
+            )
+
             self.test_function(data)
 
             self.optimise_all(data)
@@ -564,10 +661,10 @@ class ConjectureRunner(object):
         self.shrink_interesting_examples()
         self.exit_with(ExitReason.finished)
 
-    def new_conjecture_data(self, draw_bytes):
+    def new_conjecture_data(self, draw_bytes, max_length=BUFFER_SIZE):
         return ConjectureData(
             draw_bytes=draw_bytes,
-            max_length=BUFFER_SIZE,
+            max_length=max_length,
             observer=self.tree.new_observer(),
         )
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -207,3 +207,9 @@ class LazySequenceCopy(object):
             i += n
         assert 0 <= i < n
         return i
+
+
+def clamp(lower, value, upper):
+    """Given a value and lower/upper bounds, 'clamp' the value so that
+    it satisfies lower <= value <= upper."""
+    return max(lower, min(value, upper))

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -93,7 +93,7 @@ def get_seeder_and_restorer(seed=0):
 
 
 @contextlib.contextmanager
-def deterministic_PRNG():
+def deterministic_PRNG(seed=0):
     """Context manager that handles random.seed without polluting global state.
 
     See issue #1255 and PR #1295 for details and motivation - in short,
@@ -101,7 +101,7 @@ def deterministic_PRNG():
     bad idea in principle, and breaks all kinds of independence assumptions
     in practice.
     """
-    seed_all, restore_all = get_seeder_and_restorer()
+    seed_all, restore_all = get_seeder_and_restorer(seed)
     seed_all()
     try:
         yield

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -88,7 +88,7 @@ def run():
             )
 
     settings.register_profile(
-        "default", settings(max_examples=10 if IN_COVERAGE_TESTS else not_set)
+        "default", settings(max_examples=20 if IN_COVERAGE_TESTS else not_set)
     )
 
     settings.register_profile("speedy", settings(max_examples=5))

--- a/hypothesis-python/tests/cover/test_conjecture_junkdrawer.py
+++ b/hypothesis-python/tests/cover/test_conjecture_junkdrawer.py
@@ -19,7 +19,8 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
+from hypothesis import example, given, strategies as st
+from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy, clamp
 
 
 def test_out_of_range():
@@ -54,3 +55,23 @@ def test_pop():
 
     with pytest.raises(IndexError):
         x.pop()
+
+
+@example(1, 5, 10)
+@example(1, 10, 5)
+@example(5, 10, 5)
+@example(5, 1, 10)
+@given(st.integers(), st.integers(), st.integers())
+def test_clamp(lower, value, upper):
+    lower, upper = sorted((lower, upper))
+
+    clamped = clamp(lower, value, upper)
+
+    assert lower <= clamped <= upper
+
+    if lower <= value <= upper:
+        assert value == clamped
+    if lower > value:
+        assert clamped == lower
+    if value > upper:
+        assert clamped == upper

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -34,8 +34,11 @@ from hypothesis.searchstrategy.lazy import LazyStrategy
 from hypothesis.searchstrategy.strategies import SearchStrategy
 from tests.common.utils import checks_deprecated_behaviour, no_shrink
 
+HEALTH_CHECK_SETTINGS = settings(max_examples=11, database=None)
+
 
 def test_slow_generation_fails_a_health_check():
+    @HEALTH_CHECK_SETTINGS
     @given(st.integers().map(lambda x: time.sleep(0.2)))
     def test(x):
         pass
@@ -45,7 +48,7 @@ def test_slow_generation_fails_a_health_check():
 
 
 def test_slow_generation_inline_fails_a_health_check():
-    @settings(deadline=None)
+    @settings(HEALTH_CHECK_SETTINGS, deadline=None)
     @given(st.data())
     def test(data):
         data.draw(st.integers().map(lambda x: time.sleep(0.2)))
@@ -57,7 +60,7 @@ def test_slow_generation_inline_fails_a_health_check():
 def test_default_health_check_can_weaken_specific():
     import random
 
-    @settings(suppress_health_check=HealthCheck.all())
+    @settings(HEALTH_CHECK_SETTINGS, suppress_health_check=HealthCheck.all())
     @given(st.lists(st.integers(), min_size=1))
     def test(x):
         random.choice(x)
@@ -73,6 +76,7 @@ def test_suppressing_filtering_health_check():
             forbidden.add(x)
         return x not in forbidden
 
+    @HEALTH_CHECK_SETTINGS
     @given(st.integers().filter(unhealthy_filter))
     def test1(x):
         raise ValueError()
@@ -121,7 +125,7 @@ def test_filtering_most_things_fails_a_health_check():
 
 
 def test_large_data_will_fail_a_health_check():
-    @given(st.none() | st.binary(min_size=10 ** 5))
+    @given(st.none() | st.binary(min_size=10 ** 5, max_size=10 ** 5))
     @settings(database=None)
     def test(x):
         pass

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import, division, print_function
 
 import time
-from random import Random
 
 import pytest
 from pytest import raises
@@ -230,7 +229,6 @@ def test_lazy_slow_initialization_issue_2108_regression(data):
 
 
 def test_does_not_trigger_health_check_on_simple_strategies(monkeypatch):
-    prng = Random(0)
     existing_draw_bits = ConjectureData.draw_bits
 
     # We need to make drawing data artificially slow in order to trigger this
@@ -242,8 +240,8 @@ def test_does_not_trigger_health_check_on_simple_strategies(monkeypatch):
 
     monkeypatch.setattr(ConjectureData, "draw_bits", draw_bits)
 
-    for _ in range(100):
-        with deterministic_PRNG(prng.getrandbits(32)):
+    with deterministic_PRNG():
+        for _ in range(100):
             # Setting max_examples=11 ensures we have enough examples for the
             # health checks to finish running, but cuts the generation short
             # after that point to allow this test to run in reasonable time.
@@ -256,10 +254,8 @@ def test_does_not_trigger_health_check_on_simple_strategies(monkeypatch):
 
 
 def test_does_not_trigger_health_check_when_most_examples_are_small(monkeypatch):
-    prng = Random(0)
-
-    for _ in range(100):
-        with deterministic_PRNG(prng.getrandbits(32)):
+    with deterministic_PRNG():
+        for _ in range(100):
             # Setting max_examples=11 ensures we have enough examples for the
             # health checks to finish running, but cuts the generation short
             # after that point to allow this test to run in reasonable time.

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -35,9 +35,7 @@ import re
 import hypothesis.internal.reflection as reflection
 from hypothesis import settings as Settings
 from hypothesis.errors import UnsatisfiedAssumption
-from hypothesis.internal.conjecture.engine import (
-    ConjectureRunner as ConConjectureRunner,
-)
+from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.strategies import (
     booleans,
     floats,
@@ -94,7 +92,7 @@ def define_test(specifier, predicate, condition=None, p=0.5):
 
         successes = 0
         for _ in range(RUNS):
-            runner = ConConjectureRunner(
+            runner = ConjectureRunner(
                 test_function, settings=Settings(max_examples=100, phases=no_shrink)
             )
             runner.run()

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -92,8 +92,11 @@ def define_test(specifier, predicate, condition=None, p=0.5):
 
         successes = 0
         for _ in range(RUNS):
+            # We choose the max_examples a bit larger than default so that we
+            # run at least 100 examples outside of the small example generation
+            # part of the generation phase.
             runner = ConjectureRunner(
-                test_function, settings=Settings(max_examples=100, phases=no_shrink)
+                test_function, settings=Settings(max_examples=150, phases=no_shrink)
             )
             runner.run()
             if runner.interesting_examples:


### PR DESCRIPTION
Fixes #2195 (which is closed but shouldn't have been - this was a real issue).

The problem is basically that #2137 introduced a low but non-negligible probability event of generating *much* larger examples than we previously would have. This means for those examples we call `draw_bits` a lot more than we would previously have, and on sufficiently slow computers this would trigger a health check failure. This was impossible to reproduce on fast computers (because the `draw_bits` code was fast enough that it wasn't an issue) or on our CI (because time was fake) but was hitting a lot of users on Travis's rather creaky VM infrastructure on a ~weekly basis.

The solution is to spend some of our initial budget on trying to generate small test cases. This potentially has other advantages, mostly that it speeds up testing in cases where bugs are reasonably easy to find.