### PR TITLE
Roll back 5.2.0 (numpy unicode fun) for now

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch reverts :ref:`version 5.2 <v5.2.0>`, due to a
+`strange issue <https://github.com/numpy/numpy/issues/15363>`__
+where indexing an array of strings can raise an error instead of
+returning an item which contains certain surrogate characters.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -84,9 +84,9 @@ def from_dtype(dtype: np.dtype) -> st.SearchStrategy[Any]:
         result = st.integers(min_value=-overflow, max_value=overflow - 1)
     elif dtype.kind == "U":
         # Encoded in UTF-32 (four bytes/codepoint) and null-terminated
-        result = st.text(
-            alphabet=st.characters(), max_size=(dtype.itemsize or 0) // 4 or None
-        ).filter(lambda b: b[-1:] != "\0")
+        result = st.text(max_size=(dtype.itemsize or 0) // 4 or None).filter(
+            lambda b: b[-1:] != "\0"
+        )
     elif dtype.kind in ("m", "M"):
         if "[" in dtype.str:
             res = st.just(dtype.str.split("[")[-1][:-1])

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -310,6 +310,13 @@ def test_unicode_string_dtypes_generate_unicode_strings(data):
     assert isinstance(result, str)
 
 
+@given(nps.arrays(dtype="U99", shape=(10,)))
+def test_can_unicode_strings_without_decode_error(arr):
+    # See https://github.com/numpy/numpy/issues/15363
+    pass
+
+
+@pytest.mark.xfail(strict=False, reason="mitigation for issue above")
 def test_unicode_string_dtypes_need_not_be_utf8():
     def cannot_encode(string):
         try:


### PR DESCRIPTION
Because https://github.com/numpy/numpy/issues/15363.