### PR TITLE
Added support and unittest for overridden fixtures, solving #2375.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2375`, preventing incorrect failure when a function
+scoped fixture is overridden with a higher scoped fixture.

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -157,8 +157,7 @@ else:
                     argnames = frozenset(signature(item.function).parameters)
                 for fx in fx_defs:
                     if fx.argname in argnames:
-                        active_fx = item._request._get_active_fixturedef(
-                            fx.argname)
+                        active_fx = item._request._get_active_fixturedef(fx.argname)
                         if active_fx.scope == "function":
                             note_deprecation(
                                 "%s uses the %r fixture, but function-scoped"

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -156,14 +156,18 @@ else:
                 if argnames is None:
                     argnames = frozenset(signature(item.function).parameters)
                 for fx in fx_defs:
-                    if fx.scope == "function" and fx.argname in argnames:
-                        note_deprecation(
-                            "%s uses the %r fixture, but function-scoped fixtures "
-                            "should not be used with @given(...) tests, because "
-                            "fixtures are not reset between generated examples!"
-                            % (item.nodeid, fx.argname),
-                            since="2020-02-29",
-                        )
+                    if fx.argname in argnames:
+                        active_fx = item._request._get_active_fixturedef(
+                            fx.argname)
+                        if active_fx.scope == "function":
+                            note_deprecation(
+                                "%s uses the %r fixture, but function-scoped"
+                                " fixtures should not be used with @given(...)"
+                                " tests, because fixtures are not reset "
+                                "between generated examples!"
+                                % (item.nodeid, fx.argname),
+                                since="2020-02-29",
+                            )
 
             if item.get_closest_marker("parametrize") is not None:
                 # Give every parametrized test invocation a unique database key

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -102,3 +102,26 @@ def test_autouse_function_scoped_fixture(x):
 def test_given_plus_function_scoped_non_autouse_fixtures_are_deprecated(testdir):
     script = testdir.makepyfile(TESTSUITE)
     testdir.runpytest(script, "-Werror").assert_outcomes(passed=1, failed=1)
+
+
+TESTSCRIPT_OVERRIDE_FIXTURE = """
+import pytest
+from hypothesis import given, strategies as st
+
+@pytest.fixture(scope="function", name="event_loop")
+def event_loop_1():
+    return
+
+@pytest.fixture(scope="module", name="event_loop")
+def event_loop_2():
+    return
+
+@given(x=st.integers())
+def test_override_fixture(event_loop, x):
+    pass
+"""
+
+
+def test_given_plus_overridden_fixture(testdir):
+    script = testdir.makepyfile(TESTSCRIPT_OVERRIDE_FIXTURE)
+    testdir.runpytest(script, "-Werror").assert_outcomes(passed=1, failed=0)


### PR DESCRIPTION
(where the original fixture was function-scope)
Solves the build issues in https://github.com/pytest-dev/pytest-asyncio/pull/148