### PR TITLE
Generate non-UTF-8 strings for Numpy string datatype

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release allows :func:`~hypothesis.extra.numpy.from_dtype` to generate
+Unicode strings which cannot be encoded in UTF-8, but are valid in Numpy
+arrays (which use UTF-32).

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -108,9 +108,9 @@ def from_dtype(dtype):
         result = st.integers(min_value=-overflow, max_value=overflow - 1)
     elif dtype.kind == u"U":
         # Encoded in UTF-32 (four bytes/codepoint) and null-terminated
-        result = st.text(max_size=(dtype.itemsize or 0) // 4 or None).filter(
-            lambda b: b[-1:] != u"\0"
-        )
+        result = st.text(
+            alphabet=st.characters(), max_size=(dtype.itemsize or 0) // 4 or None
+        ).filter(lambda s: not s.endswith(u"\0"))
     elif dtype.kind in (u"m", u"M"):
         if "[" in dtype.str:
             res = st.just(dtype.str.split("[")[-1][:-1])

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -331,6 +331,18 @@ def test_unicode_string_dtypes_generate_unicode_strings(data):
     assert isinstance(result, text_type)
 
 
+@pytest.mark.skipif(PY2, reason="who knows, but there's only a month left anyway")
+def test_unicode_string_dtypes_need_not_be_utf8():
+    def cannot_encode(string):
+        try:
+            string.encode("utf-8")
+            return False
+        except UnicodeEncodeError:
+            return True
+
+    find_any(nps.from_dtype(np.dtype("U")), cannot_encode)
+
+
 @given(st.data())
 def test_byte_string_dtypes_generate_unicode_strings(data):
     dt = data.draw(nps.byte_string_dtypes())


### PR DESCRIPTION
Because Numpy unicode arrays are UTF-32, and I bet the difference will break a lot of downstream code.  (and if that's a problem, users can of course pass `elements=text()` or whatever else they want)