### PR TITLE
Remove rust tests from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ jobs:
     - env: TASK=check-py36
       sudo: required
       dist: xenial
-    - env: TASK=check-rust-tests
     - stage: deploy
       env: TASK=deploy
 


### PR DESCRIPTION
We already removed these from azure, and this should speed up our deploys a bit.