### PR TITLE
Refactoring for date and time strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves :func:`~hypothesis.strategies.dates` shrinking, to simplify
+year, month, and day like :func:`~hypothesis.strategies.datetimes` rather than
+minimizing the number of days since 2000-01-01.

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -24,8 +24,6 @@ from hypothesis.strategies._internal.core import (
     complex_numbers,
     composite,
     data,
-    dates,
-    datetimes,
     decimals,
     deferred,
     dictionaries,
@@ -55,11 +53,10 @@ from hypothesis.strategies._internal.core import (
     shared,
     slices,
     text,
-    timedeltas,
-    times,
     tuples,
     uuids,
 )
+from hypothesis.strategies._internal.datetime import dates, datetimes, timedeltas, times
 from hypothesis.strategies._internal.ipaddress import ip_addresses
 
 # The implementation of all of these lives in `_strategies.py`, but we

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-import datetime as dt
 import enum
 import math
 import operator
@@ -95,11 +94,6 @@ from hypothesis.strategies._internal.collections import (
     TupleStrategy,
     UniqueListStrategy,
     UniqueSampledListStrategy,
-)
-from hypothesis.strategies._internal.datetime import (
-    DateStrategy,
-    DatetimeStrategy,
-    TimedeltaStrategy,
 )
 from hypothesis.strategies._internal.deferred import DeferredStrategy
 from hypothesis.strategies._internal.functions import FunctionStrategy
@@ -1722,140 +1716,6 @@ def permutations(values: Sequence[T]) -> SearchStrategy[List[T]]:
         return builds(list)
 
     return PermutationStrategy(values)
-
-
-@defines_strategy_with_reusable_values
-@deprecated_posargs
-def datetimes(
-    min_value: dt.datetime = dt.datetime.min,
-    max_value: dt.datetime = dt.datetime.max,
-    *,
-    timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
-) -> SearchStrategy[dt.datetime]:
-    """datetimes(min_value=datetime.datetime.min, max_value=datetime.datetime.max, *, timezones=none())
-
-    A strategy for generating datetimes, which may be timezone-aware.
-
-    This strategy works by drawing a naive datetime between ``min_value``
-    and ``max_value``, which must both be naive (have no timezone).
-
-    ``timezones`` must be a strategy that generates
-    :class:`~python:datetime.tzinfo` objects (or None,
-    which is valid for naive datetimes).  A value drawn from this strategy
-    will be added to a naive datetime, and the resulting tz-aware datetime
-    returned.
-
-    .. note::
-        tz-aware datetimes from this strategy may be ambiguous or non-existent
-        due to daylight savings, leap seconds, timezone and calendar
-        adjustments, etc.  This is intentional, as malformed timestamps are a
-        common source of bugs.
-
-    :py:func:`hypothesis.extra.pytz.timezones` requires the :pypi:`pytz`
-    package, but provides all timezones in the Olsen database.
-    :py:func:`hypothesis.extra.dateutil.timezones` requires the
-    :pypi:`python-dateutil` package, and similarly provides all timezones
-    there.  If you want to allow naive datetimes, combine strategies
-    like ``none() | timezones()``.
-
-    Alternatively, you can create a list of the timezones you wish to allow
-    (e.g. from the standard library, :pypi:`dateutil <python-dateutil>`,
-    or :pypi:`pytz`) and use :py:func:`sampled_from`.
-
-    Examples from this strategy shrink towards midnight on January 1st 2000,
-    local time.
-    """
-    # Why must bounds be naive?  In principle, we could also write a strategy
-    # that took aware bounds, but the API and validation is much harder.
-    # If you want to generate datetimes between two particular moments in
-    # time I suggest (a) just filtering out-of-bounds values; (b) if bounds
-    # are very close, draw a value and subtract its UTC offset, handling
-    # overflows and nonexistent times; or (c) do something customised to
-    # handle datetimes in e.g. a four-microsecond span which is not
-    # representable in UTC.  Handling (d), all of the above, leads to a much
-    # more complex API for all users and a useful feature for very few.
-    check_type(dt.datetime, min_value, "min_value")
-    check_type(dt.datetime, max_value, "max_value")
-    if min_value.tzinfo is not None:
-        raise InvalidArgument("min_value=%r must not have tzinfo" % (min_value,))
-    if max_value.tzinfo is not None:
-        raise InvalidArgument("max_value=%r must not have tzinfo" % (max_value,))
-    check_valid_interval(min_value, max_value, "min_value", "max_value")
-    if not isinstance(timezones, SearchStrategy):
-        raise InvalidArgument(
-            "timezones=%r must be a SearchStrategy that can provide tzinfo "
-            "for datetimes (either None or dt.tzinfo objects)" % (timezones,)
-        )
-    return DatetimeStrategy(min_value, max_value, timezones)
-
-
-@defines_strategy_with_reusable_values
-def dates(
-    min_value: dt.date = dt.date.min, max_value: dt.date = dt.date.max
-) -> SearchStrategy[dt.date]:
-    """dates(min_value=datetime.date.min, max_value=datetime.date.max)
-
-    A strategy for dates between ``min_value`` and ``max_value``.
-
-    Examples from this strategy shrink towards January 1st 2000.
-    """
-    check_type(dt.date, min_value, "min_value")
-    check_type(dt.date, max_value, "max_value")
-    check_valid_interval(min_value, max_value, "min_value", "max_value")
-    if min_value == max_value:
-        return just(min_value)
-    return DateStrategy(min_value, max_value)
-
-
-@defines_strategy_with_reusable_values
-@deprecated_posargs
-def times(
-    min_value: dt.time = dt.time.min,
-    max_value: dt.time = dt.time.max,
-    *,
-    timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
-) -> SearchStrategy[dt.time]:
-    """times(min_value=datetime.time.min, max_value=datetime.time.max, *, timezones=none())
-
-    A strategy for times between ``min_value`` and ``max_value``.
-
-    The ``timezones`` argument is handled as for :py:func:`datetimes`.
-
-    Examples from this strategy shrink towards midnight, with the timezone
-    component shrinking as for the strategy that provided it.
-    """
-    check_type(dt.time, min_value, "min_value")
-    check_type(dt.time, max_value, "max_value")
-    if min_value.tzinfo is not None:
-        raise InvalidArgument("min_value=%r must not have tzinfo" % min_value)
-    if max_value.tzinfo is not None:
-        raise InvalidArgument("max_value=%r must not have tzinfo" % max_value)
-    check_valid_interval(min_value, max_value, "min_value", "max_value")
-    day = dt.date(2000, 1, 1)
-    return datetimes(
-        min_value=dt.datetime.combine(day, min_value),
-        max_value=dt.datetime.combine(day, max_value),
-        timezones=timezones,
-    ).map(lambda t: t.timetz())
-
-
-@defines_strategy_with_reusable_values
-def timedeltas(
-    min_value: dt.timedelta = dt.timedelta.min,
-    max_value: dt.timedelta = dt.timedelta.max,
-) -> SearchStrategy[dt.timedelta]:
-    """timedeltas(min_value=datetime.timedelta.min, max_value=datetime.timedelta.max)
-
-    A strategy for timedeltas between ``min_value`` and ``max_value``.
-
-    Examples from this strategy shrink towards zero.
-    """
-    check_type(dt.timedelta, min_value, "min_value")
-    check_type(dt.timedelta, max_value, "max_value")
-    check_valid_interval(min_value, max_value, "min_value", "max_value")
-    if min_value == max_value:
-        return just(min_value)
-    return TimedeltaStrategy(min_value=min_value, max_value=max_value)
 
 
 class CompositeStrategy(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -15,8 +15,17 @@
 
 import datetime as dt
 from calendar import monthrange
+from typing import Optional
 
+from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils
+from hypothesis.internal.validation import check_type, check_valid_interval
+from hypothesis.strategies._internal.core import (
+    defines_strategy_with_reusable_values,
+    deprecated_posargs,
+    just,
+    none,
+)
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
 __all__ = ["DateStrategy", "DatetimeStrategy", "TimedeltaStrategy"]
@@ -69,6 +78,103 @@ class DatetimeStrategy(SearchStrategy):
             data.mark_invalid()
 
 
+@defines_strategy_with_reusable_values
+@deprecated_posargs
+def datetimes(
+    min_value: dt.datetime = dt.datetime.min,
+    max_value: dt.datetime = dt.datetime.max,
+    *,
+    timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
+) -> SearchStrategy[dt.datetime]:
+    """datetimes(min_value=datetime.datetime.min, max_value=datetime.datetime.max, *, timezones=none())
+
+    A strategy for generating datetimes, which may be timezone-aware.
+
+    This strategy works by drawing a naive datetime between ``min_value``
+    and ``max_value``, which must both be naive (have no timezone).
+
+    ``timezones`` must be a strategy that generates
+    :class:`~python:datetime.tzinfo` objects (or None,
+    which is valid for naive datetimes).  A value drawn from this strategy
+    will be added to a naive datetime, and the resulting tz-aware datetime
+    returned.
+
+    .. note::
+        tz-aware datetimes from this strategy may be ambiguous or non-existent
+        due to daylight savings, leap seconds, timezone and calendar
+        adjustments, etc.  This is intentional, as malformed timestamps are a
+        common source of bugs.
+
+    :py:func:`hypothesis.extra.pytz.timezones` requires the :pypi:`pytz`
+    package, but provides all timezones in the Olsen database.
+    :py:func:`hypothesis.extra.dateutil.timezones` requires the
+    :pypi:`python-dateutil` package, and similarly provides all timezones
+    there.  If you want to allow naive datetimes, combine strategies
+    like ``none() | timezones()``.
+
+    Alternatively, you can create a list of the timezones you wish to allow
+    (e.g. from the standard library, :pypi:`dateutil <python-dateutil>`,
+    or :pypi:`pytz`) and use :py:func:`sampled_from`.
+
+    Examples from this strategy shrink towards midnight on January 1st 2000,
+    local time.
+    """
+    # Why must bounds be naive?  In principle, we could also write a strategy
+    # that took aware bounds, but the API and validation is much harder.
+    # If you want to generate datetimes between two particular moments in
+    # time I suggest (a) just filtering out-of-bounds values; (b) if bounds
+    # are very close, draw a value and subtract its UTC offset, handling
+    # overflows and nonexistent times; or (c) do something customised to
+    # handle datetimes in e.g. a four-microsecond span which is not
+    # representable in UTC.  Handling (d), all of the above, leads to a much
+    # more complex API for all users and a useful feature for very few.
+    check_type(dt.datetime, min_value, "min_value")
+    check_type(dt.datetime, max_value, "max_value")
+    if min_value.tzinfo is not None:
+        raise InvalidArgument("min_value=%r must not have tzinfo" % (min_value,))
+    if max_value.tzinfo is not None:
+        raise InvalidArgument("max_value=%r must not have tzinfo" % (max_value,))
+    check_valid_interval(min_value, max_value, "min_value", "max_value")
+    if not isinstance(timezones, SearchStrategy):
+        raise InvalidArgument(
+            "timezones=%r must be a SearchStrategy that can provide tzinfo "
+            "for datetimes (either None or dt.tzinfo objects)" % (timezones,)
+        )
+    return DatetimeStrategy(min_value, max_value, timezones)
+
+
+@defines_strategy_with_reusable_values
+@deprecated_posargs
+def times(
+    min_value: dt.time = dt.time.min,
+    max_value: dt.time = dt.time.max,
+    *,
+    timezones: SearchStrategy[Optional[dt.tzinfo]] = none()
+) -> SearchStrategy[dt.time]:
+    """times(min_value=datetime.time.min, max_value=datetime.time.max, *, timezones=none())
+
+    A strategy for times between ``min_value`` and ``max_value``.
+
+    The ``timezones`` argument is handled as for :py:func:`datetimes`.
+
+    Examples from this strategy shrink towards midnight, with the timezone
+    component shrinking as for the strategy that provided it.
+    """
+    check_type(dt.time, min_value, "min_value")
+    check_type(dt.time, max_value, "max_value")
+    if min_value.tzinfo is not None:
+        raise InvalidArgument("min_value=%r must not have tzinfo" % min_value)
+    if max_value.tzinfo is not None:
+        raise InvalidArgument("max_value=%r must not have tzinfo" % max_value)
+    check_valid_interval(min_value, max_value, "min_value", "max_value")
+    day = dt.date(2000, 1, 1)
+    return datetimes(
+        min_value=dt.datetime.combine(day, min_value),
+        max_value=dt.datetime.combine(day, max_value),
+        timezones=timezones,
+    ).map(lambda t: t.timetz())
+
+
 class DateStrategy(SearchStrategy):
     def __init__(self, min_value, max_value):
         assert isinstance(min_value, dt.date)
@@ -81,6 +187,24 @@ class DateStrategy(SearchStrategy):
     def do_draw(self, data):
         days = utils.integer_range(data, 0, self.days_apart, center=self.center)
         return self.min_value + dt.timedelta(days=days)
+
+
+@defines_strategy_with_reusable_values
+def dates(
+    min_value: dt.date = dt.date.min, max_value: dt.date = dt.date.max
+) -> SearchStrategy[dt.date]:
+    """dates(min_value=datetime.date.min, max_value=datetime.date.max)
+
+    A strategy for dates between ``min_value`` and ``max_value``.
+
+    Examples from this strategy shrink towards January 1st 2000.
+    """
+    check_type(dt.date, min_value, "min_value")
+    check_type(dt.date, max_value, "max_value")
+    check_valid_interval(min_value, max_value, "min_value", "max_value")
+    if min_value == max_value:
+        return just(min_value)
+    return DateStrategy(min_value, max_value)
 
 
 class TimedeltaStrategy(SearchStrategy):
@@ -103,3 +227,22 @@ class TimedeltaStrategy(SearchStrategy):
             low_bound = low_bound and val == low
             high_bound = high_bound and val == high
         return dt.timedelta(**result)
+
+
+@defines_strategy_with_reusable_values
+def timedeltas(
+    min_value: dt.timedelta = dt.timedelta.min,
+    max_value: dt.timedelta = dt.timedelta.max,
+) -> SearchStrategy[dt.timedelta]:
+    """timedeltas(min_value=datetime.timedelta.min, max_value=datetime.timedelta.max)
+
+    A strategy for timedeltas between ``min_value`` and ``max_value``.
+
+    Examples from this strategy shrink towards zero.
+    """
+    check_type(dt.timedelta, min_value, "min_value")
+    check_type(dt.timedelta, max_value, "max_value")
+    check_valid_interval(min_value, max_value, "min_value", "max_value")
+    if min_value == max_value:
+        return just(min_value)
+    return TimedeltaStrategy(min_value=min_value, max_value=max_value)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -649,7 +649,11 @@ def test_generic_collections_only_use_hashable_elements(typ):
 def test_hashable_type_unhashable_value():
     # Decimal("snan") is not hashable; we should be able to generate it.
     # See https://github.com/HypothesisWorks/hypothesis/issues/2320
-    find_any(from_type(typing.Hashable), lambda x: not types._can_hash(x))
+    find_any(
+        from_type(typing.Hashable),
+        lambda x: not types._can_hash(x),
+        settings(max_examples=10 ** 5),
+    )
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis-python/tests/datetime/test_dateutil_timezones.py
@@ -21,7 +21,7 @@ from dateutil import tz, zoneinfo
 from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.dateutil import timezones
-from hypothesis.strategies import datetimes, sampled_from, times
+from hypothesis.strategies import data, datetimes, sampled_from, times
 from tests.common.debug import minimal
 
 
@@ -79,3 +79,11 @@ def test_should_have_correct_ordering():
 
     next_interesting_tz = minimal(timezones(), lambda tz: offset(tz) > dt.timedelta(0))
     assert offset(next_interesting_tz) == dt.timedelta(seconds=3600)
+
+
+@given(data(), datetimes(), datetimes())
+def test_datetimes_stay_within_naive_bounds(data, lo, hi):
+    if lo > hi:
+        lo, hi = hi, lo
+    out = data.draw(datetimes(lo, hi, timezones=timezones()))
+    assert lo <= out.replace(tzinfo=None) <= hi

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -21,7 +21,7 @@ import pytz
 from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
-from hypothesis.strategies import datetimes, sampled_from, times
+from hypothesis.strategies import data, datetimes, sampled_from, times
 from tests.common.debug import assert_can_trigger_event, minimal
 
 
@@ -102,3 +102,11 @@ def test_can_trigger_error_in_draw_near_max_date():
         ),
         lambda event: "Failed to draw a datetime" in event,
     )
+
+
+@given(data(), datetimes(), datetimes())
+def test_datetimes_stay_within_naive_bounds(data, lo, hi):
+    if lo > hi:
+        lo, hi = hi, lo
+    out = data.draw(datetimes(lo, hi, timezones=timezones()))
+    assert lo <= out.replace(tzinfo=None) <= hi


### PR DESCRIPTION
This PR contains some preliminary refactoring for #2273, which will be much easier to review separately and is still worth merging on it's own.  Best to review commit-by-commit:

- New tests to check that we respect naive bounds correctly.  These aren't related to the other changes here, but we don't actually have any tests for this important property yet!
- Move `dates()`, `times()`, `datetimes()`, and `timedeltas()` to the `strategies._internal.datetime` module.  No actual change here, they just don't belong in `strategies._internal.core`.
- Small change to `DateStrategy` to match the shrinking behaviour of `DatetimeStrategy`.