### PR TITLE
Track the pareto front in the example database

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release adds database support for :ref:`targeted property-based testing <targeted-search>`,
+so the best examples based on the targeting will be saved and reused between runs.
+This is mostly laying groundwork for future features in this area, but
+will also make targeted property based tests more useful during development,
+where the same tests tend to get run over and over again.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -6,4 +6,4 @@ This is mostly laying groundwork for future features in this area, but
 will also make targeted property based tests more useful during development,
 where the same tests tend to get run over and over again.
 
-This release also adds a dependency on the ``sortedcontainers`` package.
+This release also adds a dependency on the :pypi:`sortedcontainers` package.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -6,4 +6,8 @@ This is mostly laying groundwork for future features in this area, but
 will also make targeted property-based tests more useful during development,
 where the same tests tend to get run over and over again.
 
+If :obj:`~hypothesis.settings.max_examples` is large, this may increase memory
+usage significantly under some circumstances, but these should be relatively
+rare.
+
 This release also adds a dependency on the :pypi:`sortedcontainers` package.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,7 +3,7 @@ RELEASE_TYPE: minor
 This release adds database support for :ref:`targeted property-based testing <targeted-search>`,
 so the best examples based on the targeting will be saved and reused between runs.
 This is mostly laying groundwork for future features in this area, but
-will also make targeted property based tests more useful during development,
+will also make targeted property-based tests more useful during development,
 where the same tests tend to get run over and over again.
 
 This release also adds a dependency on the :pypi:`sortedcontainers` package.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,9 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 This release adds database support for :ref:`targeted property-based testing <targeted-search>`,
 so the best examples based on the targeting will be saved and reused between runs.
 This is mostly laying groundwork for future features in this area, but
 will also make targeted property based tests more useful during development,
 where the same tests tend to get run over and over again.
+
+This release also adds a dependency on the ``sortedcontainers`` package.

--- a/hypothesis-python/docs/index.rst
+++ b/hypothesis-python/docs/index.rst
@@ -22,7 +22,7 @@ Hypothesis lets you write tests which instead look like this:
 2. Perform some operations on the data.
 3. Assert something about the result.
 
-This is often called property based testing, and was popularised by the
+This is often called property-based testing, and was popularised by the
 Haskell library `Quickcheck <https://hackage.haskell.org/package/QuickCheck>`_.
 
 It works by generating arbitrary data matching your specification and checking

--- a/hypothesis-python/docs/packaging.rst
+++ b/hypothesis-python/docs/packaging.rst
@@ -45,6 +45,7 @@ Other Python libraries
 Hypothesis has *mandatory* dependencies on the following libraries:
 
 * :pypi:`attrs`
+* :pypi:`sortedcontainers`
 * :pypi:`enum34` is required on Python 2.7
 
 Hypothesis has *optional* dependencies on the following libraries:

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -68,7 +68,7 @@ extras = {
 extras["all"] = sorted(sum(extras.values(), []))
 
 
-install_requires = ["attrs>=19.2.0"]
+install_requires = ["attrs>=19.2.0", "sortedcontainers>=2.1.0,<3.0.0"]
 # Using an environment marker on enum34 makes the dependency condition
 # independent of the build environemnt, which is important for wheels.
 # https://www.python.org/dev/peps/pep-0345/#environment-markers

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -94,7 +94,7 @@ setuptools.setup(
         "Issues": "https://github.com/HypothesisWorks/hypothesis/issues",
     },
     license="MPL v2",
-    description="A library for property based testing",
+    description="A library for property-based testing",
     zip_safe=False,
     extras_require=extras,
     install_requires=install_requires,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -655,6 +655,9 @@ class _Overrun(object):
     def __repr__(self):
         return "Overrun"
 
+    def as_result(self):
+        return self
+
 
 Overrun = _Overrun()
 
@@ -711,6 +714,9 @@ class ConjectureResult(object):
     def __attrs_post_init__(self):
         self.index = len(self.buffer)
         self.forced_indices = frozenset(self.forced_indices)
+
+    def as_result(self):
+        return self
 
 
 # Masks for masking off the first byte of an n-bit buffer.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -42,6 +42,7 @@ from hypothesis.internal.conjecture.datatree import (
     TreeRecordingObserver,
 )
 from hypothesis.internal.conjecture.junkdrawer import clamp
