### PR TITLE
Stop testing against EOL Django 1.11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,8 +103,6 @@ jobs:
           TASK: check-django30
         check-django22:
           TASK: check-django22
-        check-django111:
-          TASK: check-django111
         check-pandas19:
           TASK: check-pandas19
         check-pandas22:

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -66,7 +66,7 @@ extras = {
     "dpcontracts": ["dpcontracts>=0.4"],
     # We only support Django versions with upstream support - see
     # https://www.djangoproject.com/download/#supported-versions
-    "django": ["pytz>=2014.1", "django>=1.11"],
+    "django": ["pytz>=2014.1", "django>=2.2"],
 }
 
 extras["all"] = sorted(set(sum(extras.values(), [])))

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -83,13 +83,6 @@ deps =
 commands =
     python -m pytest tests/pandas -n2
 
-
-[testenv:django111]
-commands =
-    pip install .[pytz]
-    pip install django~=1.11.7
-    python -m tests.django.manage test tests.django
-
 [testenv:django22]
 commands =
     pip install .[pytz]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -439,7 +439,7 @@ def standard_tox_task(name):
 standard_tox_task("nose")
 standard_tox_task("pytest43")
 
-for n in [22, 30, 111]:
+for n in [22, 30]:
     standard_tox_task("django%d" % (n,))
 for n in [19, 20, 21, 22, 23, 24, 25, 100]:
     standard_tox_task("pandas%d" % (n,))


### PR DESCRIPTION
Because it's end-of-life upstream, per our policy we no longer support it either.  Since I can't see any compatibility code in our implementation, this is a test-only change.