### PR TITLE
Fix is_hypothesis_file internal function

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -285,6 +285,7 @@ their individual contributions.
 * `Tyler Gibbons <https://www.github.com/kavec>`_ (tyler.gibbons@flexport.com)
 * `Tyler Nickerson <https://www.github.com/nmbrgts>`_
 * `Vidya Rani <https://www.github.com/vidyarani-dg>`_ (vidyarani.d.g@gmail.com)
+* `Vincent Michel <https://www.github.com/vxgmichel>`_ (vxgmichel@gmail.com)
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)
 * `Wilfred Hughes <https://www.github.com/wilfred>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where errors in third-party extensions such as
+:pypi:`hypothesis-trio` or :pypi:`hypothesis-jsonschema` were incorrectly
+considered to be Hypothesis internal errors, which could result in
+confusing error messages.
+
+Thanks to Vincent Michel for reporting and fixing the bug!

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -17,6 +17,7 @@ import os
 import sys
 import traceback
 from inspect import getframeinfo
+from pathlib import Path
 from typing import Dict
 
 import hypothesis
@@ -33,7 +34,7 @@ def belongs_to(package):
     if not hasattr(package, "__file__"):  # pragma: no cover
         return lambda filepath: False
 
-    root = os.path.dirname(package.__file__)
+    root = Path(package.__file__).resolve().parent
     cache = {str: {}, bytes: {}}
 
     def accept(filepath):
@@ -42,7 +43,12 @@ def belongs_to(package):
             return cache[ftype][filepath]
         except KeyError:
             pass
-        result = os.path.abspath(filepath).startswith(root)
+        abspath = Path(filepath).resolve()
+        try:
+            abspath.relative_to(root)
+            result = True
+        except ValueError:
+            result = False
         cache[ftype][filepath] = result
         return result
 


### PR DESCRIPTION
This function used to incorrectly return `True` for files belonging to modules of the form `hypothesis{suffix}`. It now returns `False` for such files.