### PR TITLE
Improve `from_type(datetime.tzinfo)`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release teaches :func:`~hypothesis.strategies.from_type` how to generate
+:class:`python:datetime.timezone`.  As a result, you can now generate
+:class:`python:datetime.tzinfo` objects without having :pypi:`pytz` installed.
+
+If your tests specifically require :pypi:`pytz` timezones, you should be using
+:func:`hypothesis.extra.pytz.timezones` instead of ``st.from_type(tzinfo)``.

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -15,6 +15,7 @@
 
 import abc
 import collections
+import datetime
 import enum
 import io
 import string
@@ -35,7 +36,7 @@ from hypothesis.internal.compat import (
 )
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types
-from tests.common.debug import find_any, minimal
+from tests.common.debug import assert_all_examples, find_any, minimal
 from tests.common.utils import fails_with
 
 sentinel = object()
@@ -630,3 +631,9 @@ def test_supportscast_types_support_protocol_or_are_castable(protocol, typ, data
 def test_can_cast():
     assert types.can_cast(int, "0")
     assert not types.can_cast(int, "abc")
+
+
+@pytest.mark.parametrize("type_", [datetime.timezone, datetime.tzinfo])
+def test_timezone_lookup(type_):
+    assert issubclass(type_, datetime.tzinfo)
+    assert_all_examples(st.from_type(type_), lambda t: isinstance(t, datetime.timezone))


### PR DESCRIPTION
Currently, `from_type(datetime.tzinfo)` *may or may not work*, depending on whether you have `pytz` installed.  This kinda sucks, not least for people who don't want to use `pytz` but have it installed as a dependency of something else.

[`datetime.timezone`](https://docs.python.org/3/library/datetime.html#timezone-objects) to the rescue!  This is a standard-library type since Python 3.2, so it's always available and plays well with third-party libraries.  And registering a strategy is all we need to do for `from_type()` to work as expected for both `timezone` and its parent class `tzinfo`!

Note that the UTC offset is only required to be a whole number of minutes on Python <= 3.6, but I've left it that way for everything - `from_type()` gives *simple and valid* examples, not the full range of evil things we could build while technically being of the requested type.

CC @pganssle FYI.