### PR TITLE
Improve formatting of Hypothesis example output

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves Hypothesis's "Falsifying example" output, by breaking
+output across multiple lines where necessary, and by removing irrelevant
+information from the stateful testing output.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -578,9 +578,12 @@ class StateForActualGivenExecution(object):
                                     printer.break_()
                                     for i, v in enumerate(args):
                                         printer.pretty(v)
+                                        # We add a comma unconditionally because
+                                        # generated arguments will always be
+                                        # kwargs, so there will always be more
+                                        # to come.
                                         printer.text(",")
-                                        if (i + 1 < len(args)) or kwargs:
-                                            printer.breakable()
+                                        printer.breakable()
 
                                     # We need to make sure to print these in the argument order for
                                     # Python 2 and older versionf of Python 3.5. In modern versions

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -96,6 +96,7 @@ from hypothesis.searchstrategy.collections import TupleStrategy
 from hypothesis.searchstrategy.strategies import MappedSearchStrategy, SearchStrategy
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.utils.conventions import infer
+from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
 from hypothesis.version import __version__
 
 if False:
@@ -503,6 +504,10 @@ class StateForActualGivenExecution(object):
 
         self.test = test
 
+        self.print_given_args = getattr(
+            wrapped_test, "_hypothesis_internal_print_given_args", True
+        )
+
         self.files_to_propagate = set()
         self.failed_normally = False
 
@@ -557,17 +562,36 @@ class StateForActualGivenExecution(object):
                         if expected_failure is not None:
                             text_repr[0] = arg_string(test, args, kwargs)
 
-                        if print_example:
-                            example = "%s(%s)" % (
-                                test.__name__,
-                                arg_string(test, args, kwargs),
-                            )
-                            report("Falsifying example: %s" % (example,))
-                        elif current_verbosity() >= Verbosity.verbose:
-                            report(
-                                lambda: "Trying example: %s(%s)"
-                                % (test.__name__, arg_string(test, args, kwargs))
-                            )
+                        if print_example or current_verbosity() >= Verbosity.verbose:
+                            output = CUnicodeIO()
+
+                            printer = RepresentationPrinter(output)
+                            if print_example:
+                                printer.text("Falsifying example:")
+                            else:
+                                printer.text("Trying example:")
+
+                            if self.print_given_args:
+                                printer.text(" ")
+                                printer.text(test.__name__)
+                                with printer.group(indent=4, open="(", close=""):
+                                    printer.break_()
+                                    for i, v in enumerate(args):
+                                        printer.pretty(v)
+                                        printer.text(",")
+                                        if (i + 1 < len(args)) or kwargs:
+                                            printer.breakable()
+                                    for i, (k, v) in enumerate(kwargs.items()):
+                                        printer.text(k)
+                                        printer.text("=")
+                                        printer.pretty(v)
+                                        printer.text(",")
+                                        if i + 1 < len(kwargs):
+                                            printer.breakable()
+                                printer.break_()
+                                printer.text(")")
+                            printer.flush()
+                            report(output.getvalue())
                         return test(*args, **kwargs)
 
         # Run the test function once, via the executor hook.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -581,7 +581,25 @@ class StateForActualGivenExecution(object):
                                         printer.text(",")
                                         if (i + 1 < len(args)) or kwargs:
                                             printer.breakable()
-                                    for i, (k, v) in enumerate(kwargs.items()):
+
+                                    # We need to make sure to print these in the argument order for
+                                    # Python 2 and older versionf of Python 3.5. In modern versions
+                                    # this isn't an issue because kwargs is ordered.
+                                    arg_order = {
+                                        v: i
+                                        for i, v in enumerate(
+                                            getfullargspec(self.test).args
+                                        )
+                                    }
+                                    for i, (k, v) in enumerate(
+                                        sorted(
+                                            kwargs.items(),
+                                            key=lambda t: (
+                                                arg_order.get(t[0], float("inf")),
+                                                t[0],
+                                            ),
+                                        )
+                                    ):
                                         printer.text(k)
                                         printer.text("=")
                                         printer.pretty(v)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -576,7 +576,7 @@ class StateForActualGivenExecution(object):
                                 printer.text(test.__name__)
                                 with printer.group(indent=4, open="(", close=""):
                                     printer.break_()
