### PR TITLE
Improve optimiser algorithm

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the optimisation algorithm for :ref:`targeted property-based testing <targeted-search>`,
+so that it will find higher quality results more reliably. Specifically, in cases where it would previously have got near a local optimum,
+it will now tend to achieve the locally optimal value.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -981,7 +981,6 @@ class ConjectureData(object):
         elif self.__bytes_drawn < len(self.__prefix):
             index = self.__bytes_drawn
             buf = self.__prefix[index : index + n_bytes]
-            # We always draw prefixes as a whole number of blocks
             if len(buf) < n_bytes:
                 buf += uniform(self.__parameter.random, n_bytes - len(buf))
         else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -982,7 +982,8 @@ class ConjectureData(object):
             index = self.__bytes_drawn
             buf = self.__prefix[index : index + n_bytes]
             # We always draw prefixes as a whole number of blocks
-            assert len(buf) == n_bytes
+            if len(buf) < n_bytes:
+                buf += uniform(self.__parameter.random, n_bytes - len(buf))
         else:
             buf = self.__parameter.draw_bytes(n_bytes)
         buf = bytearray(buf)
@@ -1065,7 +1066,7 @@ class GenerationParameters(object):
     ALPHABET_FACTOR = math.log(1.0 - 1.0 / AVERAGE_ALPHABET_SIZE)
 
     def __init__(self, random):
-        self.__random = random
+        self.random = random
         self.__pure_chance = None
         self.__alphabet = {}
 
@@ -1085,10 +1086,10 @@ class GenerationParameters(object):
         if alphabet is None:
             return self.__draw_without_alphabet(n)
 
-        return self.__random.choice(alphabet)
+        return self.random.choice(alphabet)
 
     def __draw_without_alphabet(self, n):
-        return uniform(self.__random, n)
+        return uniform(self.random, n)
 
     def alphabet(self, n_bytes):
         """Returns an alphabet - a list of values to use for all blocks with
@@ -1103,7 +1104,7 @@ class GenerationParameters(object):
         except KeyError:
             pass
 
-        if self.__random.random() <= self.pure_chance:
+        if self.random.random() <= self.pure_chance:
             # Sometiems we don't want to use an alphabet (e.g. for generating
             # sets of integers having a small alphabet is disastrous), so with
             # some probability we want to generate choices that do not use the
@@ -1116,14 +1117,14 @@ class GenerationParameters(object):
             # GenerationParameters.AVERAGE_ALPHABET_SIZE.
             size = (
                 int(
-                    math.log(self.__random.random())
+                    math.log(self.random.random())
                     / GenerationParameters.ALPHABET_FACTOR
                 )
                 + 1
             )
             assert size > 0
 
-            size = self.__random.randint(1, 10)
+            size = self.random.randint(1, 10)
             result = [self.__draw_without_alphabet(n_bytes) for _ in hrange(size)]
 
         self.__alphabet[n_bytes] = result
@@ -1134,5 +1135,5 @@ class GenerationParameters(object):
         """Returns a probability with which any given draw_bytes call should
         be forced to be all pure."""
         if self.__pure_chance is None:
-            self.__pure_chance = self.__random.random()
+            self.__pure_chance = self.random.random()
         return self.__pure_chance

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -227,6 +227,9 @@ class Optimiser(object):
         if self.consider_new_test_data(attempt):
             return True
 
+        if attempt.status < Status.VALID:
+            return False
+
         ex_attempt = attempt.examples[example_index]
 
         replacement = attempt.buffer[ex_attempt.start : ex_attempt.end]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from hypothesis.internal.compat import int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.datatree import PreviouslyUnseenBehaviour
 from hypothesis.internal.conjecture.engine import (
@@ -109,15 +110,24 @@ class Optimiser(object):
         a data object and returns an index to an example where we should focus
         our efforts."""
 
-        # The basic design of this is that we assume that there is some
-        # "important prefix" that starts off the test case and that we might
-        # benefit from redrawing everything after that point. This is an
-        # especially good assumption for stateful testing, but it's not an
-        # unreasonable assumption for everything else too.
+        # The idea of this code is that we expect (possibly incorrectly, but
+        # the correctness of this code is not dependent on this assumption,
+        # only how useful it is) that the score will be either increasing or
+        # decreasing when measured as a function of any given example in the
+        # shortlex order. This is likely true in some "local" sense even if it
+        # is not true globally.
         #
-        # This means that the basic neighbourhoods we consider are to pick some
-        # prefix of the current point, keep that fixed, and regenerate the
-        # remaining test case according to some parameter.
+        # If we were to generate a replacement uniformly at random then we
+        # would lose out when the current value of the example is very near to
+        # its maximum or minimum value, so instead we either draw a larger or
+        # smaller value. When this fails to work we switch directions, so we
+        # still get a reasonable spread, but this allows us to more reliably
+        # move in the right direction.
+        upwards = True
+
+        # Often when regenerating we will "run off the end", requiring more
+        # random data than we started with. When that happens we use this
+        # parameter to regenerate it.
         parameter = GenerationParameters(self.random)
 
         # We keep running our hill climbing until we've got (fairly weak)