+from hypothesis.internal.conjecture.pareto import ParetoFront
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report
@@ -112,6 +113,16 @@ class ConjectureRunner(object):
         self.best_observed_targets = defaultdict(lambda: NO_SCORE)
         self.best_examples_of_observed_targets = {}
 
+        # We keep the pareto front in the example database if we have one. This
+        # is only marginally useful at present, but speeds up local development
+        # because it means that large targets will be quickly surfaced in your
+        # testing.
+        if self.database_key is not None and self.settings.database is not None:
+            self.pareto_front = ParetoFront(self.random)
+            self.pareto_front.on_evict(self.on_pareto_evict)
+        else:
+            self.pareto_front = None
+
         # We want to be able to get the ConjectureData object that results
         # from running a buffer without recalculating, especially during
         # shrinking where we need to know about the structure of the
@@ -163,6 +174,9 @@ class ConjectureRunner(object):
                 self.note_details(data)
 
         self.debug_data(data)
+
+        if self.pareto_front is not None and self.pareto_front.add(data.as_result()):
+            self.save_buffer(data.buffer, sub_key=b"pareto")
 
         assert len(data.buffer) <= BUFFER_SIZE
 
@@ -233,6 +247,9 @@ class ConjectureRunner(object):
             self.exit_with(ExitReason.finished)
 
         self.record_for_health_check(data)
