### PR TITLE
Python 3.8 not yet available on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,10 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
+   # We'd like to use 3.8 for builds() signature, but it's not supported yet.
+   # See https://github.com/readthedocs/readthedocs.org/issues/6324
+   # and https://github.com/readthedocs/readthedocs.org/issues/6551
+   version: 3.7
    install:
       - requirements: requirements/tools.txt
       - path: hypothesis-python/


### PR DESCRIPTION
#2345 failed because of readthedocs/readthedocs.org#6324; I've subscribed to the relevant issues.

Once their Python 3.8 image is out of beta, we'll revert this and get the signature we want in our docs (without #1104 problems) at last!