### PR TITLE
Block install on Python < 3.5.2

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,16 @@
+RELEASE_TYPE: minor
+
+This release removes support for Python 3.5.0 and 3.5.1, where the
+:mod:`python:typing` module was quite immature (e.g. missing
+:func:`~python:typing.overload` and :obj:`~python:typing.Type`).
+
+Note that Python 3.5 will reach its end-of-life in September 2020,
+and new releases of Hypothesis may drop support somewhat earlier.
+
+.. note::
+    ``pip install hypothesis`` should continue to give you the latest compatible version.
+    If you have somehow ended up with an incompatible version, you need to update your
+    packaging stack to ``pip >= 9.0`` and ``setuptools >= 24.2`` - see `here for details
+    <https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires>`__.
+    Then ``pip uninstall hypothesis && pip install hypothesis`` will get you back to
+    a compatible version.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -19,7 +19,7 @@ import warnings
 
 import setuptools
 
-if sys.version_info[:2] < (3, 5):
+if sys.version_info[:3] < (3, 5, 2):
     raise Exception(
         "This version of Python is too old to install new versions of Hypothesis.  "
         "Update `pip` and `setuptools`, try again, and you will automatically "
@@ -91,7 +91,7 @@ setuptools.setup(
     zip_safe=False,
     extras_require=extras,
     install_requires=["attrs>=19.2.0", "sortedcontainers>=2.1.0,<3.0.0"],
-    python_requires=">=3.5",
+    python_requires=">=3.5.2",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Hypothesis",

--- a/hypothesis-python/src/hypothesis/_error_if_old.py
+++ b/hypothesis-python/src/hypothesis/_error_if_old.py
@@ -18,11 +18,11 @@ import sys
 from hypothesis.version import __version__
 
 message = """
-Hypothesis {} requires Python 3.5 or later.
+Hypothesis {} requires Python 3.5.2 or later.
 
 This can only happen if your packaging toolchain is older than python_requires.
 See https://packaging.python.org/guides/distributing-packages-using-setuptools/
 """
 
-if sys.version_info < (3, 5):  # pragma: no cover
+if sys.version_info[:3] < (3, 5, 2):  # pragma: no cover
     raise Exception(message.format(__version__))

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -17,7 +17,7 @@ import re
 import string
 from datetime import timedelta
 from decimal import Decimal
-from typing import Any, Callable, Dict, TypeVar, Union
+from typing import Any, Callable, Dict, Type, TypeVar, Union
 
 import django
 import django.db.models as dm
@@ -34,12 +34,6 @@ from hypothesis.extra.pytz import timezones
 from hypothesis.internal.validation import check_type
 from hypothesis.provisional import urls
 from hypothesis.strategies import emails
-
-try:
-    # New in Python 3.5.2; so we only use the string form in annotations
-    from typing import Type
-except ImportError:
-    pass
 
 AnyField = Union[dm.Field, df.Field]
 F = TypeVar("F", bound=AnyField)
@@ -216,7 +210,7 @@ def _for_form_boolean(field):
 
 
 def register_field_strategy(
-    field_type: "Type[AnyField]", strategy: st.SearchStrategy
+    field_type: Type[AnyField], strategy: st.SearchStrategy
 ) -> None:
     """Add an entry to the global field-to-strategy lookup used by
     :func:`~hypothesis.extra.django.from_field`.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -78,13 +78,7 @@ try:
     typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
     ForwardRef = typing.ForwardRef  # type: ignore
 except AttributeError:
-    typing_root_type = (typing.TypingMeta, typing.TypeVar)  # type: ignore
-    try:
-        typing_root_type += (typing._Union,)  # type: ignore
-    except AttributeError:
-        # Under Python 3.5.0, we'll just give up... if users want strategies
-        # inferred from Union-typed attrs attributes they can try a newer Python.
-        pass
+    typing_root_type = (typing.TypingMeta, typing.TypeVar, typing._Union)  # type: ignore
     ForwardRef = typing._ForwardRef  # type: ignore
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -39,8 +39,10 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
+    overload,
 )
 from uuid import UUID
 
@@ -123,15 +125,6 @@ from hypothesis.strategies._internal.strings import (
 )
 from hypothesis.types import RandomWithSeed
 from hypothesis.utils.conventions import InferType, infer, not_set
-
-try:
-    # New in Python 3.5.2; so we only use the string form in annotations
-    from typing import Type, overload
-except ImportError:
-
-    def overload(f):
-        return f
-
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -629,7 +622,7 @@ def sampled_from(elements: Sequence[T]) -> SearchStrategy[T]:
 
 
 @overload  # noqa: F811
-def sampled_from(elements: "Type[enum.Enum]") -> SearchStrategy[Any]:
+def sampled_from(elements: Type[enum.Enum]) -> SearchStrategy[Any]:
     # `SearchStrategy[Enum]` is unreliable due to metaclass issues.
     pass  # pragma: no cover
 
@@ -1247,7 +1240,7 @@ def _defer_from_type(func: T) -> T:
 
 @cacheable
 @_defer_from_type
-def from_type(thing: "Type[Ex]") -> SearchStrategy[Ex]:
+def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     """Looks up the appropriate search strategy for the given type.
 
     ``from_type`` is used internally to fill in missing arguments to
@@ -2089,8 +2082,8 @@ def data() -> SearchStrategy[DataObject]:
 
 
 def register_type_strategy(
-    custom_type: "Type[Ex]",
-    strategy: Union[SearchStrategy[Ex], Callable[["Type[Ex]"], SearchStrategy[Ex]]],
+    custom_type: Type[Ex],
+    strategy: Union[SearchStrategy[Ex], Callable[[Type[Ex]], SearchStrategy[Ex]]],
 ) -> None:
     """Add an entry to the global type-to-strategy lookup.
 


### PR DESCRIPTION
This is designed to prevent problems like #2318 - in #2315 I tried to to add a CI job for Python 3.5.1, but it turns out that `tox` doesn't support patch versions... and so I thought the best option was to explicitly drop 3.5.0 and 3.5.1 and get ahead of the cleanups.

We're not the only project to be thinking about this: e.g. there's https://github.com/pytest-dev/pytest/pull/6470, https://github.com/python-trio/trio/issues/880, and https://github.com/python/mypy/issues/7420.  Ubuntu has shipped Python >= 3.5.2 since their 16.04.05, and [PyPI stats](https://pypistats.org/packages/hypothesis) show low 3.5 usage (much lower than 2.7), of which we think only a small portion will be affected.