### PR TITLE
Better from type supports op

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,20 @@
+RELEASE_TYPE: patch
+
+This patch improves support for the SupportsOp protocols from the 
+``typing`` when using on :func:`~hypothesis.strategies.from_type` as outlined in
+:issue:`2292`. The following types now generate more wide ranging and correct strategies
+when called with :func:`~hypothesis.strategies.from_type`:
+
+- ``typing.SupportsAbs``
+- ``typing.SupportsBytes``
+- ``typing.SupportsComplex``
+- ``typing.SupportsInt``
+- ``typing.SupportsFloat``
+- ``typing.SupportsRound``
+  
+Note that using :func:`~hypothesis.strategies.from_type` with one of the above strategies will not
+ensure that the the specified function will execute successfully (ie : the strategy returned for
+``from_type(typing.SupportsAbs)`` may include NaNs or things this will cause the ``abs`` function
+to error. )
+
+Thanks to Lea Provenzano for this patch.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -2,7 +2,7 @@ RELEASE_TYPE: minor
 
 This release improves support for the SupportsOp protocols from the :mod:`python:typing` 
 module when using on :func:`~hypothesis.strategies.from_type` as outlined in :issue:`2292`.
-The following types now generate more wide ranging and correct strategies when called 
+The following types now generate much more varied strategies when called 
 with :func:`~hypothesis.strategies.from_type`:
 
 - :class:`python:typing.SupportsAbs`

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,20 +1,20 @@
 RELEASE_TYPE: minor
 
-This release improves support for the SupportsOp protocols from the 
-``typing`` when using on :func:`~hypothesis.strategies.from_type` as outlined in
-:issue:`2292`. The following types now generate more wide ranging and correct strategies
-when called with :func:`~hypothesis.strategies.from_type`:
+This release improves support for the SupportsOp protocols from the :mod:`python:typing` 
+module when using on :func:`~hypothesis.strategies.from_type` as outlined in :issue:`2292`.
+The following types now generate more wide ranging and correct strategies when called 
+with :func:`~hypothesis.strategies.from_type`:
 
-- ``typing.SupportsAbs``
-- ``typing.SupportsBytes``
-- ``typing.SupportsComplex``
-- ``typing.SupportsInt``
-- ``typing.SupportsFloat``
-- ``typing.SupportsRound``
+- :class:`python:typing.SupportsAbs`
+- :class:`python:typing.SupportsBytes`
+- :class:`python:typing.SupportsComplex`
+- :class:`python:typing.SupportsInt`
+- :class:`python:typing.SupportsFloat`
+- :class:`python:typing.SupportsRound`
   
 Note that using :func:`~hypothesis.strategies.from_type` with one of the above strategies will not
 ensure that the the specified function will execute successfully (ie : the strategy returned for
-``from_type(typing.SupportsAbs)`` may include NaNs or things this will cause the ``abs`` function
-to error. )
+``from_type(typing.SupportsAbs)`` may include NaNs or things this will cause the :func:`python:abs`
+function to error. )
 
 Thanks to Lea Provenzano for this patch.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch improves support for the SupportsOp protocols from the 
+This release improves support for the SupportsOp protocols from the 
 ``typing`` when using on :func:`~hypothesis.strategies.from_type` as outlined in
 :issue:`2292`. The following types now generate more wide ranging and correct strategies
 when called with :func:`~hypothesis.strategies.from_type`:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -237,7 +237,7 @@ def byteable_strategy():
     byte_arrays = st.lists(byterange_ints).map(tuple)
     # strings while super common won't support without an enoding arg,
     # so we tenatively will not include...
-    return st.one_of([st.booleans(), st.binary(), byterange_ints, byte_arrays])
+    return st.one_of(st.booleans(), st.binary(), byterange_ints, byte_arrays)
 
 
 def can_cast(type, value):
@@ -356,23 +356,23 @@ else:
             # Reversible is somehow a subclass of Hashable, so we tuplize it.
             # See also the discussion at https://bugs.python.org/issue39046
             typing.Reversible: st.lists(st.integers()).map(tuple),  # type: ignore
-            typing.SupportsAbs: st.one_of([st.booleans(),
+            typing.SupportsAbs: st.one_of(st.booleans(),
                                            st.integers(),
                                            st.floats(),
                                            st.complex_numbers(),
                                            st.fractions(),
                                            st.decimals(),
                                            st.timedeltas()
-                                           ]),
+                                           ),
 
