### PR TITLE
Hashable from type bug

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -241,6 +241,7 @@ their individual contributions.
 * `Kristian Glass <https://www.github.com/doismellburning>`_
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)
 * `Lampros Mountrakis <https://www.github.com/lmount>`_
+* `Lea Provenzano <https://github.com/leaprovenzano>`_
 * `Lee Begg <https://www.github.com/llnz2>`_
 * `Lisa Goeller <https://www.github.com/lgoeller>`_
 * `Louis Taylor <https://github.com/kragniz>`_

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2272`, where inferring a 
+inferring a strategy based for :class:`python:typing.Hashable`
+or  :class:`python:typing.Sized` failed unexpectedly when
+trying to tried to access an empty `__args__` tuple.
+We now adress these collections.abc alias types more explicitly.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,7 +1,0 @@
-RELEASE_TYPE: patch
-
-This patch fixes :issue:`2272`, where inferring a 
-inferring a strategy based for :class:`python:typing.Hashable`
-or  :class:`python:typing.Sized` failed unexpectedly when
-trying to tried to access an empty `__args__` tuple.
-We now adress these collections.abc alias types more explicitly.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.strategies.from_type` with
+:class:`python:typing.Hashable` and :class:`python:typing.Sized`,
+which previously failed with an internal error on Python 3.7 or later.
+
+Thanks to Lea Provenzano for both reporting :issue:`2272`
+and writing the patch!

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -92,14 +92,6 @@ def is_typing_literal(thing):
     )
 
 
-def is_abc_interface_alias(thing):
-    # return true a generic is just an alias one of the abc interfaces which
-    # cannot be further parameterized via class.__getitem__.
-    # in 3.6 there is no origin and they are the same objects as collections.abc classes.
-    # in 3.7 they are proper generics which inherit from _GenericAlias
-    return getattr(thing, "__origin__", thing) in (collections.abc.Hashable, collections.abc.Sized)
-
-
 def from_typing_type(thing):
     # We start with special-case support for Union and Tuple - the latter
     # isn't actually a generic type. Then we handle Literal since it doesn't
@@ -170,10 +162,16 @@ def from_typing_type(thing):
     if not isinstance(thing, typing_root_type):  # pragma: no cover
         raise ResolutionFailed("Cannot resolve %s to a strategy" % (thing,))
 
-    # if thing is simply an alias around a collections abc interface ie Hashable or Sized
-    # just return the strategy of that alias.
-    if is_abc_interface_alias(thing):
-        return st.from_type(getattr(thing, "__origin__", thing))
+    # Some "generic" classes are not generic *in* anything - for example both
+    # Hashable and Sized have `__args__ == ()` on Python 3.7 or later.
+    # (In 3.6 they're just aliases for the collections.abc classes)
+    origin = getattr(thing, "__origin__", thing)
+    if (
+        typing.Hashable is not abc.Hashable
+        and origin in vars(abc).values()
+        and len(getattr(thing, "__args__", None) or []) == 0
+    ):  # pragma: no cover  # impossible on 3.6 where we measure coverage.
+        return st.from_type(origin)
 
     # Parametrised generic types have their __origin__ attribute set to the
     # un-parametrised version, which we need to use in the subclass checks.
