### PR TITLE
Refactoring stateful testing: rule-based all the way down

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release cleans up the internal machinery for :doc:`stateful`,
+after we dropped the legacy APIs in Hypothesis 5.0 (:issue:`2218`).
+There is no user-visible change.


### PR DESCRIPTION
This PR finalises the removal of `GenericStateMachine`, and inlines various pieces of the rule-based implementation directly into `run_state_machine_as_test` to remove needless indirection.  As the last significant refactoring after dropping Py2 / releasing Hypothesis 5, this closes #2218.

Vive l'hypothèse nouvelle!