### PR TITLE
Remove old debug helpers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch removes some old debugging helpers in our Numpy extra which have
+not been needed since :issue:`1963` and :issue:`2245`.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -193,7 +193,6 @@ class ArrayStrategy(SearchStrategy):
         result = np.zeros(
             shape=self.array_size, dtype=object if unsized_string_dtype else self.dtype
         )
-        print(self.dtype, result.dtype)
 
         if self.fill.is_empty:
             # We have no fill value (either because the user explicitly
@@ -476,20 +475,7 @@ def defines_dtype_strategy(strat):
     @st.defines_strategy
     @proxies(strat)
     def inner(*args, **kwargs):
-        strategy = strat(*args, **kwargs)
-
-        def convert_to_dtype(x):
-            """Helper to debug issue #1798."""
-            try:
-                return np.dtype(x)
-            except ValueError:
-                print(
-                    "Got invalid dtype value=%r from strategy=%r, function=%r"
-                    % (x, strategy, strat)
-                )
-                raise
-
-        return strategy.map(convert_to_dtype)
+        return strat(*args, **kwargs).map(np.dtype)
 
     return inner
 

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -276,22 +276,6 @@ def test_raise_invalid_argument(function, kwargs):
         function(**kwargs).example()
 
 
-@nps.defines_dtype_strategy
-def bad_dtype_strategy():
-    return st.just([("f1", "int32"), ("f1", "int32")])
-
-
-@given(st.data())
-def test_bad_dtype_strategy(capsys, data):
-    s = bad_dtype_strategy()
-    with pytest.raises(ValueError):
-        data.draw(s)
-    val = s.wrapped_strategy.mapped_strategy.value
-    assert capsys.readouterr().out.startswith(
-        "Got invalid dtype value=%r from strategy=just(%r), function=" % (val, val)
-    )
-
-
 @checks_deprecated_behaviour
 @given(st.data())
 def test_byte_string_dtype_len_0(data):


### PR DESCRIPTION
I, uh, left a `print` in #2245 which slipped through review, and while checking for similar problems noticed that we had a tricky helper that was obseleted by #1963.  This PR removes both.