### PR TITLE
Speed up calculation of example groups used by the mutator

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release improves the performance of the part of the core engine that
+deliberately generates duplicate values.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -420,6 +420,20 @@ class Examples:
         def start_example(self, i, label_index):
             self.result[i] = label_index
 
+    @calculated_example_property
+    class mutator_groups(ExampleProperty):
+        def begin(self):
+            self.groups = defaultdict(list)
+
+        def start_example(self, i, label_index):
+            depth = len(self.example_stack)
+            self.groups[label_index, depth].append(i)
+
+        def finish(self):
+            # Discard groups with only one example, since the mutator can't
+            # do anything useful with them.
+            return [g for g in self.groups.values() if len(g) >= 2]
+
     @property
     def children(self):
         if self.__children is None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -703,7 +703,7 @@ class ConjectureRunner:
         ):
             initial_calls = self.call_count
             failed_mutations = 0
-            groups = None
+
             while (
                 self.should_generate_more()
                 # We implement fairly conservative checks for how long we
@@ -712,19 +712,15 @@ class ConjectureRunner:
                 and self.call_count <= initial_calls + 5
                 and failed_mutations <= 5
             ):
-                if groups is None:
-                    groups = defaultdict(list)
-                    for ex in data.examples:
-                        groups[ex.label, ex.depth].append(ex)
-
-                    groups = [v for v in groups.values() if len(v) > 1]
-
+                groups = data.examples.mutator_groups
                 if not groups:
                     break
 
                 group = self.random.choice(groups)
 
-                ex1, ex2 = sorted(self.random.sample(group, 2), key=lambda i: i.index)
+                ex1, ex2 = [
+                    data.examples[i] for i in sorted(self.random.sample(group, 2))
+                ]
                 assert ex1.end <= ex2.start
 
                 replacements = [data.buffer[e.start : e.end] for e in [ex1, ex2]]
@@ -766,7 +762,6 @@ class ConjectureRunner:
                     )
                 ):
                     data = new_data
-                    groups = None
                     failed_mutations = 0
                 else:
                     failed_mutations += 1


### PR DESCRIPTION
My profiling of #2308 found that Hypothesis currently spends a lot of time generating the example groupings that the mutator uses to insert duplicate values.

I found that by switching to a dedicated `@calculated_example_property` implementation, I could speed up those calculations by a decent amount.

In my informal testing, this cuts about 10 seconds out of a 50 second test run, which is a nice improvement.