### PR TITLE
Add missing word in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Hypothesis
 ==========
 
-Hypothesis is family of testing libraries which let you write tests parametrized
+Hypothesis is a family of testing libraries which let you write tests parametrized
 by a source of examples. A Hypothesis implementation then generates simple and
 comprehensible examples that make your tests fail.
 This simplifies writing your tests and makes them more powerful at the same time,


### PR DESCRIPTION
While most of the changes in #2222 were subjective, I noticed that one of them was fixing a clear error in the current text.

So I took the original patch and cut it down to just this one change (preserving the original author credit), so that the improvement isn't lost.

Thanks to @Thethaa for spotting this problem!