### PR TITLE
Changes to documentation files to make them friendlier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,9 @@ The two prototype implementations of Hypothesis for other languages are:
 
 * `Hypothesis for Ruby <hypothesis-ruby>`_
   is a reasonable start on a port of Hypothesis to Ruby. It worked pretty well,
-  but uses a core Rust implementation that is unfortunately not compatible with
+  but used a core Rust implementation that is unfortunately not compatible with
   recent versions of Rust, due to its dependency on Helix (which now seems to
-  be mostly unmaintained) and as a result is currently unsupported pending a
+  be mostly unmaintained). As a result it is currently unsupported pending a
   rewrite of the bridging code between Rust and Ruby. We don't at present have
   the time or funding for this project, but it is likely not a massive undertaking
   if anyone would like to provide either of these.

--- a/hypothesis-python/README.rst
+++ b/hypothesis-python/README.rst
@@ -28,6 +28,7 @@ you're not using Hypothesis to test your project then you're missing out.
 ------------------------
 Quick Start/Installation
 ------------------------
+
 If you just want to get started:
 
 .. code-block::

--- a/hypothesis-python/docs/index.rst
+++ b/hypothesis-python/docs/index.rst
@@ -37,7 +37,9 @@ your code should make - properties that should always hold true,
 regardless of what the world throws at you. Examples of such guarantees
 might be:
 
-* Your code shouldn't throw an exception, or should only throw a particular type of exception (this works particularly well if you have a lot of internal assertions).
+* Your code shouldn't throw an exception, or should only throw a particular
+  type of exception (this works particularly well if you have a lot of internal
+  assertions).
 * If you delete an object, it is no longer visible.
 * If you serialize and then deserialize a value, then you get the same value back.
 


### PR DESCRIPTION
Hello! I'm having a look through the Hypothesis documentation files to think about ways to make them friendlier.

I've made a list of things I'd like to fix (some of which I already have). If you can think of any other things you've been meaning to bring up in the documentation feel free to mention it and I'm happy to have a look :grinning: 

- [x] hypothesis-python/docs/index.rst: Wrapped a line that was very long
- hypothesis-python/README.rst:
  - [x] Added a missing newline
  - [ ] Add a quick start example to the "Quick Start/Installation" section
- [x] README.rst: Fixed a tense in the ruby implementation description
- [ ] CONTRIBUTING.rst: split content into AUTHORS.rst and guides/README.rst, leaving a link to those two files.
- [ ] guides/api-style.rst: Add a link to subclassing definition/a thinkpiece on why y'all have such strong opinions about it!

Cheers
Caitlin