+
+    def on_pareto_evict(self, data):
+        self.settings.database.delete(self.pareto_key, data.buffer)
 
     def generate_novel_prefix(self):
         """Uses the tree to proactively generate a starting sequence of bytes
@@ -326,9 +343,9 @@ class ConjectureRunner(object):
                 HealthCheck.too_slow,
             )
 
-    def save_buffer(self, buffer):
+    def save_buffer(self, buffer, sub_key=None):
         if self.settings.database is not None:
-            key = self.database_key
+            key = self.sub_key(sub_key)
             if key is None:
                 return
             self.settings.database.save(key, hbytes(buffer))
@@ -337,13 +354,20 @@ class ConjectureRunner(object):
         if self.settings.database is not None and self.database_key is not None:
             self.settings.database.move(self.database_key, self.secondary_key, buffer)
 
-    @property
-    def secondary_key(self):
-        return b".".join((self.database_key, b"secondary"))
+    def sub_key(self, sub_key):
+        if self.database_key is None:
+            return None
+        if sub_key is None:
+            return self.database_key
+        return b".".join((self.database_key, sub_key))
 
     @property
-    def covering_key(self):
-        return b".".join((self.database_key, b"coverage"))
+    def secondary_key(self):
+        return self.sub_key(b"secondary")
+
+    @property
+    def pareto_key(self):
+        return self.sub_key(b"pareto")
 
     def note_details(self, data):
         self.__data_cache[data.buffer] = data.as_result()
@@ -449,29 +473,39 @@ class ConjectureRunner(object):
             )
             desired_size = max(2, ceil(0.1 * self.settings.max_examples))
 
-            for extra_key in [self.secondary_key, self.covering_key]:
-                if len(corpus) < desired_size:
-                    extra_corpus = list(self.settings.database.fetch(extra_key))
+            if len(corpus) < desired_size:
+                extra_corpus = list(self.settings.database.fetch(self.secondary_key))
 
-                    shortfall = desired_size - len(corpus)
+                shortfall = desired_size - len(corpus)
 
-                    if len(extra_corpus) <= shortfall:
-                        extra = extra_corpus
-                    else:
-                        extra = self.random.sample(extra_corpus, shortfall)
-                    extra.sort(key=sort_key)
-                    corpus.extend(extra)
+                if len(extra_corpus) <= shortfall:
+                    extra = extra_corpus
+                else:
+                    extra = self.random.sample(extra_corpus, shortfall)
+                extra.sort(key=sort_key)
+                corpus.extend(extra)
 
             for existing in corpus:
-                last_data = ConjectureData.for_buffer(
-                    existing, observer=self.tree.new_observer()
-                )
-                try:
-                    self.test_function(last_data)
-                finally:
-                    if last_data.status != Status.INTERESTING:
-                        self.settings.database.delete(self.database_key, existing)
-                        self.settings.database.delete(self.secondary_key, existing)
+                data = self.cached_test_function(existing)
+                if data.status != Status.INTERESTING:
+                    self.settings.database.delete(self.database_key, existing)
+                    self.settings.database.delete(self.secondary_key, existing)
+
+            # If we've not found any interesting examples so far we try some of
+            # the pareto front from the last run.
+            if len(corpus) < desired_size and not self.interesting_examples:
+                desired_extra = desired_size - len(corpus)
+                pareto_corpus = list(self.settings.database.fetch(self.pareto_key))
+                if len(pareto_corpus) > desired_extra:
+                    pareto_corpus = self.random.sample(pareto_corpus, desired_extra)
+                pareto_corpus.sort(key=sort_key)
+
+                for existing in pareto_corpus:
+                    data = self.cached_test_function(existing)
+                    if data not in self.pareto_front:
+                        self.settings.database.delete(self.pareto_key, existing)
+                    if data.status == Status.INTERESTING:
+                        break
 
     def exit_with(self, reason):
         self.debug("exit_with(%s)" % (reason.name,))
@@ -486,6 +520,8 @@ class ConjectureRunner(object):
             # so we'd rather report that they're still failing ASAP than take
             # the time to look for additional failures.
             return
+
+        self.debug("Generating new examples")
 
         zero_data = self.cached_test_function(hbytes(BUFFER_SIZE))
         if zero_data.status > Status.OVERRUN:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -42,7 +42,7 @@ from hypothesis.internal.conjecture.datatree import (
     TreeRecordingObserver,
 )
 from hypothesis.internal.conjecture.junkdrawer import clamp
-from hypothesis.internal.conjecture.pareto import ParetoFront
+from hypothesis.internal.conjecture.pareto import NO_SCORE, ParetoFront
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report
@@ -50,9 +50,6 @@ from hypothesis.reporting import base_report
 # Tell pytest to omit the body of this module from tracebacks
 # https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
 __tracebackhide__ = True
-
-
-NO_SCORE = float("-inf")
 
 
 MAX_SHRINKS = 500

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -213,3 +213,10 @@ def clamp(lower, value, upper):
     """Given a value and lower/upper bounds, 'clamp' the value so that
     it satisfies lower <= value <= upper."""
     return max(lower, min(value, upper))
+
+
+def swap(ls, i, j):
+    """Swap the elements ls[i], ls[j]."""
+    if i == j:
+        return
+    ls[i], ls[j] = ls[j], ls[i]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -29,7 +29,7 @@ from hypothesis.internal.conjecture.engine import (
 
 class Optimiser(object):
     """A fairly basic optimiser designed to increase the value of scores for
