### PR TITLE
By default always run the maximum number of stateful test steps

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release changes the size distribution of the number of steps run in
+stateful testing: It will now almost always run the maximum number of steps
+permitted.

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -865,7 +865,7 @@ def test_removes_needless_steps():
     but will still fail with very high probability.
     """
 
-    @Settings(derandomize=True, max_examples=1000)
+    @Settings(derandomize=True, max_examples=1000, deadline=None)
     class IncorrectDeletion(RuleBasedStateMachine):
         def __init__(self):
             super(IncorrectDeletion, self).__init__()
@@ -1193,25 +1193,25 @@ def test_uses_seed(capsys):
 
 
 def test_reproduce_failure_works():
-    @reproduce_failure(__version__, base64.b64encode(b"\0\0\0\0\0"))
+    @reproduce_failure(__version__, base64.b64encode(b"\x00\x00\x01\x00\x00\x00"))
     class TrivialMachine(RuleBasedStateMachine):
         @rule()
         def oops(self):
             assert False
 
     with pytest.raises(AssertionError):
-        run_state_machine_as_test(TrivialMachine)
+        run_state_machine_as_test(TrivialMachine, settings=Settings(print_blob=True))
 
 
 def test_reproduce_failure_fails_if_no_error():
-    @reproduce_failure(__version__, base64.b64encode(b"\0\0\0\0\0"))
+    @reproduce_failure(__version__, base64.b64encode(b"\x00\x00\x01\x00\x00\x00"))
     class TrivialMachine(RuleBasedStateMachine):
         @rule()
         def ok(self):
             assert True
 
     with pytest.raises(DidNotReproduce):
-        run_state_machine_as_test(TrivialMachine)
+        run_state_machine_as_test(TrivialMachine, settings=Settings(print_blob=True))
 
 
 def test_cannot_have_zero_steps():


### PR DESCRIPTION
One of the tests that was failing as a result of #2261 was an erratic failure in stateful tests that was the result of not always running enough steps.

The root cause of this is that even though we set the average size to be the maximum number of steps, our `many` function doesn't really handle that very well and actually generates things quite a lot smaller than that.

This release introduces a new trick, which is to generate the full list of steps with probability tantamount to one but *just* low enough to allow steps to be deleted during shrinking. This should allow all those tests to pass more reliably.