### PR TITLE
Warn when other decorators are used without `@given`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -256,6 +256,7 @@ their individual contributions.
 * `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (maxim.kulkin@gmail.com)
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
+* `Nick Anyos <https://www.github.com/NickAnyos>`_
 * `Paul Ganssle <https://ganssle.io>`_ (paul@ganssle.io)
 * `Paul Kehrer <https://github.com/reaperhulk>`_
 * `Paul Lorett Amazona <https://github.com/whatevergeek>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release deprecates use of :func:`@example <hypothesis.example>`,
+:func:`@seed <hypothesis.seed>`, or :func:`@reproduce_failure <hypothesis.reproduce_failure>`
+without :func:`@given <hypothesis.given>`.
+
+Thanks to Nick Anyos for the patch!

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -75,11 +75,18 @@ def test_reproduces_the_failure():
 
     @reproduce_failure(__version__, encode_failure(b))
     @given(st.binary(min_size=n, max_size=n))
-    def test(x):
+    def test_outer(x):
+        assert x != b
+
+    @given(st.binary(min_size=n, max_size=n))
+    @reproduce_failure(__version__, encode_failure(b))
+    def test_inner(x):
         assert x != b
 
     with pytest.raises(AssertionError):
-        test()
+        test_outer()
+    with pytest.raises(AssertionError):
+        test_inner()
 
 
 def test_errors_if_provided_example_does_not_reproduce_failure():

--- a/hypothesis-python/tests/pytest/test_checks.py
+++ b/hypothesis-python/tests/pytest/test_checks.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+TEST_DECORATORS_ALONE = """
+import hypothesis
+from hypothesis.strategies import composite
+
+@composite
+def test_composite_is_not_a_test(draw):
+    # This strategy will be instantiated, but no draws == no calls.
+    assert False
+
+@hypothesis.seed(0)
+def test_seed_without_given_fails():
+    pass
+
+@hypothesis.example(x=None)
+def test_example_without_given_fails():
+    pass
+
+@hypothesis.reproduce_failure(hypothesis.__version__, b"AA==")
+def test_repro_without_given_fails():
+    pass
+"""
+
+
+def test_decorators_without_given_should_fail(testdir):
+    script = testdir.makepyfile(TEST_DECORATORS_ALONE)
+    testdir.runpytest(script).assert_outcomes(passed=4)
+    testdir.runpytest(script, "-Werror").assert_outcomes(failed=4)


### PR DESCRIPTION
This replaces #2233 by @NickAnyos - because it turns out that `master` interacts weirdly with 'allow edits from maintainers' - and thus closes #2164, which wasn't an easy issue after all.