-    targeted property based testing.
+    targeted property-based testing.
 
     This implements a fairly naive hill climbing algorithm based on randomly
     regenerating parts of the test case to attempt to improve the result. It is

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from enum import Enum
+
+from hypothesis.internal.conjecture.data import ConjectureData, ConjectureResult, Status
+from hypothesis.internal.conjecture.shrinker import sort_key
+
+
+class DominanceRelation(Enum):
+    NO_DOMINANCE = 0
+    EQUAL = 1
+    LEFT_DOMINATES = 2
+    RIGHT_DOMINATES = 3
+
+
+def dominance(left, right):
+    """Returns the dominance relation between ``left`` and ``right``, according
+    to the rules that something dominates if and only if it is better in every
+    way.
+
+    The things we currently consider to be "better" are:
+
+        * Something that is smaller in shrinking order is better.
+        * Something that has higher status is better.
+        * Each ``interesting_origin`` is treated as its own score, so if two
+          interesting examples have different origins then neither dominates
+          the other.
+        * For each target observation, a higher score is better.
+
+    In "normal" operation where there are no bugs or target observations, the
+    pareto front only has one element (the smallest valid test case), but for
+    more structured or failing tests it can be useful to track, and future work
+    will depend on it more."""
+
+    if left.buffer == right.buffer:
+        return DominanceRelation.EQUAL
+
+    if sort_key(right.buffer) < sort_key(left.buffer):
+        result = dominance(right, left)
+        if result == DominanceRelation.LEFT_DOMINATES:
+            return DominanceRelation.RIGHT_DOMINATES
+        else:
+            # Because we have sort_key(left) < sort_key(right) the only options
+            # are that right is better than left or that the two are
+            # incomparable.
+            assert result == DominanceRelation.NO_DOMINANCE
+            return result
+
+    # Either left is better or there is no dominance relationship.
+    assert sort_key(left.buffer) < sort_key(right.buffer)
+
+    # The right is more interesting
+    if left.status < right.status:
+        return DominanceRelation.NO_DOMINANCE
+
+    # Things that are interesting for different reasons are incomparable in
+    # the dominance relationship.
+    if (
+        left.status == Status.INTERESTING
+        and left.interesting_origin != right.interesting_origin
+    ):
+        return DominanceRelation.NO_DOMINANCE
+
+    for target, score in left.target_observations.items():
+        if (
+            target in right.target_observations
+            and right.target_observations[target] > score
+        ):
+            return DominanceRelation.NO_DOMINANCE
+
+    return DominanceRelation.LEFT_DOMINATES
+
+
+class ParetoFront(object):
+    """Maintains an approximate pareto front of ConjectureData objects. That
+    is, we try to maintain a collection of objects such that no element of the
+    collection is pareto dominated by any other. In practice we don't quite
+    manage that, because doing so is computationally very expensive. Instead
+    we maintain a random sample of data objects that are "rarely" dominated by
+    any other element of the collection (roughly, no more than about 10%).
+
+    Only valid test cases are considered to belong to the pareto front - any
+    test case with a status less than valid is discarded.
+    """
+
+    def __init__(self, random):
+        self.__random = random
+        self.__eviction_listeners = []
+
+        self.__front = []
+        self.__contained = {}
+        self.__pending = None
+
+    def add(self, data):
+        """Attempts to add ``data`` to the pareto front. Returns True if this
+        resulted ``data`` being added, otherwise returns False (including if
+        data is already in the collection)."""
+        if data.status < Status.VALID:
+            return False
+
+        if not self.__front:
+            self.__add(data)
+            return True
+
+        if data.buffer in self.__contained:
+            return False
+
+        # We add data to the pareto front by adding it unconditionally and then
+        # doing a certain amount of randomized "clear down" - testing a random
+        # set of elements (currently 10) to see if they are dominated by
+        # something else in the collection. If they are, we remove them.
+        self.__add(data)
+        assert self.__pending is None
+        try:
+            self.__pending = data
+
+            best = data
+
+            i = len(self.__front) - 1
+            stopping = max(0, len(self.__front) - 10)
+            while i >= stopping:
+                self.__swap(i, self.__random.randint(0, i))
+
+                existing = self.__front[i]
+                dom = dominance(existing, best)
+                if dom == DominanceRelation.LEFT_DOMINATES:
+                    self.__remove(best)
+                    best = existing
+                elif dom == DominanceRelation.RIGHT_DOMINATES:
+                    self.__remove(existing)
+                i -= 1
+            return data.buffer in self.__contained
+        finally:
+            self.__pending = None
+
+    def on_evict(self, f):
+        """Register a listener function that will be called with data when it
+        gets removed from the front because something else dominates it."""
+        self.__eviction_listeners.append(f)
+
+    def __contains__(self, data):
+        return isinstance(data, (ConjectureData, ConjectureResult)) and (
+            data.buffer in self.__contained
+        )
+
+    def __iter__(self):
+        return iter(self.__front)
+
+    def __len__(self):
+        return len(self.__front)
+
+    def __add(self, data):
+        assert data.buffer not in self.__contained
+        i = len(self.__front)
+        self.__front.append(data)
+        self.__contained[data.buffer] = i
+
+    def __remove(self, data):
+        i = self.__contained[data.buffer]
+        self.__swap(i, len(self.__front) - 1)
+        self.__front.pop()
+        self.__contained.pop(data.buffer)
+        if data is not self.__pending:
+            for f in self.__eviction_listeners:
+                f(data)
+
+    def __swap(self, i, j):
+        if i == j:
+            return
+        self.__front[i], self.__front[j] = self.__front[j], self.__front[i]
+        for k in (i, j):
+            self.__contained[self.__front[k].buffer] = k

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -161,11 +161,13 @@ class ParetoFront(object):
             # collection entirely.
             dominators = [data]
 
