### PR TITLE
Warn on `@given` + function-scoped fixtures

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release adds an explicit warning for tests that are both decorated with
+:func:`@given(...) <hypothesis.given>` and request a
+:doc:`function-scoped pytest fixture <pytest:fixture>`, because such fixtures
+are only executed once for *all* Hypothesis test cases and that often causes
+trouble (:issue:`377`).
+
+It's *very* difficult to fix this on the :pypi:`pytest` side, so since 2015
+our advice has been "just don't use function-scoped fixtures with Hypothesis".
+Now we detect and warn about the issue at runtime!

--- a/hypothesis-python/tests/cover/test_mock.py
+++ b/hypothesis-python/tests/cover/test_mock.py
@@ -19,7 +19,7 @@
 import math
 from unittest import mock
 
-from _pytest.capture import CaptureFixture
+from _pytest.config import Config
 
 import hypothesis.strategies as st
 from hypothesis import given
@@ -34,15 +34,15 @@ def test_can_mock_inside_given_without_fixture(atan, thing):
 
 @mock.patch("math.atan")
 @given(thing=st.text())
-def test_can_mock_outside_given_with_fixture(atan, capsys, thing):
+def test_can_mock_outside_given_with_fixture(atan, pytestconfig, thing):
     assert isinstance(atan, mock.MagicMock)
     assert isinstance(math.atan, mock.MagicMock)
-    assert isinstance(capsys, CaptureFixture)
+    assert isinstance(pytestconfig, Config)
 
 
 @given(thing=st.text())
-def test_can_mock_within_test_with_fixture(capsys, thing):
-    assert isinstance(capsys, CaptureFixture)
+def test_can_mock_within_test_with_fixture(pytestconfig, thing):
+    assert isinstance(pytestconfig, Config)
     assert not isinstance(math.atan, mock.MagicMock)
     with mock.patch("math.atan") as atan:
         assert isinstance(atan, mock.MagicMock)


### PR DESCRIPTION
Closes #377 by automating our response of "don't do that then".

Skips the warning for `autouse=True` fixtures purely because it's usually much more difficult to fix those.  For example [you can have fixtures skip tests with a mark](https://stackoverflow.com/a/38763328/9297601) (and all `@given()` tests are marked `hypothesis` by our plugin), but this wouldn't support our own time-mocking system which inherits function-scoped-ness from `monkeypatch` and *should* apply to `@given()` tests.

So I'd call this two parts education, one part enforcement of good practice, and one part pragmatic non-enforcement.