### PR TITLE
Remove max_chance and zero_chance from GenerationParameters

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes a small internal change to the distribution of test cases.
+It is unlikely to have much user visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1067,7 +1067,6 @@ class GenerationParameters(object):
     def __init__(self, random):
         self.__random = random
         self.__zero_chance = None
-        self.__max_chance = None
         self.__pure_chance = None
         self.__alphabet = {}
 
@@ -1092,9 +1091,6 @@ class GenerationParameters(object):
     def __draw_without_alphabet(self, n):
         if self.__random.random() <= self.zero_chance:
             return hbytes(n)
-
-        if self.__random.random() <= self.max_chance:
-            return hbytes([255]) * n
 
         return uniform(self.__random, n)
 
@@ -1136,19 +1132,6 @@ class GenerationParameters(object):
 
         self.__alphabet[n_bytes] = result
         return result
-
-    @property
-    def max_chance(self):
-        """Returns a probability with which any given draw_bytes call should
-        be forced to be all 255 bytes. This is an important value because it
-        can make it more likely to push us into rare corners of the search
-        space, especially when biased_coin is being used."""
-        if self.__max_chance is None:
-            # We want to generate pure random examples every now and then. This
-            # is partly to offset too strong a bias to zero and partly because
-            # some user defined strategies may not play well with zero biasing.
-            self.__max_chance = self.__random.random() * 0.01
-        return self.__max_chance
 
     @property
     def zero_chance(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1066,7 +1066,6 @@ class GenerationParameters(object):
 
     def __init__(self, random):
         self.__random = random
-        self.__zero_chance = None
         self.__pure_chance = None
         self.__alphabet = {}
 
@@ -1089,9 +1088,6 @@ class GenerationParameters(object):
         return self.__random.choice(alphabet)
 
     def __draw_without_alphabet(self, n):
-        if self.__random.random() <= self.zero_chance:
-            return hbytes(n)
-
         return uniform(self.__random, n)
 
     def alphabet(self, n_bytes):
@@ -1132,22 +1128,6 @@ class GenerationParameters(object):
 
         self.__alphabet[n_bytes] = result
         return result
-
-    @property
-    def zero_chance(self):
-        """Returns a probability with which any given draw_bytes call should
-        be forced to be all zero. This is an important value especially because
-        it will tend to force the test case to be smaller than it otherwise
-        would be."""
-        if self.__zero_chance is None:
-            # We want to generate pure random examples every now and then. This
-            # is partly to offset too strong a bias to zero and partly because
-            # some user defined strategies may not play well with zero biasing.
-            if self.__random.randrange(0, 10) == 0:
-                self.__zero_chance = 0.0
-            else:
-                self.__zero_chance = self.__random.random() * 0.5
-        return self.__zero_chance
 
     @property
     def pure_chance(self):


### PR DESCRIPTION
This is another slimming down of `GenerationParameters`. Slightly alarmingly we can remove it and our tests seem to still pass. I could have sworn it was necessary when I added it but either something has changed since or I was hallucinating that.