### PR TITLE
Start testing in CI with Django 3.0; drop Django 2.0 testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,12 +135,10 @@ jobs:
           TASK: check-nose
         check-pytest43:
           TASK: check-pytest43
+        check-django30:
+          TASK: check-django30
         check-django22:
           TASK: check-django22
-        check-django21:
-          TASK: check-django21
-        check-django20:
-          TASK: check-django20
         check-django111:
           TASK: check-django111
         check-pandas19:

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -124,22 +124,16 @@ commands =
     pip install django~=1.11.7
     python -m tests.django.manage test tests.django
 
-[testenv:django20]
-commands =
-    pip install .[pytz]
-    pip install django~=2.0.1
-    python -m tests.django.manage test tests.django
-
-[testenv:django21]
-commands =
-    pip install .[pytz]
-    pip install django~=2.1.0
-    python -m tests.django.manage test tests.django
-
 [testenv:django22]
 commands =
     pip install .[pytz]
     pip install django~=2.2.0
+    python -m tests.django.manage test tests.django
+
+[testenv:django30]
+commands =
+    pip install .[pytz]
+    pip install django~=3.0.0
     python -m tests.django.manage test tests.django
 
 [testenv:nose]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -457,7 +457,7 @@ def standard_tox_task(name):
 standard_tox_task("nose")
 standard_tox_task("pytest43")
 
-for n in [20, 21, 22, 111]:
+for n in [22, 30, 111]:
     standard_tox_task("django%d" % (n,))
 for n in [19, 20, 21, 22, 23, 24, 25]:
     standard_tox_task("pandas%d" % (n,))


### PR DESCRIPTION
The latter has been out of support since April: https://www.djangoproject.com/download/

I just know Hypothesis users are keen to upgrade, and get those [sweet, sweet furlongs](https://docs.djangoproject.com/en/dev/releases/3.0/#django-contrib-gis).