### PR TITLE
Add dedicated phase for targeted testing

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds a dedicated phase for :ref:`targeted property-based testing <targeted-search>`,
+and (somewhat) improves the targeting algorithm so that it will find higher quality results more reliably.
+This comes at a cost of making it more likely to get stuck in a local optimum.

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -57,8 +57,9 @@ Hypothesis divides tests into four logically distinct phases:
 1. Running explicit examples :ref:`provided with the @example decorator <providing-explicit-examples>`.
 2. Rerunning a selection of previously failing examples to reproduce a previously seen error
 3. Generating new examples.
-4. Attempting to shrink an example found in phases 2 or 3 to a more manageable
-   one (explicit examples cannot be shrunk).
+4. Mutating examples for :ref:`targeted property-based testing <targeted-search>`.
+5. Attempting to shrink an example found in previous phases (other than phase 1 - explicit examples cannot be shrunk).
+   This turns potentially large and complicated examples which may be hard to read into smaller and simpler ones.
 
 The phases setting provides you with fine grained control over which of these run,
 with each phase corresponding to a value on the :class:`~hypothesis.Phase` enum:
@@ -68,7 +69,9 @@ with each phase corresponding to a value on the :class:`~hypothesis.Phase` enum:
 1. ``Phase.explicit`` controls whether explicit examples are run.
 2. ``Phase.reuse`` controls whether previous examples will be reused.
 3. ``Phase.generate`` controls whether new examples will be generated.
-4. ``Phase.shrink`` controls whether examples will be shrunk.
+4. ``Phase.target`` controls whether examples will be mutated for targeting.
+5. ``Phase.shrink`` controls whether examples will be shrunk.
+
 
 The phases argument accepts a collection with any subset of these. e.g.
 ``settings(phases=[Phase.generate, Phase.shrink])`` will generate new examples

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -503,7 +503,8 @@ class Phase(IntEnum):
     explicit = 0
     reuse = 1
     generate = 2
-    shrink = 3
+    target = 3
+    shrink = 4
 
     def __repr__(self):
         return "Phase.%s" % (self.name,)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -59,10 +59,6 @@ class Optimiser(object):
         return self.score_function(self.current_data)
 
     @property
-    def best_score(self):
-        return self.engine.best_observed_targets[self.target]
-
-    @property
     def random(self):
         return self.engine.random
 
@@ -126,9 +122,8 @@ class Optimiser(object):
 
         # We keep running our hill climbing until we've got (fairly weak)
         # evidence that we're at a local maximum.
-        max_failures = 5
+        max_failures = 10
         consecutive_failures = 0
-        improved = False
         while (
             consecutive_failures < max_failures
             # Once we've hit and interesting target it's time to stop hill
@@ -136,13 +131,6 @@ class Optimiser(object):
             # further.
             and self.current_data.status <= Status.VALID
         ):
-            at_best = self.current_score == self.best_score
-
-            if improved and at_best:
-                max_failures = 10
-            elif improved or at_best:
-                max_failures = 5
-
             if self.attempt_to_improve(
                 parameter=parameter, example_index=select_example(self.current_data)
             ):
@@ -150,7 +138,6 @@ class Optimiser(object):
                 # any evidence that we're at a local maximum so we reset the
                 # count.
                 consecutive_failures = 0
-                improved = True
             else:
                 # If we've failed in our hill climbing attempt, this could be
                 # for two reasons: We've not picked enough of the test case to

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -1452,3 +1452,23 @@ def test_prefix_cannot_exceed_buffer_size(monkeypatch):
         runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS)
         runner.run()
         assert runner.valid_examples == buffer_size
+
+
+def test_optimises_multiple_targets():
+    with deterministic_PRNG():
+
+        def test(data):
+            n = data.draw_bits(8)
+            m = data.draw_bits(8)
+            if n + m > 256:
+                data.mark_invalid()
+            data.target_observations["m"] = m
+            data.target_observations["n"] = n
+            data.target_observations["m + n"] = m + n
+
+        runner = ConjectureRunner(test, settings=TEST_SETTINGS)
+        runner.run()
+
+        assert runner.best_observed_targets["m"] == 255
+        assert runner.best_observed_targets["n"] == 255
+        assert runner.best_observed_targets["m + n"] == 256

--- a/hypothesis-python/tests/cover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/cover/test_conjecture_engine.py
@@ -34,6 +34,7 @@ from hypothesis.internal.conjecture.engine import (
     MIN_TEST_CALLS,
     ConjectureRunner,
     ExitReason,
+    RunIsComplete,
 )
 from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
 from hypothesis.internal.conjecture.shrinking import Float
@@ -1467,7 +1468,13 @@ def test_optimises_multiple_targets():
             data.target_observations["m + n"] = m + n
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.run()
+        runner.cached_test_function([200, 0])
+        runner.cached_test_function([0, 200])
+
+        try:
+            runner.optimise_targets()
+        except RunIsComplete:
+            pass
 
         assert runner.best_observed_targets["m"] == 255
         assert runner.best_observed_targets["n"] == 255

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -21,7 +21,7 @@ from operator import itemgetter
 
 import pytest
 
-from hypothesis import Phase, example, given, settings, strategies as st, target
+from hypothesis import Phase, example, given, seed, settings, strategies as st, target
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import string_types
 
@@ -131,7 +131,7 @@ def test_targeting_with_many_empty(_):
 def test_targeting_increases_max_length():
     strat = st.lists(st.booleans())
 
-    @settings(database=None, max_examples=200, phases=[Phase.generate])
+    @settings(database=None, max_examples=200, phases=[Phase.generate, Phase.target])
     @given(strat)
     def test_with_targeting(ls):
         target(float(len(ls)))
@@ -139,3 +139,26 @@ def test_targeting_increases_max_length():
 
     with pytest.raises(AssertionError):
         test_with_targeting()
+
+
+def test_targeting_can_be_disabled():
+    strat = st.lists(st.integers(0, 255))
+
+    def score(enabled):
+        result = [0]
+        phases = [Phase.generate]
+        if enabled:
+            phases.append(Phase.target)
+
+        @seed(0)
+        @settings(database=None, max_examples=200, phases=phases)
+        @given(strat)
+        def test(ls):
+            score = float(sum(ls))
+            result[0] = max(result[0], score)
+            target(score)
+
+        test()
+        return result[0]
+
+    assert score(enabled=True) > score(enabled=False)


### PR DESCRIPTION
The next thing that is broken by my ongoing total gut of generation: It turns out that generation parameters help with optimisation a *bit*, and the targeting tests go slightly flaky on their removal. This PR pulls out optimisation into its own phase and doubles down on the fact that we're just hill climbing, so spends half of our example budget running hill climbing from the best points we've found so far.

For things where pure hill climbing is a good strategy this will improve our targeting. For things where it's a bad strategy, it will hurt it, but currently we're rubbish at those anyway and we need a better algorithm before we get good at that so I'd rather we reliably succeed at things where hill climbing works