### PR TITLE
Minor cleanups to docs formatting, coverage pragmas, and release automation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ formats: all
 python:
    version: 3.7
    install:
+      - requirements: requirements/tools.txt
       - path: hypothesis-python/
         extra_requirements:
            - all

--- a/guides/api-style.rst
+++ b/guides/api-style.rst
@@ -73,8 +73,6 @@ We have a reasonably distinctive style when it comes to handling arguments:
   ``lists(elements, *, min_size=0, max_size=None, unique_by=None, unique=False)``.
   We intend to `migrate to this style after dropping Python 2 support <https://github.com/HypothesisWorks/hypothesis/issues/2130>`__
   in early 2020, with a gentle deprecation pathway.
-  New functions or argumemnts can implement a forward-compatible signature with
-  ``hypothesis.internal.reflection.reserved_to_kwonly``.
 * When adding arguments to strategies, think carefully about whether the user
   is likely to want that value to vary often. If so, make it a strategy instead
   of a value. In particular if it's likely to be common that they would want to

--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -12,13 +12,11 @@ omit =
 
 [report]
 exclude_lines =
-    @abc.abstractmethod
-    @abc.abstractproperty
-    NotImplementedError
     pragma: no cover
-    __repr__
-    __ne__
-    __copy__
-    __deepcopy__
+    raise NotImplementedError
+    def __repr__
+    def __ne__
+    def __copy__
+    def __deepcopy__
     except ImportError:
     assert all\(.+\)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes an internal error when running in an :pypi:`IPython` repl or
+:pypi:`Jupyter` notebook on Windows (:issue:`2319`), and an internal error on
+Python 3.5.1 (:issue:`2318`).

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -33,7 +33,7 @@ This release converts the type hint comments on our public API to
 :pep:`484` type annotations.
 
 Thanks to Ivan Levkivskyi for :pypi:`com2ann` - with the refactoring
-tools from :`5.0.1 <v5.0.1>` it made this process remarkably easy!
+tools from :ref:`5.0.1 <v5.0.1>` it made this process remarkably easy!
 
 .. _v5.1.2:
 
@@ -188,7 +188,7 @@ with :func:`~hypothesis.strategies.from_type`:
 
 Note that using :func:`~hypothesis.strategies.from_type` with one of the above strategies will not
 ensure that the the specified function will execute successfully (ie : the strategy returned for
-``from_type(typing.SupportsAbs)`` may include NaNs or things this will cause the :func:`python:abs`
+``from_type(typing.SupportsAbs)`` may include NaNs or things which cause the :func:`python:abs`
 function to error. )
 
 Thanks to Lea Provenzano for this patch.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -612,7 +612,7 @@ settings._define_setting(
     default=False,
     options=(True, False),
     description="""
-If set to True, Hypothesis will print code for failing examples that can be used with
+If set to ``True``, Hypothesis will print code for failing examples that can be used with
 :func:`@reproduce_failure <hypothesis.reproduce_failure>` to reproduce the failing example.
 """,
 )

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -297,7 +297,7 @@ class ArtificialDataForExample(ConjectureData):
         super().__init__(max_length=0, prefix=b"", random=None)
 
     def draw_bits(self, n):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError("Dummy object should never be asked for bits.")
 
     def draw(self, strategy):
         assert self.__draws == 0

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -17,7 +17,7 @@ import re
 import string
 from datetime import timedelta
 from decimal import Decimal
-from typing import Any, Callable, Dict, Type, TypeVar, Union
+from typing import Any, Callable, Dict, TypeVar, Union
 
 import django
 import django.db.models as dm
@@ -34,6 +34,12 @@ from hypothesis.extra.pytz import timezones
 from hypothesis.internal.validation import check_type
 from hypothesis.provisional import ip4_addr_strings, ip6_addr_strings, urls
 from hypothesis.strategies import emails
+
+try:
+    # New in Python 3.5.2; so we only use the string form in annotations
+    from typing import Type
+except ImportError:
+    pass
 
 AnyField = Union[dm.Field, df.Field]
 F = TypeVar("F", bound=AnyField)
@@ -206,7 +212,7 @@ def _for_form_boolean(field):
 
 
 def register_field_strategy(
-    field_type: Type[AnyField], strategy: st.SearchStrategy
+    field_type: "Type[AnyField]", strategy: st.SearchStrategy
 ) -> None:
     """Add an entry to the global field-to-strategy lookup used by
     :func:`~hypothesis.extra.django.from_field`.

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -37,7 +37,7 @@ from hypothesis.strategies._internal.strategies import Ex
 
 try:
     from pandas.api.types import is_categorical_dtype
-except ImportError:  # pragma: no cover
+except ImportError:
 
     def is_categorical_dtype(dt):
         if isinstance(dt, np.dtype):

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -43,11 +43,10 @@ def belongs_to(package):
             return cache[ftype][filepath]
         except KeyError:
             pass
-        abspath = Path(filepath).resolve()
         try:
-            abspath.relative_to(root)
+            Path(filepath).resolve().relative_to(root)
             result = True
-        except ValueError:
+        except Exception:
             result = False
         cache[ftype][filepath] = result
         return result

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -140,9 +140,8 @@ def required_args(target, args=(), kwargs=()):
 
 def convert_keyword_arguments(function, args, kwargs):
     """Returns a pair of a tuple and a dictionary which would be equivalent
