### PR TITLE
Don't allow stateful_step_count to be zero

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release changes the ``stateful_step_count`` setting to raise an error if
+set to ``0``. This is a backwards compatible change because a value of ``0``
+would never have worked and attempting to run it would have resulted in an
+internal assertion error.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -598,7 +598,9 @@ settings._define_setting(
 settings._define_setting(
     name="stateful_step_count",
     default=50,
-    validator=lambda x: _ensure_positive_int(x, "stateful_step_count", "2019-03-06"),
+    validator=lambda x: _ensure_positive_int(
+        x, "stateful_step_count", "2019-03-06", min_value=1
+    ),
     description="""
 Number of steps to run a stateful program for before giving up on it breaking.
 """,

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1212,3 +1212,8 @@ def test_reproduce_failure_fails_if_no_error():
 
     with pytest.raises(DidNotReproduce):
         run_state_machine_as_test(TrivialMachine)
+
+
+def test_cannot_have_zero_steps():
+    with pytest.raises(InvalidArgument):
+        Settings(stateful_step_count=0)


### PR DESCRIPTION
@Zac-HD  pointed out in https://github.com/HypothesisWorks/hypothesis/pull/2262#discussion_r355367530 that we were incorrectly validating this setting and that a `0` value was permitted but didn't work. This PR fixes that by making a `0` value an error.