### PR TITLE
Generate non-UTF-8 strings for Numpy unicode datatype

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release allows :func:`~hypothesis.extra.numpy.from_dtype` to generate
+Unicode strings which cannot be encoded in UTF-8, but are valid in Numpy
+arrays (which use UTF-32).

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -89,9 +89,9 @@ def from_dtype(dtype):
         result = st.integers(min_value=-overflow, max_value=overflow - 1)
     elif dtype.kind == "U":
         # Encoded in UTF-32 (four bytes/codepoint) and null-terminated
-        result = st.text(max_size=(dtype.itemsize or 0) // 4 or None).filter(
-            lambda b: b[-1:] != "\0"
-        )
+        result = st.text(
+            alphabet=st.characters(), max_size=(dtype.itemsize or 0) // 4 or None
+        ).filter(lambda b: b[-1:] != "\0")
     elif dtype.kind in ("m", "M"):
         if "[" in dtype.str:
             res = st.just(dtype.str.split("[")[-1][:-1])

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -310,6 +310,17 @@ def test_unicode_string_dtypes_generate_unicode_strings(data):
     assert isinstance(result, str)
 
 
+def test_unicode_string_dtypes_need_not_be_utf8():
+    def cannot_encode(string):
+        try:
+            string.encode("utf-8")
+            return False
+        except UnicodeEncodeError:
+            return True
+
+    find_any(nps.from_dtype(np.dtype("U")), cannot_encode)
+
+
 @given(st.data())
 def test_byte_string_dtypes_generate_unicode_strings(data):
     dt = data.draw(nps.byte_string_dtypes())


### PR DESCRIPTION
Another small but pleasant\* feature that is much easier now that we're Python-3-only :grin: 

\*assuming you want to find bugs, of course

Replaces #2246.