### PR TITLE
Don't recreate example groups for mutation, except when necessary

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes Hypothesis faster at generating test cases that contain
+duplicated values in their inputs.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -687,6 +687,7 @@ class ConjectureRunner:
             ):
                 initial_calls = self.call_count
                 failed_mutations = 0
+                groups = None
                 while (
                     should_generate_more()
                     # We implement fairly conservative checks for how long we
@@ -695,11 +696,12 @@ class ConjectureRunner:
                     and self.call_count <= initial_calls + 5
                     and failed_mutations <= 5
                 ):
-                    groups = defaultdict(list)
-                    for ex in data.examples:
-                        groups[ex.label, ex.depth].append(ex)
+                    if groups is None:
+                        groups = defaultdict(list)
+                        for ex in data.examples:
+                            groups[ex.label, ex.depth].append(ex)
 
-                    groups = [v for v in groups.values() if len(v) > 1]
+                        groups = [v for v in groups.values() if len(v) > 1]
 
                     if not groups:
                         break
@@ -750,6 +752,7 @@ class ConjectureRunner:
                         )
                     ):
                         data = new_data
+                        groups = None
                         failed_mutations = 0
                     else:
                         failed_mutations += 1


### PR DESCRIPTION
This quick-fix eliminates a big chunk of the performance loss that was reported in #2308.

The mutator loop was previously recalculating `groups` for each iteration, even when nothing had changed since the previous iteration. These redundant calculations took up a surprisingly large percentage of the increased runtime since 4.51.0, so avoiding them is quite helpful.

---

I have some more ambitious/vague ideas about how to speed up the mutator, but for now this is a quick and easy win.