-    passed as positional and keyword args to the function. Unless function has.
-
-    **kwargs the dictionary will always be empty.
+    passed as positional and keyword args to the function. Unless function has
+    kwonlyargs or **kwargs the dictionary will always be empty.
     """
     argspec = inspect.getfullargspec(function)
     new_args = []

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -24,7 +24,7 @@ import types
 from functools import wraps
 from tokenize import detect_encoding
 from types import ModuleType
-from typing import TypeVar
+from typing import Callable, TypeVar
 
 from hypothesis.internal.compat import (
     qualname,
@@ -34,7 +34,7 @@ from hypothesis.internal.compat import (
 )
 from hypothesis.vendor.pretty import pretty
 
-C = TypeVar("C", bound=callable)
+C = TypeVar("C", bound=Callable)
 
 
 def fully_qualified_name(f):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -412,8 +412,8 @@ def floats(
     required to represent the generated float. Valid values are 16, 32, or 64.
     Passing ``width=32`` will still use the builtin 64-bit ``float`` class,
     but always for values which can be exactly represented as a 32-bit float.
-    Half-precision floats (``width=16``) are only supported on Python 3.6, or
-    if :pypi:`Numpy` is installed.
+    Half-precision floats (``width=16``) are not supported on Python 3.5,
+    unless :pypi:`Numpy` is installed.
 
     The exclude_min and exclude_max argument can be used to generate numbers
     from open or half-open intervals, by excluding the respective endpoints.
@@ -639,8 +639,8 @@ def sampled_from(elements):
     may also generate any combination of their members.
 
     Examples from this strategy shrink by replacing them with values earlier in
-    the list. So e.g. sampled_from((10, 1)) will shrink by trying to replace
-    1 values with 10, and sampled_from((1, 10)) will shrink by trying to
+    the list. So e.g. ``sampled_from([10, 1])`` will shrink by trying to replace
+    1 values with 10, and ``sampled_from([1, 10])`` will shrink by trying to
     replace 10 values with 1.
     """
     values = check_sample(elements, "sampled_from")
