### PR TITLE
Remove deprecation from find test

### DIFF
--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -20,10 +20,8 @@ from __future__ import absolute_import, division, print_function
 from random import Random
 
 from hypothesis import Phase, find, settings, strategies as st
-from tests.common.utils import checks_deprecated_behaviour
 
 
-@checks_deprecated_behaviour
 def test_find_uses_provided_random():
     prev = None
 


### PR DESCRIPTION
Whoops. Because the build for #2239 ran before #2235 was merged, this test wasn't caught in the purge of deprecation annotations, so the build on master will now fail. This fixes that.