### PR TITLE
Inspect `__signature__` attribute of classes in `builds()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch teaches :func:`~hypothesis.strategies.builds` and
+:func:`~hypothesis.strategies.from_type` to use the ``__signature__``
+attribute of classes where it has been set, improving our support
+for :pypi:`Pydantic` models (`in pydantic >= 1.5
+<https://github.com/samuelcolvin/pydantic/pull/1034>`__).

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -28,6 +28,7 @@ from types import ModuleType
 from typing import Any, Callable, TypeVar
 
 from hypothesis.internal.compat import (
+    is_typed_named_tuple,
     qualname,
     str_to_bytes,
     to_unicode,
@@ -89,21 +90,6 @@ def function_digest(function):
     except AttributeError:
         pass
     return hasher.digest()
-
-
-def is_typed_named_tuple(cls):
-    """Return True if cls is probably a subtype of `typing.NamedTuple`.
-
-    Unfortunately types created with `class T(NamedTuple):` actually
-    subclass `tuple` directly rather than NamedTuple.  This is annoying,
-    and means we just have to hope that nobody defines a different tuple
-    subclass with similar attributes.
-    """
-    return (
-        issubclass(cls, tuple)
-        and hasattr(cls, "_fields")
-        and hasattr(cls, "_field_types")
-    )
 
 
 def required_args(target, args=(), kwargs=()):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1232,14 +1232,7 @@ def builds(
 
             return from_attrs(target, args, kwargs, required | to_infer)
         # Otherwise, try using type hints
-        if isclass(target) and not hasattr(target, "__signature__"):
-            if is_typed_named_tuple(target):
-                # Special handling for typing.NamedTuple
-                hints = target._field_types  # type: ignore
-            else:
-                hints = get_type_hints(target.__init__)  # type: ignore
-        else:
-            hints = get_type_hints(target)
+        hints = get_type_hints(target)
         if to_infer - set(hints):
             raise InvalidArgument(
                 "passed infer for %s, but there is no type annotation"
@@ -1440,7 +1433,7 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     required = required_args(thing)
     if required and not any(
         [
-            required.issubset(get_type_hints(thing.__init__)),
+            required.issubset(get_type_hints(thing)),
             attr.has(thing),
             # NamedTuples are weird enough that we need a specific check for them.
             is_typed_named_tuple(thing),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1232,7 +1232,7 @@ def builds(
 
             return from_attrs(target, args, kwargs, required | to_infer)
         # Otherwise, try using type hints
-        if isclass(target):
+        if isclass(target) and not hasattr(target, "__signature__"):
             if is_typed_named_tuple(target):
                 # Special handling for typing.NamedTuple
                 hints = target._field_types  # type: ignore

--- a/hypothesis-python/tests/nocover/test_build_signature.py
+++ b/hypothesis-python/tests/nocover/test_build_signature.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 from inspect import signature
+from typing import get_type_hints
 
 from hypothesis import given, strategies as st
 
@@ -25,6 +26,7 @@ def use_this_signature(self, a: int, b: bool = None, *, x: float, y: str):
 class Model:
     # Emulates the implementation of Pydantic models.  See e.g.
     # https://github.com/timothycrosley/hypothesis-auto/issues/10
+    __annotations__ = get_type_hints(use_this_signature)
     __signature__ = signature(use_this_signature)
 
     def __init__(self, **kwargs):

--- a/hypothesis-python/tests/nocover/test_build_signature.py
+++ b/hypothesis-python/tests/nocover/test_build_signature.py
@@ -1,0 +1,45 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from inspect import signature
+
+from hypothesis import given, strategies as st
+
+
+def use_this_signature(self, a: int, b: bool = None, *, x: float, y: str):
+    pass
+
+
+class Model:
+    # Emulates the implementation of Pydantic models.  See e.g.
+    # https://github.com/timothycrosley/hypothesis-auto/issues/10
+    __signature__ = signature(use_this_signature)
+
+    def __init__(self, **kwargs):
+        # Check that we're being called with the expected arguments
+        assert set(kwargs) == {"a", "x", "y"}
+        assert isinstance(kwargs["a"], int)
+        assert isinstance(kwargs["x"], float)
+        assert isinstance(kwargs["y"], str)
+
+
+@given(st.builds(Model))
+def test_builds_uses_signature_attribute(val):
+    assert isinstance(val, Model)
+
+
+@given(st.from_type(Model))
+def test_from_type_uses_signature_attribute(val):
+    assert isinstance(val, Model)


### PR DESCRIPTION
I had hoped that https://github.com/samuelcolvin/pydantic/pull/1034 would be sufficient for Hypothesis to infer strategies for Pydantic models (meaning, among other things, the whole FastAPI ecosystem).  However https://github.com/timothycrosley/hypothesis-auto/issues/10#issuecomment-612015106 suggests otherwise, and so this PR disables our inspect-`__init__`-for-classes logic when the class has an explicit `__signature__` attribute.

@HypothesisWorks/hypothesis-python-contributors if you have review bandwidth I'd like to get this one merged soon, so that it's out when the (overdue? https://github.com/samuelcolvin/pydantic/issues/1341) release of Pydantic 1.5 happens :slightly_smiling_face: 