### PR TITLE
Remove some tasks that take up time on CI 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
       displayName: Install dependencies
     - script: |
         cd hypothesis-python
-        pytest
+        pytest tests\cover  tests/datetime tests\numpy  tests\pandas tests\py3  tests\pytest
       displayName: Run tests
 
   - job: osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,6 @@ jobs:
           TASK: lint
         check-format:
           TASK: check-format
-        check-rust-tests:
-          TASK: check-rust-tests
         check-coverage:
           TASK: check-coverage
         check-pypy:


### PR DESCRIPTION
Main things:

* We're not using the Rust code, so it makes no sense to keep running the tests
* There are a bunch of expensive categories of test that it doesn't really make sense to run on every windows build, so this subsets our test to a reasonable set that it's worth testing across multiple OSes.