@@ -684,6 +684,7 @@ def lists(
 
     For example, the following will produce two columns of integers with both
     columns being unique respectively.
+
     .. code-block:: pycon
 
         >>> twoints = st.tuples(st.integers(), st.integers())
@@ -1692,19 +1693,18 @@ def datetimes(
         common source of bugs.
 
     :py:func:`hypothesis.extra.pytz.timezones` requires the :pypi:`pytz`
-    package, but provides all timezones in the Olsen database.  If you want to
-    allow naive datetimes, combine strategies like ``none() | timezones()``.
-
+    package, but provides all timezones in the Olsen database.
     :py:func:`hypothesis.extra.dateutil.timezones` requires the
     :pypi:`python-dateutil` package, and similarly provides all timezones
-    there.
+    there.  If you want to allow naive datetimes, combine strategies
+    like ``none() | timezones()``.
 
     Alternatively, you can create a list of the timezones you wish to allow
-    (e.g. from the standard library, :pypi:`dateutil`, or :pypi:`pytz`) and use
-    :py:func:`sampled_from`.  Ensure that simple values such as None or UTC
-    are at the beginning of the list for proper minimisation.
+    (e.g. from the standard library, :pypi:`dateutil <python-dateutil>`,
+    or :pypi:`pytz`) and use :py:func:`sampled_from`.
 
-    Examples from this strategy shrink towards midnight on January 1st 2000.
+    Examples from this strategy shrink towards midnight on January 1st 2000,
+    local time.
     """
     # Why must bounds be naive?  In principle, we could also write a strategy
     # that took aware bounds, but the API and validation is much harder.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -219,7 +219,7 @@ class Nothing(SearchStrategy):
     def do_draw(self, data):
         # This method should never be called because draw() will mark the
         # data as invalid immediately because is_empty is True.
-        raise NotImplementedError("This should never happen")  # pragma: no cover
+        raise NotImplementedError("This should never happen")
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -39,10 +39,8 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Type,
     TypeVar,
     Union,
-    overload,
 )
 from uuid import UUID
 
@@ -125,6 +123,15 @@ from hypothesis.strategies._internal.strings import (
 )
 from hypothesis.types import RandomWithSeed
 from hypothesis.utils.conventions import InferType, infer, not_set
+
+try:
+    # New in Python 3.5.2; so we only use the string form in annotations
+    from typing import Type, overload
+except ImportError:
+
+    def overload(f):
+        return f
+
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -622,7 +629,7 @@ def sampled_from(elements: Sequence[T]) -> SearchStrategy[T]:
 
 
 @overload  # noqa: F811
-def sampled_from(elements: Type[enum.Enum]) -> SearchStrategy[Any]:
+def sampled_from(elements: "Type[enum.Enum]") -> SearchStrategy[Any]:
     # `SearchStrategy[Enum]` is unreliable due to metaclass issues.
     pass  # pragma: no cover
 
@@ -1240,7 +1247,7 @@ def _defer_from_type(func: T) -> T:
 
 @cacheable
 @_defer_from_type
-def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
+def from_type(thing: "Type[Ex]") -> SearchStrategy[Ex]:
     """Looks up the appropriate search strategy for the given type.
 
     ``from_type`` is used internally to fill in missing arguments to
@@ -2085,8 +2092,8 @@ def data() -> SearchStrategy[DataObject]:
 
 
 def register_type_strategy(
-    custom_type: Type[Ex],
-    strategy: Union[SearchStrategy[Ex], Callable[[Type[Ex]], SearchStrategy[Ex]]],
+    custom_type: "Type[Ex]",
+    strategy: Union[SearchStrategy[Ex], Callable[["Type[Ex]"], SearchStrategy[Ex]]],
 ) -> None:
     """Add an entry to the global type-to-strategy lookup.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
@@ -157,8 +157,8 @@ class CharactersBuilder:
         elif category == sre.CATEGORY_NOT_WORD:
             self._categories |= UNICODE_CATEGORIES - UNICODE_WORD_CATEGORIES
             self._blacklist_chars.add("_")
-        else:  # pragma: no cover
-            raise AssertionError("Unknown character category: %s" % category)
+        else:
+            raise NotImplementedError("Unknown character category: %s" % category)
 
     def add_char(self, char):
         """Add given char to the whitelist."""
@@ -397,10 +397,10 @@ def _strategy(codes, context, is_unicode):
                 elif charset_code == sre.CATEGORY:
                     # Regex '[\w]' (char category)
                     builder.add_category(charset_value)
-                else:  # pragma: no cover
+                else:
                     # Currently there are no known code points other than
                     # handled here. This code is just future proofing
-                    raise AssertionError("Unknown charset code: %s" % charset_code)
+                    raise NotImplementedError("Unknown charset code: %s" % charset_code)
             return builder.strategy
 
         elif code == sre.ANY:
@@ -473,7 +473,7 @@ def _strategy(codes, context, is_unicode):
                 recurse(value[2]) if value[2] else st.just(empty),
             )
 
-        else:  # pragma: no cover
+        else:
             # Currently there are no known code points other than handled here.
             # This code is just future proofing
-            raise AssertionError("Unknown code point: %s" % repr(code))
+            raise NotImplementedError("Unknown code point: %s" % repr(code))

--- a/hypothesis-python/src/hypothesis/utils/conventions.py
+++ b/hypothesis-python/src/hypothesis/utils/conventions.py
@@ -13,14 +13,10 @@
 #
 # END HEADER
 
-# Notes: we use instances of these objects as singletons which serve as
-# identifiers in various patches of code.  The more specific types
-# (DefaultValueType and InferType) exist so that typecheckers such as Mypy
-# can distinguish them from the others.  DefaultValueType is only used in
-# the Django extra.
-
 
 class UniqueIdentifier:
+    """A factory for sentinel objects with nice reprs."""
+
     def __init__(self, identifier):
         self.identifier = identifier
 
@@ -28,12 +24,8 @@ class UniqueIdentifier:
         return self.identifier
 
 
-class DefaultValueType(UniqueIdentifier):
-    pass
-
-
 class InferType(UniqueIdentifier):
-    pass
+    """We have a subclass for `infer` so we can type-hint public APIs."""
 
 
 infer = InferType("infer")

--- a/hypothesis-python/tests/cover/test_escalation.py
+++ b/hypothesis-python/tests/cover/test_escalation.py
@@ -88,3 +88,8 @@ def test_is_hypothesis_file_not_confused_by_prefix(monkeypatch):
     assert not esc.is_hypothesis_file(pytest.__file__)
     assert not esc.is_hypothesis_file(root + "-suffix")
     assert not esc.is_hypothesis_file(root + "-suffix/something.py")
+
+
+@pytest.mark.parametrize("fname", ["", "<ipython-input-18-f7c304bea5eb>"])
+def test_is_hypothesis_file_does_not_error_on_invalid_paths_issue_2319(fname):
+    assert not esc.is_hypothesis_file(fname)

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -18,8 +18,7 @@ import re
 import shlex
 import subprocess
 import sys
-import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from glob import glob
 
 from coverage.config import CoverageConfig
@@ -91,17 +90,6 @@ def do_release(package):
         return
 
     os.chdir(package.BASE_DIR)
-
-    # If we're making a release late on New Year's Eve, hold the release
-    # for a few minutes and ship it at midnight.  For timeout details, see:
-    # https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts
-    max_timeout = timedelta(minutes=40)
-    while True:
-        now = datetime.utcnow()
-        if now.year == (now + max_timeout).year:
-            break
-        print("Waiting for the midnight release...")
-        time.sleep(10)
 
     print("Updating changelog and version")
     package.update_changelog_and_version()


### PR DESCRIPTION
The common thread here is that these small refactorings didn't fit into the big changes from #2218... and since there's no user-visible change I haven't tried to split them out further.

Also fixes #2318 and fixes #2319.