-            typing.SupportsComplex: st.one_of([st.booleans(),
+            typing.SupportsComplex: st.one_of(st.booleans(),
                                                st.integers(),
                                                st.floats(),
                                                st.complex_numbers(),
                                                st.decimals(),
                                                st.fractions()
-                                               ]),
-            typing.SupportsFloat: st.one_of([st.booleans(),
+                                               ),
+            typing.SupportsFloat: st.one_of(st.booleans(),
                                              st.integers(),
                                              st.floats(),
                                              st.decimals(),
@@ -380,8 +380,8 @@ else:
                                              # with floats its far more annoying to capture all
                                              # the magic in a regex. so we just stringify some floats
                                              st.floats().map(str)
-                                             ]),
-            typing.SupportsInt: st.one_of([st.booleans(),
+                                             ),
+            typing.SupportsInt: st.one_of(st.booleans(),
                                            st.integers(),
                                            st.floats(),
                                            st.uuids(),
@@ -389,7 +389,7 @@ else:
                                            # this generates strings that should able to be parsed into integers
                                            st.from_regex(
                                                r"-?\d+", fullmatch=True).filter(lambda value: can_cast(int, value))
-                                           ]),
+                                           ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
             typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
@@ -400,12 +400,12 @@ else:
     try:
         # These aren't present in the typing module backport.
         _global_type_lookup[typing.SupportsBytes] = byteable_strategy()
-        _global_type_lookup[typing.SupportsRound] = st.one_of([st.booleans(),
+        _global_type_lookup[typing.SupportsRound] = st.one_of(st.booleans(),
                                                                st.integers(),
                                                                st.floats(),
                                                                st.decimals(),
                                                                st.fractions()
-                                                               ])
+                                                               )
     except AttributeError:  # pragma: no cover
         pass
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -232,10 +232,11 @@ def byteable_strategy():
     since a call to `bytes` would require the encoding arg.
     """
     byterange_ints = st.integers(0, 255)
-    byte_arrays = st.lists(byterange_ints)
+    # SupportsBytes is a subclass of Hashable... so we tuplize it.
+    byte_arrays = st.lists(byterange_ints).map(tuple)
     # strings while super common won't support without an enoding arg,
     # so we tenatively will not include...
-    return st.booleans()| byterange_ints | byte_arrays
+    return st.booleans() | byterange_ints | byte_arrays
 
 
 _global_type_lookup = {

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -240,6 +240,15 @@ def byteable_strategy():
     return st.one_of([st.booleans(), st.binary(), byterange_ints, byte_arrays])
 
 
+def can_cast(type, value):
+    """Determine if value can be cast to type."""
+    try:
+        type(value)
+        return True
+    except TypeError:
+        return False
+
+
 _global_type_lookup = {
     # Types with core Hypothesis strategies
     type(None): st.none(),
@@ -378,7 +387,8 @@ else:
                                            st.uuids(),
                                            st.decimals(),
                                            # this generates strings that should able to be parsed into integers
-                                           st.from_regex(r"^-?([1-9]\d*)|0$", fullmatch=True)
+                                           st.from_regex(
+                                               r"-?\d+", fullmatch=True).filter(lambda value: can_cast(int, value))
                                            ]),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -351,9 +351,9 @@ else:
             typing.SupportsFloat: st.floats(),
             typing.SupportsInt: (st.booleans() | 
                                 st.integers() | 
-                                st.floats(allow_infinity=False, allow_nan=False) |
+                                st.floats() |
                                 st.uuids() |
-                                st.decimals(allow_infinity=False, allow_nan=False) |
+                                st.decimals() |
                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
                                 ),
             # xIO are only available in .io on Python 3.5, but available directly

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -356,7 +356,12 @@ else:
                 st.decimals() |
                 st.timedeltas()
             ),
-            typing.SupportsComplex: st.complex_numbers(),
+            typing.SupportsComplex: (st.booleans() |
+                                     st.integers() |
+                                     st.floats() |
+                                     st.complex_numbers() |
+                                     st.decimals() |
+                                     st.fractions()),
             typing.SupportsFloat: (
                 st.booleans() |
                 st.integers() |

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -348,38 +348,43 @@ else:
             # See also the discussion at https://bugs.python.org/issue39046
             typing.Reversible: st.lists(st.integers()).map(tuple),  # type: ignore
             typing.SupportsAbs: (
-                st.booleans() |
-                st.integers() |
-                st.floats() |
-                st.complex_numbers() |
-                st.fractions() |
-                st.decimals() |
-                st.timedeltas()
+                st.booleans()
+                | st.integers()
+                | st.floats()
+                | st.complex_numbers()
+                | st.fractions()
+                | st.decimals()
+                | st.timedeltas()
             ),
-            typing.SupportsComplex: (st.booleans() |
-                                     st.integers() |
-                                     st.floats() |
-                                     st.complex_numbers() |
-                                     st.decimals() |
-                                     st.fractions()),
+            typing.SupportsComplex: (
+                st.booleans()
+                | st.integers()
+                | st.floats()
+                | st.complex_numbers()
+                | st.decimals()
+                | st.fractions()
+            ),
             typing.SupportsFloat: (
-                st.booleans() |
-                st.integers() |
-                st.floats() |
-                st.decimals() |
-                st.fractions() |
+                st.booleans()
+                | st.integers()
+                | st.floats()
+                | st.decimals()
+                | st.fractions()
+                |
                 # with floats its far more annoying to capture all
                 # the magic in a regex. so we just stringify some floats
                 st.floats().map(str)
             ),
-            typing.SupportsInt: (st.booleans() |
-                                 st.integers() |
-                                 st.floats() |
-                                 st.uuids() |
-                                 st.decimals() |
-                                 # this generates strings that should able to be parsed into integers
-                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
-                                 ),
+            typing.SupportsInt: (
+                st.booleans()
+                | st.integers()
+                | st.floats()
+                | st.uuids()
+                | st.decimals()
+                |
+                # this generates strings that should able to be parsed into integers
+                st.from_regex(r"^-?([1-9]\d*)|0$", fullmatch=True)
+            ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
             typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
@@ -391,7 +396,8 @@ else:
         # These aren't present in the typing module backport.
         _global_type_lookup[typing.SupportsBytes] = byteable_strategy()
         _global_type_lookup[typing.SupportsRound] = (
-            st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions())
+            st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions()
+        )
     except AttributeError:  # pragma: no cover
         pass
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -370,10 +370,9 @@ else:
                 | st.floats()
                 | st.decimals()
                 | st.fractions()
-                |
                 # with floats its far more annoying to capture all
                 # the magic in a regex. so we just stringify some floats
-                st.floats().map(str)
+                |st.floats().map(str)
             ),
             typing.SupportsInt: (
                 st.booleans()
@@ -381,9 +380,8 @@ else:
                 | st.floats()
                 | st.uuids()
                 | st.decimals()
-                |
                 # this generates strings that should able to be parsed into integers
-                st.from_regex(r"^-?([1-9]\d*)|0$", fullmatch=True)
+                | st.from_regex(r"^-?([1-9]\d*)|0$", fullmatch=True)
             ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -224,10 +224,11 @@ def from_typing_type(thing):
         )
     return st.one_of(strategies)
 
+
 def byteable_strategy():
     """Since almost nothing actually has a __bytes__ method we combine known strategies
     that you can call `bytes` on.
-    
+
     we currently do not include text even though this is a fairly common use case
     since a call to `bytes` would require the encoding arg.
     """
@@ -346,16 +347,24 @@ else:
             # Reversible is somehow a subclass of Hashable, so we tuplize it.
             # See also the discussion at https://bugs.python.org/issue39046
             typing.Reversible: st.lists(st.integers()).map(tuple),  # type: ignore
-            typing.SupportsAbs: st.complex_numbers(),
+            typing.SupportsAbs: (
+                st.booleans() |
+                st.integers() |
+                st.floats() |
+                st.complex_numbers() |
+                st.fractions() |
+                st.decimals() |
+                st.timedeltas()
+            ),
             typing.SupportsComplex: st.complex_numbers(),
             typing.SupportsFloat: st.floats(),
-            typing.SupportsInt: (st.booleans() | 
-                                st.integers() | 
-                                st.floats() |
-                                st.uuids() |
-                                st.decimals() |
-                                st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
-                                ),
+            typing.SupportsInt: (st.booleans() |
+                                 st.integers() |
+                                 st.floats() |
+                                 st.uuids() |
+                                 st.decimals() |
+                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
+                                 ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
             typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
@@ -366,7 +375,8 @@ else:
     try:
         # These aren't present in the typing module backport.
         _global_type_lookup[typing.SupportsBytes] = byteable_strategy()
-        _global_type_lookup[typing.SupportsRound] = (st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions())
+        _global_type_lookup[typing.SupportsRound] = (
+            st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions())
     except AttributeError:  # pragma: no cover
         pass
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -236,7 +236,7 @@ def byteable_strategy():
     byte_arrays = st.lists(byterange_ints).map(tuple)
     # strings while super common won't support without an enoding arg,
     # so we tenatively will not include...
-    return st.booleans() | byterange_ints | byte_arrays
+    return st.booleans() | st.bytes() | byterange_ints | byte_arrays
 
 
 _global_type_lookup = {

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -349,7 +349,13 @@ else:
             typing.SupportsAbs: st.complex_numbers(),
             typing.SupportsComplex: st.complex_numbers(),
             typing.SupportsFloat: st.floats(),
-            typing.SupportsInt: st.floats(),
+            typing.SupportsInt: (st.booleans() | 
+                                st.integers() | 
+                                st.floats(allow_infinity=False, allow_nan=False) |
+                                st.uuids() |
+                                st.decimals(allow_infinity=False, allow_nan=False) |
+                                st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
+                                ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
             typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -237,7 +237,7 @@ def byteable_strategy():
     byte_arrays = st.lists(byterange_ints).map(tuple)
     # strings while super common won't support without an enoding arg,
     # so we tenatively will not include...
-    return st.booleans() | st.binary() | byterange_ints | byte_arrays
+    return st.one_of([st.booleans(), st.binary(), byterange_ints, byte_arrays])
 
 
 _global_type_lookup = {
@@ -347,42 +347,39 @@ else:
             # Reversible is somehow a subclass of Hashable, so we tuplize it.
             # See also the discussion at https://bugs.python.org/issue39046
             typing.Reversible: st.lists(st.integers()).map(tuple),  # type: ignore
-            typing.SupportsAbs: (
-                st.booleans()
-                | st.integers()
-                | st.floats()
-                | st.complex_numbers()
-                | st.fractions()
-                | st.decimals()
-                | st.timedeltas()
-            ),
-            typing.SupportsComplex: (
-                st.booleans()
-                | st.integers()
-                | st.floats()
-                | st.complex_numbers()
-                | st.decimals()
-                | st.fractions()
-            ),
-            typing.SupportsFloat: (
-                st.booleans()
-                | st.integers()
-                | st.floats()
-                | st.decimals()
-                | st.fractions()
-                # with floats its far more annoying to capture all
-                # the magic in a regex. so we just stringify some floats
-                | st.floats().map(str)
-            ),
-            typing.SupportsInt: (
-                st.booleans()
-                | st.integers()
-                | st.floats()
-                | st.uuids()
-                | st.decimals()
-                # this generates strings that should able to be parsed into integers
-                | st.from_regex(r"^-?([1-9]\d*)|0$", fullmatch=True)
-            ),
+            typing.SupportsAbs: st.one_of([st.booleans(),
+                                           st.integers(),
+                                           st.floats(),
+                                           st.complex_numbers(),
+                                           st.fractions(),
+                                           st.decimals(),
+                                           st.timedeltas()
+                                           ]),
+
+            typing.SupportsComplex: st.one_of([st.booleans(),
+                                               st.integers(),
+                                               st.floats(),
+                                               st.complex_numbers(),
+                                               st.decimals(),
+                                               st.fractions()
+                                               ]),
+            typing.SupportsFloat: st.one_of([st.booleans(),
+                                             st.integers(),
+                                             st.floats(),
+                                             st.decimals(),
+                                             st.fractions(),
+                                             # with floats its far more annoying to capture all
+                                             # the magic in a regex. so we just stringify some floats
+                                             st.floats().map(str)
+                                             ]),
+            typing.SupportsInt: st.one_of([st.booleans(),
+                                           st.integers(),
+                                           st.floats(),
+                                           st.uuids(),
+                                           st.decimals(),
+                                           # this generates strings that should able to be parsed into integers
+                                           st.from_regex(r"^-?([1-9]\d*)|0$", fullmatch=True)
+                                           ]),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
             typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
@@ -393,9 +390,12 @@ else:
     try:
         # These aren't present in the typing module backport.
         _global_type_lookup[typing.SupportsBytes] = byteable_strategy()
-        _global_type_lookup[typing.SupportsRound] = (
-            st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions()
-        )
+        _global_type_lookup[typing.SupportsRound] = st.one_of([st.booleans(),
+                                                               st.integers(),
+                                                               st.floats(),
+                                                               st.decimals(),
+                                                               st.fractions()
+                                                               ])
     except AttributeError:  # pragma: no cover
         pass
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -356,40 +356,44 @@ else:
             # Reversible is somehow a subclass of Hashable, so we tuplize it.
             # See also the discussion at https://bugs.python.org/issue39046
             typing.Reversible: st.lists(st.integers()).map(tuple),  # type: ignore
-            typing.SupportsAbs: st.one_of(st.booleans(),
-                                           st.integers(),
-                                           st.floats(),
-                                           st.complex_numbers(),
-                                           st.fractions(),
-                                           st.decimals(),
-                                           st.timedeltas()
-                                           ),
-
-            typing.SupportsComplex: st.one_of(st.booleans(),
-                                               st.integers(),
-                                               st.floats(),
-                                               st.complex_numbers(),
-                                               st.decimals(),
-                                               st.fractions()
-                                               ),
-            typing.SupportsFloat: st.one_of(st.booleans(),
-                                             st.integers(),
-                                             st.floats(),
-                                             st.decimals(),
-                                             st.fractions(),
-                                             # with floats its far more annoying to capture all
-                                             # the magic in a regex. so we just stringify some floats
-                                             st.floats().map(str)
-                                             ),
-            typing.SupportsInt: st.one_of(st.booleans(),
-                                           st.integers(),
-                                           st.floats(),
-                                           st.uuids(),
-                                           st.decimals(),
-                                           # this generates strings that should able to be parsed into integers
-                                           st.from_regex(
-                                               r"-?\d+", fullmatch=True).filter(lambda value: can_cast(int, value))
-                                           ),
+            typing.SupportsAbs: st.one_of(
+                st.booleans(),
+                st.integers(),
+                st.floats(),
+                st.complex_numbers(),
+                st.fractions(),
+                st.decimals(),
+                st.timedeltas(),
+            ),
+            typing.SupportsComplex: st.one_of(
+                st.booleans(),
+                st.integers(),
+                st.floats(),
+                st.complex_numbers(),
+                st.decimals(),
+                st.fractions(),
+            ),
+            typing.SupportsFloat: st.one_of(
+                st.booleans(),
+                st.integers(),
+                st.floats(),
+                st.decimals(),
+                st.fractions(),
+                # with floats its far more annoying to capture all
+                # the magic in a regex. so we just stringify some floats
+                st.floats().map(str),
+            ),
+            typing.SupportsInt: st.one_of(
+                st.booleans(),
+                st.integers(),
+                st.floats(),
+                st.uuids(),
+                st.decimals(),
+                # this generates strings that should able to be parsed into integers
+                st.from_regex(r"-?\d+", fullmatch=True).filter(
+                    lambda value: can_cast(int, value)
+                ),
+            ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
             typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
@@ -400,12 +404,9 @@ else:
     try:
         # These aren't present in the typing module backport.
         _global_type_lookup[typing.SupportsBytes] = byteable_strategy()
-        _global_type_lookup[typing.SupportsRound] = st.one_of(st.booleans(),
-                                                               st.integers(),
-                                                               st.floats(),
-                                                               st.decimals(),
-                                                               st.fractions()
-                                                               )
+        _global_type_lookup[typing.SupportsRound] = st.one_of(
+            st.booleans(), st.integers(), st.floats(), st.decimals(), st.fractions()
+        )
     except AttributeError:  # pragma: no cover
         pass
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -346,7 +346,7 @@ else:
     try:
         # These aren't present in the typing module backport.
         _global_type_lookup[typing.SupportsBytes] = st.binary()
-        _global_type_lookup[typing.SupportsRound] = st.complex_numbers()
+        _global_type_lookup[typing.SupportsRound] = (st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions())
     except AttributeError:  # pragma: no cover
         pass
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -357,14 +357,23 @@ else:
                 st.timedeltas()
             ),
             typing.SupportsComplex: st.complex_numbers(),
-            typing.SupportsFloat: st.floats(),
+            typing.SupportsFloat: (
+                st.booleans() |
+                st.integers() |
+                st.floats() |
+                st.decimals() |
+                st.fractions() |
+                # with floats its far more annoying to capture all
+                # the magic in a regex. so we just stringify some floats
+                st.floats().map(str)
+            ),
             typing.SupportsInt: (st.booleans() |
                                  st.integers() |
                                  st.floats() |
                                  st.uuids() |
                                  st.decimals() |
                                  # this generates strings that should able to be parsed into integers
-                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True) 
+                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
                                  ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -363,7 +363,8 @@ else:
                                  st.floats() |
                                  st.uuids() |
                                  st.decimals() |
-                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True)
+                                 # this generates strings that should able to be parsed into integers
+                                 st.from_regex(r'^-?([1-9]\d*)|0$', fullmatch=True) 
                                  ),
             # xIO are only available in .io on Python 3.5, but available directly
             # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -237,7 +237,7 @@ def byteable_strategy():
     byte_arrays = st.lists(byterange_ints).map(tuple)
     # strings while super common won't support without an enoding arg,
     # so we tenatively will not include...
-    return st.booleans() | st.bytes() | byterange_ints | byte_arrays
+    return st.booleans() | st.binary() | byterange_ints | byte_arrays
 
 
 _global_type_lookup = {

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -224,6 +224,19 @@ def from_typing_type(thing):
         )
     return st.one_of(strategies)
 
+def byteable_strategy():
+    """Since almost nothing actually has a __bytes__ method we combine known strategies
+    that you can call `bytes` on.
+    
+    we currently do not include text even though this is a fairly common use case
+    since a call to `bytes` would require the encoding arg.
+    """
+    byterange_ints = st.integers(0, 255)
+    byte_arrays = st.lists(byterange_ints)
+    # strings while super common won't support without an enoding arg,
+    # so we tenatively will not include...
+    return st.booleans()| byterange_ints | byte_arrays
+
 
 _global_type_lookup = {
     # Types with core Hypothesis strategies
@@ -345,7 +358,7 @@ else:
 
     try:
         # These aren't present in the typing module backport.
-        _global_type_lookup[typing.SupportsBytes] = st.binary()
+        _global_type_lookup[typing.SupportsBytes] = byteable_strategy()
         _global_type_lookup[typing.SupportsRound] = (st.booleans() | st.integers() | st.floats() | st.decimals() | st.fractions())
     except AttributeError:  # pragma: no cover
         pass

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -372,7 +372,7 @@ else:
                 | st.fractions()
                 # with floats its far more annoying to capture all
                 # the magic in a regex. so we just stringify some floats
-                |st.floats().map(str)
+                | st.floats().map(str)
             ),
             typing.SupportsInt: (
                 st.booleans()

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -636,7 +636,7 @@ def test_supportsop_types_support_protocol(protocol, data):
     [
         (typing.SupportsFloat, float),
         (typing.SupportsInt, int),
-        (typing.SupportsBytes, bytes),
+        (typing.SupportsBytes, bytes), # noqa: B1
         (typing.SupportsComplex, complex),
     ],
 )

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -614,7 +614,8 @@ def supports_casting(typ, thing):
     try:
         typ(thing)
         return True
-    except TypeError:
+    # if anything bad happened here return False
+    except Exception:
         return False
 
 

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -632,7 +632,8 @@ def test_supportsop_types_support_protocol(protocol, data):
 
 @pytest.mark.parametrize("protocol, typ", [(typing.SupportsFloat, float),
                                            (typing.SupportsInt, int),
-                                           (typing.SupportsBytes, bytes)
+                                           (typing.SupportsBytes, bytes),
+                                           (typing.SupportsComplex, complex)
                                            ])
 @given(data=st.data())
 def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data):

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -599,3 +599,16 @@ def test_bytestring_is_valid_sequence_of_int_and_parent_classes(type_):
         st.from_type(typing.Sequence[type_]),
         lambda val: isinstance(val, typing.ByteString),
     )
+
+
+@pytest.mark.parametrize("typ", [typing.SupportsAbs,
+                                 typing.SupportsBytes,
+                                 typing.SupportsFloat,
+                                 typing.SupportsInt,
+                                 typing.SupportsRound])
+@given(data=st.data())
+def test_SupportsOp_types_are_instances_of_type(typ, data):
+    # test values drawn from SupportsOp types are indeed considered instances
+    # of that type.
+    value = data.draw(st.from_type(typ))
+    assert isinstance(value, typ)

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -615,7 +615,6 @@ def supports_casting(typ, thing):
     try:
         typ(thing)
         return True
-    # if anything bad happened here return False
     except Exception:
         return False
 

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -645,8 +645,6 @@ def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data
     value = data.draw(st.from_type(protocol))
     # check that we aren't somehow generating instances of the protocol itself
     assert value.__class__ != protocol
-    try:
-        # test values drawn from the protocol types are
-        assert supports_protocol(protocol, value)
-    except AssertionError:
-        assert supports_casting(typ, value)
+    # test values drawn from the protocol types either support the protocol
+    # or can be cast to typ
+    assert supports_protocol(protocol, value) or supports_casting(typ, value)

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -601,20 +601,6 @@ def test_bytestring_is_valid_sequence_of_int_and_parent_classes(type_):
     )
 
 
-def supports_protocol(protocol, inst):
-    # in python < 3.8 Protocols cannot be used with isinstance
-    # this check should work for all versions.
-    return issubclass(type(inst), protocol)
-
-
-def supports_casting(typ, thing):
-    try:
-        typ(thing)
-        return True
-    except Exception:
-        return False
-
-
 @pytest.mark.parametrize("protocol", [typing.SupportsAbs, typing.SupportsRound])
 @given(data=st.data())
 def test_supportsop_types_support_protocol(protocol, data):
@@ -623,7 +609,7 @@ def test_supportsop_types_support_protocol(protocol, data):
     value = data.draw(st.from_type(protocol))
     # check that we aren't somehow generating instances of the protocol itself
     assert value.__class__ != protocol
-    assert supports_protocol(protocol, value)
+    assert issubclass(type(value), protocol)
 
 
 @pytest.mark.parametrize(
@@ -637,10 +623,14 @@ def test_supportsop_types_support_protocol(protocol, data):
 )
 @given(data=st.data())
 def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data):
-
     value = data.draw(st.from_type(protocol))
     # check that we aren't somehow generating instances of the protocol itself
     assert value.__class__ != protocol
     # test values drawn from the protocol types either support the protocol
     # or can be cast to typ
-    assert supports_protocol(protocol, value) or supports_casting(typ, value)
+    assert issubclass(type(value), protocol) or types.can_cast(typ, value)
+
+
+def test_can_cast():
+    assert types.can_cast(int, "0")
+    assert not types.can_cast(int, "abc")

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -620,8 +620,7 @@ def supports_casting(typ, thing):
         return False
 
 
-@pytest.mark.parametrize("protocol", [typing.SupportsAbs,
-                                      typing.SupportsRound])
+@pytest.mark.parametrize("protocol", [typing.SupportsAbs, typing.SupportsRound])
 @given(data=st.data())
 def test_supportsop_types_support_protocol(protocol, data):
     # test values drawn from SupportsOp types are indeed considered instances
@@ -630,11 +629,15 @@ def test_supportsop_types_support_protocol(protocol, data):
     assert supports_protocol(protocol, value)
 
 
-@pytest.mark.parametrize("protocol, typ", [(typing.SupportsFloat, float),
-                                           (typing.SupportsInt, int),
-                                           (typing.SupportsBytes, bytes),
-                                           (typing.SupportsComplex, complex)
-                                           ])
+@pytest.mark.parametrize(
+    "protocol, typ",
+    [
+        (typing.SupportsFloat, float),
+        (typing.SupportsInt, int),
+        (typing.SupportsBytes, bytes),
+        (typing.SupportsComplex, complex),
+    ],
+)
 @given(data=st.data())
 def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data):
     # test values drawn from SupportsOp types are indeed considered instances

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -602,13 +602,9 @@ def test_bytestring_is_valid_sequence_of_int_and_parent_classes(type_):
 
 
 def supports_protocol(protocol, inst):
-    try:
-        # in python 3.8 this works
-        return isinstance(inst, protocol)
-    except TypeError:
-        # in python < 3.8 Protocols cannot be used with isinstance
-        # so we do this which is less nice...
-        return issubclass(type(inst), protocol)
+    # in python < 3.8 Protocols cannot be used with isinstance
+    # this check should work for all versions.
+    return issubclass(type(inst), protocol)
 
 
 def supports_casting(typ, thing):

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -636,7 +636,7 @@ def test_supportsop_types_support_protocol(protocol, data):
     [
         (typing.SupportsFloat, float),
         (typing.SupportsInt, int),
-        (typing.SupportsBytes, bytes), # noqa: B1
+        (typing.SupportsBytes, bytes),  # noqa: B1
         (typing.SupportsComplex, complex),
     ],
 )

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -602,7 +602,6 @@ def test_bytestring_is_valid_sequence_of_int_and_parent_classes(type_):
 
 
 @pytest.mark.parametrize("typ", [typing.SupportsAbs,
-                                 typing.SupportsBytes,
                                  typing.SupportsFloat,
                                  typing.SupportsInt,
                                  typing.SupportsRound])
@@ -619,3 +618,9 @@ def test_SupportsOp_types_are_instances_of_type(typ, data):
         # so we do this which is less nice...
         assert issubclass(type(value), typ)
 
+
+@given(inp=from_type(typing.SupportsBytes))
+def test_bytes_can_be_called_on_SupportsBytes(inp):
+    # this is a special test for SupportsBytes since nothing seems to
+    # implements __bytes__ interface
+    bytes(inp)

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -611,4 +611,11 @@ def test_SupportsOp_types_are_instances_of_type(typ, data):
     # test values drawn from SupportsOp types are indeed considered instances
     # of that type.
     value = data.draw(st.from_type(typ))
-    assert isinstance(value, typ)
+    try:
+        # in python 3.8 this works
+        assert isinstance(value, typ)
+    except TypeError:
+        # in python < 3.8 Protocols cannot be used with isinstance
+        # so we do this which is less nice...
+        assert issubclass(type(value), typ)
+

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -610,6 +610,7 @@ def supports_protocol(protocol, inst):
         # so we do this which is less nice...
         return issubclass(type(inst), protocol)
 
+
 def supports_casting(typ, thing):
     try:
         typ(thing)
@@ -620,7 +621,7 @@ def supports_casting(typ, thing):
 
 
 @pytest.mark.parametrize("protocol", [typing.SupportsAbs,
-                                 typing.SupportsRound])
+                                      typing.SupportsRound])
 @given(data=st.data())
 def test_supportsop_types_support_protocol(protocol, data):
     # test values drawn from SupportsOp types are indeed considered instances
@@ -630,9 +631,9 @@ def test_supportsop_types_support_protocol(protocol, data):
 
 
 @pytest.mark.parametrize("protocol, typ", [(typing.SupportsFloat, float),
-                                 (typing.SupportsInt, int),
-                                 (typing.SupportsBytes, bytes)
-                                ])
+                                           (typing.SupportsInt, int),
+                                           (typing.SupportsBytes, bytes)
+                                           ])
 @given(data=st.data())
 def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data):
     # test values drawn from SupportsOp types are indeed considered instances

--- a/hypothesis-python/tests/py3/test_lookup.py
+++ b/hypothesis-python/tests/py3/test_lookup.py
@@ -626,6 +626,8 @@ def test_supportsop_types_support_protocol(protocol, data):
     # test values drawn from SupportsOp types are indeed considered instances
     # of that type.
     value = data.draw(st.from_type(protocol))
+    # check that we aren't somehow generating instances of the protocol itself
+    assert value.__class__ != protocol
     assert supports_protocol(protocol, value)
 
 
@@ -640,10 +642,12 @@ def test_supportsop_types_support_protocol(protocol, data):
 )
 @given(data=st.data())
 def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data):
-    # test values drawn from SupportsOp types are indeed considered instances
-    # of that type.
+
     value = data.draw(st.from_type(protocol))
+    # check that we aren't somehow generating instances of the protocol itself
+    assert value.__class__ != protocol
     try:
+        # test values drawn from the protocol types are
         assert supports_protocol(protocol, value)
     except AssertionError:
         assert supports_casting(typ, value)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -72,6 +72,7 @@ commands=
 deps =
     -r../requirements/test.txt
     pandas~=0.19.2
+    numpy~=1.17.4
 commands =
     python -m pytest tests/pandas -n2
 


### PR DESCRIPTION
this adds improvements for the ``SupportsOp`` protocols from the typing library when used with `from_type` as discussed in  https://github.com/HypothesisWorks/hypothesis/issues/2292.

