### PR TITLE
Restore compatibility with Python 3.5.0 and 3.5.1

### DIFF
--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -19,7 +19,7 @@ import inspect
 import platform
 import sys
 import time
-from typing import Tuple, Type  # noqa
+from typing import Tuple  # noqa
 
 PYPY = platform.python_implementation() == "PyPy"
 CAN_PACK_HALF_FLOAT = sys.version_info[:2] >= (3, 6)


### PR DESCRIPTION
In #2301, a "Type" import was added. This breaks Python 3.5.0/3.5.1 compatibility, since `typing.Type` was added in 3.5.2.
Also, it seems to be an unused import, since `Tuple[type, ...]` is used in line 78, using the built-in `type`, not `Type`.

Note I don't have a way to test this locally right now, but I hope the CI will take care of that.