### PR TITLE
Allow `array_dtypes()` to generate titles, as well as names, for fields

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release allows the :func:`~hypothesis.extra.numpy.array_dtypes` strategy
+to generate Numpy dtypes which have `field titles in addition to field names
+<https://docs.scipy.org/doc/numpy/user/basics.rec.html#field-titles>`__.
+We expect this to expose latent bugs where code expects that
+``set(dtype.names) == set(dtype.fields)``, though the latter may include titles.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -15,7 +15,6 @@
 
 import math
 import re
-from collections import namedtuple
 from typing import Any, NamedTuple, Sequence, Tuple, Union
 
 import numpy as np
@@ -1011,7 +1010,9 @@ _ARGUMENT_LIST = "{0}(?:,{0})*".format(_SHAPE)
 _SIGNATURE = r"^{}->{}$".format(_ARGUMENT_LIST, _SHAPE)
 _SIGNATURE_MULTIPLE_OUTPUT = r"^{0}->{0}$".format(_ARGUMENT_LIST)
 
-_GUfuncSig = namedtuple("_GUfuncSig", ["input_shapes", "result_shape"])
+_GUfuncSig = NamedTuple(
+    "_GUfuncSig", [("input_shapes", Tuple[Shape, ...]), ("result_shape", Shape)]
+)
 
 
 def _hypothesis_parse_gufunc_signature(signature, all_checks=True):

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -249,8 +249,12 @@ def test_minimise_array_strategy():
 
 @given(nps.array_dtypes(allow_subarrays=False))
 def test_can_turn_off_subarrays(dt):
-    for field, _ in dt.fields.values():
-        assert field.shape == ()
+    for name in dt.names:
+        assert dt.fields[name][0].shape == ()
+
+
+def test_array_dtypes_may_have_field_titles():
+    find_any(nps.array_dtypes(), lambda dt: len(dt.fields) > len(dt.names))
 
 
 @pytest.mark.parametrize("byteorder", ["<", ">"])


### PR DESCRIPTION
This PR closes #2275, where I noted that

> when reading [the SciPy docs on structured arrays](https://docs.scipy.org/doc/numpy/user/basics.rec.html#field-titles), I discovered that array dtypes / record dtypes / structured dtypes (we should probably mention those other terms in the docs...) can have a *title* as well as a field name.  This title is *also included in the `.fields` attribute*, which I doubt much existing code is prepared to handle.  We should generate fields with titles.

Fortunately Numpy explicitly rejects titles which are also field names, but I expect this to expose latent bugs even so - there's a lot of code that doesn't handle field titles at all.