### PR TITLE
Misc little cleanups

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch has some tiny internal code clean-ups, with no user-visible change.

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -47,7 +47,7 @@ Supported Versions
 There is quite a lot of variation between pandas versions. We only
 commit to supporting the latest version of pandas, but older minor versions are
 supported on a "best effort" basis.  Hypothesis is currently tested against
-and confirmed working with Pandas 0.19, 0.20, 0.21, 0.22, and 0.23.
+and confirmed working with every Pandas minor version from 0.19 through to 1.0.
 
 Releases that are not the latest patch release of their minor version are not
 tested or officially supported, but will probably also work unless you hit a

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -119,7 +119,7 @@ class settingsMeta(type):
         return type.__setattr__(self, name, value)
 
 
-class settings(settingsMeta("settings", (object,), {})):  # type: ignore
+class settings(metaclass=settingsMeta):
     """A settings object controls a variety of parameters that are used in
     falsification. These may control both the falsification strategy and the
     details of the data that is generated.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -157,7 +157,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         return directory
 
     def _value_path(self, key, value):
-        return os.path.join(self._key_path(key), sha384(value).hexdigest()[:16])
+        return os.path.join(self._key_path(key), _hash(value))
 
     def fetch(self, key):
         kp = self._key_path(key)

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -66,7 +66,7 @@ class EDMeta(type):
         return super().__call__(*args, **kwargs)
 
 
-class ExampleDatabase(EDMeta("ExampleDatabase", (object,), {})):  # type: ignore
+class ExampleDatabase(metaclass=EDMeta):
     """Interface class for storage systems.
 
     A key -> multiple distinct values mapping.

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -755,13 +755,6 @@ def _exception_pprint(obj, p, cycle):
     p.end_group(step, ")")
 
 
-#: the exception base
-try:
-    _exception_base = BaseException
-except NameError:  # pragma: no cover
-    _exception_base = Exception  # type: ignore
-
-
 #: printers for builtin types
 _type_pprinters = {
     int: _repr_pprint,
@@ -780,7 +773,7 @@ _type_pprinters = {
     types.MethodType: _repr_pprint,
     datetime.datetime: _repr_pprint,
     datetime.timedelta: _repr_pprint,
-    _exception_base: _exception_pprint,
+    BaseException: _exception_pprint,
     slice: _repr_pprint,
     range: _repr_pprint,
     bytes: _repr_pprint,


### PR DESCRIPTION
A rollup of tiny fixes I've spotted lately; the "big one" is either a one-line docs change for Pandas compat, or using the Python 3 syntax for metaclasses in the places remaining after #2332.

So this should be very easy to review!