### PR TITLE
Suppress flaky health check in test_still_tears_down_on_failed_assume

### DIFF
--- a/hypothesis-python/tests/cover/test_setup_teardown.py
+++ b/hypothesis-python/tests/cover/test_setup_teardown.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from hypothesis import assume, given, settings
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.strategies import integers, text
 
 
@@ -54,6 +54,7 @@ class SomeGivens(object):
         pass
 
     @given(integers())
+    @settings(suppress_health_check=[HealthCheck.filter_too_much])
     def assume_some_stuff(self, x):
         assume(x > 0)
 


### PR DESCRIPTION
This test delibearetly fails its assumption with high probability, to test how teardown handles that scenario. Occasionally it fails the assumption so many times that `HealthCheck.filter_too_much` kicks in, causing flaky failures if not suppressed.

Spotted in <https://dev.azure.com/HypothesisWorks/Hypothesis/_build/results?buildId=3077>.