-            # We now iteratively sample up to 10 elements from the approximate
-            # pareto front to check whether they should be retained.
+            # We now iteratively sample elements from the approximate pareto
+            # front to check whether they should be retained. When the set of
+            # dominators gets too large we have sampled at least 10 elements
+            # and it gets too expensive to continue, so we consider that enough
+            # due diligence.
             i = len(self.__front) - 1
-            stopping = max(0, len(self.__front) - 10)
-            while i >= stopping:
+            while i >= 0 and len(dominators) < 10:
                 self.__swap(i, self.__random.randint(0, i))
 
                 existing = self.__front[i]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -98,6 +98,30 @@ class ParetoFront(object):
 
     Only valid test cases are considered to belong to the pareto front - any
     test case with a status less than valid is discarded.
+
+    Note that the pareto front is potentially quite large, and currently this
+    will store the entire front in memory. This is bounded by the number of
+    valid examples we run, which is max_examples in normal execution, and
+    currently we do not support workflows with large max_examples which have
+    large values of max_examples very well anyway, so this isn't a major issue.
+    In future we may weish to implement some sort of paging out to disk so that
+    we can work with larger fronts.
+
+    Additionally, because this is only an approximate pareto front, there are
+    scenarios where it can be much larger than the actual pareto front. There
+    isn't a huge amount we can do about this - checking an exact pareto front
+    is intrinsically quadratic.
+
+    "Most" of the time we should be relatively close to the true pareto front,
+    say within an order of magnitude, but it's not hard to construct scenarios
+    where this is not the case. e.g. suppose we enumerate all valid test cases
+    in increasing shortlex order as s_1, ..., s_n, ... and have scores f and
+    g such that f(s_i) = min(i, N) and g(s_i) = 1 if i >= N, then the pareto
+    front is the set {s_1, ..., S_N}, but the only element of the front that
+    will dominate s_i when i > N is S_N, which we select with probability
+    1 / N. A better data structure could solve this, but at the cost of more
+    expensive operations and higher per element memory use, so we'll wait to
+    see how much of a problem this is in practice before we try that.
     """
 
     def __init__(self, random):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -25,6 +25,8 @@ from hypothesis.internal.conjecture.data import ConjectureData, ConjectureResult
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy, swap
 from hypothesis.internal.conjecture.shrinker import sort_key
 
+NO_SCORE = float("-inf")
+
 
 class DominanceRelation(Enum):
     NO_DOMINANCE = 0
@@ -35,8 +37,8 @@ class DominanceRelation(Enum):
 
 def dominance(left, right):
     """Returns the dominance relation between ``left`` and ``right``, according
-    to the rules that something dominates if and only if it is better in every
-    way.
+    to the rules that one ConjectureResult dominates another if and only if it
+    is better in every way.
 
     The things we currently consider to be "better" are:
 
@@ -81,11 +83,10 @@ def dominance(left, right):
     ):
         return DominanceRelation.NO_DOMINANCE
 
-    for target, score in left.target_observations.items():
-        if (
-            target in right.target_observations
-            and right.target_observations[target] > score
-        ):
+    for target in set(left.target_observations) | set(right.target_observations):
+        left_score = left.target_observations.get(target, NO_SCORE)
+        right_score = right.target_observations.get(target, NO_SCORE)
+        if right_score > left_score:
             return DominanceRelation.NO_DOMINANCE
 
     return DominanceRelation.LEFT_DOMINATES

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -135,7 +135,7 @@ def all_values(db):
 
 def non_covering_examples(database):
     return {
-        v for k, vs in database.data.items() if not k.endswith(b".coverage") for v in vs
+        v for k, vs in database.data.items() if not k.endswith(b".pareto") for v in vs
     }
 
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1069,3 +1069,134 @@ def test_does_not_keep_generating_when_multiple_bugs():
         runner.run()
 
     assert runner.call_count == 2
