### PR TITLE
Improve reliability of test suite under check-coverage

### DIFF
--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1439,3 +1439,19 @@ def test_number_of_examples_in_integer_range_is_bounded(n):
 
         runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS)
         runner.run()
+
+
+def test_prefix_cannot_exceed_buffer_size(monkeypatch):
+    buffer_size = 10
+    monkeypatch.setattr(engine_module, "BUFFER_SIZE", buffer_size)
+
+    with deterministic_PRNG():
+
+        def test(data):
+            while data.draw_bits(1):
+                assert len(data.buffer) <= buffer_size
+            assert len(data.buffer) <= buffer_size
+
+        runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS)
+        runner.run()
+        assert runner.valid_examples == buffer_size

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -77,7 +77,7 @@ def test_settings_are_default_in_given(x):
 def test_given_shrinks_pytest_helper_errors():
     final_value = [None]
 
-    @settings(derandomize=True)
+    @settings(derandomize=True, max_examples=100)
     @given(s.integers())
     def inner(x):
         final_value[0] = x
@@ -92,7 +92,7 @@ def test_given_shrinks_pytest_helper_errors():
 def test_pytest_skip_skips_shrinking():
     values = []
 
-    @settings(derandomize=True)
+    @settings(derandomize=True, max_examples=100)
     @given(s.integers())
     def inner(x):
         values.append(x)
@@ -106,7 +106,7 @@ def test_pytest_skip_skips_shrinking():
 
 @checks_deprecated_behaviour
 def test_can_find_with_db_eq_none():
-    find(s.integers(), bool, settings(database=None))
+    find(s.integers(), bool, settings(database=None, max_examples=100))
 
 
 @checks_deprecated_behaviour

--- a/hypothesis-python/tests/cover/test_intervalset.py
+++ b/hypothesis-python/tests/cover/test_intervalset.py
@@ -63,6 +63,7 @@ def test_intervals_match_indexes(intervals):
         assert ls.index(v) == intervals.index(v)
 
 
+@example(intervals=IntervalSet(((1, 1),)), v=0)
 @example(intervals=IntervalSet(()), v=0)
 @given(Intervals, st.integers())
 def test_error_for_index_of_not_present_value(intervals, v):

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -26,6 +26,7 @@ import pytest
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.provisional import domains, ip4_addr_strings, ip6_addr_strings, urls
+from tests.common.debug import find_any
 
 
 @given(urls())
@@ -69,3 +70,10 @@ def test_invalid_domain_arguments(max_length, max_element_length):
 @pytest.mark.parametrize("max_element_length", [None, 1, 2, 4, 8, 63])
 def test_valid_domains_arguments(max_length, max_element_length):
     domains(max_length=max_length, max_element_length=max_element_length).example()
+
+
+@pytest.mark.parametrize(
+    "strategy", [domains(), ip4_addr_strings(), ip6_addr_strings(), urls()]
+)
+def test_find_any_non_empty(strategy):
+    find_any(strategy, lambda s: len(s) > 0)

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -124,7 +124,7 @@ def test_errors_with_did_not_reproduce_if_rejected():
 def test_prints_reproduction_if_requested():
     failing_example = [None]
 
-    @settings(print_blob=True, database=None)
+    @settings(print_blob=True, database=None, max_examples=100)
     @given(st.integers())
     def test(i):
         if failing_example[0] is None and i != 0:

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -30,7 +30,7 @@ from tests.common.utils import capture_out, non_covering_examples
 def test_raises_multiple_failures_with_varying_type():
     target = [None]
 
-    @settings(database=None)
+    @settings(database=None, max_examples=100)
     @given(st.integers())
     def test(i):
         if abs(i) < 1000:
@@ -54,6 +54,7 @@ def test_raises_multiple_failures_with_varying_type():
 def test_raises_multiple_failures_when_position_varies():
     target = [None]
 
+    @settings(max_examples=100)
     @given(st.integers())
     def test(i):
         if abs(i) < 1000:
@@ -75,7 +76,7 @@ def test_raises_multiple_failures_when_position_varies():
 def test_replays_both_failing_values():
     target = [None]
 
-    @settings(database=InMemoryExampleDatabase())
+    @settings(database=InMemoryExampleDatabase(), max_examples=500)
     @given(st.integers())
     def test(i):
         if abs(i) < 1000:
@@ -97,7 +98,7 @@ def test_replays_slipped_examples_once_initial_bug_is_fixed(fix):
     target = []
     bug_fixed = False
 
