### PR TITLE
Rebuild find on top of given

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release rebuilds ``find()`` on top of ``@given`` in order to have more code in common.
+It should have minimal user visible effec.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
 This release rebuilds ``find()`` on top of ``@given`` in order to have more code in common.
-It should have minimal user visible effec.
+It should have minimal user visible effect.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -66,7 +66,6 @@ from hypothesis.internal.compat import (
     binary_type,
     get_type_hints,
     getfullargspec,
-    hbytes,
     int_from_bytes,
     qualname,
 )
@@ -86,7 +85,6 @@ from hypothesis.internal.reflection import (
     get_pretty_function_description,
     impersonate,
     is_mock,
-    nicerepr,
     proxies,
 )
 from hypothesis.reporting import (
@@ -110,10 +108,6 @@ if False:
 
 running_under_pytest = False
 global_force_seed = None
-
-
-def new_random():
-    return rnd_module.Random(rnd_module.getrandbits(128))
 
 
 @attr.s()

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1121,8 +1121,6 @@ def find(
         )
     specifier.validate()
 
-    random = random or new_random()
-
     last = [None]
 
     @settings

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1114,7 +1114,7 @@ def find(
     )
     if settings is None:
         settings = Settings(max_examples=2000)
-    settings = Settings(settings, suppress_health_check=HealthCheck.all())
+    settings = Settings(settings, suppress_health_check=HealthCheck.all(), report_multiple_bugs=False)
 
     if database_key is None and settings.database is not None:
         database_key = function_digest(condition)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -740,7 +740,7 @@ class StateForActualGivenExecution(object):
             try:
                 self.execute_once(
                     ran_example,
-                    print_example=True,
+                    print_example=not self.is_find,
                     is_final=True,
                     expected_failure=(
                         info.__expected_exception,

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -955,12 +955,7 @@ def given(
                 )
 
             state = StateForActualGivenExecution(
-                test_runner,
-                search_strategy,
-                test,
-                settings,
-                random,
-                wrapped_test,
+                test_runner, search_strategy, test, settings, random, wrapped_test,
             )
 
             reproduce_failure = wrapped_test._hypothesis_internal_use_reproduce_failure
@@ -1114,7 +1109,9 @@ def find(
     )
     if settings is None:
         settings = Settings(max_examples=2000)
-    settings = Settings(settings, suppress_health_check=HealthCheck.all(), report_multiple_bugs=False)
+    settings = Settings(
+        settings, suppress_health_check=HealthCheck.all(), report_multiple_bugs=False
+    )
 
     if database_key is None and settings.database is not None:
         database_key = function_digest(condition)

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -164,3 +164,7 @@ class StopTest(BaseException):
 
 class DidNotReproduce(HypothesisException):
     pass
+
+
+class Found(Exception):
+    """Signal that the example matches condition. Internal use only."""

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -168,3 +168,5 @@ class DidNotReproduce(HypothesisException):
 
 class Found(Exception):
     """Signal that the example matches condition. Internal use only."""
+
+    hypothesis_internal_never_escalate = True

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -450,6 +450,7 @@ class ConjectureRunner(object):
                         self.settings.database.delete(self.secondary_key, existing)
 
     def exit_with(self, reason):
+        self.debug("exit_with(%s)" % (reason.name,))
         self.exit_reason = reason
         raise RunIsComplete()
 
@@ -582,6 +583,8 @@ class ConjectureRunner(object):
         """
         if Phase.shrink not in self.settings.phases or not self.interesting_examples:
             return
+
+        self.debug("Shrinking interesting examples")
 
         for prev_data in sorted(
             self.interesting_examples.values(), key=lambda d: sort_key(d.buffer)

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -77,7 +77,12 @@ def mark_for_escalation(e):
 def escalate_hypothesis_internal_error():
     if PREVENT_ESCALATION:
         return
+
     error_type, e, tb = sys.exc_info()
+
+    if getattr(e, "hypothesis_internal_never_escalate", False):
+        return
+
     if getattr(e, "hypothesis_internal_always_escalate", False):
         raise
     filepath = traceback.extract_tb(tb)[-1][0]

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import, division, print_function
 
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, Verbosity, given, settings as Settings
-from hypothesis.errors import NoSuchExample, Unsatisfiable
+from hypothesis.errors import Found, NoSuchExample, Unsatisfiable
 from hypothesis.internal.conjecture.data import ConjectureData, StopTest
 from hypothesis.internal.reflection import get_pretty_function_description
 from tests.common.utils import no_shrink
@@ -32,9 +32,6 @@ class Timeout(BaseException):
 
 
 def minimal(definition, condition=lambda x: True, settings=None, timeout_after=10):
-    class Found(Exception):
-        """Signal that the example matches condition."""
-
     def wrapped_condition(x):
         if timeout_after is not None:
             if runtime:

--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -42,7 +42,7 @@ def test_find_uses_provided_random():
             st.text(),
             test,
             random=Random(13),
-            settings=settings(phases=[Phase.generate]),
+            settings=settings(phases=[Phase.generate], max_examples=1000),
         )
         if prev is None:
             prev = result

--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from random import Random
+
+from hypothesis import Phase, find, settings, strategies as st
+from tests.common.utils import checks_deprecated_behaviour
+
+
+@checks_deprecated_behaviour
+def test_find_uses_provided_random():
+    prev = None
+
+    for _ in range(3):
+        seen = []
+
+        def test(v):
+            if len(v) > 5:
+                if seen:
+                    return v == seen[0]
+                else:
+                    seen.append(v)
+                    return True
+
+        result = find(
+            st.text(),
+            test,
+            random=Random(13),
+            settings=settings(phases=[Phase.generate]),
+        )
+        if prev is None:
+            prev = result
+        else:
+            assert prev == result

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -94,7 +94,7 @@ def test_prints_initial_attempts_on_find():
 
         foo()
 
-    assert u"Tried non-satisfying example" in o.getvalue()
+    assert u"Trying example" in o.getvalue()
 
 
 def test_includes_intermediate_results_in_verbose_mode():


### PR DESCRIPTION
As part of repeatedly running the coverage job in order to get it stable, I found a rare failure of coverage in the `find` code. This fixes that by deleting the relevant code and rebuilding `find` on top of `given` like our `minimal` helper is already done.