### PR TITLE
Improve repr of `from_type(...)` strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch improves the repr of :func:`~hypothesis.strategies.from_type`,
+so that in most cases it will display the strategy it resolves to rather
+than ``from_type(...)``.  The latter form will continue to be used where
+resolution is not immediately successful, e.g. invalid arguments or
+recursive type definitions involving forward references.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -70,10 +70,10 @@ class LazyStrategy(SearchStrategy):
     Its parameter and distribution come from that other strategy.
     """
 
-    def __init__(self, function, args, kwargs):
+    def __init__(self, function, args, kwargs, *, force_repr=None):
         SearchStrategy.__init__(self)
         self.__wrapped_strategy = None
-        self.__representation = None
+        self.__representation = force_repr
         self.function = function
         self.__args = args
         self.__kwargs = kwargs

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -439,7 +439,7 @@ class SampledFromStrategy(SearchStrategy):
         assert self.elements
 
     def __repr__(self):
-        return "sampled_from(%s)" % ", ".join(map(repr, self.elements))
+        return "sampled_from([%s])" % ", ".join(map(repr, self.elements))
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -650,3 +650,15 @@ def test_hashable_type_unhashable_value():
     # Decimal("snan") is not hashable; we should be able to generate it.
     # See https://github.com/HypothesisWorks/hypothesis/issues/2320
     find_any(from_type(typing.Hashable), lambda x: not types._can_hash(x))
+
+
+@pytest.mark.parametrize(
+    "typ,repr_",
+    [
+        (int, "integers()"),
+        (typing.List[str], "lists(elements=text())"),
+        ("not a type", "from_type('not a type')"),
+    ],
+)
+def test_repr_passthrough(typ, repr_):
+    assert repr(st.from_type(typ)) == repr_

--- a/hypothesis-python/tests/cover/test_one_of.py
+++ b/hypothesis-python/tests/cover/test_one_of.py
@@ -32,3 +32,9 @@ def test_one_of_filtered(i):
 @given(st.one_of(st.just(100).flatmap(st.integers)))
 def test_one_of_flatmapped(i):
     assert i >= 100
+
+
+def test_one_of_single_strategy_is_noop():
+    s = st.integers()
+    assert st.one_of(s) is s
+    assert st.one_of([s]) is s


### PR DESCRIPTION
So that `repr(from_type(int))` == `integers()`, rather than `from_type(int)` - the latter is *correct*, but it's not particularly helpful!