-                                    for i, v in enumerate(args):
+                                    for v in args:
                                         printer.pretty(v)
                                         # We add a comma unconditionally because
                                         # generated arguments will always be

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -144,6 +144,7 @@ def run_state_machine_as_test(state_machine_factory, settings=None):
     run_state_machine._hypothesis_internal_use_reproduce_failure = getattr(
         state_machine_factory, "_hypothesis_internal_use_reproduce_failure", None
     )
+    run_state_machine._hypothesis_internal_print_given_args = False
 
     run_state_machine(state_machine_factory)
 

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -154,6 +154,14 @@ def counts_calls(func):
     return _inner
 
 
+def assert_output_contains_failure(output, test, *args, **kwargs):
+    assert test.__name__ + "(" in output
+    for a in args:
+        assert repr(a) in output
+    for k, v in kwargs.items():
+        assert ("%s=%r" % (k, v)) in output
+
+
 def assert_falsifying_output(
     test, *args, example_type="Falsifying", expected_exception=AssertionError, **kwargs
 ):
@@ -161,10 +169,5 @@ def assert_falsifying_output(
         with raises(expected_exception):
             test()
 
-    captured = out.getvalue()
-
-    assert "%s example: %s" % (example_type, test.__name__,) in captured
-    for a in args:
-        assert repr(a) in captured
-    for k, v in kwargs.items():
-        assert ("%s=%r" % (k, v)) in captured
+    assert "%s example:" % (example_type,)
+    assert_output_contains_failure(out.getvalue(), test, *args, **kwargs)

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -152,3 +152,19 @@ def counts_calls(func):
 
     _inner.calls = 0
     return _inner
+
+
+def assert_falsifying_output(
+    test, *args, example_type="Falsifying", expected_exception=AssertionError, **kwargs
+):
+    with capture_out() as out:
+        with raises(expected_exception):
+            test()
+
+    captured = out.getvalue()
+
+    assert "%s example: %s" % (example_type, test.__name__,) in captured
+    for a in args:
+        assert repr(a) in captured
+    for k, v in kwargs.items():
+        assert ("%s=%r" % (k, v)) in captured

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -154,20 +154,18 @@ def counts_calls(func):
     return _inner
 
 
-def assert_output_contains_failure(output, test, *args, **kwargs):
+def assert_output_contains_failure(output, test, **kwargs):
     assert test.__name__ + "(" in output
-    for a in args:
-        assert repr(a) in output
     for k, v in kwargs.items():
         assert ("%s=%r" % (k, v)) in output
 
 
 def assert_falsifying_output(
-    test, *args, example_type="Falsifying", expected_exception=AssertionError, **kwargs
+    test, example_type="Falsifying", expected_exception=AssertionError, **kwargs
 ):
     with capture_out() as out:
         with raises(expected_exception):
             test()
 
     assert "%s example:" % (example_type,)
-    assert_output_contains_failure(out.getvalue(), test, *args, **kwargs)
+    assert_output_contains_failure(out.getvalue(), test, **kwargs)

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -24,7 +24,7 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given, settings
 from hypothesis.errors import DeadlineExceeded, Flaky, InvalidArgument
-from tests.common.utils import capture_out, fails_with
+from tests.common.utils import capture_out, fails_with, assert_falsifying_output
 
 
 def test_raises_deadline_on_slow_test():
@@ -75,10 +75,10 @@ def test_deadlines_participate_in_shrinking():
         if i >= 1000:
             time.sleep(1)
 
-    with capture_out() as o:
-        with pytest.raises(DeadlineExceeded):
-            slow_if_large()
-    assert "slow_if_large(i=1000)" in o.getvalue()
+    assert_falsifying_output(
+        slow_if_large, expected_exception=DeadlineExceeded,
+        i=1000,
+    )
 
 
 def test_keeps_you_well_above_the_deadline():

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -24,7 +24,7 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given, settings
 from hypothesis.errors import DeadlineExceeded, Flaky, InvalidArgument
-from tests.common.utils import capture_out, fails_with, assert_falsifying_output
+from tests.common.utils import assert_falsifying_output, capture_out, fails_with
 
 
 def test_raises_deadline_on_slow_test():
@@ -76,8 +76,7 @@ def test_deadlines_participate_in_shrinking():
             time.sleep(1)
 
     assert_falsifying_output(
-        slow_if_large, expected_exception=DeadlineExceeded,
-        i=1000,
+        slow_if_large, expected_exception=DeadlineExceeded, i=1000,
     )
 
 

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -26,7 +26,7 @@ from hypothesis import Phase, Verbosity, example, given, note, reporting, settin
 from hypothesis.errors import DeadlineExceeded, InvalidArgument
 from hypothesis.internal.compat import integer_types, print_unicode
 from hypothesis.strategies import integers, nothing, text
-from tests.common.utils import capture_out
+from tests.common.utils import assert_falsifying_output, capture_out
 
 
 class TestInstanceMethods(TestCase):
@@ -153,12 +153,7 @@ def test_prints_output_for_explicit_examples():
     def test_positive(x):
         assert x > 0
 
-    with reporting.with_reporter(reporting.default):
-        with pytest.raises(AssertionError):
-            with capture_out() as out:
-                test_positive()
-    out = out.getvalue()
-    assert u"Falsifying example: test_positive(x=-1)" in out
+    assert_falsifying_output(test_positive, x=-1)
 
 
 def test_prints_verbose_output_for_explicit_examples():
@@ -168,11 +163,9 @@ def test_prints_verbose_output_for_explicit_examples():
     def test_always_passes(x):
         pass
 
-    with reporting.with_reporter(reporting.default):
-        with capture_out() as out:
-            test_always_passes()
-    out = out.getvalue()
-    assert u"Trying example: test_always_passes(x='NOT AN INTEGER')" in out
+    assert_falsifying_output(
+        test_always_passes, x="NOT AN INTEGER", example_type="Trying",
+    )
 
 
 def test_captures_original_repr_of_example():
@@ -182,12 +175,9 @@ def test_captures_original_repr_of_example():
         x.append(1)
         assert not x
 
-    with reporting.with_reporter(reporting.default):
-        with pytest.raises(AssertionError):
-            with capture_out() as out:
-                test_mutation()
-    out = out.getvalue()
-    assert u"Falsifying example: test_mutation(x=[])" in out
+    assert_falsifying_output(
+        test_mutation, x=[],
+    )
 
 
 def test_examples_are_tried_in_order():

--- a/hypothesis-python/tests/cover/test_falsifying_example_output.py
+++ b/hypothesis-python/tests/cover/test_falsifying_example_output.py
@@ -37,7 +37,7 @@ Falsifying example: test(
 """
 
 
-@pytest.mark.parametrize("line_break,input", [(False, "0" * 10), (True, "0" * 100),])
+@pytest.mark.parametrize("line_break,input", [(False, "0" * 10), (True, "0" * 100)])
 def test_inserts_line_breaks_only_at_appropriate_lengths(line_break, input):
     @example(input, input)
     @given(st.text(), st.text())

--- a/hypothesis-python/tests/cover/test_falsifying_example_output.py
+++ b/hypothesis-python/tests/cover/test_falsifying_example_output.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from hypothesis import example, given, strategies as st
+from tests.common.utils import capture_out
+
+OUTPUT_NO_LINE_BREAK = """
+Falsifying example: test(
+    x=%(input)s, y=%(input)s,
+)
+"""
+
+
+OUTPUT_WITH_LINE_BREAK = """
+Falsifying example: test(
+    x=%(input)s,
+    y=%(input)s,
+)
+"""
+
+
+@pytest.mark.parametrize("line_break,input", [(False, "0" * 10), (True, "0" * 100),])
+def test_inserts_line_breaks_only_at_appropriate_lengths(line_break, input):
+    @example(input, input)
+    @given(st.text(), st.text())
+    def test(x, y):
+        assert x < y
+
+    with capture_out() as cap:
+        with pytest.raises(AssertionError):
+            test()
+
+    template = OUTPUT_WITH_LINE_BREAK if line_break else OUTPUT_NO_LINE_BREAK
+
+    desired_output = template % {"input": repr(input)}
+
+    actual_output = cap.getvalue()
+
+    assert desired_output.strip() == actual_output.strip()

--- a/hypothesis-python/tests/cover/test_reporting.py
+++ b/hypothesis-python/tests/cover/test_reporting.py
@@ -103,3 +103,10 @@ def test_can_report_when_system_locale_is_ascii(monkeypatch):
         with io.open(write, "w", encoding="ascii") as write:
             monkeypatch.setattr(sys, "stdout", write)
             reporting.default(u"☃")
+
+
+def test_can_report_functions():
+    with capture_out() as out:
+        report(lambda: "foo")
+
+    assert out.getvalue().strip() == "foo"

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -24,7 +24,11 @@ from hypothesis import Phase, assume, given, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import Flaky, MultipleFailures
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
-from tests.common.utils import capture_out, non_covering_examples
+from tests.common.utils import (
+    assert_output_contains_failure,
+    capture_out,
+    non_covering_examples,
+)
 
 
 def test_raises_multiple_failures_with_varying_type():
@@ -189,8 +193,15 @@ def test_shrinks_both_failures():
         with pytest.raises(MultipleFailures):
             test()
 
-    assert "test(i=10000)" in o.getvalue()
-    assert "test(i=%d)" % (second_target[0],) in o.getvalue()
+    output = o.getvalue()
+
+    assert_output_contains_failure(
+        output, test, i=10000,
+    )
+
+    assert_output_contains_failure(
+        output, test, i=second_target[0],
+    )
 
 
 def test_handles_flaky_tests_where_only_one_is_flaky():

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -963,8 +963,7 @@ def test_initialize_rule_populate_bundle():
     assert (
         result
         == """\
-Falsifying example: run_state_machine(\
-factory=WithInitializeBundleRules, data=data(...))
+Falsifying example:
 state = WithInitializeBundleRules()
 v1 = state.initialize_a(dep='dep')
 state.fail_fast(param=v1)
@@ -1073,7 +1072,7 @@ def test_can_manually_call_initialize_rule():
     assert (
         result
         == """\
-Falsifying example: run_state_machine(factory=StateMachine, data=data(...))
+Falsifying example:
 state = StateMachine()
 state.initialize()
 state.fail_eventually()
@@ -1105,7 +1104,7 @@ def test_steps_printed_despite_pytest_fail(capsys):
     out, _ = capsys.readouterr()
     assert (
         """\
-Falsifying example: run_state_machine(factory=RaisesProblem, data=data(...))
+Falsifying example:
 state = RaisesProblem()
 state.oops()
 state.teardown()

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -39,7 +39,14 @@ from hypothesis.strategies import (
     sets,
     text,
 )
-from tests.common.utils import capture_out, fails, fails_with, no_shrink, raises
+from tests.common.utils import (
+    assert_falsifying_output,
+    capture_out,
+    fails,
+    fails_with,
+    no_shrink,
+    raises,
+)
 
 
 @given(integers(), integers())
@@ -228,13 +235,7 @@ def test_prints_on_failure_by_default():
         assume(evans >= 0)
         assert balthazar <= evans
 
-    with raises(AssertionError):
-        with capture_out() as out:
-            with reporting.with_reporter(reporting.default):
-                test_ints_are_sorted()
-    out = out.getvalue()
-    lines = [l.strip() for l in out.split("\n")]
-    assert "Falsifying example: test_ints_are_sorted(balthazar=1, evans=0)" in lines
+    assert_falsifying_output(test_ints_are_sorted, balthazar=1, evans=0)
 
 
 def test_does_not_print_on_success():

--- a/hypothesis-python/tests/py3/test_falsifying_example_output.py
+++ b/hypothesis-python/tests/py3/test_falsifying_example_output.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from hypothesis import given, strategies as st
+from tests.common.utils import capture_out
+
+
+def test_vararg_output():
+    @given(foo=st.text())
+    def test(*args, foo):
+        assert False
+
+    with capture_out() as cap:
+        with pytest.raises(AssertionError):
+            test(1, 2, 3)
+
+    assert "1, 2, 3" in cap.getvalue()


### PR DESCRIPTION
This changes our printing logic to use the pretty printing library. This is partially to give nicer output, partially to give us a bit more control over how things are printed as setup for some later features...

While here I noted that the stateful testing library outputs a bunch of garbage from `@given` that is totally irrelevant to the user, and it was easier to fix that behaviour than fix the tests to assert the right things about its format, so I did that too.