@@ -224,6 +222,7 @@ _global_type_lookup = {
     tuple: st.builds(tuple),
     list: st.builds(list),
     set: st.builds(set),
+    abc.MutableSet: st.builds(set),
     frozenset: st.builds(frozenset),
     dict: st.builds(dict),
     type(lambda: None): st.functions(),
@@ -308,7 +307,9 @@ else:
     _global_type_lookup.update(
         {
             typing.ByteString: st.binary(),
-            typing.Reversible: st.lists(st.integers()),
+            # Reversible is somehow a subclass of Hashable, so we tuplize it.
+            # See also the discussion at https://bugs.python.org/issue39046
+            typing.Reversible: st.lists(st.integers()).map(tuple),  # type: ignore
             typing.SupportsAbs: st.complex_numbers(),
             typing.SupportsComplex: st.complex_numbers(),
             typing.SupportsFloat: st.floats(),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -95,12 +95,9 @@ def is_typing_literal(thing):
 def is_abc_interface_alias(thing):
     # return true a generic is just an alias one of the abc interfaces which
     # cannot be further parameterized via class.__getitem__.
-    return getattr(thing, "__origin__", None) in (collections.abc.Hashable, collections.abc.Sized)
-
-def from_origin_type(generic):
-    # return a strategy the type strategy of the underlying origin type
-    # for the given generic with no addtional args or parameterization.
-    return st.from_type(generic.__origin__)
+    # in 3.6 there is no origin and they are the same objects as collections.abc classes.
+    # in 3.7 they are proper generics which inherit from _GenericAlias
+    return getattr(thing, "__origin__", thing) in (collections.abc.Hashable, collections.abc.Sized)
 
 
 def from_typing_type(thing):
@@ -176,7 +173,7 @@ def from_typing_type(thing):
     # if thing is simply an alias around a collections abc interface ie Hashable or Sized
     # just return the strategy of that alias.
     if is_abc_interface_alias(thing):
-        return from_origin_type(thing)
+        return st.from_type(getattr(thing, "__origin__", thing))
 
     # Parametrised generic types have their __origin__ attribute set to the
     # un-parametrised version, which we need to use in the subclass checks.

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -566,14 +566,16 @@ def test_cannot_resolve_abstract_class_with_no_concrete_subclass(instance):
 
 
 @pytest.mark.parametrize('typ', [typing.Hashable, typing.Sized])
-def test_inference_on_special_abc_generics(typ):
-    # regression test for inference bug on types from the special types
-    # from the typing module such as Hashable and Sized
+def test_inference_on_generic_collections_abc_aliases(typ):
+    # regression test for inference bug on types that are just aliases
+    # types for simple interfaces in collections abc and take no args
+    # the typing module such as Hashable and Sized
     # see https://github.com/HypothesisWorks/hypothesis/issues/2272
 
     @given(inp=infer)
-    def test_inference_special_abc_generics_inner(inp: typ):
+    def inner(inp: typ):
         assert isinstance(inp, typ)
+        assert isinstance(inp, typ.__origin__)
 
-    test_inference_special_abc_generics_inner()
+    inner()
 

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -575,7 +575,6 @@ def test_inference_on_generic_collections_abc_aliases(typ):
     @given(inp=infer)
     def inner(inp: typ):
         assert isinstance(inp, typ)
-        assert isinstance(inp, typ.__origin__)
 
     inner()
 

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -577,4 +577,3 @@ def test_inference_on_generic_collections_abc_aliases(typ):
         assert isinstance(inp, typ)
 
     inner()
-

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -563,3 +563,17 @@ class AbstractBar(abc.ABC):
 @given(st.from_type(AbstractBar))
 def test_cannot_resolve_abstract_class_with_no_concrete_subclass(instance):
     assert False, "test body unreachable as strategy cannot resolve"
+
+
+@pytest.mark.parametrize('typ', [typing.Hashable, typing.Sized])
+def test_inference_on_special_abc_generics(typ):
+    # regression test for inference bug on types from the special types
+    # from the typing module such as Hashable and Sized
+    # see https://github.com/HypothesisWorks/hypothesis/issues/2272
+
+    @given(inp=infer)
+    def test_inference_special_abc_generics_inner(inp: typ):
+        assert isinstance(inp, typ)
+
+    test_inference_special_abc_generics_inner()
+

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -565,15 +565,12 @@ def test_cannot_resolve_abstract_class_with_no_concrete_subclass(instance):
     assert False, "test body unreachable as strategy cannot resolve"
 
 
-@pytest.mark.parametrize('typ', [typing.Hashable, typing.Sized])
-def test_inference_on_generic_collections_abc_aliases(typ):
+@pytest.mark.parametrize("typ", [typing.Hashable, typing.Sized])
+@given(data=st.data())
+def test_inference_on_generic_collections_abc_aliases(typ, data):
     # regression test for inference bug on types that are just aliases
     # types for simple interfaces in collections abc and take no args
     # the typing module such as Hashable and Sized
     # see https://github.com/HypothesisWorks/hypothesis/issues/2272
-
-    @given(inp=infer)
-    def inner(inp: typ):
-        assert isinstance(inp, typ)
-
-    inner()
+    value = data.draw(st.from_type(typ))
+    assert isinstance(value, typ)


### PR DESCRIPTION
this is a little fix for https://github.com/HypothesisWorks/hypothesis/issues/2272

this is my first pr to the project so please let me know if there's anything i'm missing  in the PR there is or anything you'd like changed.... I've tried to keep with the style as much as possible.

I ended up handling it directly in the `from_typing_type`... was hoping not to but given subclass checks later down the line and the fact that so many container types covered later are virtual subclass of collections.abc.Hashable, or Sized it it seemed like a fools mission. 

