### PR TITLE
New core strategies for IP addresses

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -5,3 +5,6 @@ adds the new :func:`~hypothesis.strategies.ip_addresses` strategy to generate
 :class:`~python:ipaddress.IPv4Address`\ es and/or
 :class:`~python:ipaddress.IPv6Address`\ es (depending on the ``v`` and ``network``
 arguments).
+
+If you use them in type annotations, :func:`~hypothesis.strategies.from_type` now
+has strategies registered for :mod:`ipaddress` address, network, and interface types.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -8,3 +8,5 @@ arguments).
 
 If you use them in type annotations, :func:`~hypothesis.strategies.from_type` now
 has strategies registered for :mod:`ipaddress` address, network, and interface types.
+
+The provisional strategies for IP address strings are therefore deprecated.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+The standard library :mod:`ipaddress` module is new in Python 3, and this release
+adds the new :func:`~hypothesis.strategies.ip_addresses` strategy to generate
+:class:`~python:ipaddress.IPv4Address`\ es and/or
+:class:`~python:ipaddress.IPv6Address`\ es (depending on the ``v`` and ``network``
+arguments).

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -28,7 +28,9 @@ import string
 
 import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies._internal.core as st
+from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
+from hypothesis.strategies._internal.ipaddress import ip_addresses
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
 URL_SAFE_CHARACTERS = frozenset(string.ascii_letters + string.digits + "$-_.+!*'(),")
@@ -159,20 +161,19 @@ def urls() -> SearchStrategy[str]:
 
 @st.defines_strategy_with_reusable_values
 def ip4_addr_strings() -> SearchStrategy[str]:
-    """A strategy for IPv4 address strings.
-
-    This consists of four strings representing integers [0..255],
-    without zero-padding, joined by dots.
-    """
-    return st.builds("{}.{}.{}.{}".format, *(4 * [st.integers(0, 255)]))
+    note_deprecation(
+        "Use `ip_addresses(v=4).map(str)` instead of `ip4_addr_strings()`; "
+        "the provisional strategy is less flexible and will be removed.",
+        since="RELEASEDAY",
+    )
+    return ip_addresses(v=4).map(str)
 
 
 @st.defines_strategy_with_reusable_values
 def ip6_addr_strings() -> SearchStrategy[str]:
-    """A strategy for IPv6 address strings.
-
-    This consists of sixteen quads of hex digits (0000 .. FFFF), joined
-    by colons.  Values do not currently have zero-segments collapsed.
-    """
-    part = st.integers(0, 2 ** 16 - 1).map("{:04x}".format)
-    return st.tuples(*[part] * 8).map(lambda a: ":".join(a).upper())
+    note_deprecation(
+        "Use `ip_addresses(v=6).map(str)` instead of `ip6_addr_strings()`; "
+        "the provisional strategy is less flexible and will be removed.",
+        since="RELEASEDAY",
+    )
+    return ip_addresses(v=6).map(str)

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -60,6 +60,7 @@ from hypothesis.strategies._internal.core import (
     tuples,
     uuids,
 )
+from hypothesis.strategies._internal.ipaddress import ip_addresses
 
 # The implementation of all of these lives in `_strategies.py`, but we
 # re-export them via this module to avoid exposing implementation details
