### PR TITLE
Give `from_model` a positional-only argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: c
+language: python
+python: "3.6"
 
 os:
     - linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
 
   - job: osx
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.15'
     strategy:
       matrix:
         check-py36:

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,9 @@ source "$SCRIPTS/common.sh"
 if [ -n "${PIPELINE_WORKSPACE-}" ] ; then
     # We're on Azure Pipelines and already set up a suitable Python
     PYTHON=$(command -v python)
+elif [ -n "${TRAVIS-}" ] ; then
+    # We're on Travis and already set up a suitable Python
+    PYTHON=$(command -v python)
 else
     # Otherwise, we install it from scratch
     "$SCRIPTS/ensure-python.sh" 3.6.8

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This makes ``model`` a positional-only argument to
+:func:`~hypothesis.extra.django.from_model`, to support models
+with a field literally named "model" (:issue:`2369`).

--- a/hypothesis-python/tests/django/toystore/models.py
+++ b/hypothesis-python/tests/django/toystore/models.py
@@ -26,6 +26,11 @@ class Store(models.Model):
     company = models.ForeignKey(Company, null=False, on_delete=models.CASCADE)
 
 
+class Car(models.Model):
+    # See https://github.com/HypothesisWorks/hypothesis/issues/2369
+    model = models.CharField(max_length=100, unique=True)
+
+
 class CharmField(models.Field):
     def db_type(self, connection):
         return "char(1)"

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -21,7 +21,11 @@ from django.contrib.auth.models import User
 
 from hypothesis import HealthCheck, assume, given, infer, settings
 from hypothesis.control import reject
-from hypothesis.errors import HypothesisException, InvalidArgument
+from hypothesis.errors import (
+    HypothesisDeprecationWarning,
+    HypothesisException,
+    InvalidArgument,
+)
 from hypothesis.extra.django import (
     TestCase,
     TransactionTestCase,
@@ -31,6 +35,7 @@ from hypothesis.extra.django import (
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies import binary, just, lists
 from tests.django.toystore.models import (
+    Car,
     Company,
     CompanyExtension,
     CouldBeCharming,
@@ -187,3 +192,16 @@ class TestValidatorInference(TestCase):
     @given(from_model(User))
     def test_user_issue_1112_regression(self, user):
         assert user.username
+
+
+class TestPosOnlyArg(TestCase):
+    @given(from_model(Car))
+    def test_user_issue_2369_regression(self, val):
+        pass
+
+    def test_from_model_argspec(self):
+        self.assertRaises(TypeError, from_model().example)
+        self.assertRaises(TypeError, from_model(Car, None).example)
+        self.assertWarns(
+            HypothesisDeprecationWarning, from_model(model=Customer).example
+        )


### PR DESCRIPTION
Well, as much as possible before Python 3.8 anyway.  Closes #2369. 