### PR TITLE
Remove consecutive discards heuristic

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release removes an internal heuristic that was no longer providing much
+benefit. It is unlikely that there will be any user visible effect.

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -473,19 +473,6 @@ def test_example_equality():
         assert ex != "hello"
 
 
-def test_discarded_data_is_eventually_terminated():
-
-    data = ConjectureData.for_buffer(hbytes(100))
-
-    with pytest.raises(StopTest):
-        for _ in hrange(100):
-            data.start_example(1)
-            data.draw_bits(1)
-            data.stop_example(discard=True)
-
-    assert data.status == Status.INVALID
-
-
 @given(st.integers(0, 255), st.randoms())
 def test_partial_buffer(n, rnd):
     data = ConjectureData(prefix=[n], random=rnd, max_length=2,)

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -260,6 +260,7 @@ def test_stateful_with_one_of_bundles_states_are_deduped():
 
 
 def test_statistics_for_threshold_problem():
+    @settings(max_examples=100)
     @given(st.floats(min_value=0, allow_infinity=False))
     def threshold(error):
         target(error, label="error")


### PR DESCRIPTION
We have a heuristic in `ConjectureData` which turns long sequences of discards into invalid test cases. This PR removes that heuristic.

## Justification

This heuristic was introduced in #2030 as a workaround to performance problems. Since #2185 we no longer hit those performance problems because we mark parts of the tree with discards in them as not worth exploring, and `generate_novel_prefix` will steer us clear of there. This is a better solution: We don't artificially make some discards invalid, but we don't spend ages trying to draw many equivalent tests.
 
Meanwhile, leaving it in is a bit of a footgun - I lost about 20 minutes earlier to debugging something that turned out to be the result of triggering this (and in that case I was perfectly fine with long series of discards).