+
+
+def test_populates_the_pareto_front():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.target_observations[""] = data.draw_bits(4)
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=5000,
+                database=InMemoryExampleDatabase(),
+                suppress_health_check=HealthCheck.all(),
+            ),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) == 2 ** 4
+
+
+def test_pareto_front_contains_smallest_valid_when_not_targeting():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.draw_bits(4)
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=5000,
+                database=InMemoryExampleDatabase(),
+                suppress_health_check=HealthCheck.all(),
+            ),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) == 1
+
+
+def test_pareto_front_contains_different_interesting_reasons():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.mark_interesting(data.draw_bits(4))
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=5000,
+                database=InMemoryExampleDatabase(),
+                suppress_health_check=HealthCheck.all(),
+            ),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) == 2 ** 4
+
+
+def test_database_contains_only_pareto_front():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.target_observations["1"] = data.draw_bits(4)
+            data.draw_bits(64)
+            data.target_observations["2"] = data.draw_bits(8)
+
+        db = InMemoryExampleDatabase()
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=500, database=db, suppress_health_check=HealthCheck.all(),
+            ),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) <= 500
+
+        for v in runner.pareto_front:
+            assert v.status >= Status.VALID
+
+        assert len(db.data) == 1
+
+        (values,) = db.data.values()
+        values = set(values)
+
+        assert len(values) == len(runner.pareto_front)
+
+        for data in runner.pareto_front:
+            assert data.buffer in values
+            assert data in runner.pareto_front
+
+        for k in values:
+            assert runner.cached_test_function(k) in runner.pareto_front
+
+
+def test_clears_defunct_pareto_front():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.draw_bits(8)
+            data.draw_bits(8)
+
+        db = InMemoryExampleDatabase()
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=10000,
+                database=db,
+                suppress_health_check=HealthCheck.all(),
+                phases=[Phase.reuse],
+            ),
+            database_key=b"stuff",
+        )
+
+        for i in hrange(256):
+            db.save(runner.pareto_key, hbytes([i, 0]))
+
+        runner.run()
+
+        assert len(list(db.fetch(runner.pareto_key))) == 1

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1200,3 +1200,22 @@ def test_clears_defunct_pareto_front():
         runner.run()
 
         assert len(list(db.fetch(runner.pareto_key))) == 1
+
+
+def test_replaces_all_dominated():
+    def test(data):
+        data.target_observations["m"] = 3 - data.draw_bits(2)
+        data.target_observations["n"] = 3 - data.draw_bits(2)
+
+    runner = ConjectureRunner(
+        test,
+        settings=settings(TEST_SETTINGS, database=InMemoryExampleDatabase()),
+        database_key=b"stuff",
+    )
+
+    runner.cached_test_function([0, 1])
+    runner.cached_test_function([1, 0])
+
+    assert len(runner.pareto_front) == 2
+    runner.cached_test_function([0, 0])
+    assert len(runner.pareto_front) == 1

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -1,0 +1,116 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import absolute_import, division, print_function
+
+from hypothesis import HealthCheck, Phase, settings
+from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.internal.compat import hbytes, hrange
+from hypothesis.internal.conjecture.data import Status
+from hypothesis.internal.conjecture.engine import (
+    ConjectureRunner,
+)
+from hypothesis.internal.entropy import deterministic_PRNG
+
+
+def test_pareto_front_contains_different_interesting_reasons():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.mark_interesting(data.draw_bits(4))
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=5000,
+                database=InMemoryExampleDatabase(),
+                suppress_health_check=HealthCheck.all(),
+            ),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) == 2 ** 4
+
+
+def test_database_contains_only_pareto_front():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.target_observations["1"] = data.draw_bits(4)
+            data.draw_bits(64)
+            data.target_observations["2"] = data.draw_bits(8)
+
+        db = InMemoryExampleDatabase()
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=500, database=db, suppress_health_check=HealthCheck.all(),
+            ),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) <= 500
+
+        for v in runner.pareto_front:
+            assert v.status >= Status.VALID
+
+        assert len(db.data) == 1
+
+        (values,) = db.data.values()
+        values = set(values)
+
+        assert len(values) == len(runner.pareto_front)
+
+        for data in runner.pareto_front:
+            assert data.buffer in values
+            assert data in runner.pareto_front
+
+        for k in values:
+            assert runner.cached_test_function(k) in runner.pareto_front
+
+
+def test_clears_defunct_pareto_front():
+    with deterministic_PRNG():
+
+        def test(data):
+            data.draw_bits(8)
+            data.draw_bits(8)
+
+        db = InMemoryExampleDatabase()
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                max_examples=10000,
+                database=db,
+                suppress_health_check=HealthCheck.all(),
+                phases=[Phase.reuse],
+            ),
+            database_key=b"stuff",
+        )
+
+        for i in hrange(256):
+            db.save(runner.pareto_key, hbytes([i, 0]))
+
+        runner.run()
+
+        assert len(list(db.fetch(runner.pareto_key))) == 1

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -21,9 +21,7 @@ from hypothesis import HealthCheck, Phase, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import Status
-from hypothesis.internal.conjecture.engine import (
-    ConjectureRunner,
-)
+from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.entropy import deterministic_PRNG
 
 

