### PR TITLE
Patch `builds()` signature on py38 for pos-only `target` in docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.8
    install:
       - requirements: requirements/tools.txt
       - path: hypothesis-python/

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves the signature of :func:`~hypothesis.strategies.builds` by
+specifying ``target`` as a positional-only argument on Python 3.8 (see :pep:`570`).
+The semantics of :func:`~hypothesis.strategies.builds` have not changed at all -
+this just clarifies the documentation.


### PR DESCRIPTION
Using real positional-only parameters is sadly out of scope at least for now, but assigning to `__signature__` for the benefit of docs is easy!