@@ -132,7 +142,9 @@ class Optimiser(object):
             and self.current_data.status <= Status.VALID
         ):
             if self.attempt_to_improve(
-                parameter=parameter, example_index=select_example(self.current_data)
+                parameter=parameter,
+                example_index=select_example(self.current_data),
+                upwards=upwards,
             ):
                 # If we succeeed at improving the score then we no longer have
                 # any evidence that we're at a local maximum so we reset the
@@ -140,15 +152,15 @@ class Optimiser(object):
                 consecutive_failures = 0
             else:
                 # If we've failed in our hill climbing attempt, this could be
-                # for two reasons: We've not picked enough of the test case to
-                # capture what is interesting about this, or our parameter is
-                # not a good one for generating the extensions we want. We
-                # reset both of them in the hope of making more progress next
-                # time around.
+                # for two reasons: We're moving in the wrong direction, or our
+                # current choice of parameter is not a good one for generating
+                # the extensions. We reset both of them in the hope of making
+                # more progress next time around.
                 parameter = GenerationParameters(self.random)
+                upwards = not upwards
                 consecutive_failures += 1
 
-    def attempt_to_improve(self, example_index, parameter):
+    def attempt_to_improve(self, example_index, parameter, upwards):
         """Part of our hill climbing implementation. Attempts to improve a
         given score by regenerating an example in the data based on a new
         parameter."""
@@ -158,11 +170,46 @@ class Optimiser(object):
 
         ex = data.examples[example_index]
         assert ex.length > 0
-        prefix_size = ex.start
-        prefix = data.buffer[:prefix_size]
+        prefix = data.buffer[: ex.start]
+        suffix = data.buffer[ex.end :]
+
+        existing = data.buffer[ex.start : ex.end]
+
+        existing_as_int = int_from_bytes(existing)
+        max_int_value = (256 ** len(existing)) - 1
+
+        if existing_as_int == max_int_value and upwards:
+            return False
+
+        if existing_as_int == 0 and not upwards:
+            return False
+
+        # We make a mix of small and large jumps. Neither are guaranteeed to
+        # work, but each will work in circumstances the other might not. Small
+        # jumps are especially important for the last steps towards a local
+        # maximum - often large jumps will break some important property of the
+        # test case while small, more careful, jumps will not. On the flip side
+        # we sometimes end up in circumstances where small jumps don't work
+        # but a random draw will produce a good result with reasonable
+        # probability, and we don't want to be too timid in our optimisation as
+        # it will take too long to complete.
+        if self.random.randint(0, 1):
+            if upwards:
+                replacement_range = (existing_as_int + 1, max_int_value)
+            else:
+                replacement_range = (0, existing_as_int - 1)
+            replacement_as_int = self.random.randint(*replacement_range)
+        elif upwards:
+            replacement_as_int = existing_as_int + 1
+        else:
+            replacement_as_int = existing_as_int - 1
+
+        replacement = int_to_bytes(replacement_as_int, len(existing))
+
+        new_buffer = prefix + replacement + suffix
 
         dummy = ConjectureData(
-            prefix=prefix, parameter=parameter, max_length=BUFFER_SIZE,
+            prefix=new_buffer, parameter=parameter, max_length=BUFFER_SIZE,
         )
         try:
             self.engine.tree.simulate_test_function(dummy)
@@ -174,7 +221,7 @@ class Optimiser(object):
             pass
 
         attempt = self.engine.new_conjecture_data(
-            prefix=dummy.buffer, parameter=parameter
+            prefix=max(dummy.buffer, new_buffer, key=len), parameter=parameter
         )
         self.engine.test_function(attempt)
         if self.consider_new_test_data(attempt):
@@ -184,4 +231,4 @@ class Optimiser(object):
 
         replacement = attempt.buffer[ex_attempt.start : ex_attempt.end]
 
-        return self.consider_new_buffer(prefix + replacement + data.buffer[ex.end :])
+        return self.consider_new_buffer(prefix + replacement + suffix)

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1050,22 +1050,3 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
         results = {d.buffer for d in runner.interesting_examples.values()}
 
     assert len(results.intersection({hbytes([0, 1]), hbytes([1, 0])})) == 1
