### PR TITLE
Python 3.8 is now available on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,10 +9,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   # We'd like to use 3.8 for builds() signature, but it's not supported yet.
-   # See https://github.com/readthedocs/readthedocs.org/issues/6324
-   # and https://github.com/readthedocs/readthedocs.org/issues/6551
-   version: 3.7
+   version: 3.8
    install:
       - requirements: requirements/tools.txt
       - path: hypothesis-python/


### PR DESCRIPTION
So we can revert #2355 and get the signature improvement I wanted from #2345 :grin: 

To verify that's it's *actually* working this time, you can view a working readthedocs [build log here](https://readthedocs.org/projects/hypothesis-test-zhd/builds/10466332/) and [resulting signature here](https://hypothesis-test-zhd.readthedocs.io/en/readthedocs-config/data.html#hypothesis.strategies.builds)!