-    @settings(database=InMemoryExampleDatabase())
+    @settings(database=InMemoryExampleDatabase(), max_examples=500)
     @given(st.integers())
     def test(i):
         if abs(i) < 1000:
@@ -130,7 +131,7 @@ def test_garbage_collects_the_secondary_key():
 
     db = InMemoryExampleDatabase()
 
-    @settings(database=db)
+    @settings(database=db, max_examples=500)
     @given(st.integers())
     def test(i):
         if bug_fixed:
@@ -198,7 +199,7 @@ def test_handles_flaky_tests_where_only_one_is_flaky():
     target = []
     flaky_failed_once = [False]
 
-    @settings(database=InMemoryExampleDatabase())
+    @settings(database=InMemoryExampleDatabase(), max_examples=1000)
     @given(st.integers())
     def test(i):
         if abs(i) < 1000:

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -556,7 +556,9 @@ class RequiresInit(GenericStateMachine):
 @checks_deprecated_behaviour
 def test_can_use_factory_for_tests():
     with raises(ValueError):
-        run_state_machine_as_test(lambda: RequiresInit(42))
+        run_state_machine_as_test(
+            lambda: RequiresInit(42), settings=Settings(max_examples=100)
+        )
 
 
 @Settings(stateful_step_count=5)

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -181,6 +181,7 @@ def test_draw_time_percentage(draw_delay, test_delay):
 
 
 def test_has_lambdas_in_output():
+    @settings(max_examples=100, database=None)
     @given(st.integers().filter(lambda x: x % 2 == 0))
     def test(i):
         pass

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -86,7 +86,11 @@ def test_prints_initial_attempts_on_find():
                     return False
                 return x not in seen
 
-            find(integers(), not_first, settings=settings(verbosity=Verbosity.verbose))
+            find(
+                integers(),
+                not_first,
+                settings=settings(verbosity=Verbosity.verbose, max_examples=1000),
+            )
 
         foo()
 
@@ -97,7 +101,12 @@ def test_includes_intermediate_results_in_verbose_mode():
     with capture_verbosity() as o:
 
         @fails
-        @settings(verbosity=Verbosity.verbose, database=None, derandomize=True)
+        @settings(
+            verbosity=Verbosity.verbose,
+            database=None,
+            derandomize=True,
+            max_examples=100,
+        )
         @given(lists(integers(), min_size=1))
         def test_foo(x):
             assert sum(x) < 10000

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -203,6 +203,7 @@ def test_can_generate_scalar_dtypes(dtype):
     assert isinstance(dtype, np.dtype)
 
 
+@settings(max_examples=100)
 @given(
     nps.nested_dtypes(
         subtype_strategy=st.one_of(
@@ -214,6 +215,7 @@ def test_can_generate_compound_dtypes(dtype):
     assert isinstance(dtype, np.dtype)
 
 
+@settings(max_examples=100)
 @given(
     nps.nested_dtypes(
         subtype_strategy=st.one_of(
@@ -226,6 +228,7 @@ def test_can_generate_data_compound_dtypes(arr):
     assert isinstance(arr, np.ndarray)
 
 
+@settings(max_examples=100)
 @given(nps.nested_dtypes(max_itemsize=400), st.data())
 def test_infer_strategy_from_dtype(dtype, data):
     # Given a dtype
@@ -548,6 +551,11 @@ def test_minimize_negative_tuple_axes(ndim, data):
         nps.valid_tuple_axes(ndim, min_size, max_size), lambda x: all(i < 0 for i in x)
     )
     assert len(smallest) == min_size
+
+
+@given(nps.broadcastable_shapes((), min_side=0, max_side=0, min_dims=0, max_dims=0))
+def test_broadcastable_empty_shape(shape):
+    assert shape == ()
 
 
 @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])

--- a/hypothesis-python/tests/pytest/test_seeding.py
+++ b/hypothesis-python/tests/pytest/test_seeding.py
@@ -36,7 +36,7 @@ first = None
 @settings(database=None)
 @given(st.integers())
 def test_fails_once(some_int):
-    assume(abs(some_int) > 10000)
+    assume(abs(some_int) > 1000)
     global first
     if first is None:
         first = some_int


### PR DESCRIPTION
This pulls out a lot of the test suite related changes from #2219. Once it's merged I'll rebase on top of it.

The main thing this does is add a lot of special cases where we're currently relying on a `@given` to provide coverage. It also adds a few cases where we want to test with a higher `max_examples` than is default for `check-coverage`. 

I've been running `check-coverage` under autoclave for a while on this and I think this catches all the flakiness for `check-coverage` on master. It may not catch all other flakiness we've been seeing.