### PR TITLE
Emit deprecations in quiet mode

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release enables deprecation warnings even when the
+:obj:`~hypothesis.settings.verbosity` setting is ``quiet``,
+in preparation for Hypothesis 5.0 (:issue:`2218`).
+
+Warnings can still be filtered by the standard mechanisms
+provided in the standard-library :mod:`python:warnings` module.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -192,11 +192,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         self._construction_complete = True
 
         for d in deprecations:
-            note_deprecation(
-                d.deprecation_message,
-                since=d.deprecated_since,
-                verbosity=self.verbosity,
-            )
+            note_deprecation(d.deprecation_message, since=d.deprecated_since)
 
     def __call__(self, test):
         """Make the settings object (self) an attribute of the test.
@@ -750,17 +746,12 @@ If set to True, Hypothesis will print code for failing examples that can be used
 settings.lock_further_definitions()
 
 
-def note_deprecation(message, since, verbosity=None):
-    # type: (str, str, Verbosity) -> None
-    if verbosity is None:
-        verbosity = settings.default.verbosity
-    assert verbosity is not None
+def note_deprecation(message, since):
+    # type: (str, str) -> None
     if since != "RELEASEDAY":
         date = datetime.datetime.strptime(since, "%Y-%m-%d").date()
         assert datetime.date(2016, 1, 1) <= date
-    warning = HypothesisDeprecationWarning(message)
-    if verbosity > Verbosity.quiet:
-        warnings.warn(warning, stacklevel=2)
+    warnings.warn(HypothesisDeprecationWarning(message), stacklevel=2)
 
 
 settings.register_profile("default", settings())

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -229,12 +229,6 @@ def test_cannot_assign_default():
     assert settings().max_examples != 3
 
 
-def test_does_not_warn_if_quiet():
-    with pytest.warns(None) as rec:
-        note_deprecation("This is bad", since="RELEASEDAY", verbosity=Verbosity.quiet)
-    assert len(rec) == 0
-
-
 @settings(max_examples=7)
 @given(st.builds(lambda: settings.default))
 def test_settings_in_strategies_are_from_test_scope(s):
@@ -531,3 +525,11 @@ def test_invalid_parent():
         settings(not_settings)
 
     assert "parent=(not settings repr)" in str(excinfo.value)
+
+
+def test_note_deprecation_checks_date():
+    with pytest.warns(None) as rec:
+        note_deprecation("This is bad", since="RELEASEDAY")
+    assert len(rec) == 1
+    with pytest.raises(AssertionError):
+        note_deprecation("This is way too old", since="1999-12-31")


### PR DESCRIPTION
And encourage use of the stdlib `warnings` module (and command line flags, and env vars, etc.) to control warnings.  This is extracted from #2282 and aimed at preparing any users it will affect, as well as generally refactoring for simplicity.