@@ -89,6 +90,7 @@ __all__ = [
     "frozensets",
     "functions",
     "integers",
+    "ip_addresses",
     "iterables",
     "just",
     "lists",

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -1,0 +1,124 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
+from typing import Union
+
+from hypothesis.errors import InvalidArgument
+from hypothesis.internal.validation import check_type
+from hypothesis.strategies._internal.core import (
+    SearchStrategy,
+    binary,
+    defines_strategy_with_reusable_values,
+    integers,
+    sampled_from,
+)
+
+# See https://www.iana.org/assignments/iana-ipv4-special-registry/
+SPECIAL_IPv4_RANGES = (
+    "0.0.0.0/8",
+    "10.0.0.0/8",
+    "100.64.0.0/10",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "172.16.0.0/12",
+    "192.0.0.0/24",
+    "192.0.0.0/29",
+    "192.0.0.8/32",
+    "192.0.0.9/32",
+    "192.0.0.10/32",
+    "192.0.0.170/32",
+    "192.0.0.171/32",
+    "192.0.2.0/24",
+    "192.31.196.0/24",
+    "192.52.193.0/24",
+    "192.88.99.0/24",
+    "192.168.0.0/16",
+    "192.175.48.0/24",
+    "198.18.0.0/15",
+    "198.51.100.0/24",
+    "203.0.113.0/24",
+    "240.0.0.0/4",
+    "255.255.255.255/32",
+)
+# and https://www.iana.org/assignments/iana-ipv6-special-registry/
+SPECIAL_IPv6_RANGES = (
+    "::1/128",
+    "::/128",
+    "::ffff:0:0/96",
+    "64:ff9b::/96",
+    "64:ff9b:1::/48",
+    "100::/64",
+    "2001::/23",
+    "2001::/32",
+    "2001:1::1/128",
+    "2001:1::2/128",
+    "2001:2::/48",
+    "2001:3::/32",
+    "2001:4:112::/48",
+    "2001:10::/28",
+    "2001:20::/28",
+    "2001:db8::/32",
+    "2002::/16",
+    "2620:4f:8000::/48",
+    "fc00::/7",
+    "fe80::/10",
+)
+
+
+@defines_strategy_with_reusable_values
+def ip_addresses(
+    *, v: int = None, network: Union[str, IPv4Network, IPv6Network] = None
+) -> SearchStrategy[Union[IPv4Address, IPv6Address]]:
+    r"""Generate IP addresses - ``v=4`` for :class:`~python:ipaddress.IPv4Address`\ es,
+    ``v=6`` for :class:`~python:ipaddress.IPv6Address`\ es, or leave unspecified
+    to allow both versions.
+
+    ``network`` may be an :class:`~python:ipaddress.IPv4Network` or
+    :class:`~python:ipaddress.IPv6Network`, or a string representing a network such as
+    ``"127.0.0.0/24"`` or ``"2001:db8::/32"``.  As well as generating addresses within
+    a particular routable network, this can be used to generate addresses from a
+    reserved range listed in the
+    `IANA <https://www.iana.org/assignments/iana-ipv4-special-registry/>`__
+    `registries <https://www.iana.org/assignments/iana-ipv6-special-registry/>`__.
+
+    If you pass both ``v`` and ``network``, they must be for the same version.
+    """
+    if v is not None:
+        check_type(int, v, "v")
+        if v != 4 and v != 6:
+            raise InvalidArgument("v=%r, but only v=4 or v=6 are valid" % (v,))
+    if network is None:
+        # We use the reserved-address registries to boost the chance
+        # of generating one of the various special types of address.
+        four = binary(4, 4).map(IPv4Address) | sampled_from(
+            SPECIAL_IPv4_RANGES
+        ).flatmap(lambda network: ip_addresses(network=network))
+        six = binary(16, 16).map(IPv6Address) | sampled_from(
+            SPECIAL_IPv6_RANGES
+        ).flatmap(lambda network: ip_addresses(network=network))
+        if v == 4:
+            return four
+        if v == 6:
+            return six
+        return four | six
+    if isinstance(network, str):
+        network = ip_network(network)
+    check_type((IPv4Network, IPv6Network), network, "network")
+    assert isinstance(network, (IPv4Network, IPv6Network))  # for Mypy
+    if v not in (None, network.version):
+        raise InvalidArgument("v=%r is incompatible with network=%r" % (v, network))
+    addr_type = IPv4Address if network.version == 4 else IPv6Address
+    return integers(int(network[0]), int(network[-1])).map(addr_type)  # type: ignore

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -31,6 +31,7 @@ from hypothesis.strategies._internal.types import _global_type_lookup
 # Build a set of all types output by core strategies
 blacklist = [
     "builds",
+    "ip_addresses",
     "iterables",
     "permutations",
     "random_module",


### PR DESCRIPTION
Now that Hypothesis is Python-3-only (:tada:), there are some useful things we can rely on having available - like [the `ipaddress` module](https://docs.python.org/3/library/ipaddress.html)!  This patch:

- Adds a strategy `ip_addresses(*, v=None, network=None)`.  `v` may be either `4` or `6`; `network` may be an `IPv4Network` or `IPv6Network` object (or string - the ergonomics justify handling the cast internally).
- Deprecates `hypothesis.provisional.ip{4,6}_addr_strings()` in favor of `ip_addresses(v=...).map(str)`
- Registers strategies for `IPv{4,6}{Address,Network,Interface}` by entering them in the `_global_type_lookup` mapping in `hypothesis.strategies._internal.types`

Closes #2306.