### PR TITLE
Adjust flake8 config and drop pylint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
     test_imports.py,
     hypothesis-python/tests/py2/*,
     test_lambda_formatting.py
-ignore = F811,D1,D205,D209,D213,D400,D401,D412,D413,D999,D202,E203,E501,W503,B008,B011
+ignore = D1,D205,D209,D213,D400,D401,D412,D413,D999,D202,E203,E501,W503,B008,B011
 
 # Use flake8-alfred to forbid builtins that require compatibility wrappers.
 warn-symbols=

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch removes an internal compatibility shim that we no longer need.

--- a/hypothesis-python/src/hypothesis/_strategies.py
+++ b/hypothesis-python/src/hypothesis/_strategies.py
@@ -298,13 +298,13 @@ def one_of(args):
     pass  # pragma: no cover
 
 
-@overload
+@overload  # noqa: F811
 def one_of(*args):
     # type: (SearchStrategy[Any]) -> SearchStrategy[Any]
     pass  # pragma: no cover
 
 
-def one_of(*args):
+def one_of(*args):  # noqa: F811
     # Mypy workaround alert:  Any is too loose above; the return parameter
     # should be the union of the input parameters.  Unfortunately, Mypy <=0.600
     # raises errors due to incompatible inputs instead.  See #1270 for links.
@@ -669,14 +669,14 @@ def sampled_from(elements):
     pass  # pragma: no cover
 
 
-@overload
+@overload  # noqa: F811
 def sampled_from(elements):
     # type: (Type[enum.Enum]) -> SearchStrategy[Any]
     # `SearchStrategy[Enum]` is unreliable due to metaclass issues.
     pass  # pragma: no cover
 
 
-@defines_strategy
+@defines_strategy  # noqa: F811
 def sampled_from(elements):
     """Returns a strategy which generates any value present in ``elements``.
 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from collections import OrderedDict
 from copy import copy
 
 import attr
@@ -28,7 +29,7 @@ import hypothesis.extra.numpy as npst
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import OrderedDict, abc, hrange
+from hypothesis.internal.compat import abc, hrange
 from hypothesis.internal.coverage import check, check_function
 from hypothesis.internal.validation import (
     check_type,

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -22,7 +22,7 @@ from distutils.version import LooseVersion
 import pytest
 
 from hypothesis import Verbosity, core, settings
-from hypothesis._settings import Verbosity, note_deprecation
+from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import text_type
 from hypothesis.internal.detection import is_hypothesis_test

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -30,12 +30,6 @@ from base64 import b64encode
 from collections import namedtuple
 
 try:
-    from collections import OrderedDict, Counter
-except ImportError:
-    from ordereddict import OrderedDict  # type: ignore
-    from counter import Counter  # type: ignore
-
-try:
     from collections import abc
 except ImportError:
     import collections as abc  # type: ignore

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -15,8 +15,6 @@
 #
 # END HEADER
 
-# pylint: skip-file
-
 from __future__ import absolute_import, division, print_function
 
 import array

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -269,7 +269,7 @@ class DataTree(object):
                     assert (  # pragma: no cover
                         check_counter != 1000
                         or len(branch.children) < (2 ** n_bits)
-                        or any([not v.is_exhausted for v in branch.children.values()])
+                        or any(not v.is_exhausted for v in branch.children.values())
                     )
 
     def rewrite(self, buffer):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -596,11 +596,11 @@ class ConjectureRunner(object):
 
         while len(self.shrunk_examples) < len(self.interesting_examples):
             target, example = min(
-                [
+                (
                     (k, v)
                     for k, v in self.interesting_examples.items()
                     if k not in self.shrunk_examples
-                ],
+                ),
                 key=lambda kv: (sort_key(kv[1].buffer), sort_key(repr(kv[0]))),
             )
             self.debug("Shrinking %r" % (target,))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
 from enum import Enum
 from random import Random, getrandbits
 from weakref import WeakKeyDictionary
@@ -28,7 +28,7 @@ import attr
 from hypothesis import HealthCheck, Phase, Verbosity, settings as Settings
 from hypothesis._settings import local_settings
 from hypothesis.internal.cache import LRUReusedCache
-from hypothesis.internal.compat import Counter, ceil, hbytes, hrange, int_from_bytes
+from hypothesis.internal.compat import ceil, hbytes, hrange, int_from_bytes
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -51,7 +51,7 @@ if not CAN_PACK_HALF_FLOAT:  # pragma: no cover
         pass
     else:
 
-        def reinterpret_bits(x, from_, to):  # pylint: disable=function-redefined
+        def reinterpret_bits(x, from_, to):  # noqa: F811
             if from_ == b"!e":
                 arr = numpy.array([x], dtype=">f2")
                 if numpy.isfinite(x) and not numpy.isfinite(arr[0]):

--- a/hypothesis-python/src/hypothesis/searchstrategy/collections.py
+++ b/hypothesis-python/src/hypothesis/searchstrategy/collections.py
@@ -17,9 +17,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+from collections import OrderedDict
+
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import OrderedDict
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
 from hypothesis.internal.conjecture.utils import combine_labels
 from hypothesis.searchstrategy.strategies import (

--- a/hypothesis-python/tests/cover/test_conjecture_test_data.py
+++ b/hypothesis-python/tests/cover/test_conjecture_test_data.py
@@ -22,7 +22,7 @@ import itertools
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import given, strategies as st
+from hypothesis import given
 from hypothesis.errors import Frozen, InvalidArgument
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import (

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -59,11 +59,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from __future__ import absolute_import, division, print_function
 
 import re
-from collections import defaultdict, deque
+from collections import Counter, OrderedDict, defaultdict, deque
 
 import pytest
 
-from hypothesis.internal.compat import PY3, PYPY, Counter, OrderedDict, a_good_encoding
+from hypothesis.internal.compat import PY3, PYPY, a_good_encoding
 from hypothesis.vendor import pretty
 from tests.common.utils import capture_out
 

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -230,7 +230,7 @@ def test_groups(pattern, is_unicode, invert):
         pattern = pattern.swapcase()
         _p = group_pred
 
-        def group_pred(s):  # pylint:disable=function-redefined
+        def group_pred(s):
             return not _p(s)
 
     pattern = u"^%s\\Z" % (pattern,)

--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -23,7 +23,6 @@ from random import Random
 import pytest
 
 from hypothesis import given, settings
-from hypothesis.internal.compat import OrderedDict
 from hypothesis.strategies import (
     booleans,
     dictionaries,

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -17,11 +17,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+from collections import Counter
+
 import pytest
 
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.database import ExampleDatabase
-from hypothesis.internal.compat import Counter
 from hypothesis.strategies import (
     booleans,
     builds,

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -17,11 +17,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+from collections import OrderedDict
+
 import hypothesis.strategies as st
 from hypothesis import given, settings
 from hypothesis.control import reject
 from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
-from hypothesis.internal.compat import OrderedDict
 
 
 def foo(x):

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -17,14 +17,14 @@
 
 from __future__ import absolute_import, division, print_function
 
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from fractions import Fraction
 from functools import reduce
 
 import pytest
 
 from hypothesis import assume, settings
-from hypothesis.internal.compat import OrderedDict, hrange
+from hypothesis.internal.compat import hrange
 from hypothesis.strategies import (
     booleans,
     builds,

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -16,7 +16,6 @@ lark-parser
 mypy
 numpy
 pip-tools
-pylint
 pytest
 python-dateutil
 pyupgrade

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -6,7 +6,6 @@
 #
 alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via black
-astroid==2.3.2            # via pylint
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0
 autoflake==1.3.1
@@ -43,9 +42,8 @@ isort==4.3.21
 jedi==0.15.1              # via ipython
 jinja2==2.10.3            # via pyupio, sphinx
 lark-parser==0.7.8
-lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8, pylint
+mccabe==0.6.1             # via flake8
 more-itertools==7.2.0     # via pytest, zipp
 mypy-extensions==0.4.3    # via mypy
 mypy==0.740
@@ -68,7 +66,6 @@ pyflakes==2.1.1           # via autoflake, flake8
 pygithub==1.44            # via pyupio
 pygments==2.4.2           # via ipython, readme-renderer, sphinx
 pyjwt==1.7.1              # via pygithub
-pylint==2.4.3
 pyparsing==2.4.2          # via packaging
 pytest==5.2.2
 python-dateutil==2.8.1
@@ -83,7 +80,7 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.22.0
 restructuredtext-lint==1.3.0
 safety==1.8.5             # via pyupio
-six==1.12.0               # via astroid, bandit, bleach, dparse, packaging, pip-tools, prompt-toolkit, pygithub, python-dateutil, python-gitlab, pyupio, readme-renderer, stevedore, tox, traitlets
+six==1.12.0               # via bandit, bleach, dparse, packaging, pip-tools, prompt-toolkit, pygithub, python-dateutil, python-gitlab, pyupio, readme-renderer, stevedore, tox, traitlets
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-rtd-theme==0.4.3
@@ -102,13 +99,13 @@ tox==3.14.0
 tqdm==4.37.0              # via pyupio, twine
 traitlets==4.3.3          # via ipython
 twine==2.0.0
-typed-ast==1.4.0          # via astroid, black, mypy
+typed-ast==1.4.0          # via black, mypy
 typing-extensions==3.7.4.1  # via mypy
 urllib3==1.25.6           # via requests
 virtualenv==16.7.7        # via tox
 wcwidth==0.1.7            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.11.2             # via astroid, deprecated
+wrapt==1.11.2             # via deprecated
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -79,16 +79,6 @@ def lint():
         "--config",
         os.path.join(tools.ROOT, ".flake8"),
     )
-    # Check for redefined test functions, where e.g. a copy-pasted definition
-    # will shadow the earlier test and Pytest never sees or executes it.
-    pip_tool(
-        "pylint",
-        "--score=n",
-        "--jobs=0",
-        "--disable=all",
-        "--enable=function-redefined",
-        "hypothesis-python/tests/",
-    )
 
 
 HEAD = tools.hash_for_name("HEAD")


### PR DESCRIPTION
Turns out that the only warning we were using pylint for is covered by flake8's `F811`, if we simply avoid disabling it!

And while simplifying our linter setup, I discovered that we had some indirection in `compat.py` that hasn't been needed since Python 2.6, and decided to get an early start on the great refactoring :smile: 