### PR TITLE
Handle `datetime64`, `timedelta64` dtypes without time units

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2351`, :func:`~hypothesis.extra.numpy.arrays` would
+raise a confusing error if we inferred a strategy for ``datetime64`` or
+``timedelta64`` values with varying time units.
+
+We now infer an internally-consistent strategy for such arrays, and have a more
+helpful error message if an inconsistent strategy is explicitly specified.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -381,6 +381,7 @@ def arrays(
     dtype = np.dtype(dtype)
     if elements is None:
         elements = from_dtype(dtype)
+    check_type(SearchStrategy, elements, "elements")
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -91,6 +91,9 @@ def from_dtype(dtype: np.dtype) -> st.SearchStrategy[Any]:
         if "[" in dtype.str:
             res = st.just(dtype.str.split("[")[-1][:-1])
         else:
+            # Note that this case isn't valid to pass to arrays(), but we support
+            # it here because we'd have to guard against equivalents in arrays()
+            # regardless and drawing scalars is a valid use-case.
             res = st.sampled_from(TIME_RESOLUTIONS)
         result = st.builds(dtype.type, st.integers(-(2 ** 63), 2 ** 63 - 1), res)
     else:
@@ -135,7 +138,13 @@ class ArrayStrategy(SearchStrategy):
     def set_element(self, data, result, idx, strategy=None):
         strategy = strategy or self.element_strategy
         val = data.draw(strategy)
-        result[idx] = val
+        try:
+            result[idx] = val
+        except TypeError as err:
+            raise InvalidArgument(
+                "Could not add element=%r of %r to array of %r - possible mismatch "
+                "of time units in dtypes?" % (val, val.dtype, result.dtype)
+            ) from err
         if self._check_elements and val != result[idx] and val == val:
             raise InvalidArgument(
                 "Generated array element %r from %r cannot be represented as "
@@ -380,6 +389,16 @@ def arrays(
     # From here on, we're only dealing with values and it's relatively simple.
     dtype = np.dtype(dtype)
     if elements is None:
+        if dtype.kind in ("m", "M") and "[" not in dtype.str:
+            # For datetime and timedelta dtypes, we have a tricky situation -
+            # because they *may or may not* specify a unit as part of the dtype.
+            # If not, we flatmap over the various resolutions so that array
+            # elements have consistent units but units may vary between arrays.
+            return (
+                st.sampled_from(TIME_RESOLUTIONS)
+                .map((dtype.str + "[{}]").format)
+                .flatmap(lambda d: arrays(d, shape=shape, fill=fill, unique=unique))
+            )
         elements = from_dtype(dtype)
     check_type(SearchStrategy, elements, "elements")
     if isinstance(shape, int):

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -45,6 +45,7 @@ def e(a, **kwargs):
         e(nps.arrays, dtype=object, shape=1),
         e(nps.arrays, dtype=float, shape=1, fill=3),
         e(nps.arrays, dtype="U", shape=1, elements=st.just("abc\0\0")),
+        e(nps.arrays, dtype=int, shape=1, elements="not a strategy"),
         e(nps.byte_string_dtypes, min_len=-1),
         e(nps.byte_string_dtypes, min_len=2, max_len=1),
         e(nps.byte_string_dtypes, min_len=0, max_len=0),

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -1240,3 +1240,22 @@ def test_basic_indices_generate_valid_indexers(
         assert min_dims <= view.ndim <= (32 if max_dims is None else max_dims)
         if view.size:
             assert np.shares_memory(view, array)
+
+
+@pytest.mark.parametrize("dtype_str", ["m8", "M8"])
+@given(data=st.data())
+def test_from_dtype_works_without_time_unit(data, dtype_str):
+    arr = data.draw(nps.from_dtype(np.dtype(dtype_str)))
+    assert (dtype_str + "[") in arr.dtype.str
+
+
+@pytest.mark.parametrize("dtype_str", ["m8", "M8"])
+@given(data=st.data())
+def test_arrays_selects_consistent_time_unit(data, dtype_str):
+    arr = data.draw(nps.arrays(dtype_str, 10))
+    assert (dtype_str + "[") in arr.dtype.str
+
+
+def test_arrays_gives_useful_error_on_inconsistent_time_unit():
+    with pytest.raises(InvalidArgument, match="mismatch of time units in dtypes"):
+        nps.arrays("m8[Y]", 10, elements=nps.from_dtype(np.dtype("m8[D]"))).example()


### PR DESCRIPTION
Closes #2351. 

Contrary to my suggestion in that issue, I didn't add any validation logic to `from_dtype()` - generating scalars with varied units is at least potentially useful.  Improving `arrays()` so that we no longer infer such inconsistent strategies, and give a better error message if one is explicitly passed, is IMO sufficient.