### PR TITLE
Replace compatibility shims with native Python3 code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 
 exclude =
-    compat.py,
     hypothesis-python/src/hypothesis/vendor/*,
     test_reflection.py,
     test_imports.py,
@@ -15,7 +14,3 @@ ignore =
     B008,B011,
     # flake8-bandit security warnings we disagree with or don't mind
     S101,S102,S105,S110,S307,S311,S404,S6
-
-# Use flake8-alfred to forbid builtins that require compatibility wrappers.
-warn-symbols=
-    bytes=Instead of bytes(), use hbytes() or binary_type

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 
 exclude =
-    hypothesis-python/src/hypothesis/vendor/*,
     test_reflection.py,
     test_imports.py,
     test_lambda_formatting.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
       displayName: Install dependencies
     - script: |
         cd hypothesis-python
-        pytest
+        pytest --numprocesses auto
       displayName: Run tests
 
   - job: osx

--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -22,4 +22,3 @@ exclude_lines =
     __deepcopy__
     except ImportError:
     assert all\(.+\)
-    if __reserved is not not_set:

--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -21,6 +21,5 @@ exclude_lines =
     __copy__
     __deepcopy__
     except ImportError:
-    if PY2:
     assert all\(.+\)
     if __reserved is not not_set:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch contains many small refactorings to replace our Python 2
+compatibility functions with their native Python 3 equivalents.
+Since Hypothesis is now Python 3 only, there is no user-visible change.

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -164,7 +164,7 @@ So, convinced that our implementation is broken, we write a better one:
 .. code:: python
 
     def sort_nodes(xs):
-        for i in hrange(1, len(xs)):
+        for i in range(1, len(xs)):
             j = i - 1
             while j >= 0:
                 if xs[j].sorts_before(xs[j + 1]):

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -33,7 +33,6 @@ from hypothesis.errors import (
     InvalidArgument,
     InvalidState,
 )
-from hypothesis.internal.compat import integer_types, quiet_raise, string_types
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.internal.validation import check_type, try_convert
 from hypothesis.utils.conventions import not_set
@@ -308,14 +307,14 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         keyword arguments for each setting that will be set differently to
         parent (or settings.default, if parent is None).
         """
-        check_type(string_types, name, "name")
+        check_type(str, name, "name")
         settings._profiles[name] = settings(parent=parent, **kwargs)
 
     @staticmethod
     def get_profile(name):
         # type: (str) -> settings
         """Return the profile with the given name."""
-        check_type(string_types, name, "name")
+        check_type(str, name, "name")
         try:
             return settings._profiles[name]
         except KeyError:
@@ -330,7 +329,7 @@ class settings(settingsMeta("settings", (object,), {})):  # type: ignore
         Any setting not defined in the profile will be the library
         defined default for that setting.
         """
-        check_type(string_types, name, "name")
+        check_type(str, name, "name")
         settings._current_profile = name
         settings._assign_default_internal(settings.get_profile(name))
 
@@ -578,18 +577,16 @@ def _validate_deadline(x):
         "number of milliseconds, or None to disable the per-test-case deadline."
         % (x, type(x).__name__)
     )
-    if isinstance(x, integer_types + (float,)):
+    if isinstance(x, (int, float)):
         if isinstance(x, bool):
             raise invalid_deadline_error
         try:
             x = duration(milliseconds=x)
         except OverflowError:
-            quiet_raise(
-                InvalidArgument(
-                    "deadline=%r is invalid, because it is too large to represent "
-                    "as a timedelta. Use deadline=None to disable deadlines." % (x,)
-                )
-            )
+            raise InvalidArgument(
+                "deadline=%r is invalid, because it is too large to represent "
+                "as a timedelta. Use deadline=None to disable deadlines." % (x,)
+            ) from None
     if isinstance(x, datetime.timedelta):
         if x <= datetime.timedelta(0):
             raise InvalidArgument(

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -627,7 +627,7 @@ If set to True, Hypothesis will print code for failing examples that can be used
 settings.lock_further_definitions()
 
 
-def note_deprecation(message, since):
+def note_deprecation(message, *, since):
     # type: (str, str) -> None
     if since != "RELEASEDAY":
         date = datetime.datetime.strptime(since, "%Y-%m-%d").date()

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -18,7 +18,6 @@ import traceback
 
 from hypothesis import Verbosity, settings
 from hypothesis.errors import CleanupFailed, InvalidArgument, UnsatisfiedAssumption
-from hypothesis.internal.compat import string_types
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import report, verbose_report
@@ -171,7 +170,7 @@ def target(observation, label=""):
     check_type(float, observation, "observation")
     if math.isinf(observation) or math.isnan(observation):
         raise InvalidArgument("observation=%r must be a finite float." % observation)
-    check_type(string_types, label, "label")
+    check_type(str, label, "label")
 
     context = _current_build_context.value
     if context is None:

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -168,7 +168,7 @@ def target(observation, label=""):
     example shrinks right down to the threshold of failure (:issue:`2180`).
     """
     check_type(float, observation, "observation")
-    if math.isinf(observation) or math.isnan(observation):
+    if not math.isfinite(observation):
         raise InvalidArgument("observation=%r must be a finite float." % observation)
     check_type(str, label, "label")
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -24,6 +24,8 @@ import sys
 import traceback
 import warnings
 import zlib
+from inspect import getfullargspec
+from io import StringIO
 from random import Random
 from unittest import TestCase
 
@@ -54,13 +56,9 @@ from hypothesis.errors import (
 )
 from hypothesis.executors import new_style_executor
 from hypothesis.internal.compat import (
-    PY2,
     bad_django_TestCase,
     benchmark_time,
-    binary_type,
     get_type_hints,
-    getfullargspec,
-    hbytes,
     int_from_bytes,
     qualname,
 )
@@ -95,7 +93,7 @@ from hypothesis.strategies._internal.strategies import (
     SearchStrategy,
 )
 from hypothesis.utils.conventions import infer
-from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
+from hypothesis.vendor.pretty import RepresentationPrinter
 from hypothesis.version import __version__
 
 if False:
@@ -182,9 +180,7 @@ def reproduce_failure(version, blob):
 
 
 def encode_failure(buffer):
-    # This needs to be a real bytes() instance, so we use binary_type()
-    # instead of hbytes() here.
-    buffer = binary_type(buffer)
+    buffer = bytes(buffer)
     compressed = zlib.compress(buffer)
     if len(compressed) < len(buffer):
         buffer = b"\1" + compressed
@@ -308,10 +304,7 @@ class ArtificialDataForExample(ConjectureData):
     def __init__(self, kwargs):
         self.__draws = 0
         self.__kwargs = kwargs
-
-        super().__init__(
-            max_length=0, prefix=hbytes(), random=None,
-        )
+        super().__init__(max_length=0, prefix=b"", random=None)
 
     def draw_bits(self, n):
         raise NotImplementedError()  # pragma: no cover
@@ -562,7 +555,7 @@ class StateForActualGivenExecution:
                             text_repr[0] = arg_string(test, args, kwargs)
 
                         if print_example or current_verbosity() >= Verbosity.verbose:
-                            output = CUnicodeIO()
+                            output = StringIO()
 
                             printer = RepresentationPrinter(output)
                             if print_example:
@@ -1088,18 +1081,8 @@ def given(
                     # full of Hypothesis internals they don't care about.
                     # We have to do this inline, to avoid adding another
                     # internal stack frame just when we've removed the rest.
-                    if PY2:
-                        # Python 2 doesn't have Exception.with_traceback(...);
-                        # instead it has a three-argument form of the `raise`
-                        # statement.  Unfortunately this is a SyntaxError on
-                        # Python 3, and before Python 2.7.9 it was *also* a
-                        # SyntaxError to use it in a nested function so we
-                        # can't `exec` or `eval` our way out (BPO-21591).
-                        # So unless we break some versions of Python 2, none
-                        # of them get traceback elision.
-                        raise
-                    # On Python 3, we swap out the real traceback for our
-                    # trimmed version.  Using a variable ensures that the line
+                    #
+                    # Using a variable for our trimmed error ensures that the line
                     # which will actually appear in tracebacks is as clear as
                     # possible - "raise the_error_hypothesis_found".
                     the_error_hypothesis_found = e.with_traceback(

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -276,12 +276,6 @@ def is_invalid_test(name, original_argspec, given_arguments, given_kwargs):
             "%s() got an unexpected keyword argument %r, from `%s=%r` in @given"
             % (name, arg, arg, given_kwargs[arg])
         )
-    for a in original_argspec.args:
-        if isinstance(a, list):  # pragma: no cover
-            return invalid(
-                "Cannot decorate function %s() because it has destructuring arguments"
-                % (name,)
-            )
     if original_argspec.defaults or original_argspec.kwonlydefaults:
         return invalid("Cannot apply @given to a function with defaults.")
     missing = [repr(kw) for kw in original_argspec.kwonlyargs if kw not in given_kwargs]

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -177,10 +177,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         mkdir_p(self._key_path(key))
         path = self._value_path(key, value)
         if not os.path.exists(path):
-            suffix = binascii.hexlify(os.urandom(16))
-            if not isinstance(suffix, str):  # pragma: no branch
-                # On Python 3, binascii.hexlify returns bytes
-                suffix = suffix.decode("ascii")
+            suffix = binascii.hexlify(os.urandom(16)).decode("ascii")
             tmpname = path + "." + suffix
             with open(tmpname, "wb") as o:
                 o.write(value)

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -20,7 +20,6 @@ from hashlib import sha384
 
 from hypothesis.configuration import mkdir_p, storage_directory
 from hypothesis.errors import HypothesisException, HypothesisWarning
-from hypothesis.internal.compat import hbytes
 from hypothesis.utils.conventions import not_set
 
 
@@ -124,10 +123,10 @@ class InMemoryExampleDatabase(ExampleDatabase):
         yield from self.data.get(key, ())
 
     def save(self, key, value):
-        self.data.setdefault(key, set()).add(hbytes(value))
+        self.data.setdefault(key, set()).add(bytes(value))
 
     def delete(self, key, value):
-        self.data.get(key, set()).discard(hbytes(value))
+        self.data.get(key, set()).discard(bytes(value))
 
     def close(self):
         pass
@@ -167,7 +166,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         for path in os.listdir(kp):
             try:
                 with open(os.path.join(kp, path), "rb") as i:
-                    yield hbytes(i.read())
+                    yield i.read()
             except OSError:
                 pass
 

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -34,6 +34,7 @@ infeasible.  We may also be quite aggressive in bumping the minimum version of
 Lark, unless someone volunteers to either fund or do the maintainence.
 """
 
+from inspect import getfullargspec
 
 import attr
 import lark
@@ -41,7 +42,6 @@ from lark.grammar import NonTerminal, Terminal
 
 import hypothesis.strategies._internal.core as st
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import getfullargspec, string_types
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal import SearchStrategy
@@ -188,7 +188,7 @@ class LarkStrategy(SearchStrategy):
 
 def check_explicit(name):
     def inner(value):
-        check_type(string_types, value, "value drawn from " + name)
+        check_type(str, value, "value drawn from " + name)
         return value
 
     return inner

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -25,7 +25,7 @@ import hypothesis.strategies._internal.core as st
 from hypothesis import assume
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.coverage import check_function
-from hypothesis.internal.reflection import proxies, reserved_means_kwonly_star
+from hypothesis.internal.reflection import proxies
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
@@ -1023,16 +1023,15 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
 
 
 @st.defines_strategy
-@reserved_means_kwonly_star
 def mutually_broadcastable_shapes(
-    __reserved=not_set,  # type: Any
+    *,
     num_shapes=not_set,  # type: Union[UniqueIdentifier, int]
     signature=not_set,  # type: Union[UniqueIdentifier, str]
     base_shape=(),  # type: Shape
     min_dims=0,  # type: int
     max_dims=None,  # type: int
     min_side=1,  # type: int
-    max_side=None,  # type: int
+    max_side=None  # type: int
 ):
     # type: (...) -> st.SearchStrategy[BroadcastableShapes]
     """Return a strategy for generating a specified number of shapes, N, that are
@@ -1108,9 +1107,6 @@ def mutually_broadcastable_shapes(
         BroadcastableShapes(input_shapes=((3, 4, 2), (1, 2)), result_shape=(3, 4))
         BroadcastableShapes(input_shapes=((4, 2), (1, 2, 3)), result_shape=(4, 3))
     """
-    if __reserved is not not_set:
-        raise InvalidArgument("Do not pass the __reserved argument.")
-
     arg_msg = "Pass either the `num_shapes` or the `signature` argument, but not both."
     if num_shapes is not not_set:
         check_argument(signature is not_set, arg_msg)
@@ -1251,16 +1247,10 @@ class BasicIndexStrategy(SearchStrategy):
 
 
 @st.defines_strategy
-@reserved_means_kwonly_star
 def basic_indices(
-    shape,
-    __reserved=not_set,
-    min_dims=0,
-    max_dims=None,
-    allow_newaxis=False,
-    allow_ellipsis=True,
+    shape, *, min_dims=0, max_dims=None, allow_newaxis=False, allow_ellipsis=True
 ):
-    # type: (Shape, Any, int, int, bool, bool) -> st.SearchStrategy[BasicIndex]
+    # type: (Shape, int, int, bool, bool) -> st.SearchStrategy[BasicIndex]
     """
     The ``basic_indices`` strategy generates `basic indexes
     <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`__  for
@@ -1288,10 +1278,8 @@ def basic_indices(
     # Arguments to exclude scalars, zero-dim arrays, and dims of size zero were
     # all considered and rejected.  We want users to explicitly consider those
     # cases if they're dealing in general indexers, and while it's fiddly we can
-    # back-compatibly add them later (hence using __reserved to sim kwonlyargs).
+    # back-compatibly add them later (hence using kwonlyargs).
     check_type(tuple, shape, "shape")
-    if __reserved is not not_set:
-        raise InvalidArgument("Do not pass the __reserved argument.")
     check_type(bool, allow_ellipsis, "allow_ellipsis")
     check_type(bool, allow_newaxis, "allow_newaxis")
     check_type(int, min_dims, "min_dims")

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -16,6 +16,7 @@
 import math
 import re
 from collections import namedtuple
+from typing import NamedTuple, Tuple
 
 import numpy as np
 
@@ -23,31 +24,17 @@ import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies._internal.core as st
 from hypothesis import assume
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import (
-    PY2,
-    hrange,
-    integer_types,
-    quiet_raise,
-    string_types,
-)
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies, reserved_means_kwonly_star
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 
-if PY2:
-    BroadcastableShapes = namedtuple(
-        "BroadcastableShapes", ["input_shapes", "result_shape"]
-    )
-else:
-    from typing import NamedTuple, Tuple
-
-    Shape = Tuple[int, ...]  # noqa
-    BroadcastableShapes = NamedTuple(
-        "BroadcastableShapes",
-        [("input_shapes", Tuple[Shape, ...]), ("result_shape", Shape)],
-    )
+Shape = Tuple[int, ...]  # noqa
+BroadcastableShapes = NamedTuple(
+    "BroadcastableShapes",
+    [("input_shapes", Tuple[Shape, ...]), ("result_shape", Shape)],
+)
 
 if False:
     from typing import Any, Union, Sequence, Tuple  # noqa
@@ -207,7 +194,7 @@ class ArrayStrategy(SearchStrategy):
                     else:
                         elements.reject()
             else:
-                for i in hrange(len(result)):
+                for i in range(len(result)):
                     self.set_element(data, result, i)
         else:
             # We draw numpy arrays as "sparse with an offset". We draw a
@@ -398,11 +385,11 @@ def arrays(
     dtype = np.dtype(dtype)
     if elements is None:
         elements = from_dtype(dtype)
-    if isinstance(shape, integer_types):
+    if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
     check_argument(
-        all(isinstance(s, integer_types) for s in shape),
+        all(isinstance(s, int) for s in shape),
         "Array shape must be integer in each dimension, provided shape was {}",
         shape,
     )
@@ -414,8 +401,8 @@ def arrays(
 def array_shapes(min_dims=1, max_dims=None, min_side=1, max_side=None):
     # type: (int, int, int, int) -> st.SearchStrategy[Shape]
     """Return a strategy for array shapes (tuples of int >= 1)."""
-    check_type(integer_types, min_dims, "min_dims")
-    check_type(integer_types, min_side, "min_side")
+    check_type(int, min_dims, "min_dims")
+    check_type(int, min_side, "min_side")
     if min_dims > 32:
         raise InvalidArgument(
             "Got min_dims=%r, but numpy does not support arrays greater than 32 dimensions"
@@ -423,7 +410,7 @@ def array_shapes(min_dims=1, max_dims=None, min_side=1, max_side=None):
         )
     if max_dims is None:
         max_dims = min(min_dims + 2, 32)
-    check_type(integer_types, max_dims, "max_dims")
+    check_type(int, max_dims, "max_dims")
     if max_dims > 32:
         raise InvalidArgument(
             "Got max_dims=%r, but numpy does not support arrays greater than 32 dimensions"
@@ -431,7 +418,7 @@ def array_shapes(min_dims=1, max_dims=None, min_side=1, max_side=None):
         )
     if max_side is None:
         max_side = min_side + 5
-    check_type(integer_types, max_side, "max_side")
+    check_type(int, max_side, "max_side")
     order_check("dims", 0, min_dims, max_dims)
     order_check("side", 0, min_side, max_side)
 
@@ -645,10 +632,7 @@ def array_dtypes(
     drawn from the given subtype strategy."""
     order_check("size", 0, min_size, max_size)
     # Field names must be native strings and the empty string is weird; see #1963.
-    if PY2:
-        field_names = st.binary(min_size=1)
-    else:
-        field_names = st.text(min_size=1)
+    field_names = st.text(min_size=1)
     elements = st.tuples(field_names, subtype_strategy)
     if allow_subarrays:
         elements |= st.tuples(
@@ -714,9 +698,9 @@ def valid_tuple_axes(ndim, min_size=0, max_size=None):
     if max_size is None:
         max_size = ndim
 
-    check_type(integer_types, ndim, "ndim")
-    check_type(integer_types, min_size, "min_size")
-    check_type(integer_types, max_size, "max_size")
+    check_type(int, ndim, "ndim")
+    check_type(int, min_size, "min_size")
+    check_type(int, max_size, "max_size")
     order_check("size", 0, min_size, max_size)
     check_valid_interval(max_size, ndim, "max_size", "ndim")
 
@@ -755,18 +739,18 @@ def broadcastable_shapes(shape, min_dims=0, max_dims=None, min_side=1, max_side=
     """
     check_type(tuple, shape, "shape")
     strict_check = max_side is None or max_dims is None
-    check_type(integer_types, min_side, "min_side")
-    check_type(integer_types, min_dims, "min_dims")
+    check_type(int, min_side, "min_side")
+    check_type(int, min_dims, "min_dims")
 
     if max_dims is None:
         max_dims = min(32, max(len(shape), min_dims) + 2)
     else:
-        check_type(integer_types, max_dims, "max_dims")
+        check_type(int, max_dims, "max_dims")
 
     if max_side is None:
         max_side = max(tuple(shape[-max_dims:]) + (min_side,)) + 2
     else:
-        check_type(integer_types, max_side, "max_side")
+        check_type(int, max_side, "max_side")
 
     order_check("dims", 0, min_dims, max_dims)
     order_check("side", 0, min_side, max_side)
@@ -1032,7 +1016,9 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
                         raise InvalidArgument(frozen_optional_err % (name, signature))
                 except ValueError:
                     if name.strip("?") in (names_out - names_in):
-                        quiet_raise(InvalidArgument(only_out_err % (name, signature)))
+                        raise InvalidArgument(
+                            only_out_err % (name, signature)
+                        ) from None
     return _GUfuncSig(input_shapes=input_shapes, result_shape=result_shape)
 
 
@@ -1128,8 +1114,8 @@ def mutually_broadcastable_shapes(
     arg_msg = "Pass either the `num_shapes` or the `signature` argument, but not both."
     if num_shapes is not not_set:
         check_argument(signature is not_set, arg_msg)
-        check_type(integer_types, num_shapes, "num_shapes")
-        assert isinstance(num_shapes, integer_types)  # for mypy
+        check_type(int, num_shapes, "num_shapes")
+        assert isinstance(num_shapes, int)  # for mypy
         check_argument(num_shapes >= 1, "num_shapes={} must be at least 1", num_shapes)
         parsed_signature = None
         sig_dims = 0
@@ -1140,7 +1126,7 @@ def mutually_broadcastable_shapes(
                 "Expected a string, but got invalid signature=None.  "
                 "(maybe .signature attribute of an element-wise ufunc?)"
             )
-        check_type(string_types, signature, "signature")
+        check_type(str, signature, "signature")
         parsed_signature = _hypothesis_parse_gufunc_signature(signature)
         sig_dims = min(
             map(len, parsed_signature.input_shapes + (parsed_signature.result_shape,))
@@ -1150,18 +1136,18 @@ def mutually_broadcastable_shapes(
 
     check_type(tuple, base_shape, "base_shape")
     strict_check = max_dims is not None
-    check_type(integer_types, min_side, "min_side")
-    check_type(integer_types, min_dims, "min_dims")
+    check_type(int, min_side, "min_side")
+    check_type(int, min_dims, "min_dims")
 
     if max_dims is None:
         max_dims = min(32 - sig_dims, max(len(base_shape), min_dims) + 2)
     else:
-        check_type(integer_types, max_dims, "max_dims")
+        check_type(int, max_dims, "max_dims")
 
     if max_side is None:
         max_side = max(tuple(base_shape[-max_dims:]) + (min_side,)) + 2
     else:
-        check_type(integer_types, max_side, "max_side")
+        check_type(int, max_side, "max_side")
 
     order_check("dims", 0, min_dims, max_dims)
     order_check("side", 0, min_side, max_side)
@@ -1308,18 +1294,18 @@ def basic_indices(
         raise InvalidArgument("Do not pass the __reserved argument.")
     check_type(bool, allow_ellipsis, "allow_ellipsis")
     check_type(bool, allow_newaxis, "allow_newaxis")
-    check_type(integer_types, min_dims, "min_dims")
+    check_type(int, min_dims, "min_dims")
     if max_dims is None:
         max_dims = min(max(len(shape), min_dims) + 2, 32)
     else:
-        check_type(integer_types, max_dims, "max_dims")
+        check_type(int, max_dims, "max_dims")
     order_check("dims", 0, min_dims, max_dims)
     check_argument(
         max_dims <= 32,
         "max_dims=%r, but numpy arrays have at most 32 dimensions" % (max_dims,),
     )
     check_argument(
-        all(isinstance(x, integer_types) and x >= 0 for x in shape),
+        all(isinstance(x, int) and x >= 0 for x in shape),
         "shape=%r, but all dimensions must be of integer size >= 0" % (shape,),
     )
     return BasicIndexStrategy(
@@ -1375,7 +1361,7 @@ def integer_array_indices(shape, result_shape=array_shapes(), dtype="int"):
     """
     check_type(tuple, shape, "shape")
     check_argument(
-        shape and all(isinstance(x, integer_types) and x > 0 for x in shape),
+        shape and all(isinstance(x, int) and x > 0 for x in shape),
         "shape=%r must be a non-empty tuple of integers > 0" % (shape,),
     )
     check_type(SearchStrategy, result_shape, "result_shape")

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -13,7 +13,7 @@
 #
 # END HEADER
 
-from collections import OrderedDict
+from collections import OrderedDict, abc
 from copy import copy
 
 import attr
@@ -25,7 +25,6 @@ import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies._internal.core as st
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import abc, hrange
 from hypothesis.internal.coverage import check, check_function
 from hypothesis.internal.validation import (
     check_type,
@@ -574,7 +573,7 @@ def data_frames(
                     )
                 seen = {c.name: set() for c in columns_without_fill if c.unique}
 
-                for i in hrange(len(index)):
+                for i in range(len(index)):
                     for c in columns_without_fill:
                         if c.unique:
                             for _ in range(5):
@@ -631,8 +630,8 @@ def data_frames(
                 while all_seen[-1] is None:
                     all_seen.pop()
 
-            for row_index in hrange(len(index)):
-                for _ in hrange(5):
+            for row_index in range(len(index)):
+                for _ in range(5):
                     original_row = draw(rows)
                     row = original_row
                     if isinstance(row, dict):

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -19,7 +19,6 @@ import pytest
 
 from hypothesis import Verbosity, core, settings
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import text_type
 from hypothesis.internal.detection import is_hypothesis_test
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.statistics import collector
@@ -38,7 +37,7 @@ class StoringReporter:
     def __call__(self, msg):
         if self.config.getoption("capture", "fd") == "no":
             default_reporter(msg)
-        if not isinstance(msg, text_type):
+        if not isinstance(msg, str):
             msg = repr(msg)
         self.results.append(msg)
 

--- a/hypothesis-python/src/hypothesis/internal/cathetus.py
+++ b/hypothesis-python/src/hypothesis/internal/cathetus.py
@@ -13,7 +13,7 @@
 #
 # END HEADER
 
-from math import fabs, isinf, isnan, sqrt
+from math import fabs, inf, isinf, isnan, nan, sqrt
 from sys import float_info
 
 
@@ -35,21 +35,21 @@ def cathetus(h, a):
     Based on the C99 implementation https://github.com/jjgreen/cathetus
     """
     if isnan(h):
-        return float("nan")
+        return nan
 
     if isinf(h):
         if isinf(a):
-            return float("nan")
+            return nan
         else:
             # Deliberately includes the case when isnan(a), because the
             # C99 standard mandates that hypot(inf, nan) == inf
-            return float("inf")
+            return inf
 
     h = fabs(h)
     a = fabs(a)
 
     if h < a:
-        return float("nan")
+        return nan
 
     # Thanks to floating-point precision issues when performing multiple
     # operations on extremely large or small values, we may rarely calculate

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -22,7 +22,6 @@ import unicodedata
 
 from hypothesis.configuration import mkdir_p, storage_directory
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hunichr
 
 if False:
     from typing import Dict, Tuple
@@ -66,10 +65,10 @@ def charmap():
             # https://github.com/HypothesisWorks/hypothesis/issues/2108 but it helps.
             category = unicodedata.category  # Local variable -> ~20% speedup!
             tmp_charmap = {}
-            last_cat = category(hunichr(0))
+            last_cat = category(chr(0))
             last_start = 0
             for i in range(1, sys.maxunicode + 1):
-                cat = category(hunichr(i))
+                cat = category(chr(i))
                 if cat != last_cat:
                     tmp_charmap.setdefault(last_cat, []).append([last_start, i - 1])
                     last_cat, last_start = cat, i

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -13,49 +13,16 @@
 #
 # END HEADER
 
-import array
 import codecs
 import importlib
 import inspect
-import math
 import platform
-import re
 import sys
 import time
-from base64 import b64encode
-from collections import namedtuple
+from typing import Tuple, Type  # noqa
 
-try:
-    from collections import abc
-except ImportError:
-    import collections as abc  # type: ignore
-
-try:
-    from itertools import accumulate
-except ImportError:
-
-    def accumulate(iterable, func=lambda a, b: a + b):
-        it = iter(iterable)
-        try:
-            total = next(it)
-        except StopIteration:
-            return
-        yield total
-        for element in it:
-            total = func(total, element)
-            yield total
-
-
-if False:
-    from typing import Type, Tuple  # noqa
-
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 PYPY = platform.python_implementation() == "PyPy"
-CAN_UNPACK_BYTE_ARRAY = sys.version_info[:3] >= (2, 7, 4)
 CAN_PACK_HALF_FLOAT = sys.version_info[:2] >= (3, 6)
-
 WINDOWS = platform.system() == "Windows"
 
 
@@ -63,212 +30,28 @@ def bit_length(n):
     return n.bit_length()
 
 
-def quiet_raise(exc):
-    # Overridden by Py3 version, iff `raise XXX from None` is valid
-    raise exc
+def str_to_bytes(s):
+    return s.encode(a_good_encoding())
 
 
-if PY3:
-
-    def str_to_bytes(s):
-        return s.encode(a_good_encoding())
-
-    def int_to_text(i):
-        return str(i)
-
-    text_type = str
-    binary_type = bytes
-    hrange = range
-    ARG_NAME_ATTRIBUTE = "arg"
-    integer_types = (int,)
-    hunichr = chr
-
-    def unicode_safe_repr(x):
-        return repr(x)
-
-    def isidentifier(s):
-        return s.isidentifier()
-
-    def escape_unicode_characters(s):
-        return codecs.encode(s, "unicode_escape").decode("ascii")
-
-    def print_unicode(x):
-        print(x)
-
-    exec(
-        """
-def quiet_raise(exc):
-    raise exc from None
-"""
-    )
-
-    def int_from_bytes(data):
-        return int.from_bytes(data, "big")
-
-    def int_to_bytes(i, size):
-        return i.to_bytes(size, "big")
-
-    def to_bytes_sequence(ls):
-        return bytes(ls)
-
-    def int_to_byte(i):
-        return bytes([i])
-
-    import struct
-
-    struct_pack = struct.pack
-    struct_unpack = struct.unpack
-
-    def benchmark_time():
-        return time.monotonic()
+def escape_unicode_characters(s):
+    return codecs.encode(s, "unicode_escape").decode("ascii")
 
 
-else:
-    import struct
-
-    def struct_pack(*args):
-        return hbytes(struct.pack(*args))
-
-    if CAN_UNPACK_BYTE_ARRAY:
-
-        def struct_unpack(fmt, string):
-            return struct.unpack(fmt, string)
-
-    else:
-
-        def struct_unpack(fmt, string):
-            return struct.unpack(fmt, str(string))
-
-    def int_from_bytes(data):
-        if CAN_UNPACK_BYTE_ARRAY:
-            unpackable_data = data
-        elif isinstance(data, bytearray):
-            unpackable_data = bytes(data)
-        else:
-            unpackable_data = data
-        assert isinstance(data, (bytes, bytearray))
-        result = 0
-        i = 0
-        while i + 4 <= len(data):
-            result <<= 32
-            result |= struct.unpack(">I", unpackable_data[i : i + 4])[0]
-            i += 4
-        while i < len(data):
-            result <<= 8
-            result |= data[i]
-            i += 1
-        return int(result)
-
-    def int_to_bytes(i, size):
-        assert i >= 0
-        result = bytearray(size)
-        j = size - 1
-        arg = i
-        while i and j >= 0:
-            result[j] = i & 255
-            i >>= 8
-            j -= 1
-        if i:
-            raise OverflowError("i=%r cannot be represented in %r bytes" % (arg, size))
-        return hbytes(result)
-
-    int_to_byte = chr
-
-    def to_bytes_sequence(ls):
-        return bytearray(ls)
-
-    def str_to_bytes(s):
-        return s
-
-    def int_to_text(i):
-        return str(i).decode("ascii")
-
-    VALID_PYTHON_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-
-    def isidentifier(s):
-        return VALID_PYTHON_IDENTIFIER.match(s)
-
-    def unicode_safe_repr(x):
-        r = repr(x)
-        assert isinstance(r, str)
-        return r.decode(a_good_encoding())
-
-    text_type = unicode
-    binary_type = str
-
-    def hrange(start_or_finish, finish=None, step=None):
-        try:
-            if step is None:
-                if finish is None:
-                    return xrange(start_or_finish)
-                else:
-                    return xrange(start_or_finish, finish)
-            else:
-                return xrange(start_or_finish, finish, step)
-        except OverflowError:
-            if step == 0:
-                raise ValueError("step argument may not be zero")
-            if step is None:
-                step = 1
-            if finish is not None:
-                start = start_or_finish
-            else:
-                start = 0
-                finish = start_or_finish
-            assert step != 0
-            if step > 0:
-
-                def shimrange():
-                    i = start
-                    while i < finish:
-                        yield i
-                        i += step
-
-            else:
-
-                def shimrange():
-                    i = start
-                    while i > finish:
-                        yield i
-                        i += step
-
-            return shimrange()
-
-    ARG_NAME_ATTRIBUTE = "id"
-    integer_types = (int, long)
-    hunichr = unichr
-
-    def escape_unicode_characters(s):
-        return codecs.encode(s, "string_escape")
-
-    def print_unicode(x):
-        if isinstance(x, unicode):
-            x = x.encode(a_good_encoding())
-        print(x)
-
-    def benchmark_time():
-        return time.time()
+def int_from_bytes(data):
+    return int.from_bytes(data, "big")
 
 
-# coverage mixes unicode and str filepaths on Python 2, which causes us
-# problems if we're running under unicodenazi (it might also cause problems
-# when not running under unicodenazi, but hard to say for sure). This method
-# exists to work around that: If we're given a unicode filepath, we turn it
-# into a string file path using the appropriate encoding. See
-# https://bitbucket.org/ned/coveragepy/issues/602/ for more information.
-if PY2:
-
-    def encoded_filepath(filepath):
-        if isinstance(filepath, text_type):
-            return filepath.encode(sys.getfilesystemencoding())
-        else:
-            return filepath
+def int_to_bytes(i, size):
+    return i.to_bytes(size, "big")
 
 
-else:
+def int_to_byte(i):
+    return bytes([i])
 
-    def encoded_filepath(filepath):
-        return filepath
+
+def benchmark_time():
+    return time.monotonic()
 
 
 def a_good_encoding():
@@ -276,7 +59,7 @@ def a_good_encoding():
 
 
 def to_unicode(x):
-    if isinstance(x, text_type):
+    if isinstance(x, str):
         return x
     else:
         return x.decode(a_good_encoding())
@@ -285,10 +68,6 @@ def to_unicode(x):
 def qualname(f):
     try:
         return f.__qualname__
-    except AttributeError:
-        pass
-    try:
-        return f.im_class.__name__ + "." + f.__name__
     except AttributeError:
         return f.__name__
 
@@ -315,34 +94,11 @@ else:
         ForwardRef = typing._ForwardRef  # type: ignore
 
 
-if PY2:
-    FullArgSpec = namedtuple(
-        "FullArgSpec",
-        "args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations",
-    )
-
-    def getfullargspec(func):
-        args, varargs, varkw, defaults = inspect.getargspec(func)
-        return FullArgSpec(
-            args,
-            varargs,
-            varkw,
-            defaults,
-            [],
-            None,
-            getattr(func, "__annotations__", {}),
-        )
-
-
-else:
-    from inspect import getfullargspec, FullArgSpec
-
-
 if sys.version_info[:2] < (3, 6):
 
     def get_type_hints(thing):
         try:
-            spec = getfullargspec(thing)
+            spec = inspect.getfullargspec(thing)
             return {
                 k: v
                 for k, v in spec.annotations.items()
@@ -365,24 +121,22 @@ else:
 importlib_invalidate_caches = getattr(importlib, "invalidate_caches", lambda: ())
 
 
-if PY2:
-    CODE_FIELD_ORDER = [
-        "co_argcount",
-        "co_nlocals",
-        "co_stacksize",
-        "co_flags",
-        "co_code",
-        "co_consts",
-        "co_names",
-        "co_varnames",
-        "co_filename",
-        "co_name",
-        "co_firstlineno",
-        "co_lnotab",
-        "co_freevars",
-        "co_cellvars",
-    ]
-else:
+def update_code_location(code, newfile, newlineno):
+    """Take a code object and lie shamelessly about where it comes from.
+
+    Why do we want to do this? It's for really shallow reasons involving
+    hiding the hypothesis_temporary_module code from test runners like
+    pytest's verbose mode. This is a vastly disproportionate terrible
+    hack that I've done purely for vanity, and if you're reading this
+    code you're probably here because it's broken something and now
+    you're angry at me. Sorry.
+    """
+    if hasattr(code, "replace"):
+        # Python 3.8 added positional-only params (PEP 570), and thus changed
+        # the layout of code objects.  In beta1, the `.replace()` method was
+        # added to facilitate future-proof code.  See BPO-37032 for details.
+        return code.replace(co_filename=newfile, co_firstlineno=newlineno)
+
     # This field order is accurate for 3.5 - 3.7, but not 3.8 when a new field
     # was added for positional-only arguments.  However it also added a .replace()
     # method that we use instead of field indices, so they're fine as-is.
@@ -403,123 +157,10 @@ else:
         "co_freevars",
         "co_cellvars",
     ]
-
-
-def update_code_location(code, newfile, newlineno):
-    """Take a code object and lie shamelessly about where it comes from.
-
-    Why do we want to do this? It's for really shallow reasons involving
-    hiding the hypothesis_temporary_module code from test runners like
-    pytest's verbose mode. This is a vastly disproportionate terrible
-    hack that I've done purely for vanity, and if you're reading this
-    code you're probably here because it's broken something and now
-    you're angry at me. Sorry.
-    """
-    if hasattr(code, "replace"):
-        # Python 3.8 added positional-only params (PEP 570), and thus changed
-        # the layout of code objects.  In beta1, the `.replace()` method was
-        # added to facilitate future-proof code.  See BPO-37032 for details.
-        return code.replace(co_filename=newfile, co_firstlineno=newlineno)
-
     unpacked = [getattr(code, name) for name in CODE_FIELD_ORDER]
     unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile
     unpacked[CODE_FIELD_ORDER.index("co_firstlineno")] = newlineno
     return type(code)(*unpacked)
-
-
-class compatbytes(bytearray):
-    __name__ = "bytes"
-
-    def __init__(self, *args, **kwargs):
-        bytearray.__init__(self, *args, **kwargs)
-        self.__hash = None
-
-    def __str__(self):
-        return bytearray.__str__(self)
-
-    def __repr__(self):
-        return "compatbytes(b%r)" % (str(self),)
-
-    def __hash__(self):
-        if self.__hash is None:
-            self.__hash = hash(str(self))
-        return self.__hash
-
-    def count(self, value):
-        c = 0
-        for w in self:
-            if w == value:
-                c += 1
-        return c
-
-    def index(self, value):
-        for i, v in enumerate(self):
-            if v == value:
-                return i
-        raise ValueError("Value %r not in sequence %r" % (value, self))
-
-    def __add__(self, value):
-        assert isinstance(value, compatbytes)
-        return compatbytes(bytearray.__add__(self, value))
-
-    def __radd__(self, value):
-        assert isinstance(value, compatbytes)
-        return compatbytes(bytearray.__add__(value, self))
-
-    def __mul__(self, value):
-        return compatbytes(bytearray.__mul__(self, value))
-
-    def __rmul__(self, value):
-        return compatbytes(bytearray.__rmul__(self, value))
-
-    def __getitem__(self, *args, **kwargs):
-        r = bytearray.__getitem__(self, *args, **kwargs)
-        if isinstance(r, bytearray):
-            return compatbytes(r)
-        else:
-            return r
-
-    __setitem__ = None  # type: ignore
-
-    def join(self, parts):
-        result = bytearray()
-        first = True
-        for p in parts:
-            if not first:
-                result.extend(self)
-            first = False
-            result.extend(p)
-        return compatbytes(result)
-
-    def __contains__(self, value):
-        return any(v == value for v in self)
-
-
-if PY2:
-    hbytes = compatbytes
-    reasonable_byte_type = bytearray
-    string_types = (str, unicode)
-else:
-    hbytes = bytes
-    reasonable_byte_type = bytes
-    string_types = (str,)
-
-
-EMPTY_BYTES = hbytes(b"")
-
-if PY2:
-
-    def to_str(s):
-        if isinstance(s, unicode):
-            return s.encode(a_good_encoding())
-        assert isinstance(s, str)
-        return s
-
-
-else:
-
-    def to_str(s):
-        return s
 
 
 def cast_unicode(s, encoding=None):
@@ -530,13 +171,6 @@ def cast_unicode(s, encoding=None):
 
 def get_stream_enc(stream, default=None):
     return getattr(stream, "encoding", None) or default
-
-
-def implements_iterator(it):
-    """Turn things with a __next__ attribute into iterators on Python 2."""
-    if PY2 and not hasattr(it, "next") and hasattr(it, "__next__"):
-        it.next = it.__next__
-    return it
 
 
 # Under Python 2, math.floor and math.ceil return floats, which cannot
@@ -560,24 +194,6 @@ def ceil(x):
 
 
 try:
-    from math import gcd
-except ImportError:
-    from fractions import gcd
-
-
-if PY2:
-
-    def b64decode(s):
-        from base64 import b64decode as base
-
-        return hbytes(base(s))
-
-
-else:
-    from base64 import b64decode
-
-
-try:
     from django.test import TransactionTestCase
 
     def bad_django_TestCase(runner):
@@ -595,15 +211,3 @@ except Exception:
     # Can't use ImportError, because of e.g. Django config errors
     def bad_django_TestCase(runner):
         return False
-
-
-if PY2:
-    LIST_CODES = ("q", "Q", "O")
-else:
-    LIST_CODES = ("O",)
-
-
-def array_or_list(code, contents):
-    if code in LIST_CODES:
-        return list(contents)
-    return array.array(code, contents)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -15,8 +15,6 @@
 
 from collections import defaultdict
 
-from hypothesis.internal.compat import hrange
-
 
 class Chooser:
     """A source of nondeterminism for use in shrink passes."""
@@ -75,7 +73,7 @@ class Chooser:
         next_value = list(self.__choices)
         if next_value:
             next_value[-1] += 1
-            for i in hrange(len(next_value) - 1, -1, -1):
+            for i in range(len(next_value) - 1, -1, -1):
                 if next_value[i] >= self.__node_trail[i].n:
                     next_value[i] = 0
                     if i > 0:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -22,12 +22,8 @@ from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import (
     benchmark_time,
     bit_length,
-    hbytes,
-    hrange,
     int_from_bytes,
     int_to_bytes,
-    text_type,
-    unicode_safe_repr,
 )
 from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
 from hypothesis.internal.conjecture.utils import calc_label_from_name
@@ -427,7 +423,7 @@ class Examples:
     @property
     def children(self):
         if self.__children is None:
-            self.__children = [IntList() for _ in hrange(len(self))]
+            self.__children = [IntList() for _ in range(len(self))]
             for i, p in enumerate(self.parentage):
                 if i > 0:
                     self.__children[p].append(i)
@@ -645,12 +641,12 @@ class Blocks:
             self.owner = None
 
     def __iter__(self):
-        for i in hrange(len(self)):
+        for i in range(len(self)):
             yield self[i]
 
     def __repr__(self):
         parts = []
-        for i in hrange(len(self)):
+        for i in range(len(self)):
             b = self.__known_block(i)
             if b is None:
                 parts.append("...")
@@ -732,7 +728,7 @@ class ConjectureResult:
 
 # Masks for masking off the first byte of an n-bit buffer.
 # The appropriate mask is stored at position n % 8.
-BYTE_MASKS = [(1 << n) - 1 for n in hrange(8)]
+BYTE_MASKS = [(1 << n) - 1 for n in range(8)]
 BYTE_MASKS[0] = 255
 
 
@@ -840,8 +836,8 @@ class ConjectureData:
 
     def note(self, value):
         self.__assert_not_frozen("note")
-        if not isinstance(value, text_type):
-            value = unicode_safe_repr(value)
+        if not isinstance(value, str):
+            value = repr(value)
         self.output += value
 
     def draw(self, strategy, label=None):
@@ -959,7 +955,7 @@ class ConjectureData:
 
     def freeze(self):
         if self.frozen:
-            assert isinstance(self.buffer, hbytes)
+            assert isinstance(self.buffer, bytes)
             return
         self.finish_time = benchmark_time()
         assert len(self.buffer) == self.index
@@ -973,7 +969,7 @@ class ConjectureData:
 
         self.frozen = True
 
-        self.buffer = hbytes(self.buffer)
+        self.buffer = bytes(self.buffer)
         self.events = frozenset(self.events)
         self.observer.conclude_test(self.status, self.interesting_origin)
 
@@ -1006,7 +1002,7 @@ class ConjectureData:
         # If we have a number of bits that is not a multiple of 8
         # we have to mask off the high bits.
         buf[0] &= BYTE_MASKS[n % 8]
-        buf = hbytes(buf)
+        buf = bytes(buf)
         result = int_from_bytes(buf)
 
         self.observer.draw_bits(n, forced is not None, result)
@@ -1018,7 +1014,7 @@ class ConjectureData:
         self.index = len(self.buffer)
 
         if forced is not None:
-            self.forced_indices.update(hrange(initial, self.index))
+            self.forced_indices.update(range(initial, self.index))
 
         self.blocks.add_endpoint(self.index)
 
@@ -1032,7 +1028,7 @@ class ConjectureData:
     def write(self, string):
         """Write ``string`` to the output buffer."""
         self.__assert_not_frozen("write")
-        string = hbytes(string)
+        string = bytes(string)
         if not string:
             return
         self.draw_bits(len(string) * 8, forced=int_from_bytes(string))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -16,7 +16,7 @@
 import attr
 
 from hypothesis.errors import Flaky, HypothesisException
-from hypothesis.internal.compat import hbytes, int_to_bytes
+from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     DataObserver,
@@ -237,11 +237,11 @@ class DataTree:
                             break
                     # We've now found a value that is allowed to
                     # vary, so what follows is not fixed.
-                    return hbytes(novel_prefix)
+                    return bytes(novel_prefix)
             else:
                 assert not isinstance(current_node.transition, (Conclusion, Killed))
                 if current_node.transition is None:
-                    return hbytes(novel_prefix)
+                    return bytes(novel_prefix)
                 branch = current_node.transition
                 assert isinstance(branch, Branch)
                 n_bits = branch.bit_length
@@ -253,7 +253,7 @@ class DataTree:
                         child = branch.children[k]
                     except KeyError:
                         append_int(n_bits, k)
-                        return hbytes(novel_prefix)
+                        return bytes(novel_prefix)
                     if not child.is_exhausted:
                         append_int(n_bits, k)
                         current_node = child
@@ -273,7 +273,7 @@ class DataTree:
         the rewritten buffer and the status we would get from running that
         buffer with the test function. If the status cannot be predicted
         from the existing values it will be None."""
-        buffer = hbytes(buffer)
+        buffer = bytes(buffer)
 
         data = ConjectureData.for_buffer(buffer)
         try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -23,7 +23,7 @@ import attr
 from hypothesis import HealthCheck, Phase, Verbosity, settings as Settings
 from hypothesis._settings import local_settings
 from hypothesis.internal.cache import LRUReusedCache
-from hypothesis.internal.compat import ceil, hbytes, int_from_bytes
+from hypothesis.internal.compat import ceil, int_from_bytes
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,
@@ -341,7 +341,7 @@ class ConjectureRunner:
             key = self.sub_key(sub_key)
             if key is None:
                 return
-            self.settings.database.save(key, hbytes(buffer))
+            self.settings.database.save(key, bytes(buffer))
 
     def downgrade_buffer(self, buffer):
         if self.settings.database is not None and self.database_key is not None:
@@ -516,7 +516,7 @@ class ConjectureRunner:
 
         self.debug("Generating new examples")
 
-        zero_data = self.cached_test_function(hbytes(BUFFER_SIZE))
+        zero_data = self.cached_test_function(bytes(BUFFER_SIZE))
         if zero_data.status > Status.OVERRUN:
             self.__data_cache.pin(zero_data.buffer)
 
@@ -618,7 +618,7 @@ class ConjectureRunner:
                 and consecutive_zero_extend_is_invalid < 5
             ):
                 minimal_example = self.cached_test_function(
-                    prefix + hbytes(BUFFER_SIZE - len(prefix))
+                    prefix + bytes(BUFFER_SIZE - len(prefix))
                 )
 
                 if minimal_example.status < Status.VALID:
@@ -930,7 +930,7 @@ class ConjectureRunner:
         result has discards if we cannot determine from previous runs whether
         it will have a discard.
         """
-        buffer = hbytes(buffer)[:BUFFER_SIZE]
+        buffer = bytes(buffer)[:BUFFER_SIZE]
 
         max_length = min(BUFFER_SIZE, len(buffer) + extend)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
@@ -15,7 +15,6 @@
 
 from array import array
 
-from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.floats import float_to_int, int_to_float
 
@@ -100,7 +99,7 @@ def exponent_key(e):
         return unbiased
 
 
-ENCODING_TABLE = array("H", sorted(hrange(MAX_EXPONENT + 1), key=exponent_key))
+ENCODING_TABLE = array("H", sorted(range(MAX_EXPONENT + 1), key=exponent_key))
 DECODING_TABLE = array("H", [0]) * len(ENCODING_TABLE)
 
 for i, b in enumerate(ENCODING_TABLE):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -17,12 +17,13 @@
 obviously belong anywhere else. If you spot a better home for
 anything that lives here, please move it."""
 
-from hypothesis.internal.compat import (
-    array_or_list,
-    hbytes,
-    int_to_bytes,
-    integer_types,
-)
+import array
+
+
+def array_or_list(code, contents):
+    if code == "O":
+        return list(contents)
+    return array.array(code, contents)
 
 
 def replace_all(buffer, replacements):
@@ -41,7 +42,7 @@ def replace_all(buffer, replacements):
         offset += len(r) - (v - u)
     result.extend(buffer[prev:])
     assert len(result) == len(buffer) + offset
-    return hbytes(result)
+    return bytes(result)
 
 
 ARRAY_CODES = ["B", "H", "I", "L", "Q", "O"]
@@ -69,7 +70,7 @@ class IntList:
             raise AssertionError("Could not create storage for %r" % (values,))
         if isinstance(self.__underlying, list):
             for v in self.__underlying:
-                if v < 0 or not isinstance(v, integer_types):
+                if v < 0 or not isinstance(v, int):
                     raise ValueError("Could not create IntList for %r" % (values,))
 
     @classmethod
@@ -152,8 +153,8 @@ def binary_search(lo, hi, f):
 
 
 def uniform(random, n):
-    """Returns an hbytes of length n, distributed uniformly at random."""
-    return int_to_bytes(random.getrandbits(n * 8), n)
+    """Returns a bytestring of length n, distributed uniformly at random."""
+    return random.getrandbits(n * 8).to_bytes(n, "big")
 
 
 class LazySequenceCopy:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -25,7 +25,7 @@ MAX_PRECISE_INTEGER = 2 ** 53
 
 class Float(Shrinker):
     def setup(self):
-        self.NAN = float("nan")
+        self.NAN = math.nan
         self.debugging_enabled = True
 
     def make_immutable(self, f):
@@ -46,11 +46,11 @@ class Float(Shrinker):
         return lex1 < lex2
 
     def short_circuit(self):
-        for g in [sys.float_info.max, float("inf"), float("nan")]:
+        for g in [sys.float_info.max, math.inf, math.nan]:
             self.consider(g)
 
-        # If we're stuck at a nasty float don't try to shrink it further. These
-        if math.isinf(self.current) or math.isnan(self.current):
+        # If we're stuck at a nasty float don't try to shrink it further.
+        if not math.isfinite(self.current):
             return True
 
         # If its too large to represent as an integer, bail out here. It's

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/integer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/integer.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.shrinking.common import Shrinker, find_integer
 
 
@@ -30,7 +29,7 @@ class Integer(Shrinker):
     """
 
     def short_circuit(self):
-        for i in hrange(2):
+        for i in range(2):
             if self.consider(i):
                 return True
         self.mask_high_bits()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/lexical.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/lexical.py
@@ -13,7 +13,7 @@
 #
 # END HEADER
 
-from hypothesis.internal.compat import hbytes, int_from_bytes, int_to_bytes
+from hypothesis.internal.compat import int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
 from hypothesis.internal.conjecture.shrinking.ordering import Ordering
@@ -26,7 +26,7 @@ This module implements a lexicographic minimizer for blocks of bytes.
 
 class Lexical(Shrinker):
     def make_immutable(self, value):
-        return hbytes(value)
+        return bytes(value)
 
     @property
     def size(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.shrinking.common import Shrinker, find_integer
 
 
@@ -77,7 +76,7 @@ class Ordering(Shrinker):
         regions centered on each element, where that element is treated as
         fixed and the elements around it are sorted..
         """
-        for i in hrange(1, len(self.current) - 1):
+        for i in range(1, len(self.current) - 1):
             if self.current[i - 1] <= self.current[i] <= self.current[i + 1]:
                 continue
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -17,15 +17,13 @@ import enum
 import hashlib
 import heapq
 import sys
-from collections import OrderedDict
+from collections import OrderedDict, abc
 from fractions import Fraction
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import (
-    abc,
     bit_length,
     floor,
-    hrange,
     int_from_bytes,
     qualname,
     str_to_bytes,
@@ -263,7 +261,7 @@ class Sampler:
 
         n = len(weights)
 
-        self.table = [[i, None, None] for i in hrange(n)]
+        self.table = [[i, None, None] for i in range(n)]
 
         total = sum(weights)
 

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -18,7 +18,6 @@ import random
 import sys
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import integer_types
 
 RANDOMS_TO_MANAGE = [random]  # type: list
 
@@ -65,7 +64,7 @@ def get_seeder_and_restorer(seed=0):
     to force determinism on simulation or scheduling frameworks which avoid
     using the global random state.  See e.g. #1709.
     """
-    assert isinstance(seed, integer_types) and 0 <= seed < 2 ** 32
+    assert isinstance(seed, int) and 0 <= seed < 2 ** 32
     states = []  # type: list
 
     if "numpy" in sys.modules and not any(

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -26,7 +26,6 @@ from hypothesis.errors import (
     StopTest,
     UnsatisfiedAssumption,
 )
-from hypothesis.internal.compat import binary_type, encoded_filepath, text_type
 
 if False:
     from typing import Dict  # noqa
@@ -37,7 +36,7 @@ def belongs_to(package):
         return lambda filepath: False
 
     root = os.path.dirname(package.__file__)
-    cache = {text_type: {}, binary_type: {}}
+    cache = {str: {}, bytes: {}}
 
     def accept(filepath):
         ftype = type(filepath)
@@ -45,10 +44,8 @@ def belongs_to(package):
             return cache[ftype][filepath]
         except KeyError:
             pass
-        new_filepath = encoded_filepath(filepath)
-        result = os.path.abspath(new_filepath).startswith(root)
+        result = os.path.abspath(filepath).startswith(root)
         cache[ftype][filepath] = result
-        cache[type(new_filepath)][new_filepath] = result
         return result
 
     accept.__name__ = "is_%s_file" % (package.__name__,)

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -18,7 +18,6 @@ import math
 from numbers import Rational, Real
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import integer_types
 from hypothesis.internal.coverage import check_function
 
 
@@ -27,9 +26,8 @@ def check_type(typ, arg, name=""):
     if name:
         name += "="
     if not isinstance(arg, typ):
-        if isinstance(typ, tuple) and len(typ) == 1:
-            typ = typ[0]
         if isinstance(typ, tuple):
+            assert len(typ) >= 2, "Use bare type instead of len-1 tuple"
             typ_string = "one of %s" % (", ".join(t.__name__ for t in typ))
         else:
             typ_string = typ.__name__
@@ -47,7 +45,7 @@ def check_valid_integer(value):
     """
     if value is None:
         return
-    check_type(integer_types, value)
+    check_type(int, value)
 
 
 @check_function
@@ -56,7 +54,7 @@ def check_valid_bound(value, name):
 
     Otherwise raises InvalidArgument.
     """
-    if value is None or isinstance(value, integer_types + (Rational,)):
+    if value is None or isinstance(value, (int, Rational)):
         return
     if not isinstance(value, (Real, decimal.Decimal)):
         raise InvalidArgument("%s=%r must be a real number." % (name, value))
@@ -100,7 +98,7 @@ def check_valid_size(value, name):
     """
     if value is None and name != "min_size":
         return
-    check_type(integer_types, value, name)
+    check_type(int, value, name)
     if value < 0:
         raise InvalidArgument("Invalid size %s=%r < 0" % (name, value))
 

--- a/hypothesis-python/src/hypothesis/reporting.py
+++ b/hypothesis-python/src/hypothesis/reporting.py
@@ -16,11 +16,7 @@
 import inspect
 
 from hypothesis._settings import Verbosity, settings
-from hypothesis.internal.compat import (
-    binary_type,
-    escape_unicode_characters,
-    print_unicode,
-)
+from hypothesis.internal.compat import escape_unicode_characters
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
 
@@ -30,9 +26,9 @@ def silent(value):
 
 def default(value):
     try:
-        print_unicode(value)
+        print(value)
     except UnicodeEncodeError:
-        print_unicode(escape_unicode_characters(value))
+        print(escape_unicode_characters(value))
 
 
 reporter = DynamicVariable(default)
@@ -53,7 +49,7 @@ def current_verbosity():
 def to_text(textish):
     if inspect.isfunction(textish):
         textish = textish()
-    if isinstance(textish, binary_type):
+    if isinstance(textish, bytes):
         textish = textish.decode("utf-8")
     return textish
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/attrs.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/attrs.py
@@ -20,7 +20,7 @@ import attr
 
 import hypothesis.strategies as st
 from hypothesis.errors import ResolutionFailed
-from hypothesis.internal.compat import get_type_hints, string_types
+from hypothesis.internal.compat import get_type_hints
 from hypothesis.strategies._internal.types import is_a_type, type_sorting_key
 from hypothesis.utils.conventions import infer
 
@@ -66,7 +66,7 @@ def from_attrs_attribute(attrib, target):
             vs = [validator]
         for v in vs:
             if isinstance(v, attr.validators._InValidator):
-                if isinstance(v.options, string_types):
+                if isinstance(v.options, str):
                     in_collections.append(list(all_substrings(v.options)))
                 else:
                     in_collections.append(v.options)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -54,7 +54,6 @@ from hypothesis.internal.reflection import (
     nicerepr,
     proxies,
     required_args,
-    reserved_means_kwonly_star,
 )
 from hypothesis.internal.validation import (
     check_type,
@@ -430,7 +429,7 @@ def floats(
     Excluding either signed zero will also exclude the other.
     Attempting to exclude an endpoint which is None will raise an error;
     use ``allow_infinity=False`` to generate finite floats.  You can however
-    use e.g. ``min_value=float("-inf"), exclude_min=True`` to exclude only
+    use e.g. ``min_value=-math.inf, exclude_min=True`` to exclude only
     one infinite endpoint.
 
     Examples from this strategy have a complicated and hard to explain
@@ -481,9 +480,9 @@ def floats(
             "%d - use max_value=%r instead" % (max_arg, width, max_value)
         )
 
-    if exclude_min and (min_value is None or min_value == float("inf")):
+    if exclude_min and (min_value is None or min_value == math.inf):
         raise InvalidArgument("Cannot exclude min_value=%r" % (min_value,))
-    if exclude_max and (max_value is None or max_value == float("-inf")):
+    if exclude_max and (max_value is None or max_value == -math.inf):
         raise InvalidArgument("Cannot exclude max_value=%r" % (max_value,))
 
     if min_value is not None and (
@@ -505,9 +504,9 @@ def floats(
             max_value = next_down(max_value, width)
         assert max_value < max_arg  # type: ignore
 
-    if min_value == float("-inf"):
+    if min_value == -math.inf:
         min_value = None
-    if max_value == float("inf"):
+    if max_value == math.inf:
         max_value = None
 
     bad_zero_bounds = (
@@ -538,9 +537,9 @@ def floats(
                 "Cannot have allow_infinity=%r, with both min_value and "
                 "max_value" % (allow_infinity)
             )
-    elif min_value == float("inf"):
+    elif min_value == math.inf:
         raise InvalidArgument("allow_infinity=False excludes min_value=inf")
-    elif max_value == float("-inf"):
+    elif max_value == -math.inf:
         raise InvalidArgument("allow_infinity=False excludes max_value=-inf")
 
     unbounded_floats = FloatStrategy(
@@ -837,11 +836,10 @@ def iterables(
 
 
 @defines_strategy
-@reserved_means_kwonly_star
 def fixed_dictionaries(
     mapping,  # type: Dict[T, SearchStrategy[Ex]]
-    __reserved=not_set,  # type: Any
-    optional=None,  # type: Dict[T, SearchStrategy[Ex]]
+    *,
+    optional=None  # type: Dict[T, SearchStrategy[Ex]]
 ):
     # type: (...) -> SearchStrategy[Dict[T, Ex]]
     """Generates a dictionary of the same type as mapping with a fixed set of
@@ -858,8 +856,6 @@ def fixed_dictionaries(
     check_type(dict, mapping, "mapping")
     for k, v in mapping.items():
         check_strategy(v, "mapping[%r]" % (k,))
-    if __reserved is not not_set:
-        raise InvalidArgument("Do not pass __reserved; got %r" % (__reserved,))
     if optional is not None:
         check_type(dict, optional, "optional")
         for k, v in optional.items():
@@ -1915,7 +1911,7 @@ def complex_numbers(
     check_valid_magnitude(min_magnitude, "min_magnitude")
     check_valid_magnitude(max_magnitude, "max_magnitude")
     check_valid_interval(min_magnitude, max_magnitude, "min_magnitude", "max_magnitude")
-    if max_magnitude == float("inf"):
+    if max_magnitude == math.inf:
         max_magnitude = None
     if min_magnitude == 0:
         min_magnitude = None

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -13,7 +13,8 @@
 #
 # END HEADER
 
-from hypothesis.internal.compat import getfullargspec
+from inspect import getfullargspec
+
 from hypothesis.internal.reflection import (
     arg_string,
     convert_keyword_arguments,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -78,7 +78,7 @@ NASTY_FLOATS = sorted(
         1.192092896e-07,
         2.2204460492503131e-016,
     ]
-    + [float("inf"), float("nan")] * 5,
+    + [math.inf, math.nan] * 5,
     key=flt.float_to_lex,
 )
 NASTY_FLOATS = list(map(float, NASTY_FLOATS))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -26,7 +26,6 @@ from hypothesis.errors import (
     NonInteractiveExampleWarning,
     UnsatisfiedAssumption,
 )
-from hypothesis.internal.compat import bit_length, hrange
 from hypothesis.internal.conjecture.utils import (
     calc_label_from_cls,
     calc_label_from_name,
@@ -483,7 +482,7 @@ class SampledFromStrategy(SearchStrategy):
 
         # Start with ordinary rejection sampling. It's fast if it works, and
         # if it doesn't work then it was only a small amount of overhead.
-        for _ in hrange(3):
+        for _ in range(3):
             i = cu.integer_range(data, 0, len(self.elements) - 1)
             if check_index(i):
                 return self.elements[i]
@@ -495,7 +494,7 @@ class SampledFromStrategy(SearchStrategy):
 
         # Figure out the bit-length of the index that we will write back after
         # choosing an allowed element.
-        write_length = bit_length(len(self.elements))
+        write_length = len(self.elements).bit_length()
 
         # Impose an arbitrary cutoff to prevent us from wasting too much time
         # on very large element lists.
@@ -511,7 +510,7 @@ class SampledFromStrategy(SearchStrategy):
         # of them at random. But if we encounter the speculatively-chosen one,
         # just use that and return immediately.
         allowed_indices = []
-        for i in hrange(min(len(self.elements), cutoff)):
+        for i in range(min(len(self.elements), cutoff)):
             if check_index(i):
                 allowed_indices.append(i)
                 if len(allowed_indices) > speculative_index:
@@ -740,7 +739,7 @@ class FilteredStrategy(SearchStrategy):
         data.note_event(lazyformat("Retried draw from %r to satisfy filter", self))
 
     def default_do_filtered_draw(self, data):
-        for i in hrange(3):
+        for i in range(3):
             start_index = data.index
             value = data.draw(self.filtered_strategy)
             if self.condition(value):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
@@ -15,7 +15,6 @@
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import charmap
-from hypothesis.internal.compat import binary_type, hunichr
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.strategies._internal.strategies import (
@@ -65,7 +64,7 @@ class OneCharStringStrategy(SearchStrategy):
 
     def do_draw(self, data):
         i = integer_range(data, 0, len(self.intervals) - 1, center=self.zero_point)
-        return hunichr(self.intervals[i])
+        return chr(self.intervals[i])
 
 
 class StringStrategy(MappedSearchStrategy):
@@ -82,25 +81,9 @@ class StringStrategy(MappedSearchStrategy):
         return "".join(ls)
 
 
-class BinaryStringStrategy(MappedSearchStrategy):
-    """A strategy for strings of bytes, defined in terms of a strategy for
-    lists of bytes."""
-
-    def __repr__(self):
-        return "%r.map(bytearray).map(%s)" % (
-            self.mapped_strategy,
-            binary_type.__name__,
-        )
-
-    def pack(self, x):
-        assert isinstance(x, list), repr(x)
-        ba = bytearray(x)
-        return binary_type(ba)
-
-
 class FixedSizeBytes(SearchStrategy):
     def __init__(self, size):
         self.size = size
 
     def do_draw(self, data):
-        return binary_type(data.draw_bytes(self.size))
+        return bytes(data.draw_bytes(self.size))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -286,7 +286,7 @@ try:  # pragma: no cover
         arrays,
         array_shapes,
         scalar_dtypes,
-        nested_dtypes,
+        array_dtypes,
         from_dtype,
         integer_dtypes,
         unsigned_integer_dtypes,
@@ -294,7 +294,7 @@ try:  # pragma: no cover
 
     _global_type_lookup.update(
         {
-            np.dtype: nested_dtypes(),
+            np.dtype: array_dtypes(),
             np.ndarray: arrays(scalar_dtypes(), array_shapes(max_dims=2)),
         }
     )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -21,19 +21,12 @@ import functools
 import inspect
 import io
 import numbers
-import sys
 import uuid
+from types import FunctionType
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
-from hypothesis.internal.compat import (
-    PY2,
-    ForwardRef,
-    abc,
-    binary_type,
-    text_type,
-    typing_root_type,
-)
+from hypothesis.internal.compat import ForwardRef, typing_root_type
 from hypothesis.strategies._internal.lazy import unwrap_strategies
 from hypothesis.strategies._internal.strategies import OneOfStrategy
 
@@ -47,7 +40,7 @@ def type_sorting_key(t):
     if not isinstance(t, type):  # pragma: no cover
         # Some generics in the typing module are not actually types in 3.7
         return (2, repr(t))
-    return (int(issubclass(t, abc.Container)), repr(t))
+    return (int(issubclass(t, collections.abc.Container)), repr(t))
 
 
 def try_issubclass(thing, superclass):
@@ -163,8 +156,8 @@ def from_typing_type(thing):
     # (In 3.6 they're just aliases for the collections.abc classes)
     origin = getattr(thing, "__origin__", thing)
     if (
-        typing.Hashable is not abc.Hashable
-        and origin in vars(abc).values()
+        typing.Hashable is not collections.abc.Hashable
+        and origin in vars(collections.abc).values()
         and len(getattr(thing, "__args__", None) or []) == 0
     ):  # pragma: no cover  # impossible on 3.6 where we measure coverage.
         return st.from_type(origin)
@@ -202,7 +195,7 @@ def from_typing_type(thing):
             union_elems = elem_type.__union_params__  # python 3.5 only
         else:
             union_elems = ()
-        if PY2 or not any(
+        if not any(
             isinstance(T, type) and issubclass(int, T)
             for T in list(union_elems) + [elem_type]
         ):
@@ -239,8 +232,8 @@ _global_type_lookup = {
     complex: st.complex_numbers(),
     fractions.Fraction: st.fractions(),
     decimal.Decimal: st.decimals(),
-    text_type: st.text(),
-    binary_type: st.binary(),
+    str: st.text(),
+    bytes: st.binary(),
     datetime.datetime: st.datetimes(),
     datetime.date: st.dates(),
     datetime.time: st.times(),
@@ -249,10 +242,10 @@ _global_type_lookup = {
     tuple: st.builds(tuple),
     list: st.builds(list),
     set: st.builds(set),
-    abc.MutableSet: st.builds(set),
+    collections.abc.MutableSet: st.builds(set),
     frozenset: st.builds(frozenset),
     dict: st.builds(dict),
-    type(lambda: None): st.functions(),
+    FunctionType: st.functions(),
     # Built-in types
     type(Ellipsis): st.just(Ellipsis),
     type(NotImplemented): st.just(NotImplemented),
@@ -268,32 +261,14 @@ _global_type_lookup = {
         st.none() | st.integers(),
         st.none() | st.integers(),
         st.none() | st.integers(),
-    )
+    ),
+    range: st.one_of(
+        st.integers(min_value=0).map(range),
+        st.builds(range, st.integers(), st.integers()),
+        st.builds(range, st.integers(), st.integers(), st.integers().filter(bool)),
+    ),
     # Pull requests with more types welcome!
 }
-
-if PY2:
-    # xrange's |stop - start| must fit in a C long
-    int64_strat = st.integers(-sys.maxint // 2, sys.maxint // 2)  # noqa
-    _global_type_lookup.update(
-        {
-            int: st.integers().filter(lambda x: isinstance(x, int)),
-            long: st.integers().map(long),  # noqa
-            xrange: st.integers(min_value=0, max_value=sys.maxint).map(xrange)  # noqa
-            | st.builds(xrange, int64_strat, int64_strat)  # noqa
-            | st.builds(
-                xrange, int64_strat, int64_strat, int64_strat.filter(bool)  # noqa
-            ),
-        }
-    )
-else:
-    _global_type_lookup.update(
-        {
-            range: st.integers(min_value=0).map(range)
-            | st.builds(range, st.integers(), st.integers())
-            | st.builds(range, st.integers(), st.integers(), st.integers().filter(bool))
-        }
-    )
 
 _global_type_lookup[type] = st.sampled_from(
     [type(None)] + sorted(_global_type_lookup, key=str)

--- a/hypothesis-python/src/hypothesis/vendor/__init__.py
+++ b/hypothesis-python/src/hypothesis/vendor/__init__.py
@@ -1,7 +1,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis/
 #
-# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -80,8 +80,6 @@ from collections import deque
 from contextlib import contextmanager
 from io import StringIO
 
-from hypothesis.internal.compat import PY3, cast_unicode, get_stream_enc, string_types
-
 __all__ = [
     "pretty",
     "pprint",
@@ -110,24 +108,11 @@ def _safe_getattr(obj, attr, default=None):
         return default
 
 
-if PY3:
-    CUnicodeIO = StringIO
-else:  # pragma: no cover
-
-    class CUnicodeIO(StringIO):
-        """StringIO that casts str to unicode on Python 2."""
-
-        def write(self, text):
-            return super().write(
-                cast_unicode(text, encoding=get_stream_enc(sys.stdout))
-            )
-
-
 def pretty(
     obj, verbose=False, max_width=79, newline="\n", max_seq_length=MAX_SEQ_LENGTH
 ):
     """Pretty print the object's representation."""
-    stream = CUnicodeIO()
+    stream = StringIO()
     printer = RepresentationPrinter(
         stream, verbose, max_width, newline, max_seq_length=max_seq_length
     )
@@ -728,13 +713,13 @@ def _type_pprint(obj, p, cycle):
     mod = _safe_getattr(obj, "__module__", None)
     try:
         name = obj.__qualname__
-        if not isinstance(name, string_types):  # pragma: no cover
+        if not isinstance(name, str):  # pragma: no cover
             # This can happen if the type implements __qualname__ as a property
             # or other descriptor in Python 2.
             raise Exception("Try __name__")
     except Exception:  # pragma: no cover
         name = obj.__name__
-        if not isinstance(name, string_types):
+        if not isinstance(name, str):
             name = "<unknown type>"
 
     if mod in (None, "__builtin__", "builtins", "exceptions"):

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -1,7 +1,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis/
 #
-# Most of this work is copyright (C) 2013-2019 David R. MacIver
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-# -*- coding: utf-8 -*-
 """
 Python advanced pretty printer.  This pretty printer is intended to
 replace the old `pprint` python module which does not allow developers
@@ -137,7 +136,7 @@ def pprint(
 class _PrettyPrinterBase:
     @contextmanager
     def indent(self, indent):
-        """with statement support for indenting/dedenting."""
+        """`with`-statement support for indenting/dedenting."""
         self.indentation += indent
         try:
             yield
@@ -146,7 +145,7 @@ class _PrettyPrinterBase:
 
     @contextmanager
     def group(self, indent=0, open="", close=""):
-        """like begin_group / end_group but for the with statement."""
+        """Like begin_group / end_group but for the with statement."""
         self.begin_group(indent, open)
         try:
             yield
@@ -261,7 +260,7 @@ class PrettyPrinter(_PrettyPrinterBase):
         self.indentation += indent
 
     def _enumerate(self, seq):
-        """like enumerate, but with an upper limit on the number of items."""
+        """Like enumerate, but with an upper limit on the number of items."""
         for idx, x in enumerate(seq):
             if self.max_seq_length and idx >= self.max_seq_length:
                 self.text(",")
@@ -487,12 +486,6 @@ class GroupQueue:
             pass
 
 
-try:
-    _baseclass_reprs = (object.__repr__, types.InstanceType.__repr__)
-except AttributeError:  # Python 3
-    _baseclass_reprs = (object.__repr__,)  # type: ignore
-
-
 def _default_pprint(obj, p, cycle):
     """The default print function.
 
@@ -501,7 +494,7 @@ def _default_pprint(obj, p, cycle):
 
     """
     klass = _safe_getattr(obj, "__class__", None) or type(obj)
-    if _safe_getattr(klass, "__repr__", None) not in _baseclass_reprs:
+    if _safe_getattr(klass, "__repr__", None) is not object.__repr__:
         # A user-provided repr. Find newlines and replace them with p.break_()
         _repr_pprint(obj, p, cycle)
         return
@@ -788,25 +781,10 @@ _type_pprinters = {
     datetime.datetime: _repr_pprint,
     datetime.timedelta: _repr_pprint,
     _exception_base: _exception_pprint,
+    slice: _repr_pprint,
+    range: _repr_pprint,
+    bytes: _repr_pprint,
 }
-
-try:  # pragma: no cover
-    if types.DictProxyType != dict:
-        _type_pprinters[types.DictProxyType] = _dict_pprinter_factory(
-            "<dictproxy {", "}>"
-        )
-    _type_pprinters[types.ClassType] = _type_pprint
-    _type_pprinters[types.SliceType] = _repr_pprint
-except AttributeError:  # Python 3
-    _type_pprinters[slice] = _repr_pprint
-
-try:  # pragma: no cover
-    _type_pprinters[xrange] = _repr_pprint  # type: ignore
-    _type_pprinters[long] = _repr_pprint  # type: ignore
-    _type_pprinters[unicode] = _repr_pprint  # type: ignore
-except NameError:
-    _type_pprinters[range] = _repr_pprint
-    _type_pprinters[bytes] = _repr_pprint
 
 #: printers for types specified by name
 _deferred_type_pprinters = {}  # type: ignore

--- a/hypothesis-python/tests/common/__init__.py
+++ b/hypothesis-python/tests/common/__init__.py
@@ -41,16 +41,9 @@ from hypothesis.strategies import (
 )
 from tests.common.debug import TIME_INCREMENT
 
-try:
-    import pytest
-except ImportError:
-    pytest = None
-
-
 __all__ = ["standard_types", "OrderedPair", "TIME_INCREMENT"]
 
 OrderedPair = namedtuple("OrderedPair", ("left", "right"))
-
 
 ordered_pair = integers().flatmap(
     lambda right: integers(min_value=0).map(

--- a/hypothesis-python/tests/common/strategies.py
+++ b/hypothesis-python/tests/common/strategies.py
@@ -15,7 +15,6 @@
 
 import time
 
-from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.strategies._internal import SearchStrategy
 
 
@@ -35,7 +34,7 @@ class HardToShrink(SearchStrategy):
         self.accepted = set()
 
     def do_draw(self, data):
-        x = hbytes([data.draw_bits(8) for _ in range(100)])
+        x = bytes([data.draw_bits(8) for _ in range(100)])
         if x in self.accepted:
             return True
         ls = self.__last
@@ -46,7 +45,7 @@ class HardToShrink(SearchStrategy):
                 return True
             else:
                 return False
-        diffs = [i for i in hrange(len(x)) if x[i] != ls[i]]
+        diffs = [i for i in range(len(x)) if x[i] != ls[i]]
         if len(diffs) == 1:
             i = diffs[0]
             if x[i] + 1 == ls[i]:

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -16,11 +16,10 @@
 import contextlib
 import sys
 import traceback
-from io import BytesIO, StringIO
+from io import StringIO
 
 from hypothesis._settings import Phase
 from hypothesis.errors import HypothesisDeprecationWarning
-from hypothesis.internal.compat import PY2
 from hypothesis.internal.reflection import proxies
 from hypothesis.reporting import default, with_reporter
 
@@ -54,7 +53,7 @@ def flaky(max_runs, min_passes):
 def capture_out():
     old_out = sys.stdout
     try:
-        new_out = BytesIO() if PY2 else StringIO()
+        new_out = StringIO()
         sys.stdout = new_out
         with with_reporter(default):
             yield new_out

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -70,10 +70,7 @@ def consistently_increment_time(monkeypatch):
         frozen[0] = True
 
     monkeypatch.setattr(time_module, "time", time)
-    try:
-        monkeypatch.setattr(time_module, "monotonic", time)
-    except AttributeError:
-        assert sys.version_info[0] == 2
+    monkeypatch.setattr(time_module, "monotonic", time)
     monkeypatch.setattr(time_module, "sleep", sleep)
     monkeypatch.setattr(time_module, "freeze", freeze, raising=False)
 

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -17,7 +17,6 @@ from contextlib import contextmanager
 
 import hypothesis.internal.conjecture.engine as engine_module
 from hypothesis import HealthCheck, settings
-from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.utils import calc_label_from_name
@@ -41,7 +40,7 @@ def run_to_data(f):
 
 
 def run_to_buffer(f):
-    return hbytes(run_to_data(f).buffer)
+    return bytes(run_to_data(f).buffer)
 
 
 @contextmanager

--- a/hypothesis-python/tests/conjecture/test_choice_tree.py
+++ b/hypothesis-python/tests/conjecture/test_choice_tree.py
@@ -15,7 +15,6 @@
 
 import hypothesis.strategies as st
 from hypothesis import given
-from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.choicetree import ChoiceTree
 
 
@@ -41,11 +40,11 @@ def test_can_enumerate_a_shallow_set(ls):
 def test_can_enumerate_a_nested_set():
     @exhaust
     def nested(chooser):
-        i = chooser.choose(hrange(10))
-        j = chooser.choose(hrange(10), condition=lambda j: j > i)
+        i = chooser.choose(range(10))
+        j = chooser.choose(range(10), condition=lambda j: j > i)
         return (i, j)
 
-    assert sorted(nested) == [(i, j) for i in hrange(10) for j in hrange(i + 1, 10)]
+    assert sorted(nested) == [(i, j) for i in range(10) for j in range(i + 1, 10)]
 
 
 def test_can_enumerate_empty():
@@ -59,7 +58,7 @@ def test_can_enumerate_empty():
 def test_all_filtered_child():
     @exhaust
     def all_filtered(chooser):
-        chooser.choose(hrange(10), condition=lambda j: False)
+        chooser.choose(range(10), condition=lambda j: False)
 
     assert all_filtered == []
 
@@ -71,8 +70,8 @@ def test_skips_over_exhausted_children():
     def f(chooser):
         results.append(
             (
-                chooser.choose(hrange(3), condition=lambda x: x > 0),
-                chooser.choose(hrange(2)),
+                chooser.choose(range(3), condition=lambda x: x > 0),
+                chooser.choose(range(2)),
             )
         )
 
@@ -87,7 +86,7 @@ def test_skips_over_exhausted_children():
 
 def test_wraps_around_to_beginning():
     def f(chooser):
-        chooser.choose(hrange(3))
+        chooser.choose(range(3))
 
     tree = ChoiceTree()
 

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -19,7 +19,6 @@ import pytest
 
 from hypothesis import HealthCheck, settings
 from hypothesis.errors import Flaky
-from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
 from hypothesis.internal.conjecture.datatree import DataTree
 from hypothesis.internal.conjecture.engine import ConjectureRunner
@@ -38,7 +37,7 @@ def runner_for(*examples):
         runner.exit_with = lambda reason: None
         ran_examples = []
         for e in examples:
-            e = hbytes(e)
+            e = bytes(e)
             data = runner.cached_test_function(e)
             ran_examples.append((e, data))
         for e, d in ran_examples:
@@ -115,7 +114,7 @@ def test_novel_prefixes_are_novel():
     runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
     for _ in range(100):
         prefix = runner.tree.generate_novel_prefix(runner.random)
-        example = prefix + hbytes(8 - len(prefix))
+        example = prefix + bytes(8 - len(prefix))
         assert runner.tree.rewrite(example)[1] is None
         result = runner.cached_test_function(example)
         assert runner.tree.rewrite(example)[0] == result.buffer
@@ -140,9 +139,9 @@ def test_overruns_if_prefix():
 
 
 def test_stores_the_tree_flat_until_needed():
-    @runner_for(hbytes(10))
+    @runner_for(bytes(10))
     def runner(data):
-        for _ in hrange(10):
+        for _ in range(10):
             data.draw_bits(1)
         data.mark_interesting()
 
@@ -167,7 +166,7 @@ def test_split_in_the_middle():
 
 
 def test_stores_forced_nodes():
-    @runner_for(hbytes(3))
+    @runner_for(bytes(3))
     def runner(data):
         data.draw_bits(1, forced=0)
         data.draw_bits(1)
@@ -304,14 +303,14 @@ def test_changing_value_of_forced_is_flaky():
 
 def test_does_not_truncate_if_unseen():
     tree = DataTree()
-    b = hbytes([1, 2, 3, 4])
+    b = bytes([1, 2, 3, 4])
     assert tree.rewrite(b) == (b, None)
 
 
 def test_truncates_if_seen():
     tree = DataTree()
 
-    b = hbytes([1, 2, 3, 4])
+    b = bytes([1, 2, 3, 4])
 
     data = ConjectureData.for_buffer(b, observer=tree.new_observer())
     data.draw_bits(8)

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -19,7 +19,7 @@ import pytest
 
 import hypothesis.internal.conjecture.floats as flt
 from hypothesis import assume, example, given, strategies as st
-from hypothesis.internal.compat import ceil, floor, hbytes, int_from_bytes, int_to_bytes
+from hypothesis.internal.compat import ceil, floor, int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import float_to_int
@@ -72,7 +72,7 @@ def test_double_reverse(i):
 @example(1.0)
 @given(st.floats())
 def test_draw_write_round_trip(f):
-    d = ConjectureData.for_buffer(hbytes(10))
+    d = ConjectureData.for_buffer(bytes(10))
     flt.write_float(d, f)
     d2 = ConjectureData.for_buffer(d.buffer)
     g = flt.draw_float(d2)
@@ -162,7 +162,7 @@ def float_runner(start, condition):
             data.mark_interesting()
 
     runner = ConjectureRunner(test_function)
-    runner.cached_test_function(int_to_bytes(flt.float_to_lex(start), 8) + hbytes(1))
+    runner.cached_test_function(int_to_bytes(flt.float_to_lex(start), 8) + bytes(1))
     assert runner.interesting_examples
     return runner
 

--- a/hypothesis-python/tests/conjecture/test_intlist.py
+++ b/hypothesis-python/tests/conjecture/test_intlist.py
@@ -17,7 +17,6 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import assume, given
-from hypothesis.internal.compat import PY2
 from hypothesis.internal.conjecture.junkdrawer import IntList
 
 non_neg_lists = st.lists(st.integers(min_value=0, max_value=2 ** 63 - 1))
@@ -45,10 +44,6 @@ def test_basic_equality():
     assert not s
 
 
-@pytest.mark.skipif(
-    PY2,
-    reason="The Python 2 list fallback handles this and we don't really care enough to validate it there.",
-)
 def test_error_on_invalid_value():
     with pytest.raises(ValueError):
         IntList([-1])

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -16,7 +16,6 @@
 import pytest
 
 from hypothesis import example, given, strategies as st
-from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.junkdrawer import (
     IntList,
     LazySequenceCopy,
@@ -108,7 +107,7 @@ def test_assignment():
 
 
 def test_replacement():
-    replace_all(hbytes([1, 1, 1]), [(1, 3, hbytes([3, 4]))]) == hbytes([1, 3, 4, 1])
+    replace_all(bytes([1, 1, 1]), [(1, 3, bytes([3, 4]))]) == bytes([1, 3, 4, 1])
 
 
 def test_int_list_cannot_contain_negative():

--- a/hypothesis-python/tests/conjecture/test_minimizer.py
+++ b/hypothesis-python/tests/conjecture/test_minimizer.py
@@ -16,56 +16,55 @@
 from collections import Counter
 from random import Random
 
-from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.shrinking import Lexical
 
 
 def test_shrink_to_zero():
-    assert Lexical.shrink(
-        hbytes([255] * 8), lambda x: True, random=Random(0)
-    ) == hbytes(8)
+    assert Lexical.shrink(bytes([255] * 8), lambda x: True, random=Random(0)) == bytes(
+        8
+    )
 
 
 def test_shrink_to_smallest():
     assert Lexical.shrink(
-        hbytes([255] * 8), lambda x: sum(x) > 10, random=Random(0)
-    ) == hbytes([0] * 7 + [11])
+        bytes([255] * 8), lambda x: sum(x) > 10, random=Random(0)
+    ) == bytes([0] * 7 + [11])
 
 
 def test_float_hack_fails():
     assert Lexical.shrink(
-        hbytes([255] * 8), lambda x: x[0] >> 7, random=Random(0)
-    ) == hbytes([128] + [0] * 7)
+        bytes([255] * 8), lambda x: x[0] >> 7, random=Random(0)
+    ) == bytes([128] + [0] * 7)
 
 
 def test_can_sort_bytes_by_reordering():
-    start = hbytes([5, 4, 3, 2, 1, 0])
+    start = bytes([5, 4, 3, 2, 1, 0])
     finish = Lexical.shrink(start, lambda x: set(x) == set(start), random=Random(0))
-    assert finish == hbytes([0, 1, 2, 3, 4, 5])
+    assert finish == bytes([0, 1, 2, 3, 4, 5])
 
 
 def test_can_sort_bytes_by_reordering_partially():
-    start = hbytes([5, 4, 3, 2, 1, 0])
+    start = bytes([5, 4, 3, 2, 1, 0])
     finish = Lexical.shrink(
         start, lambda x: set(x) == set(start) and x[0] > x[-1], random=Random(0)
     )
-    assert finish == hbytes([1, 2, 3, 4, 5, 0])
+    assert finish == bytes([1, 2, 3, 4, 5, 0])
 
 
 def test_can_sort_bytes_by_reordering_partially2():
-    start = hbytes([5, 4, 3, 2, 1, 0])
+    start = bytes([5, 4, 3, 2, 1, 0])
     finish = Lexical.shrink(
         start,
         lambda x: Counter(x) == Counter(start) and x[0] > x[2],
         random=Random(0),
         full=True,
     )
-    assert finish <= hbytes([1, 2, 0, 3, 4, 5])
+    assert finish <= bytes([1, 2, 0, 3, 4, 5])
 
 
 def test_can_sort_bytes_by_reordering_partially_not_cross_stationary_element():
-    start = hbytes([5, 3, 0, 2, 1, 4])
+    start = bytes([5, 3, 0, 2, 1, 4])
     finish = Lexical.shrink(
         start, lambda x: set(x) == set(start) and x[3] == 2, random=Random(0)
     )
-    assert finish <= hbytes([0, 3, 5, 2, 1, 4])
+    assert finish <= bytes([0, 3, 5, 2, 1, 4])

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -16,7 +16,7 @@
 import pytest
 
 from hypothesis import settings
-from hypothesis.internal.compat import hbytes, hrange, int_to_bytes
+from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -98,7 +98,7 @@ def test_can_optimise_last_with_following_empty():
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, max_examples=100)
         )
-        runner.cached_test_function(hbytes(101))
+        runner.cached_test_function(bytes(101))
 
         with pytest.raises(RunIsComplete):
             runner.optimise_targets()
@@ -143,7 +143,7 @@ def test_targeting_can_drive_length_very_high():
             data.target_observations[""] = min(count, 100)
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.cached_test_function(hbytes(10))
+        runner.cached_test_function(bytes(10))
 
         try:
             runner.optimise_targets()
@@ -164,7 +164,7 @@ def test_optimiser_when_test_grows_buffer_to_invalid():
                 data.mark_invalid()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.cached_test_function(hbytes(10))
+        runner.cached_test_function(bytes(10))
 
         try:
             runner.optimise_targets()
@@ -181,10 +181,10 @@ def test_can_patch_up_examples():
             data.start_example(42)
             m = data.draw_bits(6)
             data.target_observations["m"] = m
-            for _ in hrange(m):
+            for _ in range(m):
                 data.draw_bits(1)
             data.stop_example()
-            for i in hrange(4):
+            for i in range(4):
                 if i != data.draw_bits(8):
                     data.mark_invalid()
 
@@ -212,7 +212,7 @@ def test_optimiser_when_test_grows_buffer_to_overflow():
                     data.mark_invalid()
 
             runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-            runner.cached_test_function(hbytes(10))
+            runner.cached_test_function(bytes(10))
 
             try:
                 runner.optimise_targets()

--- a/hypothesis-python/tests/conjecture/test_order_shrinking.py
+++ b/hypothesis-python/tests/conjecture/test_order_shrinking.py
@@ -17,7 +17,6 @@ from random import Random
 
 import hypothesis.strategies as st
 from hypothesis import example, given
-from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.shrinking import Ordering
 
 
@@ -50,7 +49,7 @@ def test_can_partially_sort_a_list_2():
 
 
 def test_adaptively_shrinks_around_hole():
-    initial = list(hrange(1000, 0, -1))
+    initial = list(range(1000, 0, -1))
     initial[500] = 2000
 
     intended_result = sorted(initial)

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -15,7 +15,7 @@
 
 from hypothesis import HealthCheck, Phase, settings
 from hypothesis.database import InMemoryExampleDatabase
-from hypothesis.internal.compat import hbytes, hrange, int_to_bytes
+from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -102,8 +102,8 @@ def test_clears_defunct_pareto_front():
             database_key=b"stuff",
         )
 
-        for i in hrange(256):
-            db.save(runner.pareto_key, hbytes([i, 0]))
+        for i in range(256):
+            db.save(runner.pareto_key, bytes([i, 0]))
 
         runner.run()
 
@@ -130,7 +130,7 @@ def test_down_samples_the_pareto_front():
             database_key=b"stuff",
         )
 
-        for i in hrange(10000):
+        for i in range(10000):
             db.save(runner.pareto_key, int_to_bytes(i, 2))
 
         runner.reuse_existing_examples()
@@ -159,7 +159,7 @@ def test_stops_loading_pareto_front_if_interesting():
             database_key=b"stuff",
         )
 
-        for i in hrange(10000):
+        for i in range(10000):
             db.save(runner.pareto_key, int_to_bytes(i, 2))
 
         runner.reuse_existing_examples()

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -20,7 +20,6 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given
 from hypothesis.errors import Frozen, InvalidArgument
-from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import (
     MAX_DEPTH,
     ConjectureData,
@@ -62,7 +61,7 @@ def test_can_draw_zero_bytes():
 
 
 def test_draw_past_end_sets_overflow():
-    x = ConjectureData.for_buffer(hbytes(5))
+    x = ConjectureData.for_buffer(bytes(5))
     with pytest.raises(StopTest) as e:
         x.draw_bytes(6)
     assert e.value.testcounter == x.testcounter
@@ -77,7 +76,7 @@ def test_notes_repr():
 
 
 def test_can_mark_interesting():
-    x = ConjectureData.for_buffer(hbytes())
+    x = ConjectureData.for_buffer(b"")
     with pytest.raises(StopTest):
         x.mark_interesting()
     assert x.frozen
@@ -85,12 +84,12 @@ def test_can_mark_interesting():
 
 
 def test_drawing_zero_bits_is_free():
-    x = ConjectureData.for_buffer(hbytes())
+    x = ConjectureData.for_buffer(b"")
     assert x.draw_bits(0) == 0
 
 
 def test_can_mark_invalid():
-    x = ConjectureData.for_buffer(hbytes())
+    x = ConjectureData.for_buffer(b"")
     with pytest.raises(StopTest):
         x.mark_invalid()
     assert x.frozen
@@ -132,7 +131,7 @@ def test_triviality():
     d.draw_bits(1)
     d.stop_example(1)
 
-    d.write(hbytes([2]))
+    d.write(bytes([2]))
     d.freeze()
 
     def eg(u, v):
@@ -145,7 +144,7 @@ def test_triviality():
 
 
 def test_example_depth_marking():
-    d = ConjectureData.for_buffer(hbytes(24))
+    d = ConjectureData.for_buffer(bytes(24))
 
     # These draw sizes are chosen so that each example has a unique length.
     d.draw_bytes(2)
@@ -163,14 +162,14 @@ def test_example_depth_marking():
 
 
 def test_has_examples_even_when_empty():
-    d = ConjectureData.for_buffer(hbytes())
+    d = ConjectureData.for_buffer(b"")
     d.draw(st.just(False))
     d.freeze()
     assert d.examples
 
 
 def test_has_cached_examples_even_when_overrun():
-    d = ConjectureData.for_buffer(hbytes(1))
+    d = ConjectureData.for_buffer(bytes(1))
     d.start_example(3)
     d.draw_bits(1)
     d.stop_example()
@@ -186,17 +185,17 @@ def test_has_cached_examples_even_when_overrun():
 def test_can_write_empty_string():
     d = ConjectureData.for_buffer([1, 1, 1])
     d.draw_bits(1)
-    d.write(hbytes())
+    d.write(b"")
     d.draw_bits(1)
     d.draw_bits(0, forced=0)
     d.draw_bits(1)
-    assert d.buffer == hbytes([1, 1, 1])
+    assert d.buffer == bytes([1, 1, 1])
 
 
 def test_blocks_preserve_identity():
     n = 10
     d = ConjectureData.for_buffer([1] * 10)
-    for _ in hrange(n):
+    for _ in range(n):
         d.draw_bits(1)
     d.freeze()
     blocks = [d.blocks[i] for i in range(n)]
@@ -207,10 +206,10 @@ def test_blocks_preserve_identity():
 
 def test_compact_blocks_during_generation():
     d = ConjectureData.for_buffer([1] * 10)
-    for _ in hrange(5):
+    for _ in range(5):
         d.draw_bits(1)
     assert len(list(d.blocks)) == 5
-    for _ in hrange(5):
+    for _ in range(5):
         d.draw_bits(1)
     assert len(list(d.blocks)) == 10
 
@@ -218,7 +217,7 @@ def test_compact_blocks_during_generation():
 def test_handles_indices_like_a_list():
     n = 5
     d = ConjectureData.for_buffer([1] * n)
-    for _ in hrange(n):
+    for _ in range(n):
         d.draw_bits(1)
     assert d.blocks[-1] is d.blocks[n - 1]
     assert d.blocks[-n] is d.blocks[0]
@@ -243,7 +242,7 @@ def test_can_observe_draws():
             self.log.append(("concluded",) + args)
 
     observer = LoggingObserver()
-    x = ConjectureData.for_buffer(hbytes([1, 2, 3]), observer=observer)
+    x = ConjectureData.for_buffer(bytes([1, 2, 3]), observer=observer)
 
     x.draw_bits(1)
     x.draw_bits(7, forced=10)
@@ -267,7 +266,7 @@ def test_calls_concluded_implicitly():
 
     observer = NoteConcluded()
 
-    x = ConjectureData.for_buffer(hbytes([1]), observer=observer)
+    x = ConjectureData.for_buffer(bytes([1]), observer=observer)
     x.draw_bits(1)
     x.freeze()
 
@@ -277,10 +276,10 @@ def test_calls_concluded_implicitly():
 def test_handles_start_indices_like_a_list():
     n = 5
     d = ConjectureData.for_buffer([1] * n)
-    for _ in hrange(n):
+    for _ in range(n):
         d.draw_bits(1)
 
-    for i in hrange(-2 * n, 2 * n + 1):
+    for i in range(-2 * n, 2 * n + 1):
         try:
             start = d.blocks.start(i)
         except IndexError:
@@ -301,7 +300,7 @@ def test_last_block_length():
     with pytest.raises(IndexError):
         d.blocks.last_block_length
 
-    for n in hrange(1, 5 + 1):
+    for n in range(1, 5 + 1):
         d.draw_bits(n * 8)
         assert d.blocks.last_block_length == n
 
@@ -321,7 +320,7 @@ def test_examples_show_up_as_discarded():
 
 
 def test_examples_support_negative_indexing():
-    d = ConjectureData.for_buffer(hbytes(2))
+    d = ConjectureData.for_buffer(bytes(2))
     d.draw_bits(1)
     d.draw_bits(1)
     d.freeze()
@@ -329,17 +328,17 @@ def test_examples_support_negative_indexing():
 
 
 def test_can_override_label():
-    d = ConjectureData.for_buffer(hbytes(2))
+    d = ConjectureData.for_buffer(bytes(2))
     d.draw(st.booleans(), label=7)
     d.freeze()
     assert any(ex.label == 7 for ex in d.examples)
 
 
 def test_will_mark_too_deep_examples_as_invalid():
-    d = ConjectureData.for_buffer(hbytes(0))
+    d = ConjectureData.for_buffer(bytes(0))
 
     s = st.none()
-    for _ in hrange(MAX_DEPTH + 1):
+    for _ in range(MAX_DEPTH + 1):
         s = s.map(lambda x: x)
 
     with pytest.raises(StopTest):
@@ -348,34 +347,34 @@ def test_will_mark_too_deep_examples_as_invalid():
 
 
 def test_empty_strategy_is_invalid():
-    d = ConjectureData.for_buffer(hbytes(0))
+    d = ConjectureData.for_buffer(bytes(0))
     with pytest.raises(StopTest):
         d.draw(st.nothing())
     assert d.status == Status.INVALID
 
 
 def test_will_error_on_find():
-    d = ConjectureData.for_buffer(hbytes(0))
+    d = ConjectureData.for_buffer(bytes(0))
     d.is_find = True
     with pytest.raises(InvalidArgument):
         d.draw(st.data())
 
 
 def test_can_note_non_str():
-    d = ConjectureData.for_buffer(hbytes(0))
+    d = ConjectureData.for_buffer(bytes(0))
     x = object()
     d.note(x)
     assert repr(x) in d.output
 
 
 def test_can_note_str_as_non_repr():
-    d = ConjectureData.for_buffer(hbytes(0))
+    d = ConjectureData.for_buffer(bytes(0))
     d.note("foo")
     assert d.output == "foo"
 
 
 def test_result_is_overrun():
-    d = ConjectureData.for_buffer(hbytes(0))
+    d = ConjectureData.for_buffer(bytes(0))
     with pytest.raises(StopTest):
         d.draw_bits(1)
     assert d.as_result() is Overrun
@@ -387,12 +386,12 @@ def test_trivial_before_force_agrees_with_trivial_after():
     d.draw_bits(1, forced=1)
     d.draw_bits(1)
 
-    t1 = [d.blocks.trivial(i) for i in hrange(3)]
+    t1 = [d.blocks.trivial(i) for i in range(3)]
     d.freeze()
     r = d.as_result()
     t2 = [b.trivial for b in r.blocks]
     assert d.blocks.owner is None
-    t3 = [r.blocks.trivial(i) for i in hrange(3)]
+    t3 = [r.blocks.trivial(i) for i in range(3)]
 
     assert t1 == t2 == t3
 
@@ -404,7 +403,7 @@ def test_events_are_noted():
 
 
 def test_blocks_end_points():
-    d = ConjectureData.for_buffer(hbytes(4))
+    d = ConjectureData.for_buffer(bytes(4))
     d.draw_bits(1)
     d.draw_bits(16, forced=1)
     d.draw_bits(8)
@@ -416,7 +415,7 @@ def test_blocks_end_points():
 
 
 def test_blocks_lengths():
-    d = ConjectureData.for_buffer(hbytes(7))
+    d = ConjectureData.for_buffer(bytes(7))
     d.draw_bits(32)
     d.draw_bits(16)
     d.draw_bits(1)
@@ -424,7 +423,7 @@ def test_blocks_lengths():
 
 
 def test_child_indices():
-    d = ConjectureData.for_buffer(hbytes(4))
+    d = ConjectureData.for_buffer(bytes(4))
 
     d.start_example(0)  # examples[1]
     d.start_example(0)  # examples[2]
@@ -446,7 +445,7 @@ def test_child_indices():
 
 
 def test_example_equality():
-    d = ConjectureData.for_buffer(hbytes(2))
+    d = ConjectureData.for_buffer(bytes(2))
 
     d.start_example(0)
     d.draw_bits(1)
@@ -481,7 +480,7 @@ def test_structural_coverage_is_cached():
 
 
 def test_examples_create_structural_coverage():
-    data = ConjectureData.for_buffer(hbytes(0))
+    data = ConjectureData.for_buffer(bytes(0))
     data.start_example(42)
     data.stop_example()
     data.freeze()
@@ -489,7 +488,7 @@ def test_examples_create_structural_coverage():
 
 
 def test_discarded_examples_do_not_create_structural_coverage():
-    data = ConjectureData.for_buffer(hbytes(0))
+    data = ConjectureData.for_buffer(bytes(0))
     data.start_example(42)
     data.stop_example(discard=True)
     data.freeze()
@@ -497,7 +496,7 @@ def test_discarded_examples_do_not_create_structural_coverage():
 
 
 def test_children_of_discarded_examples_do_not_create_structural_coverage():
-    data = ConjectureData.for_buffer(hbytes(0))
+    data = ConjectureData.for_buffer(bytes(0))
     data.start_example(10)
     data.start_example(42)
     data.stop_example()

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -30,7 +30,6 @@ from hypothesis import (
     strategies as st,
 )
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
@@ -39,17 +38,17 @@ def test_does_draw_data_for_empty_range():
     data = ConjectureData.for_buffer(b"\1")
     assert cu.integer_range(data, 1, 1) == 1
     data.freeze()
-    assert data.buffer == hbytes(b"\0")
+    assert data.buffer == b"\0"
 
 
 def test_uniform_float_shrinks_to_zero():
-    d = ConjectureData.for_buffer(hbytes([0] * 7))
+    d = ConjectureData.for_buffer(bytes(7))
     assert cu.fractional_float(d) == 0.0
     assert len(d.buffer) == 7
 
 
 def test_uniform_float_can_draw_1():
-    d = ConjectureData.for_buffer(hbytes([255] * 7))
+    d = ConjectureData.for_buffer(bytes([255] * 7))
     assert cu.fractional_float(d) == 1.0
     assert len(d.buffer) == 7
 
@@ -86,7 +85,7 @@ def test_unbiased_coin_has_no_second_order():
     counts = Counter()
 
     for i in range(256):
-        buf = hbytes([i])
+        buf = bytes([i])
         data = ConjectureData.for_buffer(buf)
         result = cu.biased_coin(data, 0.5)
         if data.buffer == buf:
@@ -111,7 +110,7 @@ def test_drawing_impossible_coin_still_writes():
 
 def test_drawing_an_exact_fraction_coin():
     count = 0
-    for i in hrange(8):
+    for i in range(8):
         if cu.biased_coin(ConjectureData.for_buffer([i]), Fraction(3, 8)):
             count += 1
     assert count == 3

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 import sys
+from inspect import getfullargspec
 
 import attr
 import pytest
@@ -21,7 +22,6 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import getfullargspec
 from hypothesis.internal.reflection import (
     convert_positional_arguments,
     define_function_signature,

--- a/hypothesis-python/tests/cover/test_cathetus.py
+++ b/hypothesis-python/tests/cover/test_cathetus.py
@@ -42,35 +42,31 @@ def test_cathetus_huge_no_overflow():
     h = sys.float_info.max
     a = h / math.sqrt(2)
     b = cathetus(h, a)
-    assert not (
-        math.isinf(b) or math.isnan(b)
-    ), "expecting finite cathetus(%g, %g), got %g" % (h, a, b)
+    assert math.isfinite(b), "expecting finite cathetus(%g, %g), got %g" % (h, a, b)
 
 
 def test_cathetus_large_no_overflow():
     h = sys.float_info.max / 3
     a = h / math.sqrt(2)
     b = cathetus(h, a)
-    assert not (
-        math.isinf(b) or math.isnan(b)
-    ), "expecting finite cathetus(%g, %g), got %g" % (h, a, b)
+    assert math.isfinite(b), "expecting finite cathetus(%g, %g), got %g" % (h, a, b)
 
 
 @pytest.mark.parametrize(
     "h,a",
     [
         # NaN hypot
-        (float("nan"), 3),
-        (float("nan"), 0),
-        (float("nan"), float("inf")),
-        (float("nan"), float("nan")),
+        (math.nan, 3),
+        (math.nan, 0),
+        (math.nan, math.inf),
+        (math.nan, math.nan),
         # Infeasible
         (2, 3),
         (2, -3),
-        (2, float("inf")),
-        (2, float("nan")),
+        (2, math.inf),
+        (2, math.nan),
         # Surprisingly consistent with c99 hypot()
-        (float("inf"), float("inf")),
+        (math.inf, math.inf),
     ],
 )
 def test_cathetus_nan(h, a):
@@ -78,13 +74,7 @@ def test_cathetus_nan(h, a):
 
 
 @pytest.mark.parametrize(
-    "h,a",
-    [
-        (float("inf"), 3),
-        (float("inf"), -3),
-        (float("inf"), 0),
-        (float("inf"), float("nan")),
-    ],
+    "h,a", [(math.inf, 3), (math.inf, -3), (math.inf, 0), (math.inf, math.nan)],
 )
 def test_cathetus_infinite(h, a):
     assert math.isinf(cathetus(h, a))

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -22,7 +22,6 @@ import unicodedata
 import hypothesis.internal.charmap as cm
 import hypothesis.strategies as st
 from hypothesis import assume, given
-from hypothesis.internal.compat import hunichr
 
 
 def test_charmap_contains_all_unicode():
@@ -37,7 +36,7 @@ def test_charmap_has_right_categories():
     for cat, intervals in cm.charmap().items():
         for u, v in intervals:
             for i in range(u, v + 1):
-                real = unicodedata.category(hunichr(i))
+                real = unicodedata.category(chr(i))
                 assert real == cat, "%d is %s but reported in %s" % (i, real, cat)
 
 
@@ -58,7 +57,7 @@ def test_query_matches_categories(exclude, include):
     assert_valid_range_list(values)
     for u, v in values:
         for i in (u, v, (u + v) // 2):
-            cat = unicodedata.category(hunichr(i))
+            cat = unicodedata.category(chr(i))
             if include is not None:
                 assert cat in include
             assert cat not in exclude
@@ -81,7 +80,7 @@ def test_query_matches_categories_codepoints(exclude, include, m1, m2):
 
 @given(st.sampled_from(cm.categories()), st.integers(0, sys.maxunicode))
 def test_exclude_only_excludes_from_that_category(cat, i):
-    c = hunichr(i)
+    c = chr(i)
     assume(unicodedata.category(c) != cat)
     intervals = cm.query(exclude_categories=(cat,))
     assert any(a <= i <= b for a, b in intervals)

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -98,5 +98,3 @@ def test_minmax_magnitude_equal(data, mag):
         assert math.isclose(abs(val), mag)
     except OverflowError:
         reject()
-    except AttributeError:
-        pass  # Python 2.7.3 does not have math.isclose

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -18,7 +18,6 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange
 from tests.common.debug import minimal
 from tests.common.utils import flaky
 
@@ -26,7 +25,7 @@ from tests.common.utils import flaky
 @st.composite
 def badly_draw_lists(draw, m=0):
     length = draw(st.integers(m, m + 10))
-    return [draw(st.integers()) for _ in hrange(length)]
+    return [draw(st.integers()) for _ in range(length)]
 
 
 def test_simplify_draws():

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -18,7 +18,6 @@ import datetime as dt
 import pytest
 
 from hypothesis import given, settings
-from hypothesis.internal.compat import hrange
 from hypothesis.strategies import dates, datetimes, timedeltas, times
 from tests.common.debug import find_any, minimal
 
@@ -90,7 +89,7 @@ def test_can_find_before_the_year_2000():
     assert minimal(dates(), lambda x: x.year < 2000).year == 1999
 
 
-@pytest.mark.parametrize("month", hrange(1, 13))
+@pytest.mark.parametrize("month", range(1, 13))
 def test_can_find_each_month(month):
     find_any(dates(), lambda x: x.month == month, settings(max_examples=10 ** 6))
 

--- a/hypothesis-python/tests/cover/test_deferred_strategies.py
+++ b/hypothesis-python/tests/cover/test_deferred_strategies.py
@@ -17,7 +17,6 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange
 from tests.common.debug import assert_no_examples, minimal
 
 
@@ -131,7 +130,7 @@ def test_very_deep_deferral():
         else:
             return st.deferred(lambda: st.tuples(strategies[(i + 1) % len(strategies)]))
 
-    strategies = list(map(strat, hrange(100)))
+    strategies = list(map(strat, range(100)))
 
     assert strategies[0].has_reusable_values
     assert not strategies[0].is_empty

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -54,10 +54,10 @@ def fn_ktest(*fnkwargs):
 
 
 @fn_ktest(
-    (ds.integers, {"min_value": float("nan")}),
+    (ds.integers, {"min_value": math.nan}),
     (ds.integers, {"min_value": 2, "max_value": 1}),
-    (ds.integers, {"min_value": float("nan")}),
-    (ds.integers, {"max_value": float("nan")}),
+    (ds.integers, {"min_value": math.nan}),
+    (ds.integers, {"max_value": math.nan}),
     (ds.integers, {"min_value": decimal.Decimal("1.5")}),
     (ds.integers, {"max_value": decimal.Decimal("1.5")}),
     (ds.integers, {"min_value": -1.5, "max_value": -0.5}),
@@ -71,8 +71,8 @@ def fn_ktest(*fnkwargs):
         ds.datetimes,
         {"min_value": datetime(2017, 8, 22), "max_value": datetime(2017, 8, 21)},
     ),
-    (ds.decimals, {"min_value": float("nan")}),
-    (ds.decimals, {"max_value": float("nan")}),
+    (ds.decimals, {"min_value": math.nan}),
+    (ds.decimals, {"max_value": math.nan}),
     (ds.decimals, {"min_value": 2, "max_value": 1}),
     (ds.decimals, {"max_value": "-snan"}),
     (ds.decimals, {"max_value": complex(1, 2)}),
@@ -91,8 +91,8 @@ def fn_ktest(*fnkwargs):
         ds.dictionaries,
         {"keys": ds.booleans(), "values": ds.booleans(), "min_size": 10, "max_size": 1},
     ),
-    (ds.floats, {"min_value": float("nan")}),
-    (ds.floats, {"max_value": float("nan")}),
+    (ds.floats, {"min_value": math.nan}),
+    (ds.floats, {"max_value": math.nan}),
     (ds.floats, {"min_value": complex(1, 2)}),
     (ds.floats, {"max_value": complex(1, 2)}),
     (ds.floats, {"exclude_min": None}),
@@ -102,8 +102,8 @@ def fn_ktest(*fnkwargs):
     (ds.floats, {"min_value": 1.8, "width": 32}),
     (ds.floats, {"max_value": 1.8, "width": 32}),
     (ds.fractions, {"min_value": 2, "max_value": 1}),
-    (ds.fractions, {"min_value": float("nan")}),
-    (ds.fractions, {"max_value": float("nan")}),
+    (ds.fractions, {"min_value": math.nan}),
+    (ds.fractions, {"max_value": math.nan}),
     (ds.fractions, {"max_denominator": 0}),
     (ds.fractions, {"max_denominator": 1.5}),
     (ds.fractions, {"min_value": complex(1, 2)}),
@@ -114,7 +114,7 @@ def fn_ktest(*fnkwargs):
     (ds.lists, {"elements": ds.integers(), "min_size": -10, "max_size": -9}),
     (ds.lists, {"elements": ds.integers(), "max_size": -9}),
     (ds.lists, {"elements": ds.integers(), "min_size": -10}),
-    (ds.lists, {"elements": ds.integers(), "min_size": float("nan")}),
+    (ds.lists, {"elements": ds.integers(), "min_size": math.nan}),
     (ds.lists, {"elements": ds.nothing(), "max_size": 1}),
     (ds.lists, {"elements": "hi"}),
     (ds.lists, {"elements": ds.integers(), "unique_by": 1}),
@@ -125,7 +125,7 @@ def fn_ktest(*fnkwargs):
     (ds.text, {"alphabet": [1]}),
     (ds.text, {"alphabet": ["abc"]}),
     (ds.binary, {"min_size": 10, "max_size": 9}),
-    (ds.floats, {"min_value": float("nan")}),
+    (ds.floats, {"min_value": math.nan}),
     (ds.floats, {"min_value": "0"}),
     (ds.floats, {"max_value": "0"}),
     (ds.floats, {"min_value": 0.0, "max_value": -0.0}),
@@ -134,10 +134,10 @@ def fn_ktest(*fnkwargs):
     (ds.floats, {"min_value": 0.0, "allow_nan": True}),
     (ds.floats, {"max_value": 0.0, "allow_nan": True}),
     (ds.floats, {"min_value": 0.0, "max_value": 1.0, "allow_infinity": True}),
-    (ds.floats, {"min_value": float("inf"), "allow_infinity": False}),
-    (ds.floats, {"max_value": float("-inf"), "allow_infinity": False}),
-    (ds.complex_numbers, {"min_magnitude": float("nan")}),
-    (ds.complex_numbers, {"max_magnitude": float("nan")}),
+    (ds.floats, {"min_value": math.inf, "allow_infinity": False}),
+    (ds.floats, {"max_value": -math.inf, "allow_infinity": False}),
+    (ds.complex_numbers, {"min_magnitude": math.nan}),
+    (ds.complex_numbers, {"max_magnitude": math.nan}),
     (ds.complex_numbers, {"max_magnitude": complex(1, 2)}),
     (ds.complex_numbers, {"min_magnitude": -1}),
     (ds.complex_numbers, {"max_magnitude": -1}),
@@ -216,8 +216,8 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.floats, {}),
     (ds.floats, {"min_value": 1.0}),
     (ds.floats, {"max_value": 1.0}),
-    (ds.floats, {"min_value": float("inf")}),
-    (ds.floats, {"max_value": float("-inf")}),
+    (ds.floats, {"min_value": math.inf}),
+    (ds.floats, {"max_value": -math.inf}),
     (ds.floats, {"max_value": 1.0, "min_value": -1.0}),
     (ds.floats, {"max_value": 1.0, "min_value": -1.0, "allow_infinity": False}),
     (ds.floats, {"min_value": 1.0, "allow_nan": False}),
@@ -232,7 +232,7 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.complex_numbers, {"allow_nan": False}),
     (ds.complex_numbers, {"allow_nan": False, "allow_infinity": True}),
     (ds.complex_numbers, {"allow_nan": False, "allow_infinity": False}),
-    (ds.complex_numbers, {"max_magnitude": float("inf"), "allow_infinity": True}),
+    (ds.complex_numbers, {"max_magnitude": math.inf, "allow_infinity": True}),
     (ds.sampled_from, {"elements": [1]}),
     (ds.sampled_from, {"elements": [1, 2, 3]}),
     (ds.fixed_dictionaries, {"mapping": {1: ds.integers()}}),
@@ -336,15 +336,15 @@ def test_decimal_is_in_bounds(x):
 
 
 def test_float_can_find_max_value_inf():
-    assert minimal(ds.floats(max_value=float("inf")), lambda x: math.isinf(x)) == float(
+    assert minimal(ds.floats(max_value=math.inf), lambda x: math.isinf(x)) == float(
         "inf"
     )
-    assert minimal(ds.floats(min_value=0.0), lambda x: math.isinf(x)) == float("inf")
+    assert minimal(ds.floats(min_value=0.0), lambda x: math.isinf(x)) == math.inf
 
 
 def test_float_can_find_min_value_inf():
     minimal(ds.floats(), lambda x: x < 0 and math.isinf(x))
-    minimal(ds.floats(min_value=float("-inf"), max_value=0.0), lambda x: math.isinf(x))
+    minimal(ds.floats(min_value=-math.inf, max_value=0.0), lambda x: math.isinf(x))
 
 
 def test_can_find_none_list():

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -20,7 +20,6 @@ import pytest
 
 from hypothesis import Phase, Verbosity, example, given, note, reporting, settings
 from hypothesis.errors import DeadlineExceeded, InvalidArgument
-from hypothesis.internal.compat import integer_types, print_unicode
 from hypothesis.strategies import integers, nothing, text
 from tests.common.utils import assert_falsifying_output, capture_out
 
@@ -29,17 +28,17 @@ class TestInstanceMethods(TestCase):
     @given(integers())
     @example(1)
     def test_hi_1(self, x):
-        assert isinstance(x, integer_types)
+        assert isinstance(x, int)
 
     @given(integers())
     @example(x=1)
     def test_hi_2(self, x):
-        assert isinstance(x, integer_types)
+        assert isinstance(x, int)
 
     @given(x=integers())
     @example(x=1)
     def test_hi_3(self, x):
-        assert isinstance(x, integer_types)
+        assert isinstance(x, int)
 
 
 def test_kwarg_example_on_testcase():
@@ -47,7 +46,7 @@ def test_kwarg_example_on_testcase():
         @given(integers())
         @example(x=1)
         def test_hi(self, x):
-            assert isinstance(x, integer_types)
+            assert isinstance(x, int)
 
     Stuff("test_hi").test_hi()
 
@@ -183,7 +182,7 @@ def test_examples_are_tried_in_order():
     @settings(phases=[Phase.explicit])
     @example(x=3)
     def test(x):
-        print_unicode("x -> %d" % (x,))
+        print("x -> %d" % (x,))
 
     with capture_out() as out:
         with reporting.with_reporter(reporting.default):
@@ -205,7 +204,7 @@ def test_prints_note_in_failing_example():
             with pytest.raises(AssertionError):
                 test()
     v = out.getvalue()
-    print_unicode(v)
+    print(v)
     assert "x -> 43" in v
     assert "x -> 42" not in v
 

--- a/hypothesis-python/tests/cover/test_feature_flags.py
+++ b/hypothesis-python/tests/cover/test_feature_flags.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 from hypothesis import given, strategies as st
-from hypothesis.internal.compat import hrange
 from hypothesis.strategies._internal.featureflags import FeatureFlags, FeatureStrategy
 from tests.common.debug import find_any, minimal
 
@@ -22,11 +21,11 @@ STRAT = FeatureStrategy()
 
 
 def test_can_all_be_enabled():
-    find_any(STRAT, lambda x: all(x.is_enabled(i) for i in hrange(100)))
+    find_any(STRAT, lambda x: all(x.is_enabled(i) for i in range(100)))
 
 
 def test_minimizes_open():
-    features = hrange(10)
+    features = range(10)
 
     flags = minimal(STRAT, lambda x: [x.is_enabled(i) for i in features])
 
@@ -34,7 +33,7 @@ def test_minimizes_open():
 
 
 def test_minimizes_individual_features_to_open():
-    features = list(hrange(10))
+    features = list(range(10))
 
     flags = minimal(
         STRAT, lambda x: sum(x.is_enabled(i) for i in features) < len(features)

--- a/hypothesis-python/tests/cover/test_float_nastiness.py
+++ b/hypothesis-python/tests/cover/test_float_nastiness.py
@@ -242,21 +242,21 @@ def test_can_exclude_endpoints(x):
     assert 0 < x < 1
 
 
-@given(st.floats(float("-inf"), -1e307, exclude_min=True))
+@given(st.floats(-math.inf, -1e307, exclude_min=True))
 def test_can_exclude_neg_infinite_endpoint(x):
     assert not math.isinf(x)
 
 
-@given(st.floats(1e307, float("inf"), exclude_max=True))
+@given(st.floats(1e307, math.inf, exclude_max=True))
 def test_can_exclude_pos_infinite_endpoint(x):
     assert not math.isinf(x)
 
 
 def test_exclude_infinite_endpoint_is_invalid():
     with pytest.raises(InvalidArgument):
-        st.floats(min_value=float("inf"), exclude_min=True).validate()
+        st.floats(min_value=math.inf, exclude_min=True).validate()
     with pytest.raises(InvalidArgument):
-        st.floats(max_value=float("-inf"), exclude_max=True).validate()
+        st.floats(max_value=-math.inf, exclude_max=True).validate()
 
 
 @pytest.mark.parametrize("lo,hi", [(True, False), (False, True), (True, True)])

--- a/hypothesis-python/tests/cover/test_float_utils.py
+++ b/hypothesis-python/tests/cover/test_float_utils.py
@@ -27,11 +27,11 @@ def test_can_handle_straddling_zero():
 @pytest.mark.parametrize(
     "func,val",
     [
-        (next_up, float("nan")),
-        (next_up, float("inf")),
+        (next_up, math.nan),
+        (next_up, math.inf),
         (next_up, -0.0),
-        (next_down, float("nan")),
-        (next_down, float("-inf")),
+        (next_down, math.nan),
+        (next_down, -math.inf),
         (next_down, 0.0),
     ],
 )

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -13,11 +13,12 @@
 #
 # END HEADER
 
+from inspect import getfullargspec
+
 import pytest
 
 from hypothesis import given
 from hypothesis.errors import InvalidArgument, InvalidState
-from hypothesis.internal.compat import getfullargspec
 from hypothesis.strategies import booleans, functions
 
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -27,12 +27,7 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, assume, given, infer, settings
 from hypothesis.errors import InvalidArgument, ResolutionFailed, Unsatisfiable
-from hypothesis.internal.compat import (
-    ForwardRef,
-    get_type_hints,
-    integer_types,
-    typing_root_type,
-)
+from hypothesis.internal.compat import ForwardRef, get_type_hints, typing_root_type
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types
 from tests.common.debug import find_any, minimal
@@ -395,9 +390,9 @@ def test_resolves_NewType():
     typ = typing.NewType("T", int)
     nested = typing.NewType("NestedT", typ)
     uni = typing.NewType("UnionT", typing.Optional[int])
-    assert isinstance(from_type(typ).example(), integer_types)
-    assert isinstance(from_type(nested).example(), integer_types)
-    assert isinstance(from_type(uni).example(), integer_types + (type(None),))
+    assert isinstance(from_type(typ).example(), int)
+    assert isinstance(from_type(nested).example(), int)
+    assert isinstance(from_type(uni).example(), (int, type(None)))
 
 
 E = enum.Enum("E", "a b c")

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -14,7 +14,7 @@
 # END HEADER
 
 import decimal
-from math import copysign
+from math import copysign, inf
 
 import pytest
 
@@ -40,16 +40,8 @@ def test_fuzz_floats_bounds(data):
     low, high = data.draw(tuples(bound, bound), label="low, high")
     if low is not None and high is not None and low > high:
         low, high = high, low
-    exmin = (
-        low is not None
-        and low != float("inf")
-        and data.draw(booleans(), label="exclude_min")
-    )
-    exmax = (
-        high is not None
-        and high != float("-inf")
-        and data.draw(booleans(), label="exclude_max")
-    )
+    exmin = low is not None and low != inf and data.draw(booleans(), label="ex_min")
+    exmax = high is not None and high != -inf and data.draw(booleans(), label="ex_max")
     try:
         val = data.draw(
             floats(low, high, exclude_min=exmin, exclude_max=exmax), label="value"

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -17,6 +17,7 @@ import sys
 from copy import deepcopy
 from functools import partial
 from inspect import FullArgSpec, getfullargspec
+from unittest.mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
 import pytest
 
@@ -36,11 +37,6 @@ from hypothesis.internal.reflection import (
     unbind_method,
 )
 from tests.common.utils import raises
-
-try:
-    from unittest.mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
-except ImportError:
-    from mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
 
 def do_conversion_test(f, args, kwargs):

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -16,11 +16,11 @@
 import sys
 from copy import deepcopy
 from functools import partial
+from inspect import FullArgSpec, getfullargspec
 
 import pytest
 
 import hypothesis.internal.reflection as reflection
-from hypothesis.internal.compat import PY2, PY3, FullArgSpec, getfullargspec
 from hypothesis.internal.reflection import (
     arg_string,
     convert_keyword_arguments,
@@ -621,16 +621,6 @@ def test_can_handle_repr_of_none():
     assert arg_string(foo, [], {"x": None}) == "x=None"
 
 
-if not PY3:
-
-    def test_can_handle_non_unicode_repr_containing_non_ascii():
-        def foo(x):
-            pass
-
-        assert arg_string(foo, [BittySnowman()], {}) == "x=☃"
-        assert arg_string(foo, [], {"x": BittySnowman()}) == "x=☃"
-
-
 def test_kwargs_appear_in_arg_string():
     def varargs(*args, **kwargs):
         pass
@@ -689,7 +679,6 @@ def test_can_handle_unicode_identifier_in_same_line_as_lambda_def():
     assert get_pretty_function_description(is_str_pi) == "lambda x: x == pi"
 
 
-@pytest.mark.skipif(PY2, reason="detect_encoding does not exist in Python 2")
 def test_can_render_lambda_with_no_encoding(monkeypatch):
     is_positive = lambda x: x > 0
 
@@ -701,7 +690,6 @@ def test_can_render_lambda_with_no_encoding(monkeypatch):
     assert get_pretty_function_description(is_positive) == "lambda x: x > 0"
 
 
-@pytest.mark.skipif(PY2, reason="detect_encoding does not exist in Python 2")
 def test_does_not_crash_on_utf8_lambda_without_encoding(monkeypatch):
     # Monkey-patching out the `detect_encoding` method here means
     # that our reflection can't detect the encoding of the source file, and

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -22,13 +22,12 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import assume, given, settings
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import PY2, PY3, PYPY, hrange, hunichr
+from hypothesis.internal.compat import PYPY
 from hypothesis.strategies._internal.regex import (
     SPACE_CHARS,
     UNICODE_DIGIT_CATEGORIES,
     UNICODE_SPACE_CATEGORIES,
     UNICODE_SPACE_CHARS,
-    UNICODE_WEIRD_NONWORD_CHARS,
     UNICODE_WORD_CATEGORIES,
     base_regex_strategy,
 )
@@ -56,18 +55,12 @@ def is_unicode_space(s):
 
 def is_word(s):
     return all(
-        c == "_"
-        or (
-            (PY3 or c not in UNICODE_WEIRD_NONWORD_CHARS)
-            and unicodedata.category(c) in UNICODE_WORD_CATEGORIES
-        )
-        for c in s
+        c == "_" or unicodedata.category(c) in UNICODE_WORD_CATEGORIES for c in s
     )
 
 
 def ascii_regex(pattern):
-    flags = re.ASCII if PY3 else 0
-    return re.compile(pattern, flags)
+    return re.compile(pattern, re.ASCII)
 
 
 def unicode_regex(pattern):
@@ -77,8 +70,8 @@ def unicode_regex(pattern):
 def _test_matching_pattern(pattern, isvalidchar, is_unicode=False):
     r = unicode_regex(pattern) if is_unicode else ascii_regex(pattern)
 
-    codepoints = hrange(0, sys.maxunicode + 1) if is_unicode else hrange(1, 128)
-    for c in [hunichr(x) for x in codepoints]:
+    codepoints = range(0, sys.maxunicode + 1) if is_unicode else range(1, 128)
+    for c in [chr(x) for x in codepoints]:
         if isvalidchar(c):
             assert r.search(c), (
                 '"%s" supposed to match "%s" (%r, category "%s"), '
@@ -273,7 +266,7 @@ def test_groupref_not_shared_between_regex():
 
 
 @pytest.mark.skipif(
-    PYPY or PY2,  # Skip for now so we can test the rest
+    PYPY,  # Skip for now so we can test the rest
     reason=r"Triggers bugs in poor handling of unicode in re for these implementations",
 )
 @given(st.data())

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -20,7 +20,8 @@ import unicodedata
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import assume, given, settings
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis._settings import local_settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import PYPY
 from hypothesis.strategies._internal.regex import (
@@ -143,7 +144,8 @@ def test_matching(category, predicate, invert, is_unicode):
 def test_can_generate(pattern, encode):
     if encode:
         pattern = pattern.encode("ascii")
-    assert_all_examples(st.from_regex(pattern), re.compile(pattern).search)
+    with local_settings(settings(suppress_health_check=[HealthCheck.data_too_large])):
+        assert_all_examples(st.from_regex(pattern), re.compile(pattern).search)
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_regressions.py
+++ b/hypothesis-python/tests/cover/test_regressions.py
@@ -14,15 +14,11 @@
 # END HEADER
 
 import random
+from unittest.mock import Mock
 
 import pytest
 
 from hypothesis import Verbosity, assume, given, seed, settings, strategies as st
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
 
 
 def strat():

--- a/hypothesis-python/tests/cover/test_reporting.py
+++ b/hypothesis-python/tests/cover/test_reporting.py
@@ -20,7 +20,6 @@ import pytest
 
 from hypothesis import given, reporting
 from hypothesis._settings import Verbosity, settings
-from hypothesis.internal.compat import PY2
 from hypothesis.reporting import debug_report, report, verbose_report
 from hypothesis.strategies import integers
 from tests.common.utils import capture_out
@@ -90,7 +89,6 @@ def test_does_print_verbose_in_debug():
     assert "Hi" in o.getvalue()
 
 
-@pytest.mark.skipif(PY2, reason="Output streams don't have encodings in python 2")
 def test_can_report_when_system_locale_is_ascii(monkeypatch):
     read, write = os.pipe()
     with open(read, "r", encoding="ascii") as read:

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -31,12 +31,11 @@ from hypothesis import (
 )
 from hypothesis.core import decode_failure, encode_failure
 from hypothesis.errors import DidNotReproduce, InvalidArgument, UnsatisfiedAssumption
-from hypothesis.internal.compat import hbytes
 from tests.common.utils import capture_out, no_shrink
 
 
-@example(hbytes(20))  # shorter compressed
-@example(hbytes(3))  # shorter uncompressed
+@example(bytes(20))  # shorter compressed
+@example(bytes(3))  # shorter uncompressed
 @given(st.binary() | st.binary(min_size=100))
 def test_encoding_loop(b):
     assert decode_failure(encode_failure(b)) == b

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -19,7 +19,6 @@ import enum
 import hypothesis.strategies as st
 from hypothesis import given
 from hypothesis.errors import FailedHealthCheck, InvalidArgument, Unsatisfiable
-from hypothesis.internal.compat import hrange
 from hypothesis.strategies import sampled_from
 from tests.common.utils import fails_with
 
@@ -47,13 +46,13 @@ def test_can_sample_enums(member):
 
 
 @fails_with(FailedHealthCheck)
-@given(sampled_from(hrange(10)).filter(lambda x: x < 0))
+@given(sampled_from(range(10)).filter(lambda x: x < 0))
 def test_unsat_filtered_sampling(x):
     assert False
 
 
 @fails_with(Unsatisfiable)
-@given(sampled_from(hrange(2)).filter(lambda x: x < 0))
+@given(sampled_from(range(2)).filter(lambda x: x < 0))
 def test_unsat_filtered_sampling_in_rejection_stage(x):
     # Rejecting all possible indices before we calculate the allowed indices
     # takes an early exit path, so we need this test to cover that branch.
@@ -61,11 +60,11 @@ def test_unsat_filtered_sampling_in_rejection_stage(x):
 
 
 def test_easy_filtered_sampling():
-    x = sampled_from(hrange(100)).filter(lambda x: x == 0).example()
+    x = sampled_from(range(100)).filter(lambda x: x == 0).example()
     assert x == 0
 
 
-@given(sampled_from(hrange(100)).filter(lambda x: x == 99))
+@given(sampled_from(range(100)).filter(lambda x: x == 99))
 def test_filtered_sampling_finds_rare_value(x):
     assert x == 99
 
@@ -80,7 +79,7 @@ def test_does_not_include_duplicates_even_when_duplicated_in_collection(ls):
     assert len(ls) <= 1
 
 
-@given(st.lists(st.sampled_from(hrange(100)), max_size=3, unique=True))
+@given(st.lists(st.sampled_from(range(100)), max_size=3, unique=True))
 def test_max_size_is_respected_with_unique_sampled_from(ls):
     assert len(ls) <= 3
 

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -19,7 +19,6 @@ from collections import namedtuple
 import pytest
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import text_type
 from hypothesis.strategies import booleans, integers, just, randoms, tuples
 from hypothesis.strategies._internal.strategies import one_of_strategies
 from hypothesis.types import RandomWithSeed
@@ -50,7 +49,7 @@ def last(xs):
 def test_random_repr_has_seed():
     rnd = randoms().example()
     seed = rnd.seed
-    assert text_type(seed) in repr(rnd)
+    assert str(seed) in repr(rnd)
 
 
 def test_random_only_produces_special_random():

--- a/hypothesis-python/tests/cover/test_seed_printing.py
+++ b/hypothesis-python/tests/cover/test_seed_printing.py
@@ -22,7 +22,6 @@ import hypothesis.strategies as st
 from hypothesis import Verbosity, assume, given, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck
-from hypothesis.internal.compat import hrange
 from tests.common.utils import all_values, capture_out
 
 
@@ -77,7 +76,7 @@ def test_uses_global_force(monkeypatch):
 
     output = []
 
-    for _ in hrange(2):
+    for _ in range(2):
         with capture_out() as o:
             with pytest.raises(ValueError):
                 test()

--- a/hypothesis-python/tests/cover/test_shrink_budgeting.py
+++ b/hypothesis-python/tests/cover/test_shrink_budgeting.py
@@ -19,7 +19,6 @@ from random import Random
 
 import pytest
 
-from hypothesis.internal.compat import ceil
 from hypothesis.internal.conjecture.shrinking import Integer, Lexical, Ordering
 
 
@@ -34,7 +33,7 @@ def measure_baseline(cls, value, **kwargs):
 def test_meets_budgetary_requirements(cls, example):
     # Somewhat arbitrary but not unreasonable budget.
     n = len(example)
-    budget = n * ceil(math.log(n, 2)) + 5
+    budget = n * math.ceil(math.log(n, 2)) + 5
     assert measure_baseline(cls, example) <= budget
 
 

--- a/hypothesis-python/tests/cover/test_simple_characters.py
+++ b/hypothesis-python/tests/cover/test_simple_characters.py
@@ -18,7 +18,6 @@ import unicodedata
 import pytest
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import text_type
 from hypothesis.strategies import characters
 from tests.common.debug import assert_no_examples, find_any, minimal
 from tests.common.utils import fails_with
@@ -108,8 +107,8 @@ def test_whitelisted_characters_overlap_blacklisted_characters():
             whitelist_characters=good_chars,
             blacklist_characters=bad_chars,
         ).example()
-        assert repr(good_chars) in text_type(exc)
-        assert repr(bad_chars) in text_type(exc)
+        assert repr(good_chars) in str(exc)
+        assert repr(bad_chars) in str(exc)
 
 
 def test_whitelisted_characters_override():

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -23,7 +23,6 @@ from hypothesis import __version__, reproduce_failure, seed, settings as Setting
 from hypothesis.control import current_build_context
 from hypothesis.database import ExampleDatabase
 from hypothesis.errors import DidNotReproduce, Flaky, InvalidArgument, InvalidDefinition
-from hypothesis.internal.compat import print_unicode
 from hypothesis.stateful import (
     Bundle,
     RuleBasedStateMachine,
@@ -139,7 +138,7 @@ class DepthMachine(RuleBasedStateMachine):
 
 class MultipleRulesSameFuncMachine(RuleBasedStateMachine):
     def myfunc(self, data):
-        print_unicode(data)
+        print(data)
 
     rule1 = rule(data=just("rule1data"))(myfunc)
     rule2 = rule(data=just("rule2data"))(myfunc)
@@ -280,10 +279,10 @@ def test_bad_machines_fail(machine):
             with raises(AssertionError):
                 test_class().runTest()
     except Exception:
-        print_unicode(o.getvalue())
+        print(o.getvalue())
         raise
     v = o.getvalue()
-    print_unicode(v)
+    print(v)
     steps = [l for l in v.splitlines() if "Step " in l or "state." in l]
     assert 1 <= len(steps) <= 50
 

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -19,7 +19,6 @@ import pytest
 
 from hypothesis import Phase, example, given, seed, settings, strategies as st, target
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import string_types
 
 
 @example(0.0, "this covers the branch where context.data is None")
@@ -81,7 +80,7 @@ def everything_except(type_):
 @example(float("-inf"), "")
 @example("1", "Non-float observations are invalid")
 @example(0.0, ["a list of strings is not a valid label"])
-@given(observation=everything_except(float), label=everything_except(string_types))
+@given(observation=everything_except(float), label=everything_except(str))
 def test_disallowed_inputs_to_target(observation, label):
     with pytest.raises(InvalidArgument):
         target(observation, label)

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -24,7 +24,6 @@ from hypothesis.errors import (
     InvalidArgument,
     ResolutionFailed,
 )
-from hypothesis.internal.compat import PY2, integer_types
 from hypothesis.strategies._internal import types
 from hypothesis.strategies._internal.core import _strategies
 from hypothesis.strategies._internal.types import _global_type_lookup
@@ -39,7 +38,7 @@ blacklist = [
     "runner",
     "sampled_from",
 ]
-types_with_core_strat = set(integer_types)
+types_with_core_strat = set()
 for thing in (
     getattr(st, name)
     for name in sorted(_strategies)
@@ -58,10 +57,7 @@ for thing in (
 def test_resolve_core_strategies(typ):
     @given(st.from_type(typ))
     def inner(ex):
-        if PY2 and issubclass(typ, integer_types):
-            assert isinstance(ex, integer_types)
-        else:
-            assert isinstance(ex, typ)
+        assert isinstance(ex, typ)
 
     inner()
 

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -96,13 +96,6 @@ class ParentUnknownType:
     pass
 
 
-def test_can_resolve_trivial_types():
-    # Under Python 2, this inherits a special wrapper_descriptor slots
-    # thing from object.__init__, which chokes inspect.getargspec.
-    # from_type should and does work anyway; see issues #1655 and #1656.
-    st.from_type(ParentUnknownType).example()
-
-
 class UnknownType(ParentUnknownType):
     def __init__(self, arg):
         pass
@@ -180,7 +173,7 @@ def test_pulic_interface_works():
         fails.example()
 
 
-def test_given_can_infer_on_py2():
+def test_given_can_infer_from_manual_annotations():
     # Editing annotations before decorating is hilariously awkward, but works!
     def inner(a):
         pass

--- a/hypothesis-python/tests/cover/test_unittest.py
+++ b/hypothesis-python/tests/cover/test_unittest.py
@@ -20,7 +20,6 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import FailedHealthCheck, HypothesisWarning
-from hypothesis.internal.compat import PY2
 from tests.common.utils import fails_with
 
 
@@ -38,7 +37,7 @@ class Thing_with_a_subThing(unittest.TestCase):
 def test_subTest():
     suite = unittest.TestSuite()
     suite.addTest(Thing_with_a_subThing("thing"))
-    stream = io.BytesIO() if PY2 else io.StringIO()
+    stream = io.StringIO()
     out = unittest.TextTestRunner(stream=stream).run(suite)
     assert len(out.failures) <= out.testsRun, out
 

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -231,8 +231,6 @@ def test_valid_sizes(strategy, min_size, max_size):
 
 
 def test_check_type_with_tuple_of_length_two():
-    # This test covers logic for length-two tuples that is essential on PY2,
-    # e.g. string_types (str, unicode) which are all length-one on Python 3.
     def type_checker(x):
         check_type((int, str), x, "x")
 

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -21,7 +21,6 @@ import pytz
 from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
-from hypothesis.internal.compat import PY2
 from hypothesis.strategies import datetimes, sampled_from, times
 from tests.common.debug import assert_can_trigger_event, minimal
 
@@ -96,12 +95,6 @@ def test_time_bounds_must_be_naive(name, val):
         times(**{name: val}).validate()
 
 
-@pytest.mark.skipif(
-    PY2,
-    reason="""This test fails mysteriously on Python 2 and
-between its impending deprecation and the nicheness of the test it's not
-really worth debugging it.""",
-)
 def test_can_trigger_error_in_draw_near_max_date():
     assert_can_trigger_event(
         datetimes(

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -28,7 +28,6 @@ from hypothesis.extra.django import (
     from_model,
     register_field_strategy,
 )
-from hypothesis.internal.compat import text_type
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies import binary, just, lists
 from tests.django.toystore.models import (
@@ -125,12 +124,12 @@ class TestGetsBasicModels(TestCase):
     @given(from_model(OddFields))
     def test_odd_fields(self, x):
         assert isinstance(x.uuid, UUID)
-        assert isinstance(x.slug, text_type)
+        assert isinstance(x.slug, str)
         assert " " not in x.slug
-        assert isinstance(x.ipv4, text_type)
+        assert isinstance(x.ipv4, str)
         assert len(x.ipv4.split(".")) == 4
         assert all(int(i) in range(256) for i in x.ipv4.split("."))
-        assert isinstance(x.ipv6, text_type)
+        assert isinstance(x.ipv6, str)
         assert set(x.ipv6).issubset(set("0123456789abcdefABCDEF:."))
 
     @given(from_model(ManyTimes))

--- a/hypothesis-python/tests/lark/test_grammar.py
+++ b/hypothesis-python/tests/lark/test_grammar.py
@@ -21,7 +21,6 @@ from lark.lark import Lark
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.lark import from_lark
-from hypothesis.internal.compat import integer_types, text_type
 from hypothesis.strategies import data, just
 from tests.common.debug import find_any
 
@@ -63,8 +62,8 @@ def test_generates_valid_json(string):
     [
         ("dict", dict),
         ("list", list),
-        ("STRING", text_type),
-        ("NUMBER", integer_types + (float,)),
+        ("STRING", str),
+        ("NUMBER", (int, float)),
         ("TRUE", bool),
         ("FALSE", bool),
         ("NULL", type(None)),

--- a/hypothesis-python/tests/nocover/test_bad_repr.py
+++ b/hypothesis-python/tests/nocover/test_bad_repr.py
@@ -13,12 +13,8 @@
 #
 # END HEADER
 
-import pytest
-
 import hypothesis.strategies as st
 from hypothesis import given
-from hypothesis.internal.compat import PY3
-from hypothesis.internal.reflection import arg_string
 
 
 class BadRepr:
@@ -44,16 +40,6 @@ def test_sampling_snowmen():
 
 def varargs(*args, **kwargs):
     pass
-
-
-@pytest.mark.skipif(PY3, reason="Unicode repr is kosher on python 3")
-def test_arg_strings_are_bad_repr_safe():
-    assert arg_string(varargs, (Frosty,), {}) == "☃"
-
-
-@pytest.mark.skipif(PY3, reason="Unicode repr is kosher on python 3")
-def test_arg_string_kwargs_are_bad_repr_safe():
-    assert arg_string(varargs, (), {"x": Frosty}) == "x=☃"
 
 
 @given(

--- a/hypothesis-python/tests/nocover/test_compat.py
+++ b/hypothesis-python/tests/nocover/test_compat.py
@@ -13,38 +13,14 @@
 #
 # END HEADER
 
-import inspect
-import warnings
-
-import pytest
-
 from hypothesis import given, strategies as st
 from hypothesis.internal.compat import (
-    FullArgSpec,
     ceil,
     floor,
-    getfullargspec,
-    hrange,
     int_from_bytes,
     int_to_bytes,
-    integer_types,
     qualname,
 )
-
-
-def test_small_hrange():
-    assert list(hrange(5)) == [0, 1, 2, 3, 4]
-    assert list(hrange(3, 5)) == [3, 4]
-    assert list(hrange(1, 10, 2)) == [1, 3, 5, 7, 9]
-
-
-def test_large_hrange():
-    n = 1 << 1024
-    assert list(hrange(n, n + 5, 2)) == [n, n + 2, n + 4]
-    assert list(hrange(n, n)) == []
-
-    with pytest.raises(ValueError):
-        hrange(n, n, 0)
 
 
 class Foo:
@@ -56,34 +32,6 @@ def test_qualname():
     assert qualname(Foo.bar) == "Foo.bar"
     assert qualname(Foo().bar) == "Foo.bar"
     assert qualname(qualname) == "qualname"
-
-
-def a(b, c, d):
-    pass
-
-
-def b(c, d, *ar):
-    pass
-
-
-def c(c, d, *ar, **k):
-    pass
-
-
-def d(a1, a2=1, a3=2, a4=None):
-    pass
-
-
-@pytest.mark.parametrize("f", [a, b, c, d])
-def test_agrees_on_argspec(f):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        basic = inspect.getargspec(f)
-    full = getfullargspec(f)
-    assert basic.args == full.args
-    assert basic.varargs == full.varargs
-    assert basic.keywords == full.varkw
-    assert basic.defaults == full.defaults
 
 
 @given(st.binary())
@@ -110,22 +58,6 @@ def test_to_bytes_in_big_endian_order(x, y):
     assert int_to_bytes(x, 8) <= int_to_bytes(y, 8)
 
 
-@pytest.mark.skipif(
-    not hasattr(inspect, "getfullargspec"),
-    reason="inspect.getfullargspec only exists under Python 3",
-)
-def test_inspection_compat():
-    assert getfullargspec is inspect.getfullargspec
-
-
-@pytest.mark.skipif(
-    not hasattr(inspect, "FullArgSpec"),
-    reason="inspect.FullArgSpec only exists under Python 3",
-)
-def test_inspection_result_compat():
-    assert FullArgSpec is inspect.FullArgSpec
-
-
 @given(st.fractions())
 def test_ceil(x):
     """The compat ceil function always has the Python 3 semantics.
@@ -134,11 +66,11 @@ def test_ceil(x):
     integers - for example, `float(2**53) == float(2**53 + 1)` - and this
     is obviously incorrect for unlimited-precision integer operations.
     """
-    assert isinstance(ceil(x), integer_types)
+    assert isinstance(ceil(x), int)
     assert x <= ceil(x) < x + 1
 
 
 @given(st.fractions())
 def test_floor(x):
-    assert isinstance(floor(x), integer_types)
+    assert isinstance(floor(x), int)
     assert x - 1 < floor(x) <= x

--- a/hypothesis-python/tests/nocover/test_conjecture_int_list.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_int_list.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import hypothesis.strategies as st
-from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.junkdrawer import IntList
 from hypothesis.stateful import RuleBasedStateMachine, initialize, invariant, rule
 
@@ -33,7 +32,7 @@ def valid_index(draw):
 def valid_slice(draw):
     machine = draw(st.runner())
     result = [
-        draw(st.integers(0, max(3, len(machine.model) * 2 - 1))) for _ in hrange(2)
+        draw(st.integers(0, max(3, len(machine.model) * 2 - 1))) for _ in range(2)
     ]
     result.sort()
     return slice(*result)

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -19,13 +19,12 @@ import hypothesis.strategies as st
 from hypothesis import assume, core, find, given, settings
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import NoSuchExample, Unsatisfiable
-from hypothesis.internal.compat import hbytes
 from hypothesis.internal.entropy import deterministic_PRNG
 from tests.common.utils import all_values, non_covering_examples
 
 
 def has_a_non_zero_byte(x):
-    return any(hbytes(x))
+    return any(bytes(x))
 
 
 def test_saves_incremental_steps_in_database():

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -21,7 +21,6 @@ import pytest
 import hypothesis.internal.escalation as esc
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, Phase, Verbosity, assume, given, note, settings
-from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
@@ -75,7 +74,7 @@ def run_language_test_for(root, data, seed):
         node = root
         while not isinstance(node, Terminal):
             if isinstance(node, Write):
-                local_data.write(hbytes(node.value))
+                local_data.write(node.value)
                 node = node.child
             else:
                 assert isinstance(node, Branch)

--- a/hypothesis-python/tests/nocover/test_filtering.py
+++ b/hypothesis-python/tests/nocover/test_filtering.py
@@ -17,7 +17,6 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import given
-from hypothesis.internal.compat import hrange
 from hypothesis.strategies import integers, lists
 
 
@@ -38,8 +37,8 @@ def test_filter_correctly(specifier, condition):
 one_to_twenty_strategies = [
     st.integers(1, 20),
     st.integers(0, 19).map(lambda x: x + 1),
-    st.sampled_from(hrange(1, 21)),
-    st.sampled_from(hrange(0, 20)).map(lambda x: x + 1),
+    st.sampled_from(range(1, 21)),
+    st.sampled_from(range(0, 20)).map(lambda x: x + 1),
 ]
 
 

--- a/hypothesis-python/tests/nocover/test_floating.py
+++ b/hypothesis-python/tests/nocover/test_floating.py
@@ -81,7 +81,7 @@ def test_is_not_negative_infinite(x):
 @given(floats())
 @TRY_HARDER
 def test_is_int(x):
-    assume(not (math.isinf(x) or math.isnan(x)))
+    assume(math.isfinite(x))
     assert x == int(x)
 
 
@@ -89,7 +89,7 @@ def test_is_int(x):
 @given(floats())
 @TRY_HARDER
 def test_is_not_int(x):
-    assume(not (math.isinf(x) or math.isnan(x)))
+    assume(math.isfinite(x))
     assert x != int(x)
 
 
@@ -97,7 +97,7 @@ def test_is_not_int(x):
 @given(floats())
 @TRY_HARDER
 def test_is_in_exact_int_range(x):
-    assume(not (math.isinf(x) or math.isnan(x)))
+    assume(math.isfinite(x))
     assert x + 1 != x
 
 

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -18,7 +18,6 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import hrange
 from tests.common.utils import counts_calls, fails_with
 
 
@@ -31,7 +30,7 @@ def test_filter_large_lists(n):
         assert cond.calls < filter_limit
         return x % 2 != 0
 
-    s = st.sampled_from(hrange(n)).filter(cond)
+    s = st.sampled_from(range(n)).filter(cond)
 
     @given(s)
     def run(x):
@@ -47,8 +46,8 @@ def rare_value_strategy(n, target):
         """Helper function to avoid Python variable scoping issues."""
         return s.filter(lambda x: x != forbidden)
 
-    s = st.sampled_from(hrange(n))
-    for i in hrange(n):
+    s = st.sampled_from(range(n))
+    for i in range(n):
         if i != target:
             s = forbid(s, i)
 

--- a/hypothesis-python/tests/nocover/test_simple_numbers.py
+++ b/hypothesis-python/tests/nocover/test_simple_numbers.py
@@ -109,7 +109,7 @@ def test_negative_floats_simplify_to_zero():
 
 
 def test_minimal_infinite_float_is_positive():
-    assert minimal(floats(), math.isinf) == float("inf")
+    assert minimal(floats(), math.isinf) == math.inf
 
 
 def test_can_minimal_infinite_negative_float():
@@ -126,7 +126,7 @@ def test_minimize_nan():
 
 def test_minimize_very_large_float():
     t = sys.float_info.max / 2
-    assert t <= minimal(floats(), lambda x: x >= t) < float("inf")
+    assert t <= minimal(floats(), lambda x: x >= t) < math.inf
 
 
 def is_integral(value):
@@ -138,8 +138,7 @@ def is_integral(value):
 
 def test_can_minimal_float_far_from_integral():
     minimal(
-        floats(),
-        lambda x: not (math.isnan(x) or math.isinf(x) or is_integral(x * (2 ** 32))),
+        floats(), lambda x: math.isfinite(x) and not is_integral(x * (2 ** 32)),
     )
 
 

--- a/hypothesis-python/tests/nocover/test_strategy_state.py
+++ b/hypothesis-python/tests/nocover/test_strategy_state.py
@@ -136,9 +136,7 @@ class HypothesisSpec(RuleBasedStateMachine):
 
     @rule(target=strategies, left=varied_floats, right=varied_floats)
     def float_range(self, left, right):
-        for f in (math.isnan, math.isinf):
-            for x in (left, right):
-                assume(not f(x))
+        assume(math.isfinite(left) and math.isfinite(right))
         left, right = sorted((left, right))
         assert left <= right
         # exclude deprecated case where left = 0.0 and right = -0.0

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -271,19 +271,3 @@ def e(a, **kwargs):
 def test_raise_invalid_argument(function, kwargs):
     with pytest.raises(InvalidArgument):
         function(**kwargs).example()
-
-
-def test_test_basic_indices_kwonly_emulation():
-    with pytest.raises(TypeError):
-        nps.basic_indices((), 0, 1).validate()
-    with pytest.raises(TypeError):
-        nps.basic_indices((), __reserved=None).validate()
-
-
-@pytest.mark.parametrize("args", ({}, (1,), {"num_shapes": 1, "__reserved": None}))
-def test_test_mutually_broadcastable_shapes_kwonly_emulation(args):
-    with pytest.raises(TypeError):
-        if isinstance(args, dict):
-            nps.mutually_broadcastable_shapes(**args).validate()
-        else:
-            nps.mutually_broadcastable_shapes(*args).validate()

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -338,7 +338,7 @@ def test_cannot_generate_unique_array_of_too_many_elements():
     nps.arrays(
         elements=st.just(0.0),
         dtype=float,
-        fill=st.just(float("nan")),
+        fill=st.just(np.nan),
         shape=st.integers(0, 20),
         unique=True,
     )
@@ -360,7 +360,7 @@ def test_may_fill_with_nan_when_unique_is_set():
             elements=st.floats(allow_nan=False),
             shape=10,
             unique=True,
-            fill=st.just(float("nan")),
+            fill=st.just(np.nan),
         ),
         lambda x: np.isnan(x).any(),
     )
@@ -372,7 +372,7 @@ def test_may_fill_with_nan_when_unique_is_set():
         elements=st.floats(allow_nan=False),
         shape=10,
         unique=True,
-        fill=st.just(float("nan")),
+        fill=st.just(np.nan),
     )
 )
 def test_is_still_unique_with_nan_fill(xs):

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -15,6 +15,7 @@
 
 import sys
 from functools import reduce
+from itertools import zip_longest
 
 import numpy as np
 import pytest
@@ -23,16 +24,9 @@ import hypothesis.extra.numpy as nps
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, assume, given, note, settings
 from hypothesis.errors import InvalidArgument, Unsatisfiable
-from hypothesis.internal.compat import PY2, binary_type, text_type
 from hypothesis.strategies._internal import SearchStrategy
 from tests.common.debug import find_any, minimal
 from tests.common.utils import fails_with, flaky
-
-if PY2:
-    from itertools import izip_longest as zip_longest
-else:
-    from itertools import zip_longest
-
 
 ANY_SHAPE = nps.array_shapes(min_dims=0, max_dims=32, min_side=0, max_side=32)
 ANY_NONZERO_SHAPE = nps.array_shapes(min_dims=0, max_dims=32, min_side=1, max_side=32)
@@ -57,8 +51,8 @@ STANDARD_TYPES = list(
             "datetime64",
             "timedelta64",
             bool,
-            text_type,
-            binary_type,
+            str,
+            bytes,
         ],
     )
 )
@@ -93,16 +87,6 @@ def test_can_handle_zero_dimensions(x):
 @given(nps.arrays("uint32", (5, 5)))
 def test_generates_unsigned_ints(x):
     assert (x >= 0).all()
-
-
-@given(st.data())
-def test_can_handle_long_shapes(data):
-    """We can eliminate this test once we drop Py2 support."""
-    for tt in (int,):
-        X = data.draw(nps.arrays(float, (tt(5),)))
-        assert X.shape == (5,)
-        X = data.draw(nps.arrays(float, (tt(5), tt(5))))
-        assert X.shape == (5, 5)
 
 
 @given(nps.arrays(int, (1,)))
@@ -323,14 +307,14 @@ def test_can_cast_for_arrays(data):
 def test_unicode_string_dtypes_generate_unicode_strings(data):
     dt = data.draw(nps.unicode_string_dtypes())
     result = data.draw(nps.from_dtype(dt))
-    assert isinstance(result, text_type)
+    assert isinstance(result, str)
 
 
 @given(st.data())
 def test_byte_string_dtypes_generate_unicode_strings(data):
     dt = data.draw(nps.byte_string_dtypes())
     result = data.draw(nps.from_dtype(dt))
-    assert isinstance(result, binary_type)
+    assert isinstance(result, bytes)
 
 
 @pytest.mark.parametrize("dtype", ["U", "S", "a"])

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -108,7 +108,7 @@ def test_can_specify_both_rows_and_columns_dict(d):
         [
             pdst.column(
                 "A",
-                fill=st.just(float("nan")),
+                fill=st.just(np.nan),
                 dtype=float,
                 elements=st.floats(allow_nan=False),
             )
@@ -149,7 +149,7 @@ def test_data_frames_with_timestamp_columns(df):
 
 @given(
     pdst.data_frames(
-        pdst.columns(["A"], dtype=float, fill=st.just(float("nan")), unique=True)
+        pdst.columns(["A"], dtype=float, fill=st.just(np.nan), unique=True)
     )
 )
 def test_unique_column_with_fill(df):
@@ -162,7 +162,7 @@ def test_arbitrary_data_frames(data):
     columns = data.draw(
         st.lists(
             column_strategy(),
-            unique_by=lambda c: c.name if c.name is not None else float("nan"),
+            unique_by=lambda c: c.name if c.name is not None else np.nan,
         )
     )
 

--- a/hypothesis-python/tests/pandas/test_series.py
+++ b/hypothesis-python/tests/pandas/test_series.py
@@ -40,9 +40,7 @@ def test_series_respects_size_bounds(s):
 
 
 def test_can_fill_series():
-    nan_backed = pdst.series(
-        elements=st.floats(allow_nan=False), fill=st.just(float("nan"))
-    )
+    nan_backed = pdst.series(elements=st.floats(allow_nan=False), fill=st.just(np.nan))
     find_any(nan_backed, lambda x: np.isnan(x).any())
 
 

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -17,7 +17,7 @@ import sys
 
 import pytest
 
-from hypothesis.internal.compat import PY2, WINDOWS, escape_unicode_characters, hunichr
+from hypothesis.internal.compat import WINDOWS, escape_unicode_characters
 
 pytest_plugins = "pytester"
 
@@ -47,7 +47,6 @@ UNICODE_EMITTING = """
 import pytest
 from hypothesis import given, settings, Verbosity
 from hypothesis.strategies import text
-from hypothesis.internal.compat import PY3
 import sys
 
 def test_emits_unicode():
@@ -64,7 +63,6 @@ def test_emits_unicode():
     WINDOWS,
     reason=("Encoding issues in running the subprocess, possibly pytest's fault"),
 )
-@pytest.mark.skipif(PY2, reason="Output streams don't have encodings in python 2")
 def test_output_emitting_unicode(testdir, monkeypatch):
     monkeypatch.setenv("LC_ALL", "C")
     monkeypatch.setenv("LANG", "C")
@@ -74,7 +72,7 @@ def test_output_emitting_unicode(testdir, monkeypatch):
     )
     out = "\n".join(result.stdout.lines)
     assert "test_emits_unicode" in out
-    assert hunichr(1001) in out or escape_unicode_characters(hunichr(1001)) in out
+    assert chr(1001) in out or escape_unicode_characters(chr(1001)) in out
     assert result.ret == 0
 
 

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -13,16 +13,13 @@
 #
 # END HEADER
 
+from unittest.mock import Mock, create_autospec
+
 import pytest
 
 from hypothesis import example, given
 from hypothesis.strategies import integers
 from tests.common.utils import fails
-
-try:
-    from unittest.mock import Mock, create_autospec
-except ImportError:
-    from mock import Mock, create_autospec
 
 
 @pytest.fixture

--- a/hypothesis-python/tests/pytest/test_seeding.py
+++ b/hypothesis-python/tests/pytest/test_seeding.py
@@ -17,8 +17,6 @@ import re
 
 import pytest
 
-from hypothesis.internal.compat import hrange
-
 pytest_plugins = "pytester"
 
 
@@ -52,7 +50,7 @@ def test_runs_repeatably_when_seed_is_set(seed, testdir):
         testdir.runpytest(
             script, "--verbose", "--strict", "--hypothesis-seed", str(seed)
         )
-        for _ in hrange(2)
+        for _ in range(2)
     ]
 
     for r in results:

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -152,9 +152,9 @@ test_can_produce_short_strings_with_some_non_ascii = define_test(
     text(), lambda x: any(ord(c) > 127 for c in x), condition=lambda x: len(x) <= 3
 )
 
-test_can_produce_positive_infinity = define_test(floats(), lambda x: x == float("inf"))
+test_can_produce_positive_infinity = define_test(floats(), lambda x: x == math.inf)
 
-test_can_produce_negative_infinity = define_test(floats(), lambda x: x == float("-inf"))
+test_can_produce_negative_infinity = define_test(floats(), lambda x: x == -math.inf)
 
 test_can_produce_nan = define_test(floats(), math.isnan)
 

--- a/hypothesis-python/tests/quality/test_integers.py
+++ b/hypothesis-python/tests/quality/test_integers.py
@@ -26,7 +26,6 @@ from hypothesis import (
     reject,
     settings,
 )
-from hypothesis.internal.compat import hbytes
 from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.strategies._internal.numbers import WideRangeIntStrategy
@@ -46,7 +45,7 @@ def problems(draw):
             pass
         else:
             if stop > 0 and k > 0:
-                return (draw(st.integers(0, k - 1)), hbytes(d.buffer))
+                return (draw(st.integers(0, k - 1)), bytes(d.buffer))
 
 
 @example((2, b"\x00\x00\n\x01"))
@@ -61,7 +60,6 @@ def problems(draw):
 @given(problems())
 def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
     n, blob = problem
-    blob = hbytes(blob)
     try:
         d = ConjectureData.for_buffer(blob)
         k = d.draw(st.integers())

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -20,7 +20,7 @@ import pytest
 import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies as st
 from hypothesis import settings
-from hypothesis.internal.compat import ceil, hrange
+from hypothesis.internal.compat import ceil
 from hypothesis.internal.conjecture.engine import ConjectureData, ConjectureRunner
 from hypothesis.strategies._internal import SearchStrategy
 
@@ -47,7 +47,7 @@ class LinearLists(SearchStrategy):
         self.__elements = elements
 
     def do_draw(self, data):
-        return [data.draw(self.__elements) for _ in hrange(data.draw(self.__length))]
+        return [data.draw(self.__elements) for _ in range(data.draw(self.__length))]
 
 
 class Matrices(SearchStrategy):
@@ -60,7 +60,7 @@ class Matrices(SearchStrategy):
         n = data.draw(self.__length)
         m = data.draw(self.__length)
 
-        return [data.draw(self.__elements) for _ in hrange(n * m)]
+        return [data.draw(self.__elements) for _ in range(n * m)]
 
 
 LOTS = 10 ** 6

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -19,7 +19,6 @@ import pytest
 
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis import HealthCheck, settings
-from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.conjecture.engine import ConjectureData, ConjectureRunner
 from hypothesis.strategies._internal import SearchStrategy
 
@@ -98,13 +97,13 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
     starts = [b.start for b in data.blocks if b.length == 2]
     assert len(starts) % 2 == 0
 
-    for i in hrange(0, len(starts), 2):
+    for i in range(0, len(starts), 2):
         # Now for each leaf position in the tree we try inserting a poison
         # value artificially. Additionally, we add a marker to the end that
         # must be preserved. The marker means that we are not allow to rely on
         # discarding the end of the buffer to get the desired shrink.
         u = starts[i]
-        marker = hbytes([1, 2, 3, 4])
+        marker = bytes([1, 2, 3, 4])
 
         def test_function_with_poison(data):
             v = data.draw(strat)
@@ -117,7 +116,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
         )
 
         runner.cached_test_function(
-            data.buffer[:u] + hbytes([255]) * 4 + data.buffer[u + 4 :] + marker
+            data.buffer[:u] + bytes([255]) * 4 + data.buffer[u + 4 :] + marker
         )
 
         assert runner.interesting_examples

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -20,7 +20,6 @@ from functools import reduce
 import pytest
 
 from hypothesis import assume, settings
-from hypothesis.internal.compat import hrange
 from hypothesis.strategies import (
     booleans,
     builds,
@@ -62,7 +61,7 @@ def test_minimize_string_to_empty():
 
 
 def test_minimize_one_of():
-    for _ in hrange(100):
+    for _ in range(100):
         assert minimal(integers() | text() | booleans()) in (0, "", False)
 
 

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -18,14 +18,14 @@ from math import log
 
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, Phase, Verbosity, assume, example, given, settings
-from hypothesis.internal.compat import ceil, hbytes, int_from_bytes
+from hypothesis.internal.compat import ceil, int_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
 
 @st.composite
 def problem(draw):
-    b = hbytes(draw(st.binary(min_size=1, max_size=8)))
+    b = draw(st.binary(min_size=1, max_size=8))
     m = int_from_bytes(b) * 256
     assume(m > 0)
     marker = draw(st.binary(max_size=8))
@@ -71,9 +71,6 @@ def test_avoids_zig_zag_trap(p):
 
     random.seed(0)
 
-    b = hbytes(b)
-    marker = hbytes(marker)
-
     n_bits = 8 * (len(b) + 1)
 
     def test_function(data):
@@ -92,7 +89,7 @@ def test_avoids_zig_zag_trap(p):
         settings=settings(base_settings, phases=(Phase.generate, Phase.shrink)),
     )
 
-    runner.cached_test_function(b + hbytes([0]) + b + hbytes([1]) + marker)
+    runner.cached_test_function(b + bytes([0]) + b + bytes([1]) + marker)
 
     assert runner.interesting_examples
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,7 +15,3 @@ warn_redundant_casts = True
 
 [mypy-hypothesis.internal.*]
 ignore_errors = True
-
-# Annotating PY2-only code not worth the trouble for just a few months
-[mypy-hypothesis.vendor.pretty]
-ignore_errors = True

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -6,7 +6,6 @@ coverage
 django
 dpcontracts
 flake8
-flake8-alfred
 flake8-bandit
 flake8-bugbear
 flake8-comprehensions

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -27,7 +27,6 @@ dparse==0.4.1             # via pyupio, safety
 dpcontracts==0.6.0
 entrypoints==0.3          # via flake8
 filelock==3.0.12          # via tox
-flake8-alfred==1.1.1
 flake8-bandit==2.1.2
 flake8-bugbear==19.8.0
 flake8-comprehensions==3.1.4

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -170,8 +170,6 @@ HEADER = """
 @task()
 def format():
     def should_format_file(path):
-        if "vendor" in path.split(os.path.sep):
-            return False
         return path.endswith(".py")
 
     def should_format_doc_file(path):


### PR DESCRIPTION
- [x] Shrink `compat.py` to only the changes between Python 3 minor versions
      (this is the bulk of the changes, and mostly straightforward)
- [x] Replace the `reserved_means_kwonly_star` decorator with, well, `*,` in signatures
- [x] Remove the `NaN` time case in statistics; Python 3.5+ always have `time.monotonic()`
  (and adding positive floats always gives a positive result)
- [x] Checked all remaining cases of `git grep -E "[pP]y(thon)? ?2"`
- [x] Checked `# pragma: no cover`s for version-dependent behaviour
- [x] Use `math.isfinite` instead of the lengthier `isnan`+`isinf` combination
- [x] Consider `math.inf` and `math.nan` instead of `float("inf")` and `float("nan")`
- [x] Check each `except ImportError`; they might just be version-dependent

This is a smaller diff than #2299, but somewhat more complicated!  Note that per #2218, everything related to type annotations and the `from_type()` strategy is left for the PR after this one :smile: 