### PR TITLE
Internal refactoring for ConjectureData

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release refactors some of Hypothesis's internal interfaces for representing
+data generation. It should have no user visible effect.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -65,6 +65,7 @@ from hypothesis.internal.compat import (
     binary_type,
     get_type_hints,
     getfullargspec,
+    hbytes,
     int_from_bytes,
     qualname,
 )
@@ -310,12 +311,12 @@ class ArtificialDataForExample(ConjectureData):
         self.__draws = 0
         self.__kwargs = kwargs
 
-        def draw_bytes(data, n):
-            raise NotImplementedError()  # pragma: no cover
-
         super(ArtificialDataForExample, self).__init__(
-            max_length=0, draw_bytes=draw_bytes
+            max_length=0, prefix=hbytes(), parameter=None,
         )
+
+    def draw_bits(self, n):
+        raise NotImplementedError()  # pragma: no cover
 
     def draw(self, strategy):
         assert self.__draws == 0

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import math
 from collections import defaultdict
 from enum import IntEnum
 
@@ -33,7 +34,7 @@ from hypothesis.internal.compat import (
     text_type,
     unicode_safe_repr,
 )
-from hypothesis.internal.conjecture.junkdrawer import IntList
+from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.escalation import mark_for_escalation
 
@@ -1052,3 +1053,135 @@ def bits_to_bytes(n):
     Equivalent to (n + 7) // 8, but slightly faster. This really is
     called enough times that that matters."""
     return (n + 7) >> 3
+
+
+generation_parameters_count = 0
+
+
+class GenerationParameters(object):
+    """Parameters to control generation of examples."""
+
+    AVERAGE_ALPHABET_SIZE = 3
+
+    ALPHABET_FACTOR = math.log(1.0 - 1.0 / AVERAGE_ALPHABET_SIZE)
+
+    def __init__(self, random):
+        self.__random = random
+        self.__zero_chance = None
+        self.__max_chance = None
+        self.__pure_chance = None
+        self.__alphabet = {}
+
+        global generation_parameters_count
+        generation_parameters_count += 1
+
+        self.__id = generation_parameters_count
+
+    def __repr__(self):
+        return "GenerationParameters(%d)" % (self.__id,)
+
+    def draw_bytes(self, n):
+        """Draw an n-byte block from the distribution defined by this instance
+        of generation parameters."""
+        alphabet = self.alphabet(n)
+
+        if alphabet is None:
+            return self.__draw_without_alphabet(n)
+
+        return self.__random.choice(alphabet)
+
+    def __draw_without_alphabet(self, n):
+        if self.__random.random() <= self.zero_chance:
+            return hbytes(n)
+
+        if self.__random.random() <= self.max_chance:
+            return hbytes([255]) * n
+
+        return uniform(self.__random, n)
+
+    def alphabet(self, n_bytes):
+        """Returns an alphabet - a list of values to use for all blocks with
+        this number of bytes - or None if this value should be generated
+        without an alphabet.
+
+        This is designed to promote duplication in the test case that would
+        otherwise happen with very low probability.
+        """
+        try:
+            return self.__alphabet[n_bytes]
+        except KeyError:
+            pass
+
+        if self.__random.random() <= self.pure_chance:
+            # Sometiems we don't want to use an alphabet (e.g. for generating
+            # sets of integers having a small alphabet is disastrous), so with
+            # some probability we want to generate choices that do not use the
+            # alphabet. As with other factors we set this probability globally
+            # across the whole choice of distribution so we have various levels
+            # of mixing.
+            result = None
+        else:
+            # We draw the size as a geometric distribution with average size
+            # GenerationParameters.AVERAGE_ALPHABET_SIZE.
+            size = (
+                int(
+                    math.log(self.__random.random())
+                    / GenerationParameters.ALPHABET_FACTOR
+                )
+                + 1
+            )
+            assert size > 0
+
+            size = self.__random.randint(1, 10)
+            result = [self.__draw_without_alphabet(n_bytes) for _ in hrange(size)]
+
+        self.__alphabet[n_bytes] = result
+        return result
+
+    @property
+    def max_chance(self):
+        """Returns a probability with which any given draw_bytes call should
+        be forced to be all 255 bytes. This is an important value because it
+        can make it more likely to push us into rare corners of the search
+        space, especially when biased_coin is being used."""
+        if self.__max_chance is None:
+            # We want to generate pure random examples every now and then. This
+            # is partly to offset too strong a bias to zero and partly because
+            # some user defined strategies may not play well with zero biasing.
+            self.__max_chance = self.__random.random() * 0.01
+        return self.__max_chance
+
+    @property
+    def zero_chance(self):
+        """Returns a probability with which any given draw_bytes call should
+        be forced to be all zero. This is an important value especially because
+        it will tend to force the test case to be smaller than it otherwise
+        would be."""
+        if self.__zero_chance is None:
+            # We want to generate pure random examples every now and then. This
+            # is partly to offset too strong a bias to zero and partly because
+            # some user defined strategies may not play well with zero biasing.
+            if self.__random.randrange(0, 10) == 0:
+                self.__zero_chance = 0.0
+            else:
+                self.__zero_chance = self.__random.random() * 0.5
+        return self.__zero_chance
+
+    @property
+    def pure_chance(self):
+        """Returns a probability with which any given draw_bytes call should
+        be forced to be all pure."""
+        if self.__pure_chance is None:
+            self.__pure_chance = self.__random.random()
+        return self.__pure_chance
+
+
+def draw_bytes_with(prefix, parameter):
+    def draw_bytes(data, n):
+        if data.index < len(prefix):
+            result = prefix[data.index : data.index + n]
+            # We always draw prefixes as a whole number of blocks
+            return result
+        return parameter.draw_bytes(n)
+
+    return draw_bytes

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -35,7 +35,6 @@ from hypothesis.internal.conjecture.data import (
     Overrun,
     Status,
     StopTest,
-    draw_bytes_with,
 )
 from hypothesis.internal.conjecture.datatree import (
     DataTree,
@@ -609,7 +608,7 @@ class ConjectureRunner(object):
                 # starting from the new novel prefix that has discovered.
                 try:
                     trial_data = self.new_conjecture_data(
-                        draw_bytes_with(prefix, parameter), max_length=max_length
+                        prefix=prefix, parameter=parameter, max_length=max_length
                     )
                     self.tree.simulate_test_function(trial_data)
                     continue
@@ -631,7 +630,7 @@ class ConjectureRunner(object):
                 max_length = BUFFER_SIZE
 
             data = self.new_conjecture_data(
-                draw_bytes_with(prefix, parameter), max_length=max_length
+                prefix=prefix, parameter=parameter, max_length=max_length
             )
 
             self.test_function(data)
@@ -660,9 +659,10 @@ class ConjectureRunner(object):
         self.shrink_interesting_examples()
         self.exit_with(ExitReason.finished)
 
-    def new_conjecture_data(self, draw_bytes, max_length=BUFFER_SIZE):
+    def new_conjecture_data(self, prefix, parameter, max_length=BUFFER_SIZE):
         return ConjectureData(
-            draw_bytes=draw_bytes,
+            prefix=prefix,
+            parameter=parameter,
             max_length=max_length,
             observer=self.tree.new_observer(),
         )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -17,7 +17,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import math
 from collections import Counter, defaultdict
 from enum import Enum
 from random import Random, getrandbits
@@ -28,20 +27,22 @@ import attr
 from hypothesis import HealthCheck, Phase, Verbosity, settings as Settings
 from hypothesis._settings import local_settings
 from hypothesis.internal.cache import LRUReusedCache
-from hypothesis.internal.compat import ceil, hbytes, hrange, int_from_bytes
+from hypothesis.internal.compat import ceil, hbytes, int_from_bytes
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,
+    GenerationParameters,
     Overrun,
     Status,
     StopTest,
+    draw_bytes_with,
 )
 from hypothesis.internal.conjecture.datatree import (
     DataTree,
     PreviouslyUnseenBehaviour,
     TreeRecordingObserver,
 )
-from hypothesis.internal.conjecture.junkdrawer import clamp, uniform
+from hypothesis.internal.conjecture.junkdrawer import clamp
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report
@@ -818,135 +819,3 @@ class ConjectureRunner(object):
         result = str(event)
         self.events_to_strings[event] = result
         return result
-
-
-generation_parameters_count = 0
-
-
-class GenerationParameters(object):
-    """Parameters to control generation of examples."""
-
-    AVERAGE_ALPHABET_SIZE = 3
-
-    ALPHABET_FACTOR = math.log(1.0 - 1.0 / AVERAGE_ALPHABET_SIZE)
-
-    def __init__(self, random):
-        self.__random = random
-        self.__zero_chance = None
-        self.__max_chance = None
-        self.__pure_chance = None
-        self.__alphabet = {}
-
-        global generation_parameters_count
-        generation_parameters_count += 1
-
-        self.__id = generation_parameters_count
-
-    def __repr__(self):
-        return "GenerationParameters(%d)" % (self.__id,)
-
-    def draw_bytes(self, n):
-        """Draw an n-byte block from the distribution defined by this instance
-        of generation parameters."""
-        alphabet = self.alphabet(n)
-
-        if alphabet is None:
-            return self.__draw_without_alphabet(n)
-
-        return self.__random.choice(alphabet)
-
-    def __draw_without_alphabet(self, n):
-        if self.__random.random() <= self.zero_chance:
-            return hbytes(n)
-
-        if self.__random.random() <= self.max_chance:
-            return hbytes([255]) * n
-
-        return uniform(self.__random, n)
-
-    def alphabet(self, n_bytes):
-        """Returns an alphabet - a list of values to use for all blocks with
-        this number of bytes - or None if this value should be generated
-        without an alphabet.
-
-        This is designed to promote duplication in the test case that would
-        otherwise happen with very low probability.
-        """
-        try:
-            return self.__alphabet[n_bytes]
-        except KeyError:
-            pass
-
-        if self.__random.random() <= self.pure_chance:
-            # Sometiems we don't want to use an alphabet (e.g. for generating
-            # sets of integers having a small alphabet is disastrous), so with
-            # some probability we want to generate choices that do not use the
-            # alphabet. As with other factors we set this probability globally
-            # across the whole choice of distribution so we have various levels
-            # of mixing.
-            result = None
-        else:
-            # We draw the size as a geometric distribution with average size
-            # GenerationParameters.AVERAGE_ALPHABET_SIZE.
-            size = (
-                int(
-                    math.log(self.__random.random())
-                    / GenerationParameters.ALPHABET_FACTOR
-                )
-                + 1
-            )
-            assert size > 0
-
-            size = self.__random.randint(1, 10)
-            result = [self.__draw_without_alphabet(n_bytes) for _ in hrange(size)]
-
-        self.__alphabet[n_bytes] = result
-        return result
-
-    @property
-    def max_chance(self):
-        """Returns a probability with which any given draw_bytes call should
-        be forced to be all 255 bytes. This is an important value because it
-        can make it more likely to push us into rare corners of the search
-        space, especially when biased_coin is being used."""
-        if self.__max_chance is None:
-            # We want to generate pure random examples every now and then. This
-            # is partly to offset too strong a bias to zero and partly because
-            # some user defined strategies may not play well with zero biasing.
-            self.__max_chance = self.__random.random() * 0.01
-        return self.__max_chance
-
-    @property
-    def zero_chance(self):
-        """Returns a probability with which any given draw_bytes call should
-        be forced to be all zero. This is an important value especially because
-        it will tend to force the test case to be smaller than it otherwise
-        would be."""
-        if self.__zero_chance is None:
-            # We want to generate pure random examples every now and then. This
-            # is partly to offset too strong a bias to zero and partly because
-            # some user defined strategies may not play well with zero biasing.
-            if self.__random.randrange(0, 10) == 0:
-                self.__zero_chance = 0.0
-            else:
-                self.__zero_chance = self.__random.random() * 0.5
-        return self.__zero_chance
-
-    @property
-    def pure_chance(self):
-        """Returns a probability with which any given draw_bytes call should
-        be forced to be all pure."""
-        if self.__pure_chance is None:
-            self.__pure_chance = self.__random.random()
-        return self.__pure_chance
-
-
-def draw_bytes_with(prefix, parameter):
-    def draw_bytes(data, n):
-        if data.index < len(prefix):
-            result = prefix[data.index : data.index + n]
-            # We always draw prefixes as a whole number of blocks
-            return result
-        return parameter.draw_bytes(n)
-
-    return draw_bytes

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -23,7 +23,6 @@ from hypothesis.internal.conjecture.engine import (
     BUFFER_SIZE,
     NO_SCORE,
     GenerationParameters,
-    draw_bytes_with,
 )
 
 
@@ -176,7 +175,7 @@ class Optimiser(object):
         prefix = data.buffer[:prefix_size]
 
         dummy = ConjectureData(
-            draw_bytes=draw_bytes_with(prefix, parameter), max_length=BUFFER_SIZE
+            prefix=prefix, parameter=parameter, max_length=BUFFER_SIZE,
         )
         try:
             self.engine.tree.simulate_test_function(dummy)
@@ -188,7 +187,7 @@ class Optimiser(object):
             pass
 
         attempt = self.engine.new_conjecture_data(
-            draw_bytes_with(dummy.buffer, parameter)
+            prefix=dummy.buffer, parameter=parameter
         )
         self.engine.test_function(attempt)
         if self.consider_new_test_data(attempt):

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -146,10 +146,7 @@ def test_terminates_shrinks(n, monkeypatch):
     db = InMemoryExampleDatabase()
 
     def generate_new_examples(self):
-        def draw_bytes(data, n):
-            return hbytes([255] * n)
-
-        self.test_function(self.new_conjecture_data(draw_bytes))
+        self.cached_test_function([255] * 1000)
 
     monkeypatch.setattr(
         ConjectureRunner, "generate_new_examples", generate_new_examples

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -25,11 +25,7 @@ import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies as st
 from hypothesis import settings
 from hypothesis.internal.compat import ceil, hrange
-from hypothesis.internal.conjecture.engine import (
-    ConjectureData,
-    ConjectureRunner,
-    uniform,
-)
+from hypothesis.internal.conjecture.engine import ConjectureData, ConjectureRunner
 from hypothesis.searchstrategy import SearchStrategy
 
 POISON = "POISON"
@@ -71,15 +67,6 @@ class Matrices(SearchStrategy):
         return [data.draw(self.__elements) for _ in hrange(n * m)]
 
 
-class TrialRunner(ConjectureRunner):
-    def generate_new_examples(self):
-        def draw_bytes(data, n):
-            return uniform(self.random, n)
-
-        while not self.interesting_examples:
-            self.test_function(self.new_conjecture_data(draw_bytes))
-
-
 LOTS = 10 ** 6
 
 TRIAL_SETTINGS = settings(max_examples=LOTS, database=None)
@@ -101,7 +88,9 @@ def test_minimal_poisoned_containers(seed, size, p, strategy_class, monkeypatch)
         if POISON in v:
             data.mark_interesting()
 
-    runner = TrialRunner(test_function, random=Random(seed), settings=TRIAL_SETTINGS)
+    runner = ConjectureRunner(
+        test_function, random=Random(seed), settings=TRIAL_SETTINGS
+    )
     runner.run()
     (v,) = runner.interesting_examples.values()
     result = ConjectureData.for_buffer(v.buffer).draw(strategy)

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -24,11 +24,7 @@ import pytest
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis import HealthCheck, settings
 from hypothesis.internal.compat import hbytes, hrange
-from hypothesis.internal.conjecture.engine import (
-    ConjectureData,
-    ConjectureRunner,
-    uniform,
-)
+from hypothesis.internal.conjecture.engine import ConjectureData, ConjectureRunner
 from hypothesis.searchstrategy import SearchStrategy
 
 POISON = "POISON"
@@ -96,11 +92,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
 
     runner = ConjectureRunner(test_function, random=random, settings=TEST_SETTINGS)
 
-    while not runner.interesting_examples:
-        runner.test_function(
-            runner.new_conjecture_data(lambda data, n: uniform(random, n))
-        )
-
+    runner.generate_new_examples()
     runner.shrink_interesting_examples()
 
     (data,) = runner.interesting_examples.values()


### PR DESCRIPTION
This removes a lot of the flexibility from the `ConjectureData` interface and moves the `GenerationParameters` class into the `data` module.

This isn't a particularly important change, but it sets the scene for some things I want to do later and cleans up the code a bit.