### PR TITLE
Migrate to keyword-only arguments

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@ ignore =
     # `black` creates these ones
     E203,E501,W503,
     # Various codes from flake8-docstrings we don't care for
-    D1,D205,D209,D213,D400,D401,D412,D413,D999,D202,
+    D1,D205,D209,D213,D400,D401,D402,D412,D413,D999,D202,
     # flake8-bugbear options we disagree with
     B008,B011,
     # flake8-bandit security warnings we disagree with or don't mind

--- a/guides/api-style.rst
+++ b/guides/api-style.rst
@@ -71,8 +71,10 @@ We have a reasonably distinctive style when it comes to handling arguments:
 * Arguments which have a default value should also be keyword-only.
   For example, the ideal signature for lists would be
   ``lists(elements, *, min_size=0, max_size=None, unique_by=None, unique=False)``.
-  We intend to `migrate to this style after dropping Python 2 support <https://github.com/HypothesisWorks/hypothesis/issues/2130>`__
-  in early 2020, with a gentle deprecation pathway.
+  We are part-way through a deprecation cycle to convert existing APIs to
+  keyword-only arguments; all new APIs should use them natively.
+  New functions or arguments can implement a forward-compatible signature with
+  ``hypothesis.internal.reflection.reserved_to_kwonly``.
 * When adding arguments to strategies, think carefully about whether the user
   is likely to want that value to vary often. If so, make it a strategy instead
   of a value. In particular if it's likely to be common that they would want to

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+:gh-file:`Our style guide <guides/api-style.rst>` suggests that optional
+parameters should usually be keyword-only arguments (see :pep:`3102`) to
+prevent confusion based on positional arguments - for example,
+:func:`hypothesis.strategies.floats` takes up to *four* boolean flags
+and many of the Numpy strategies have both ``dims`` and ``side`` bounds.
+
+This release converts most optional parameters in our API to use
+keyword-only arguments - and adds a compatibility shim so you get
+warnings rather than errors everywhere (:issue:`2130`).

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -17,6 +17,8 @@ import datetime
 import os
 import sys
 