-
-
-def test_does_not_keep_generating_when_multiple_bugs():
-    def test(data):
-        if data.draw_bits(64) > 0:
-            data.draw_bits(64)
-            data.mark_interesting()
-
-    with deterministic_PRNG():
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                TEST_SETTINGS, report_multiple_bugs=False, phases=[Phase.generate]
-            ),
-        )
-
-        runner.run()
-
-    assert runner.call_count == 2

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1050,3 +1050,22 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
         results = {d.buffer for d in runner.interesting_examples.values()}
 
     assert len(results.intersection({hbytes([0, 1]), hbytes([1, 0])})) == 1
+
+
+def test_does_not_keep_generating_when_multiple_bugs():
+    def test(data):
+        if data.draw_bits(64) > 0:
+            data.draw_bits(64)
+            data.mark_interesting()
+
+    with deterministic_PRNG():
+        runner = ConjectureRunner(
+            test,
+            settings=settings(
+                TEST_SETTINGS, report_multiple_bugs=False, phases=[Phase.generate]
+            ),
+        )
+
+        runner.run()
+
+    assert runner.call_count == 2

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -17,6 +17,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
+from hypothesis import settings
+from hypothesis.internal.compat import hbytes, int_to_bytes
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
 from tests.conjecture.common import TEST_SETTINGS
@@ -65,3 +69,51 @@ def test_optimises_when_last_element_is_empty():
             pass
 
         assert runner.best_observed_targets["n"] == 255
+
+
+def test_can_optimise_last_with_following_empty():
+    with deterministic_PRNG():
+
+        def test(data):
+            for _ in range(100):
+                data.draw_bits(2)
+            data.target_observations[""] = data.draw_bits(8)
+            data.start_example(1)
+            data.stop_example()
+
+        runner = ConjectureRunner(
+            test, settings=settings(TEST_SETTINGS, max_examples=100)
+        )
+        runner.cached_test_function(hbytes(101))
+
+        with pytest.raises(RunIsComplete):
+            runner.optimise_targets()
+        assert runner.best_observed_targets[""] == 255
+
+
+@pytest.mark.parametrize("lower, upper", [(0, 1000), (13, 100), (1000, 2 ** 16 - 1),])
+@pytest.mark.parametrize("score_up", [False, True])
+def test_can_find_endpoints_of_a_range(lower, upper, score_up):
+    with deterministic_PRNG():
+
+        def test(data):
+            n = data.draw_bits(16)
+            if n < lower or n > upper:
+                data.mark_invalid()
+            if not score_up:
+                n = -n
+            data.target_observations["n"] = n
+
+        runner = ConjectureRunner(
+            test, settings=settings(TEST_SETTINGS, max_examples=1000)
+        )
+        runner.cached_test_function(int_to_bytes((lower + upper) // 2, 2))
+
+        try:
+            runner.optimise_targets()
+        except RunIsComplete:
+            pass
+        if score_up:
+            assert runner.best_observed_targets["n"] == upper
+        else:
+            assert runner.best_observed_targets["n"] == -lower

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -91,7 +91,7 @@ def test_can_optimise_last_with_following_empty():
         assert runner.best_observed_targets[""] == 255
 
 
-@pytest.mark.parametrize("lower, upper", [(0, 1000), (13, 100), (1000, 2 ** 16 - 1),])
+@pytest.mark.parametrize("lower, upper", [(0, 1000), (13, 100), (1000, 2 ** 16 - 1)])
 @pytest.mark.parametrize("score_up", [False, True])
 def test_can_find_endpoints_of_a_range(lower, upper, score_up):
     with deterministic_PRNG():

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -29,6 +29,7 @@ from hypothesis.internal.conjecture.data import (
     MAX_DEPTH,
     ConjectureData,
     DataObserver,
+    GenerationParameters,
     Overrun,
     Status,
     StopTest,
@@ -483,3 +484,12 @@ def test_discarded_data_is_eventually_terminated():
             data.stop_example(discard=True)
 
     assert data.status == Status.INVALID
+
+
+@given(st.integers(0, 255), st.randoms())
+def test_partial_buffer(n, rnd):
+    data = ConjectureData(
+        prefix=[n], parameter=GenerationParameters(rnd), max_length=2,
+    )
+
+    assert data.draw_bytes(2)[0] == n


### PR DESCRIPTION
Towards the end of #2266 I wrote a bunch of extra tests for the optimiser, only to find out that they failed. Sad face.

The basic problem this solves is that the optimiser hasn't *really* been doing hill climbing so far, in that it hasn't actually had a specific direction to go in, it just kinda bimbled around and hoped to improve the score by randomly perturbing bits. This PR makes a first step towards fixing that by turning it into an actual hill climb. As a result it can now:

1. More reliably find local optima because it's capable of determining what a sensible "direction" is for it to move in and reliably moving in that direction.
2. Making small steps when small steps are necessary rather than just generating random stuff

This is still far from perfect but it's able to do a lot better than the old algorithm on these tests.