### PR TITLE
Include highest `target` scores of failing tests in statistics

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+:ref:`statistics` now include the best score seen for each label, which can help avoid
+`the threshold problem <https://hypothesis.works/articles/threshold-problem/>`__  when
+the minimal example shrinks right down to the threshold of failure (:issue:`2180`).

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -166,6 +166,11 @@ def target(observation, label=""):
         ``hypothesis.target`` is considered experimental, and may be radically
         changed or even removed in a future version.  If you find it useful,
         please let us know so we can share and build on that success!
+
+    :ref:`statistics` include the best score seen for each label,
+    which can help avoid `the threshold problem
+    <https://hypothesis.works/articles/threshold-problem/>`__ when the minimal
+    example shrinks right down to the threshold of failure (:issue:`2180`).
     """
     check_type(float, observation, "observation")
     if math.isinf(observation) or math.isnan(observation):

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -34,6 +34,7 @@ class Statistics(object):
             + engine.status_runtimes.get(Status.OVERRUN, [])
         )
         self.failing_examples = len(engine.status_runtimes.get(Status.INTERESTING, ()))
+        self.targets = dict(engine.best_observed_targets)
 
         runtimes = sorted(
             engine.status_runtimes.get(Status.VALID, [])
@@ -108,6 +109,10 @@ class Statistics(object):
             % (self.draw_time_percentage,),
             "  - Stopped because %s" % (self.exit_reason,),
         ]
+        if self.targets:
+            lines.append("  - Highest target scores:")
+            for label, score in sorted(self.targets.items(), key=lambda x: x[::-1]):
+                lines.append("{:>20g}  ({})".format(score, repr(label)))
         if self.events:
             lines.append("  - Events:")
             lines += ["    * %s" % (event,) for event in self.events]


### PR DESCRIPTION
This is designed to help with the "threshold problem" where minimal examples can make serious problems look trivial.  If you're running with `--hypothesis-show-statistics` it should help with #2180.

@aarchiba: I *don't* think this solves your UX problem, but I think it's a generally useful thing to make visible - and we can do it much sooner than the ambitious stuff in #2192.  Comments most welcome.