### PR TITLE
Fix boundary condition error in pass_to_descendant

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a small internal bug in shrinking which could have caused it
+to perform slightly more tests than were necessary. Fixing this shouldn't have
+much effect but it will make shrinking slightly faster.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -636,6 +636,9 @@ class Shrinker(object):
 
         ancestor = ls[i]
 
+        if i + 1 == len(ls) or ls[i + 1].start >= ancestor.end:
+            return
+
         @self.cached(label, i)
         def descendants():
             lo = i + 1
@@ -646,9 +649,13 @@ class Shrinker(object):
                     hi = mid
                 else:
                     lo = mid
-            return ls[i + 1 : hi]
+            return [t for t in ls[i + 1 : hi] if t.length < ancestor.length]
 
         descendant = chooser.choose(descendants, lambda ex: ex.length > 0)
+
+        assert ancestor.start <= descendant.start
+        assert ancestor.end >= descendant.end
+        assert descendant.length < ancestor.length
 
         self.incorporate_new_buffer(
             self.buffer[: ancestor.start]


### PR DESCRIPTION
This fixes two small bugs in `pass_to_descendant`: One which could cause it to try shrinks that weren't actually to descendants if the example picked was a block and so had no descendants (which is wrong, though harmless), and another which could pick descendants of the same length (which is useless).