### PR TITLE
Validate strategies before drawing from them

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release fixes some cases where we might previously have failed to run the
+validation logic for some strategies. As a result tests which would previously
+have been silently testing significantly less than they should may now start
+to raise ``InvalidArgument`` now that these errors are caught.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -838,6 +838,8 @@ class ConjectureData(object):
             # See https://github.com/HypothesisWorks/hypothesis/issues/2108
             start_time = benchmark_time()
 
+        strategy.validate()
+
         if strategy.is_empty:
             self.mark_invalid()
 

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -27,11 +27,13 @@ from hypothesis.internal.validation import check_type
 from hypothesis.strategies import (
     binary,
     booleans,
+    data,
     dictionaries,
     floats,
     frozensets,
     integers,
     lists,
+    nothing,
     recursive,
     sets,
     text,
@@ -259,3 +261,12 @@ def test_check_type_with_tuple_of_length_two():
     type_checker("1")
     with pytest.raises(InvalidArgument, match="Expected one of int, str but got "):
         type_checker(1.0)
+
+
+def test_validation_happens_on_draw():
+    @given(data())
+    def test(data):
+        data.draw(integers().flatmap(lambda _: lists(nothing(), min_size=1)))
+
+    with pytest.raises(InvalidArgument, match="has no values"):
+        test()


### PR DESCRIPTION
I discovered by accident that if you use a strategy inside `flatmap` it doesn't ever get validated. This isn't ideal!

Due to the way most of our strategies are defined this *mostly* doesn't matter, but strategies with custom `do_validate` methods would have been missing out.

This fixes the problem my making it impossible and calling `validate()` in every `draw()`. This is cheap because `validate()` remembers its answer and is only run once.