### PR TITLE
Add notion of "tagging" to test cases and use it in pareto front calculations

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This release expands the set of test cases that Hypothesis saves in its
+database for future runs to include a representative set of "structurally
+different" test cases - e.g. it might try to save test cases where a given list
+is empty or not.
+
+Currently this is unlikely to have much user visible impact except to produce
+slightly more consistent behaviour between consecutive runs of a test suite.
+It is mostly groundwork for future improvements which will exploit this
+functionality more effectively.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -65,6 +65,21 @@ class Status(IntEnum):
         return "Status.%s" % (self.name,)
 
 
+@attr.s(frozen=True, slots=True)
+class StructuralCoverageTag(object):
+    label = attr.ib()
+
+
+STRUCTURAL_COVERAGE_CACHE = {}
+
+
+def structural_coverage(label):
+    try:
+        return STRUCTURAL_COVERAGE_CACHE[label]
+    except KeyError:
+        return STRUCTURAL_COVERAGE_CACHE.setdefault(label, StructuralCoverageTag(label))
+
+
 class Example(object):
     """Examples track the hierarchical structure of draws from the byte stream,
     within a single test run.
@@ -706,6 +721,7 @@ class ConjectureResult(object):
     extra_information = attr.ib()
     has_discards = attr.ib()
     target_observations = attr.ib()
+    tags = attr.ib()
     forced_indices = attr.ib(repr=False)
     examples = attr.ib(repr=False)
 
@@ -772,6 +788,11 @@ class ConjectureData(object):
         # ConjectureRunner.generate_new_examples and fed to TargetSelector.
         self.target_observations = {}
 
+        # Tags which indicate something about which part of the search space
+        # this example is in. These are used to guide generation.
+        self.tags = set()
+        self.labels_for_structure_stack = []
+
         # Normally unpopulated but we need this in the niche case
         # that self.as_result() is Overrun but we still want the
         # examples for reporting purposes.
@@ -813,6 +834,7 @@ class ConjectureData(object):
                 else None,
                 has_discards=self.has_discards,
                 target_observations=self.target_observations,
+                tags=frozenset(self.tags),
                 forced_indices=self.forced_indices,
             )
             self.blocks.transfer_ownership(self.__result)
@@ -886,6 +908,7 @@ class ConjectureData(object):
             self.max_depth = self.depth
         self.__example_record.start_example(label)
         self.consecutive_discard_counts.append(0)
+        self.labels_for_structure_stack.append({label})
 
     def stop_example(self, discard=False):
         if self.frozen:
@@ -896,6 +919,15 @@ class ConjectureData(object):
         self.depth -= 1
         assert self.depth >= -1
         self.__example_record.stop_example(discard)
+
+        labels_for_structure = self.labels_for_structure_stack.pop()
+
+        if not discard:
+            if self.labels_for_structure_stack:
+                self.labels_for_structure_stack[-1].update(labels_for_structure)
+            else:
+                self.tags.update([structural_coverage(l) for l in labels_for_structure])
+
         if self.consecutive_discard_counts:
             # We block long sequences of discards. This helps us avoid performance
             # problems where there is rejection sampling. In particular tests which

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -75,6 +75,9 @@ def dominance(left, right):
     if left.status < right.status:
         return DominanceRelation.NO_DOMINANCE
 
+    if not right.tags.issubset(left.tags):
+        return DominanceRelation.NO_DOMINANCE
+
     # Things that are interesting for different reasons are incomparable in
     # the dominance relationship.
     if (

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -169,3 +169,23 @@ def test_stops_loading_pareto_front_if_interesting():
         runner.reuse_existing_examples()
 
         assert runner.call_count == 1
+
+
+def test_uses_tags_in_calculating_pareto_front():
+    with deterministic_PRNG():
+
+        def test(data):
+            if data.draw_bits(1):
+                data.start_example(11)
+                data.draw_bits(8)
+                data.stop_example()
+
+        runner = ConjectureRunner(
+            test,
+            settings=settings(max_examples=10, database=InMemoryExampleDatabase(),),
+            database_key=b"stuff",
+        )
+
+        runner.run()
+
+        assert len(runner.pareto_front) == 2

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -33,6 +33,7 @@ from hypothesis.internal.conjecture.data import (
     Overrun,
     Status,
     StopTest,
+    structural_coverage,
 )
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
@@ -493,3 +494,34 @@ def test_partial_buffer(n, rnd):
     )
 
     assert data.draw_bytes(2)[0] == n
+
+
+def test_structural_coverage_is_cached():
+    assert structural_coverage(50) is structural_coverage(50)
+
+
+def test_examples_create_structural_coverage():
+    data = ConjectureData.for_buffer(hbytes(0))
+    data.start_example(42)
+    data.stop_example()
+    data.freeze()
+    assert structural_coverage(42) in data.tags
+
+
+def test_discarded_examples_do_not_create_structural_coverage():
+    data = ConjectureData.for_buffer(hbytes(0))
+    data.start_example(42)
+    data.stop_example(discard=True)
+    data.freeze()
+    assert structural_coverage(42) not in data.tags
+
+
+def test_children_of_discarded_examples_do_not_create_structural_coverage():
+    data = ConjectureData.for_buffer(hbytes(0))
+    data.start_example(10)
+    data.start_example(42)
+    data.stop_example()
+    data.stop_example(discard=True)
+    data.freeze()
+    assert structural_coverage(42) not in data.tags
+    assert structural_coverage(10) not in data.tags


### PR DESCRIPTION
This gives `ConjectureData` and `ConjectureResult` a notion of *tags* - binary labels which distinguish them in some way. A test case only pareto dominates another if it has a superset of its tags. Functionally, tags are "just" targeting scores that only take the values 0 or 1, but they're worth treating separately because this allows for a more efficient and natural implementation.

In this PR the only tags introduced are structural coverage ones, which indicate that a particular strategy has drawn a non-discarded result.

Currently this isn't *very* useful, and is mostly a set up for two pieces of future work:

1. Once we start doing pareto optimisation, having tags should help us find more interesting corners of the search space.
2. tags are the natural hook point for getting back to to having coverage guided testing - each coverage target (lines, branches, whatever) becomes its own tag.