### PR TITLE
Explicitly check that @settings(parent) received a settings instance

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the error message when
+:func:`@settings <hypothesis.settings>` tries to inherit settings from a
+``parent`` argument that isn't a ``settings`` instance.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -159,6 +159,10 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
 
     def __init__(self, parent=None, **kwargs):
         # type: (settings, **Any) -> None
+        if parent is not None and not isinstance(parent, settings):
+            raise InvalidArgument(
+                "Invalid argument: parent=%r is not a settings instance" % (parent,)
+            )
         if kwargs.get("derandomize"):
             if kwargs.get("database") is not None:
                 raise InvalidArgument(

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -518,3 +518,16 @@ def test_max_example_eq_0_warns_and_disables_generation():
     calls = [0]
     inner()
     assert calls[0] == 1
+
+
+def test_invalid_parent():
+    class NotSettings(object):
+        def __repr__(self):
+            return "(not settings repr)"
+
+    not_settings = NotSettings()
+
+    with pytest.raises(InvalidArgument) as excinfo:
+        settings(not_settings)
+
+    assert "parent=(not settings repr)" in str(excinfo.value)


### PR DESCRIPTION
While messing around with some other things, I noticed that if you accidentally pass something to `@settings` without a keyword, it gets treated as default settings to inherit from.

This results in confusing error messages when that object isn't actually a `settings` instance, and the implementation tries to copy settings from it.

This PR therefore adds an explicit `isinstance` check with a more helpful error message.