+import sphinx_rtd_theme
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
@@ -86,12 +88,9 @@ extlinks = {
 
 # -- Options for HTML output ----------------------------------------------
 
-if os.environ.get("READTHEDOCS", None) != "True":
-    # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+html_theme = "sphinx_rtd_theme"
 
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_static_path = ["_static"]
 

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -20,6 +20,7 @@ from typing import Any
 from hypothesis import Verbosity, settings
 from hypothesis.errors import CleanupFailed, InvalidArgument, UnsatisfiedAssumption
 from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import report, verbose_report
 from hypothesis.utils.dynamicvariables import DynamicVariable
@@ -121,7 +122,8 @@ def event(value: str) -> None:
     context.data.note_event(value)
 
 
-def target(observation: float, label: str = "") -> None:
+@deprecated_posargs
+def target(observation: float, *, label: str = "") -> None:
     """Calling this function with a ``float`` observation gives it feedback
     with which to guide our search for inputs that will cause an error, in
     addition to all the usual heuristics.  Observations must always be finite.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -75,6 +75,7 @@ from hypothesis.internal.reflection import (
     arg_string,
     convert_positional_arguments,
     define_function_signature,
+    deprecated_posargs,
     function_digest,
     get_pretty_function_description,
     impersonate,
@@ -1104,12 +1105,14 @@ def given(
     return run_test_as_given
 
 
+@deprecated_posargs
 def find(
     specifier: SearchStrategy[Ex],
     condition: Callable[[Any], bool],
+    *,
     settings: Settings = None,
     random: Random = None,
-    database_key: bytes = None,
+    database_key: bytes = None
 ) -> Ex:
     """Returns the minimal example from the given strategy ``specifier`` that
     matches the predicate function ``condition``."""

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -44,6 +44,7 @@ from lark.grammar import NonTerminal, Terminal
 import hypothesis.strategies._internal.core as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.utils import calc_label_from_name
+from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal import SearchStrategy
 
@@ -194,10 +195,12 @@ def check_explicit(name):
 
 @st.cacheable
 @st.defines_strategy_with_reusable_values
+@deprecated_posargs
 def from_lark(
     grammar: lark.lark.Lark,
+    *,
     start: str = None,
-    explicit: Dict[str, st.SearchStrategy[str]] = None,
+    explicit: Dict[str, st.SearchStrategy[str]] = None
 ) -> st.SearchStrategy[str]:
     """A strategy for strings accepted by the given context-free grammar.
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -25,7 +25,7 @@ import hypothesis.strategies._internal.core as st
 from hypothesis import assume
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.coverage import check_function
-from hypothesis.internal.reflection import proxies
+from hypothesis.internal.reflection import deprecated_posargs, proxies
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis.strategies._internal.strategies import T
@@ -286,12 +286,14 @@ def fill_for(elements, unique, fill, name=""):
 
 
 @st.defines_strategy
+@deprecated_posargs
 def arrays(
     dtype: Any,
     shape: Union[int, Shape, st.SearchStrategy[Shape]],
+    *,
     elements: st.SearchStrategy[Any] = None,
     fill: st.SearchStrategy[Any] = None,
-    unique: bool = False,
+    unique: bool = False
 ) -> st.SearchStrategy[np.ndarray]:
     r"""Returns a strategy for generating :class:`numpy:numpy.ndarray`\ s.
 
@@ -392,8 +394,9 @@ def arrays(
 
 
 @st.defines_strategy
+@deprecated_posargs
 def array_shapes(
-    min_dims: int = 1, max_dims: int = None, min_side: int = 1, max_side: int = None,
+    *, min_dims: int = 1, max_dims: int = None, min_side: int = 1, max_side: int = None
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for array shapes (tuples of int >= 1)."""
     check_type(int, min_dims, "min_dims")
@@ -480,8 +483,9 @@ def dtype_factory(kind, sizes, valid_sizes, endianness):
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def unsigned_integer_dtypes(
-    endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
+    *, endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for unsigned integer dtypes.
 
@@ -496,8 +500,9 @@ def unsigned_integer_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def integer_dtypes(
-    endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
+    *, endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for signed integer dtypes.
 
@@ -508,8 +513,9 @@ def integer_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def floating_dtypes(
-    endianness: str = "?", sizes: Sequence[int] = (16, 32, 64)
+    *, endianness: str = "?", sizes: Sequence[int] = (16, 32, 64)
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for floating-point dtypes.
 
@@ -524,8 +530,9 @@ def floating_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def complex_number_dtypes(
-    endianness: str = "?", sizes: Sequence[int] = (64, 128)
+    *, endianness: str = "?", sizes: Sequence[int] = (64, 128)
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for complex-number dtypes.
 
@@ -563,8 +570,9 @@ def validate_time_slice(max_period, min_period):
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def datetime64_dtypes(
-    max_period: str = "Y", min_period: str = "ns", endianness: str = "?"
+    *, max_period: str = "Y", min_period: str = "ns", endianness: str = "?"
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for datetime64 dtypes, with various precisions from
     year to attosecond."""
@@ -577,8 +585,9 @@ def datetime64_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def timedelta64_dtypes(
-    max_period: str = "Y", min_period: str = "ns", endianness: str = "?"
+    *, max_period: str = "Y", min_period: str = "ns", endianness: str = "?"
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for timedelta64 dtypes, with various precisions from
     year to attosecond."""
@@ -591,8 +600,9 @@ def timedelta64_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def byte_string_dtypes(
-    endianness: str = "?", min_len: int = 1, max_len: int = 16
+    *, endianness: str = "?", min_len: int = 1, max_len: int = 16
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for generating bytestring dtypes, of various lengths
     and byteorder.
@@ -606,8 +616,9 @@ def byte_string_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def unicode_string_dtypes(
-    endianness: str = "?", min_len: int = 1, max_len: int = 16
+    *, endianness: str = "?", min_len: int = 1, max_len: int = 16
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for generating unicode string dtypes, of various
     lengths and byteorder.
@@ -621,11 +632,13 @@ def unicode_string_dtypes(
 
 
 @defines_dtype_strategy
+@deprecated_posargs
 def array_dtypes(
     subtype_strategy: st.SearchStrategy[np.dtype] = scalar_dtypes(),
+    *,
     min_size: int = 1,
     max_size: int = 5,
-    allow_subarrays: bool = False,
+    allow_subarrays: bool = False
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for generating array (compound) dtypes, with members
     drawn from the given subtype strategy."""
@@ -646,10 +659,12 @@ def array_dtypes(
 
 
 @st.defines_strategy
+@deprecated_posargs
 def nested_dtypes(
     subtype_strategy: st.SearchStrategy[np.dtype] = scalar_dtypes(),
+    *,
     max_leaves: int = 10,
-    max_itemsize: int = None,
+    max_itemsize: int = None
 ) -> st.SearchStrategy[np.dtype]:
     """Return the most-general dtype strategy.
 
@@ -660,13 +675,16 @@ def nested_dtypes(
     argument.
     """
     return st.recursive(
-        subtype_strategy, lambda x: array_dtypes(x, allow_subarrays=True), max_leaves
+        subtype_strategy,
+        lambda x: array_dtypes(x, allow_subarrays=True),
+        max_leaves=max_leaves,
     ).filter(lambda d: max_itemsize is None or d.itemsize <= max_itemsize)
 
 
 @st.defines_strategy
+@deprecated_posargs
 def valid_tuple_axes(
-    ndim: int, min_size: int = 0, max_size: int = None
+    ndim: int, *, min_size: int = 0, max_size: int = None
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.
@@ -707,16 +725,20 @@ def valid_tuple_axes(
     axes = st.integers(0, max(0, 2 * ndim - 1)).map(
         lambda x: x if x < ndim else x - 2 * ndim
     )
-    return st.lists(axes, min_size, max_size, unique_by=lambda x: x % ndim).map(tuple)
+    return st.lists(
+        axes, min_size=min_size, max_size=max_size, unique_by=lambda x: x % ndim
+    ).map(tuple)
 
 
 @st.defines_strategy
+@deprecated_posargs
 def broadcastable_shapes(
     shape: Shape,
+    *,
     min_dims: int = 0,
     max_dims: int = None,
     min_side: int = 1,
-    max_side: int = None,
+    max_side: int = None
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for generating shapes that are broadcast-compatible
     with the provided shape.
@@ -1313,10 +1335,12 @@ def basic_indices(
 
 
 @st.defines_strategy
+@deprecated_posargs
 def integer_array_indices(
     shape: Shape,
+    *,
     result_shape: SearchStrategy[Shape] = array_shapes(),
-    dtype: np.dtype = "int",
+    dtype: np.dtype = "int"
 ) -> st.SearchStrategy[Tuple[np.ndarray, ...]]:
     """Return a search strategy for tuples of integer-arrays that, when used
     to index into an array of shape ``shape``, given an array whose shape

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -27,6 +27,7 @@ import hypothesis.strategies._internal.core as st
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.coverage import check, check_function
+from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.internal.validation import (
     check_type,
     check_valid_interval,
@@ -174,12 +175,14 @@ def range_indexes(
 
 @st.cacheable
 @st.defines_strategy
+@deprecated_posargs
 def indexes(
+    *,
     elements: st.SearchStrategy[Ex] = None,
     dtype: Any = None,
     min_size: int = 0,
     max_size: int = None,
-    unique: bool = True,
+    unique: bool = True
 ) -> st.SearchStrategy[pandas.Index]:
     """Provides a strategy for producing a :class:`pandas.Index`.
 
@@ -213,12 +216,14 @@ def indexes(
 
 
 @st.defines_strategy
+@deprecated_posargs
 def series(
+    *,
     elements: st.SearchStrategy[Ex] = None,
     dtype: Any = None,
     index: st.SearchStrategy[Union[Sequence, pandas.Index]] = None,
     fill: st.SearchStrategy[Ex] = None,
-    unique: bool = False,
+    unique: bool = False
 ) -> st.SearchStrategy[pandas.Series]:
     """Provides a strategy for producing a :class:`pandas.Series`.
 
@@ -327,12 +332,14 @@ class column:
     unique = attr.ib(default=False)
 
 
+@deprecated_posargs
 def columns(
     names_or_number: Union[int, Sequence[str]],
+    *,
     dtype: Any = None,
     elements: st.SearchStrategy[Ex] = None,
     fill: st.SearchStrategy[Ex] = None,
-    unique: bool = False,
+    unique: bool = False
 ) -> List[column]:
     """A convenience function for producing a list of :class:`column` objects
     of the same general shape.
@@ -353,11 +360,13 @@ def columns(
     ]
 
 
+@deprecated_posargs
 @st.defines_strategy
 def data_frames(
     columns: Sequence[column] = None,
+    *,
     rows: st.SearchStrategy[Union[dict, Sequence[Any]]] = None,
-    index: st.SearchStrategy[Ex] = None,
+    index: st.SearchStrategy[Ex] = None
 ) -> st.SearchStrategy[pandas.DataFrame]:
     """Provides a strategy for producing a :class:`pandas.DataFrame`.
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -19,6 +19,7 @@ to really unreasonable lengths to produce pretty output."""
 import ast
 import hashlib
 import inspect
+import os
 import re
 import types
 from functools import wraps
@@ -35,6 +36,7 @@ from hypothesis.internal.compat import (
 from hypothesis.vendor.pretty import pretty
 
 C = TypeVar("C", bound=Callable)
+READTHEDOCS = os.environ.get("READTHEDOCS", None) == "True"
 
 
 def fully_qualified_name(f):
@@ -601,6 +603,10 @@ def deprecated_posargs(func: C) -> C:
     This turns out to be fairly tricky to get right with our preferred style of
     error handling (exhaustive) and various function-rewriting wrappers.
     """
+    if READTHEDOCS:  # pragma: no cover
+        # Documentation should show the new signatures without deprecation helpers.
+        return func
+
     signature = inspect.signature(func)
     parameters = list(signature.parameters.values())
     vararg = inspect.Parameter(

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -24,7 +24,7 @@ import types
 from functools import wraps
 from tokenize import detect_encoding
 from types import ModuleType
-from typing import Callable, TypeVar
+from typing import Any, Callable, TypeVar
 
 from hypothesis.internal.compat import (
     qualname,
@@ -224,7 +224,12 @@ def convert_positional_arguments(function, args, kwargs):
             )
         else:
             new_kwargs[name] = arg
-    return (tuple(args[len(argspec.args) :]), new_kwargs)
+
+    deprecated_posargs = getattr(function, "__deprecated_posargs", ())
+    for param, val in zip(deprecated_posargs, args[len(argspec.args) :]):
+        new_kwargs[param.name] = val
+
+    return (tuple(args[len(argspec.args) + len(deprecated_posargs) :]), new_kwargs)
 
 
 def extract_all_lambdas(tree):
@@ -587,4 +592,69 @@ def proxies(target):
             )
         )
 
+    return accept
+
+
+def deprecated_posargs(func: C) -> C:
+    """Insert a `*__deprecated_posargs,` shim in place of the `*,` for kwonly args.
+
+    This turns out to be fairly tricky to get right with our preferred style of
+    error handling (exhaustive) and various function-rewriting wrappers.
+    """
+    signature = inspect.signature(func)
+    parameters = list(signature.parameters.values())
+    vararg = inspect.Parameter(
+        name="__deprecated_posargs",
+        kind=inspect.Parameter.VAR_POSITIONAL,
+        annotation=Any,
+    )
+
+    # If we're passed any VAR_POSITIONAL args, we'll use this sequence of
+    # params to match them up with the correct KEYWORD_ONLY argument after
+    # checking that it has its default value - if you're passing by name,
+    # can't have also been passing positionally before we deprecated that.
+    deprecated = []
+    for i, arg in enumerate(tuple(parameters)):
+        if arg.kind == inspect.Parameter.KEYWORD_ONLY:
+            if not deprecated:
+                parameters.insert(i, vararg)
+            deprecated.append(arg)
+
+    func.__signature__ = signature.replace(parameters=parameters)
+
+    @proxies(func)
+    def accept(*args, **kwargs):
+        bound = func.__signature__.bind_partial(*args, **kwargs)
+        bad_posargs = bound.arguments.pop("__deprecated_posargs", None) or ()
+        if len(bad_posargs) > len(deprecated):
+            # We have more positional arguments than the wrapped func has parameters,
+            # so there's no way this ever worked.  We know that this bind will fail
+            # but attempting it will raise a nice descriptive TypeError.
+            signature.bind_partial(*args, **kwargs)
+        for param, pos in zip(deprecated, bad_posargs):
+            # Unfortunately, another layer of our function-wrapping logic passes in
+            # all the default arguments as explicit arguments.  This means that if
+            # someone explicitly passes some value for a parameter as a positional
+            # argument and *the default value* as a keyword argument, we'll emit a
+            # deprecation warning but not an immediate error.  Ah well...
+            if bound.arguments.get(param.name, param.default) != param.default:
+                raise TypeError(
+                    "Cannot pass {name}={p} positionally and {name}={n} by name!".format(
+                        name=param.name, p=pos, n=bound.arguments[param.name]
+                    )
+                )
+            from hypothesis._settings import note_deprecation
+
+            note_deprecation(
+                "%s was passed %s=%r as a positional argument, which will be a "
+                "keyword-only argument in a future version."
+                % (qualname(func), param.name, pos),
+                since="RELEASEDAY",
+            )
+            bound.arguments[param.name] = pos
+        return func(*bound.args, **bound.kwargs)
+
+    # We use these in convert_positional_arguments, to ensure that the LazyStrategy
+    # repr of strategy objects look sensible (and will work without this shim).
+    accept.__deprecated_posargs = tuple(deprecated)
     return accept

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -30,6 +30,7 @@ import hypothesis.internal.conjecture.utils as cu
 import hypothesis.strategies._internal.core as st
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
+from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.strategies._internal.ipaddress import ip_addresses
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
@@ -134,8 +135,9 @@ class DomainNameStrategy(SearchStrategy):
 
 
 @st.defines_strategy_with_reusable_values
+@deprecated_posargs
 def domains(
-    max_length: int = 255, max_element_length: int = 63,
+    *, max_length: int = 255, max_element_length: int = 63
 ) -> SearchStrategy[str]:
     """Generate :rfc:`1035` compliant fully qualified domain names."""
     return DomainNameStrategy(

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -36,7 +36,13 @@ from hypothesis._settings import HealthCheck, Verbosity, settings as Settings
 from hypothesis.control import current_build_context
 from hypothesis.core import given
 from hypothesis.errors import InvalidArgument, InvalidDefinition
-from hypothesis.internal.reflection import function_digest, nicerepr, proxies, qualname
+from hypothesis.internal.reflection import (
+    deprecated_posargs,
+    function_digest,
+    nicerepr,
+    proxies,
+    qualname,
+)
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import current_verbosity, report
 from hypothesis.strategies._internal.featureflags import FeatureStrategy
@@ -60,7 +66,8 @@ class TestCaseProperty:  # pragma: no cover
         raise AttributeError("Cannot delete TestCase")
 
 
-def run_state_machine_as_test(state_machine_factory, settings=None):
+@deprecated_posargs
+def run_state_machine_as_test(state_machine_factory, *, settings=None):
     """Run a state machine definition as a test, either silently doing nothing
     or printing a minimal breaking program and raising an exception.
 
@@ -404,7 +411,8 @@ PRECONDITION_MARKER = "hypothesis_stateful_precondition"
 INVARIANT_MARKER = "hypothesis_stateful_invariant"
 
 
-def rule(targets=(), target=None, **kwargs):
+@deprecated_posargs
+def rule(*, targets=(), target=None, **kwargs):
     """Decorator for RuleBasedStateMachine. Any name present in target or
     targets will define where the end result of this function should go. If
     both are empty then the end result will be discarded.
@@ -453,7 +461,8 @@ def rule(targets=(), target=None, **kwargs):
     return accept
 
 
-def initialize(targets=(), target=None, **kwargs):
+@deprecated_posargs
+def initialize(*, targets=(), target=None, **kwargs):
     """Decorator for RuleBasedStateMachine.
 
     An initialize decorator behaves like a rule, but the decorated

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -115,9 +115,9 @@ __all__ = [
     "SearchStrategy",
 ]
 
-assert _strategies.issubset(set(__all__)), (
-    _strategies - set(__all__),
-    set(__all__) - _strategies,
+assert set(_strategies).issubset(__all__), (
+    set(_strategies) - set(__all__),
+    set(__all__) - set(_strategies),
 )
 _public = {n for n in dir() if n[0] not in "_@"}
 assert set(__all__) == _public, (set(__all__) - _public, _public - set(__all__))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -71,6 +71,7 @@ from hypothesis.internal.floats import (
 )
 from hypothesis.internal.reflection import (
     define_function_signature,
+    deprecated_posargs,
     is_typed_named_tuple,
     nicerepr,
     proxies,
@@ -390,14 +391,16 @@ def booleans() -> SearchStrategy[bool]:
 
 @cacheable
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def floats(
     min_value: Real = None,
     max_value: Real = None,
+    *,
     allow_nan: bool = None,
     allow_infinity: bool = None,
     width: int = 64,
     exclude_min: bool = False,
-    exclude_max: bool = False,
+    exclude_max: bool = False
 ) -> SearchStrategy[float]:
     """Returns a strategy which generates floats.
 
@@ -664,12 +667,14 @@ def sampled_from(elements):
 
 @cacheable
 @defines_strategy
+@deprecated_posargs
 def lists(
     elements: SearchStrategy[Ex],
+    *,
     min_size: int = 0,
     max_size: int = None,
     unique_by: UniqueBy = None,
-    unique: bool = False,
+    unique: bool = False
 ) -> SearchStrategy[List[Ex]]:
     """Returns a list containing values drawn from elements with length in the
     interval [min_size, max_size] (no bounds in that direction if these are
@@ -753,8 +758,9 @@ def lists(
 
 @cacheable
 @defines_strategy
+@deprecated_posargs
 def sets(
-    elements: SearchStrategy[Ex], min_size: int = 0, max_size: int = None,
+    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: int = None
 ) -> SearchStrategy[Set[Ex]]:
     """This has the same behaviour as lists, but returns sets instead.
 
@@ -772,8 +778,9 @@ def sets(
 
 @cacheable
 @defines_strategy
+@deprecated_posargs
 def frozensets(
-    elements: SearchStrategy[Ex], min_size: int = 0, max_size: int = None,
+    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: int = None
 ) -> SearchStrategy[FrozenSet[Ex]]:
     """This is identical to the sets function but instead returns
     frozensets."""
@@ -798,12 +805,14 @@ class PrettyIter:
 
 
 @defines_strategy
+@deprecated_posargs
 def iterables(
     elements: SearchStrategy[Ex],
+    *,
     min_size: int = 0,
     max_size: int = None,
     unique_by: UniqueBy = None,
-    unique: bool = False,
+    unique: bool = False
 ) -> SearchStrategy[Iterable[Ex]]:
     """This has the same behaviour as lists, but returns iterables instead.
 
@@ -861,12 +870,14 @@ def fixed_dictionaries(
 
 @cacheable
 @defines_strategy
+@deprecated_posargs
 def dictionaries(
     keys: SearchStrategy[Ex],
     values: SearchStrategy[T],
+    *,
     dict_class: type = dict,
     min_size: int = 0,
-    max_size: int = None,
+    max_size: int = None
 ) -> SearchStrategy[Dict[Ex, T]]:
     # Describing the exact dict_class to Mypy drops the key and value types,
     # so we report Dict[K, V] instead of Mapping[Any, Any] for now.  Sorry!
@@ -895,13 +906,15 @@ def dictionaries(
 
 @cacheable
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def characters(
+    *,
     whitelist_categories: Sequence[str] = None,
     blacklist_categories: Sequence[str] = None,
     blacklist_characters: Sequence[str] = None,
     min_codepoint: int = None,
     max_codepoint: int = None,
-    whitelist_characters: Sequence[str] = None,
+    whitelist_characters: Sequence[str] = None
 ) -> SearchStrategy[str]:
     r"""Generates characters, length-one :class:`python:str`\ ings,
     following specified filtering rules.
@@ -1000,12 +1013,14 @@ def characters(
 
 @cacheable
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def text(
     alphabet: Union[Sequence[str], SearchStrategy[str]] = characters(
         blacklist_categories=("Cs",)
     ),
+    *,
     min_size: int = 0,
-    max_size: int = None,
+    max_size: int = None
 ) -> SearchStrategy[str]:
     """Generates strings with characters drawn from ``alphabet``, which should
     be a collection of length one strings or a strategy generating such strings.
@@ -1054,8 +1069,9 @@ def text(
 
 @cacheable
 @defines_strategy
+@deprecated_posargs
 def from_regex(
-    regex: Union[AnyStr, Pattern[AnyStr]], fullmatch: bool = False
+    regex: Union[AnyStr, Pattern[AnyStr]], *, fullmatch: bool = False
 ) -> SearchStrategy[AnyStr]:
     r"""Generates strings that contain a match for the given regex (i.e. ones
     for which :func:`python:re.search` will return a non-None result).
@@ -1094,7 +1110,8 @@ def from_regex(
 
 @cacheable
 @defines_strategy_with_reusable_values
-def binary(min_size: int = 0, max_size: int = None) -> SearchStrategy[bytes]:
+@deprecated_posargs
+def binary(*, min_size: int = 0, max_size: int = None) -> SearchStrategy[bytes]:
     """Generates :class:`python:bytes`.
 
     min_size and max_size have the usual interpretations.
@@ -1154,7 +1171,7 @@ def random_module() -> SearchStrategy[RandomSeeder]:
 
     Examples from these strategy shrink to seeds closer to zero.
     """
-    return shared(RandomModule(), "hypothesis.strategies.random_module()")
+    return shared(RandomModule(), key="hypothesis.strategies.random_module()")
 
 
 @cacheable
@@ -1425,10 +1442,12 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
 
 @cacheable
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def fractions(
     min_value: Union[Real, str] = None,
     max_value: Union[Real, str] = None,
-    max_denominator: int = None,
+    *,
+    max_denominator: int = None
 ) -> SearchStrategy[Fraction]:
     """Returns a strategy which generates Fractions.
 
@@ -1533,12 +1552,14 @@ def _as_finite_decimal(
 
 @cacheable
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def decimals(
     min_value: Union[Real, str] = None,
     max_value: Union[Real, str] = None,
+    *,
     allow_nan: bool = None,
     allow_infinity: bool = None,
-    places: int = None,
+    places: int = None
 ) -> SearchStrategy[Decimal]:
     """Generates instances of :class:`python:decimal.Decimal`, which may be:
 
@@ -1619,10 +1640,12 @@ def decimals(
     return strat | (sampled_from(special) if special else nothing())
 
 
+@deprecated_posargs
 def recursive(
     base: SearchStrategy[Ex],
     extend: Callable[[SearchStrategy[Any]], SearchStrategy[T]],
-    max_leaves: int = 100,
+    *,
+    max_leaves: int = 100
 ) -> SearchStrategy[Union[T, Ex]]:
     """base: A strategy to start from.
 
@@ -1680,10 +1703,12 @@ def permutations(values: Sequence[T]) -> SearchStrategy[List[T]]:
 
 
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def datetimes(
     min_value: dt.datetime = dt.datetime.min,
     max_value: dt.datetime = dt.datetime.max,
-    timezones: SearchStrategy[Optional[dt.tzinfo]] = none(),
+    *,
+    timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
 ) -> SearchStrategy[dt.datetime]:
     """A strategy for generating datetimes, which may be timezone-aware.
 
@@ -1757,10 +1782,12 @@ def dates(
 
 
 @defines_strategy_with_reusable_values
+@deprecated_posargs
 def times(
     min_value: dt.time = dt.time.min,
     max_value: dt.time = dt.time.max,
-    timezones: SearchStrategy[Optional[dt.tzinfo]] = none(),
+    *,
+    timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
 ) -> SearchStrategy[dt.time]:
     """A strategy for times between ``min_value`` and ``max_value``.
 
@@ -1854,11 +1881,13 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
 
 @defines_strategy_with_reusable_values
 @cacheable
+@deprecated_posargs
 def complex_numbers(
+    *,
     min_magnitude: Optional[Real] = 0,
     max_magnitude: Optional[Real] = None,
     allow_infinity: bool = None,
-    allow_nan: bool = None,
+    allow_nan: bool = None
 ) -> SearchStrategy[complex]:
     """Returns a strategy that generates complex numbers.
 
@@ -1942,7 +1971,8 @@ def complex_numbers(
     return constrained_complex()
 
 
-def shared(base: SearchStrategy[Ex], key: Hashable = None) -> SearchStrategy[Ex]:
+@deprecated_posargs
+def shared(base: SearchStrategy[Ex], *, key: Hashable = None) -> SearchStrategy[Ex]:
     """Returns a strategy that draws a single shared value per run, drawn from
     base. Any two shared instances with the same key will share the same value,
     otherwise the identity of this strategy will be used. That is:
@@ -1964,7 +1994,8 @@ def shared(base: SearchStrategy[Ex], key: Hashable = None) -> SearchStrategy[Ex]
 
 @cacheable
 @defines_strategy_with_reusable_values
-def uuids(version: int = None) -> SearchStrategy[UUID]:
+@deprecated_posargs
+def uuids(*, version: int = None) -> SearchStrategy[UUID]:
     """Returns a strategy that generates :class:`UUIDs <uuid.UUID>`.
 
     If the optional version argument is given, value is passed through
@@ -2008,7 +2039,8 @@ class RunnerStrategy(SearchStrategy):
 
 
 @defines_strategy_with_reusable_values
-def runner(default: Any = not_set) -> SearchStrategy[Any]:
+@deprecated_posargs
+def runner(*, default: Any = not_set) -> SearchStrategy[Any]:
     """A strategy for getting "the current test runner", whatever that may be.
     The exact meaning depends on the entry point, but it will usually be the
     associated 'self' value for it.
@@ -2180,8 +2212,9 @@ def emails() -> SearchStrategy[str]:
 
 
 @defines_strategy
+@deprecated_posargs
 def functions(
-    like: Callable[..., Any] = lambda: None, returns: SearchStrategy[Any] = none(),
+    *, like: Callable[..., Any] = lambda: None, returns: SearchStrategy[Any] = none()
 ) -> SearchStrategy[Callable[..., Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -24,7 +24,7 @@ import typing
 from decimal import Context, Decimal, localcontext
 from fractions import Fraction
 from functools import reduce
-from inspect import getfullargspec, isabstract, isclass
+from inspect import getfullargspec, isabstract, isclass, signature
 from typing import (
     Any,
     AnyStr,
@@ -132,7 +132,7 @@ UniqueBy = Union[Callable[[Ex], Hashable], Tuple[Callable[[Ex], Hashable], ...]]
 # See https://github.com/python/mypy/issues/3186 - numbers.Real is wrong!
 Real = Union[int, float, Fraction, Decimal]
 
-_strategies = set()
+_strategies = {}  # type: Dict[str, Callable[..., SearchStrategy]]
 
 
 class FloatKey:
@@ -192,7 +192,7 @@ def base_defines_strategy(force_reusable: bool) -> Callable[[T], T]:
     def decorator(strategy_definition):
         """A decorator that registers the function as a strategy and makes it
         lazily evaluated."""
-        _strategies.add(strategy_definition.__name__)
+        _strategies[strategy_definition.__name__] = signature(strategy_definition)
 
         @proxies(strategy_definition)
         def accept(*args, **kwargs):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1710,7 +1710,9 @@ def datetimes(
     *,
     timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
 ) -> SearchStrategy[dt.datetime]:
-    """A strategy for generating datetimes, which may be timezone-aware.
+    """datetimes(min_value=datetime.datetime.min, max_value=datetime.datetime.max, *, timezones=none())
+
+    A strategy for generating datetimes, which may be timezone-aware.
 
     This strategy works by drawing a naive datetime between ``min_value``
     and ``max_value``, which must both be naive (have no timezone).
@@ -1769,7 +1771,9 @@ def datetimes(
 def dates(
     min_value: dt.date = dt.date.min, max_value: dt.date = dt.date.max
 ) -> SearchStrategy[dt.date]:
-    """A strategy for dates between ``min_value`` and ``max_value``.
+    """dates(min_value=datetime.date.min, max_value=datetime.date.max)
+
+    A strategy for dates between ``min_value`` and ``max_value``.
 
     Examples from this strategy shrink towards January 1st 2000.
     """
@@ -1789,7 +1793,9 @@ def times(
     *,
     timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
 ) -> SearchStrategy[dt.time]:
-    """A strategy for times between ``min_value`` and ``max_value``.
+    """times(min_value=datetime.time.min, max_value=datetime.time.max, *, timezones=none())
+
+    A strategy for times between ``min_value`` and ``max_value``.
 
     The ``timezones`` argument is handled as for :py:func:`datetimes`.
 
@@ -1816,7 +1822,9 @@ def timedeltas(
     min_value: dt.timedelta = dt.timedelta.min,
     max_value: dt.timedelta = dt.timedelta.max,
 ) -> SearchStrategy[dt.timedelta]:
-    """A strategy for timedeltas between ``min_value`` and ``max_value``.
+    """timedeltas(min_value=datetime.timedelta.min, max_value=datetime.timedelta.max)
+
+    A strategy for timedeltas between ``min_value`` and ``max_value``.
 
     Examples from this strategy shrink towards zero.
     """
@@ -2218,7 +2226,9 @@ def functions(
 ) -> SearchStrategy[Callable[..., Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737
-    """A strategy for functions, which can be used in callbacks.
+    """functions(*, like=lambda: None, returns=none())
+
+    A strategy for functions, which can be used in callbacks.
 
     The generated functions will mimic the interface of ``like``, which must
     be a callable (including a class, method, or function).  The return value

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -103,10 +103,10 @@ def ip_addresses(
     if network is None:
         # We use the reserved-address registries to boost the chance
         # of generating one of the various special types of address.
-        four = binary(4, 4).map(IPv4Address) | sampled_from(
+        four = binary(min_size=4, max_size=4).map(IPv4Address) | sampled_from(
             SPECIAL_IPv4_RANGES
         ).flatmap(lambda network: ip_addresses(network=network))
-        six = binary(16, 16).map(IPv6Address) | sampled_from(
+        six = binary(min_size=16, max_size=16).map(IPv6Address) | sampled_from(
             SPECIAL_IPv6_RANGES
         ).flatmap(lambda network: ip_addresses(network=network))
         if v == 4:

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -98,7 +98,7 @@ def test_pytest_skip_skips_shrinking():
 
 
 def test_can_find_with_db_eq_none():
-    find(s.integers(), bool, settings(database=None, max_examples=100))
+    find(s.integers(), bool, settings=settings(database=None, max_examples=100))
 
 
 def test_no_such_example():

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -26,7 +26,7 @@ def func_a():
     pass
 
 
-@given(functions(func_a, booleans()))
+@given(functions(like=func_a, returns=booleans()))
 def test_functions_no_args(f):
     assert f.__name__ == "func_a"
     assert f is not func_a
@@ -37,7 +37,7 @@ def func_b(a, b, c):
     pass
 
 
-@given(functions(func_b, booleans()))
+@given(functions(like=func_b, returns=booleans()))
 def test_functions_with_args(f):
     assert f.__name__ == "func_b"
     assert f is not func_b
@@ -50,7 +50,7 @@ def func_c(**kwargs):
     pass
 
 
-@given(functions(func_c, booleans()))
+@given(functions(like=func_c, returns=booleans()))
 def test_functions_kw_args(f):
     assert f.__name__ == "func_c"
     assert f is not func_c
@@ -59,7 +59,7 @@ def test_functions_kw_args(f):
     assert isinstance(f(a=1, b=2, c=3), bool)
 
 
-@given(functions(lambda: None, booleans()))
+@given(functions(like=lambda: None, returns=booleans()))
 def test_functions_argless_lambda(f):
     assert f.__name__ == "<lambda>"
     with pytest.raises(TypeError):
@@ -67,7 +67,7 @@ def test_functions_argless_lambda(f):
     assert isinstance(f(), bool)
 
 
-@given(functions(lambda a: None, booleans()))
+@given(functions(like=lambda a: None, returns=booleans()))
 def test_functions_lambda_with_arg(f):
     assert f.__name__ == "<lambda>"
     with pytest.raises(TypeError):
@@ -78,7 +78,7 @@ def test_functions_lambda_with_arg(f):
 @pytest.mark.parametrize("like,returns", [(None, booleans()), (lambda: None, None)])
 def test_invalid_arguments(like, returns):
     with pytest.raises(InvalidArgument):
-        functions(like, returns).example()
+        functions(like=like, returns=returns).example()
 
 
 def test_functions_valid_within_given_invalid_outside():
@@ -97,16 +97,16 @@ def test_functions_valid_within_given_invalid_outside():
 def test_can_call_default_like_arg():
     # This test is somewhat silly, but coverage complains about the uncovered
     # branch for calling it otherwise and alternative workarounds are worse.
-    like, returns = getfullargspec(functions).defaults
-    assert like() is None
-    assert returns.example() is None
+    defaults = getfullargspec(functions).kwonlydefaults
+    assert defaults["like"]() is None
+    assert defaults["returns"].example() is None
 
 
 def func(arg, *, kwonly_arg):
     pass
 
 
-@given(functions(func))
+@given(functions(like=func))
 def test_functions_strategy_with_kwonly_args(f):
     with pytest.raises(TypeError):
         f(1, 2)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -656,7 +656,7 @@ def test_hashable_type_unhashable_value():
     "typ,repr_",
     [
         (int, "integers()"),
-        (typing.List[str], "lists(elements=text())"),
+        (typing.List[str], "lists(text())"),
         ("not a type", "from_type('not a type')"),
     ],
 )

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -76,7 +76,7 @@ def test_fuzz_fractions_bounds(data):
     if low is not None and high is not None and low > high:
         low, high = high, low
     try:
-        val = data.draw(fractions(low, high, denom), label="value")
+        val = data.draw(fractions(low, high, max_denominator=denom), label="value")
     except InvalidArgument:
         reject()  # fractions too close for given max_denominator
     if low is not None:

--- a/hypothesis-python/tests/cover/test_runner_strategy.py
+++ b/hypothesis-python/tests/cover/test_runner_strategy.py
@@ -38,10 +38,10 @@ def test_cannot_use_in_find_without_default():
 
 def test_is_default_in_find():
     t = object()
-    assert find(st.runner(t), lambda x: True) == t
+    assert find(st.runner(default=t), lambda x: True) == t
 
 
-@given(st.runner(1))
+@given(st.runner(default=1))
 def test_is_default_without_self(runner):
     assert runner == 1
 

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -643,14 +643,14 @@ def test_saves_failing_example_in_database():
     db = ExampleDatabase(":memory:")
     with raises(AssertionError):
         run_state_machine_as_test(
-            SetStateMachine, Settings(database=db, max_examples=100)
+            SetStateMachine, settings=Settings(database=db, max_examples=100)
         )
     assert any(list(db.data.values()))
 
 
 def test_can_run_with_no_db():
     with raises(AssertionError):
-        run_state_machine_as_test(SetStateMachine, Settings(database=None))
+        run_state_machine_as_test(SetStateMachine, settings=Settings(database=None))
 
 
 def test_stateful_double_rule_is_forbidden(recwarn):

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -24,7 +24,7 @@ from hypothesis.errors import InvalidArgument
 @example(0.0, "this covers the branch where context.data is None")
 @given(observation=st.floats(allow_nan=False, allow_infinity=False), label=st.text())
 def test_allowed_inputs_to_target(observation, label):
-    target(observation, label)
+    target(observation, label=label)
 
 
 @given(
@@ -32,7 +32,7 @@ def test_allowed_inputs_to_target(observation, label):
     label=st.sampled_from(["a", "few", "labels"]),
 )
 def test_allowed_inputs_to_target_fewer_labels(observation, label):
-    target(observation, label)
+    target(observation, label=label)
 
 
 @given(st.floats(min_value=1, max_value=10))
@@ -49,7 +49,7 @@ def test_target_without_label(observation):
 )
 def test_multiple_target_calls(args):
     for observation, label in args:
-        target(observation, label)
+        target(observation, label=label)
 
 
 @given(
@@ -83,12 +83,12 @@ def everything_except(type_):
 @given(observation=everything_except(float), label=everything_except(str))
 def test_disallowed_inputs_to_target(observation, label):
     with pytest.raises(InvalidArgument):
-        target(observation, label)
+        target(observation, label=label)
 
 
 def test_cannot_target_outside_test():
     with pytest.raises(InvalidArgument):
-        target(1.0, "example label")
+        target(1.0, label="example label")
 
 
 @given(st.none())

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -31,6 +31,8 @@ from hypothesis.strategies._internal.types import _global_type_lookup
 # Build a set of all types output by core strategies
 blacklist = [
     "builds",
+    "from_regex",
+    "from_type",
     "ip_addresses",
     "iterables",
     "permutations",

--- a/hypothesis-python/tests/nocover/test_argument_validation.py
+++ b/hypothesis-python/tests/nocover/test_argument_validation.py
@@ -13,7 +13,12 @@
 #
 # END HEADER
 
+from inspect import Parameter
+
+import pytest
+
 import hypothesis.strategies as st
+from hypothesis.strategies._internal.core import _strategies
 from tests.common.arguments import argument_validation_test, e
 
 BAD_ARGS = []
@@ -43,3 +48,16 @@ for ex in [
 BAD_ARGS.extend([e(st.lists, st.nothing(), unique=True, min_size=1)])
 
 test_raise_invalid_argument = argument_validation_test(BAD_ARGS)
+
+
+@pytest.mark.parametrize("name", sorted(_strategies))
+def test_consistent_with_api_guide_on_kwonly_args(name):
+    # Enforce our style-guide: if it has a default value, it should be
+    # keyword-only with a very few exceptions.
+    for arg in _strategies[name].parameters.values():
+        assert (
+            arg.default == Parameter.empty
+            or arg.kind != Parameter.POSITIONAL_OR_KEYWORD
+            or arg.name in ("min_value", "max_value", "subtype_strategy", "columns")
+            or name in ("text", "range_indexes", "badly_draw_lists", "write_pattern")
+        ), "need kwonly args in %s" % (name,)

--- a/hypothesis-python/tests/numpy/test_fill_values.py
+++ b/hypothesis-python/tests/numpy/test_fill_values.py
@@ -19,7 +19,7 @@ from hypothesis.extra.numpy import arrays
 from tests.common.debug import find_any, minimal
 
 
-@given(arrays(object, 100, st.builds(list)))
+@given(arrays(object, 100, elements=st.builds(list)))
 def test_generated_lists_are_distinct(ls):
     assert len(set(map(id, ls))) == len(ls)
 
@@ -32,14 +32,14 @@ def distinct_integers(draw):
     return i
 
 
-@given(arrays("uint64", 10, distinct_integers()))
+@given(arrays("uint64", 10, elements=distinct_integers()))
 def test_does_not_reuse_distinct_integers(arr):
     assert len(set(arr)) == len(arr)
 
 
 def test_may_reuse_distinct_integers_if_asked():
     find_any(
-        arrays("uint64", 10, distinct_integers(), fill=distinct_integers()),
+        arrays("uint64", 10, elements=distinct_integers(), fill=distinct_integers()),
         lambda x: len(set(x)) < len(x),
     )
 


### PR DESCRIPTION
Keyword-only arguments are great, because - assuming you have sensible names - they make complicated function signatures readable at the call site *without* needing to check the definition for e.g. the order of all the boolean flags.  This PR:

- Converts all arguments with default values into keyword-only arguments, with only a few exceptions
  - `min_value` and `max_value`, because call sites are still clear with positional arguments.
  - `alphabet` in `st.text()`, `subdtype_strategy` in the Numpy extra, and `columns` in the Pandas extra.  The first argument in these cases has a clear interpretation, so positional is fine.
  - `extra.pandas.range_indices()`, where min_size and max_size are obvious even by position
- Adds the `@deprecated_posargs` decorator, which inserts a `*__deprecated_posargs` argument.  This ensures that existing code continues to work (albeit with deprecation warnings), while raising an error if passed too many posargs or if any argument is passed by both name and position.

Closes #2130. 