--- a/hypothesis-python/tests/cover/test_phases.py
+++ b/hypothesis-python/tests/cover/test_phases.py
@@ -101,7 +101,7 @@ def test_will_save_when_reuse_not_in_phases():
     with pytest.raises(ValueError):
         test_usage()
 
-    (saved,) = [v for k, v in database.data.items() if b"coverage" not in k]
+    (saved,) = [v for k, v in database.data.items() if b"pareto" not in k]
     assert len(saved) == 1
 
 

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -49,7 +49,10 @@ generics = sorted(
 
 @pytest.mark.parametrize("typ", generics)
 def test_resolve_typing_module(typ):
-    @settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
+    @settings(
+        suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+        database=None,
+    )
     @given(from_type(typ))
     def inner(ex):
         if typ in (typing.BinaryIO, typing.TextIO):

--- a/hypothesis-python/tests/pytest/test_parametrized_db_keys.py
+++ b/hypothesis-python/tests/pytest/test_parametrized_db_keys.py
@@ -35,7 +35,7 @@ def test_dummy_for_parametrized_db_keys(hi, i):
 
 
 def test_DB_keys_for_parametrized_test():
-    assert len(DB.data) == 3
+    assert len(DB.data) == 6
 """
 
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,5 @@
 attrs
+sortedcontainers
 pexpect
 pytest
 pytest-xdist

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,5 +20,6 @@ pytest-forked==1.1.3      # via pytest-xdist
 pytest-xdist==1.30.0
 pytest==5.2.2
 six==1.12.0               # via packaging, pytest-xdist
+sortedcontainers==2.1.0
 wcwidth==0.1.7            # via pytest
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -23,6 +23,7 @@ pyupgrade
 pyupio
 requests
 restructuredtext-lint
+sortedcontainers
 sphinx
 sphinx-rtd-theme
 toml

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -112,4 +112,4 @@ wrapt==1.11.2             # via deprecated
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via ipython, safety, sphinx, twine
+# setuptools==42.0.2        # via ipython, safety, sphinx, twine

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -86,6 +86,7 @@ safety==1.8.5             # via pyupio
 six==1.12.0               # via bandit, bleach, dparse, packaging, pip-tools, prompt-toolkit, pygithub, python-dateutil, python-gitlab, pyupio, readme-renderer, stevedore, tox, traitlets
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
+sortedcontainers==2.1.0
 sphinx-rtd-theme==0.4.3
 sphinx==2.2.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx

--- a/tooling/setup.py
+++ b/tooling/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     package_dir={"": SOURCE},
     url=("https://github.com/HypothesisWorks/hypothesis-python/tree/master/tooling"),
     license="MPL v2",
-    description="A library for property based testing",
+    description="A library for property-based testing",
     python_requires=">=3.6",
     long_description=open(README).read(),
 )


### PR DESCRIPTION
This adds a data structure that lets us track an approximate pareto front. It doesn't do much with this at present - just stores it in the example database - but this lays the groundwork for potential other future work that makes better use of it.