### PR TITLE
Fix from_type bytestring/sequence issues

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2257`, where :func:`~hypothesis.strategies.from_type`
+could incorrectly generate bytestrings when passed a generic
+:class:`python:typing.Sequence` such as ``Sequence[set]``.

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -23,6 +23,8 @@ import enum
 import io
 import string
 import sys
+import typing
+from numbers import Real
 
 import pytest
 
@@ -40,7 +42,6 @@ from hypothesis.strategies._internal import types
 from tests.common.debug import find_any, minimal
 from tests.common.utils import fails_with
 
-typing = pytest.importorskip("typing")
 sentinel = object()
 generics = sorted(
     (t for t in types._global_type_lookup if isinstance(t, typing_root_type)), key=str
@@ -574,3 +575,23 @@ def test_inference_on_generic_collections_abc_aliases(typ, data):
     # see https://github.com/HypothesisWorks/hypothesis/issues/2272
     value = data.draw(st.from_type(typ))
     assert isinstance(value, typ)
+
+
+@given(st.from_type(typing.Sequence[set]))
+def test_bytestring_not_treated_as_generic_sequence(val):
+    # Check that we don't fall into the specific problem from
+    # https://github.com/HypothesisWorks/hypothesis/issues/2257
+    assert not isinstance(val, typing.ByteString)
+    # Check it hasn't happened again from some other non-generic sequence type.
+    for x in val:
+        assert isinstance(x, set)
+
+
+@pytest.mark.parametrize(
+    "type_", [int, Real, object, typing.Union[int, str], typing.Union[Real, str]]
+)
+def test_bytestring_is_valid_sequence_of_int_and_parent_classes(type_):
+    find_any(
+        st.from_type(typing.Sequence[type_]),
+        lambda val: isinstance(val, typing.ByteString),
+    )


### PR DESCRIPTION
This bug turned out to be surprisingly subtle: it turns on the fact that `typing.ByteString` has a registered strategy (namely `st.binary()`), is a subclass of `typing.Sequence`, but is *not* a generic type.

The solution is an inelegant hack, like everything else in the ~~`typing` module~~ `from_type` backend, but has the considerable advantage of working.

We still consider `bytes` to be a subclass of `Sequence[int]` though, or any `Sequence[Union[int, ...]]` - it wouldn't do to let people relax *too* much :grin: 




Fixes #2257, cc @mvaled 