### PR TITLE
Datetime improvements: generate `fold=1` and consistent treatment of imaginary times

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+This release improves our support for datetimes and times around DST transitions.
+
+:func:`~hypothesis.strategies.times` and :func:`~hypothesis.strategies.datetimes`
+are now sometimes generated with ``fold=1``, indicating that they represent the
+second occurrence of a given wall-time when clocks are set backwards.
+This may be set even when there is no transition, in which case the ``fold``
+value should be ignored.
+
+For consistency, timezones provided by the :pypi:`pytz` package can now
+generate imaginary times.  This has always been the case for other timezones.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -10,3 +10,6 @@ value should be ignored.
 
 For consistency, timezones provided by the :pypi:`pytz` package can now
 generate imaginary times.  This has always been the case for other timezones.
+
+If you prefer the previous behaviour, :func:`~hypothesis.strategies.datetimes`
+now takes an argument ``allow_imaginary`` which defaults to ``True``.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -9,7 +9,10 @@ This may be set even when there is no transition, in which case the ``fold``
 value should be ignored.
 
 For consistency, timezones provided by the :pypi:`pytz` package can now
-generate imaginary times.  This has always been the case for other timezones.
+generate imaginary times (such as the hour skipped over when clocks 'spring forward'
+to daylight saving time, or during some historical timezone transitions).
+All other timezones have always supported generation of imaginary times.
 
 If you prefer the previous behaviour, :func:`~hypothesis.strategies.datetimes`
-now takes an argument ``allow_imaginary`` which defaults to ``True``.
+now takes an argument ``allow_imaginary`` which defaults to ``True`` but
+can be set to ``False`` for any timezones strategy.

--- a/hypothesis-python/src/hypothesis/extra/dateutil.py
+++ b/hypothesis-python/src/hypothesis/extra/dateutil.py
@@ -18,11 +18,10 @@
 hypothesis[dateutil]
 --------------------
 
-This module provides ``dateutil`` timezones.
+This module provides :pypi:`dateutil <python-dateutil>` timezones.
 
-You can use this strategy to make
-:py:func:`hypothesis.strategies.datetimes` and
-:py:func:`hypothesis.strategies.times` produce timezone-aware values.
+You can use this strategy to make :func:`~hypothesis.strategies.datetimes`
+and :func:`~hypothesis.strategies.times` produce timezone-aware values.
 """
 
 import datetime as dt
@@ -47,7 +46,7 @@ def __zone_sort_key(zone):
 @st.cacheable
 @st.defines_strategy
 def timezones() -> st.SearchStrategy[dt.tzinfo]:
-    """Any timezone in dateutil.
+    """Any timezone from :pypi:`dateutil <python-dateutil>`.
 
     This strategy minimises to UTC, or the timezone with the smallest offset
     from UTC as of 2000-01-01, and is designed for use with

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -139,8 +139,8 @@ def test_naive_times_are_naive(dt):
     assert dt.tzinfo is None
 
 
-# The fold attribute was added in Python 3.6, but is also missing from PyPy.
-# See https://bitbucket.org/pypy/pypy/issues/2987 for details.
+# The fold attribute was added in Python 3.6.  It's less clear why this also fails
+# on pypy3.6, but it seems to canonicalise fold to 0 for non-ambiguous times...
 @pytest.mark.skipif(PYPY or sys.version_info[:2] < (3, 6), reason="see comment")
 def test_can_generate_datetime_with_fold_1():
     find_any(datetimes(), lambda d: d.fold)

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -14,10 +14,12 @@
 # END HEADER
 
 import datetime as dt
+import sys
 
 import pytest
 
 from hypothesis import given, settings
+from hypothesis.internal.compat import PYPY
 from hypothesis.strategies import dates, datetimes, timedeltas, times
 from tests.common.debug import find_any, minimal
 
@@ -135,3 +137,15 @@ def test_can_generate_naive_time():
 @given(times())
 def test_naive_times_are_naive(dt):
     assert dt.tzinfo is None
+
+
+# The fold attribute was added in Python 3.6, but is also missing from PyPy.
+# See https://bitbucket.org/pypy/pypy/issues/2987 for details.
+@pytest.mark.skipif(PYPY or sys.version_info[:2] < (3, 6), reason="see comment")
+def test_can_generate_datetime_with_fold_1():
+    find_any(datetimes(), lambda d: d.fold)
+
+
+@pytest.mark.skipif(PYPY or sys.version_info[:2] < (3, 6), reason="see comment")
+def test_can_generate_time_with_fold_1():
+    find_any(times(), lambda d: d.fold)

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -68,6 +68,7 @@ def fn_ktest(*fnkwargs):
     (ds.dates, {"min_value": date(2017, 8, 22), "max_value": date(2017, 8, 21)}),
     (ds.datetimes, {"min_value": "fish"}),
     (ds.datetimes, {"max_value": "fish"}),
+    (ds.datetimes, {"allow_imaginary": 0}),
     (
         ds.datetimes,
         {"min_value": datetime(2017, 8, 22), "max_value": datetime(2017, 8, 21)},

--- a/hypothesis-python/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis-python/tests/datetime/test_dateutil_timezones.py
@@ -19,10 +19,12 @@ import pytest
 from dateutil import tz, zoneinfo
 
 from hypothesis import assume, given
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import FailedHealthCheck, InvalidArgument
 from hypothesis.extra.dateutil import timezones
-from hypothesis.strategies import data, datetimes, sampled_from, times
-from tests.common.debug import minimal
+from hypothesis.strategies import data, datetimes, just, sampled_from, times
+from hypothesis.strategies._internal.datetime import datetime_does_not_exist
+from tests.common.debug import assert_all_examples, find_any, minimal
+from tests.common.utils import fails_with
 
 
 def test_utc_is_minimal():
@@ -87,3 +89,41 @@ def test_datetimes_stay_within_naive_bounds(data, lo, hi):
         lo, hi = hi, lo
     out = data.draw(datetimes(lo, hi, timezones=timezones()))
     assert lo <= out.replace(tzinfo=None) <= hi
+
+
+DAY_WITH_IMAGINARY_HOUR_KWARGS = {
+    # The day of a spring-forward transition; 2am is imaginary
+    "min_value": dt.datetime(2020, 10, 4),
+    "max_value": dt.datetime(2020, 10, 5),
+    "timezones": just(tz.gettz("Australia/Sydney")),
+}
+
+
+@given(datetimes(timezones=timezones()) | datetimes(**DAY_WITH_IMAGINARY_HOUR_KWARGS))
+def test_dateutil_exists_our_not_exists_are_inverse(value):
+    assert datetime_does_not_exist(value) == (not tz.datetime_exists(value))
+
+
+def test_datetimes_can_exclude_imaginary():
+    find_any(
+        datetimes(**DAY_WITH_IMAGINARY_HOUR_KWARGS, allow_imaginary=True),
+        lambda x: not tz.datetime_exists(x),
+    )
+    assert_all_examples(
+        datetimes(**DAY_WITH_IMAGINARY_HOUR_KWARGS, allow_imaginary=False),
+        tz.datetime_exists,
+    )
+
+
+@fails_with(FailedHealthCheck)
+@given(
+    datetimes(
+        max_value=dt.datetime(1, 1, 1, 9),
+        timezones=just(tz.gettz("Australia/Sydney")),
+        allow_imaginary=False,
+    )
+)
+def test_non_imaginary_datetimes_at_boundary(val):
+    # This is expected to fail because Australia/Sydney is UTC+10,
+    # and the filter logic overflows when checking for round-trips.
+    assert False

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -17,12 +17,18 @@ import datetime as dt
 
 import pytest
 import pytz
+from dateutil.tz import datetime_exists
 
 from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
-from hypothesis.strategies import data, datetimes, sampled_from, times
-from tests.common.debug import assert_can_trigger_event, minimal
+from hypothesis.strategies import data, datetimes, just, sampled_from, times
+from tests.common.debug import (
+    assert_all_examples,
+    assert_can_trigger_event,
+    find_any,
+    minimal,
+)
 
 
 def test_utc_is_minimal():
@@ -110,3 +116,36 @@ def test_datetimes_stay_within_naive_bounds(data, lo, hi):
         lo, hi = hi, lo
     out = data.draw(datetimes(lo, hi, timezones=timezones()))
     assert lo <= out.replace(tzinfo=None) <= hi
+
+
+@pytest.mark.xfail(reason="is_dst not equivalent to fold when DST offset is negative")
+def test_datetimes_can_exclude_imaginary():
+    # The day of a spring-forward transition; 2am is imaginary
+    australia = {
+        "min_value": dt.datetime(2020, 10, 4),
+        "max_value": dt.datetime(2020, 10, 5),
+        "timezones": just(pytz.timezone("Australia/Sydney")),
+    }
+    # Ireland uses  *negative* offset DST, which means that our sloppy interpretation
+    # of "is_dst=not fold" bypasses the filter for imaginary times.  This is basically
+    # unfixable without redesigning pytz per PEP-495, and it's much more likely to be
+    # replaced by dateutil or PEP-615 zoneinfo in the standard library instead.
+    # (we use both so an optimistic `is_dst=bool(fold)` also fails the test)
+    ireland = {
+        "min_value": dt.datetime(2019, 3, 31),
+        "max_value": dt.datetime(2019, 4, 1),
+        "timezones": just(pytz.timezone("Europe/Dublin")),
+    }
+    # Sanity check: fail unless those days contain an imaginary hour to filter out
+    find_any(
+        datetimes(**australia, allow_imaginary=True), lambda x: not datetime_exists(x),
+    )
+    find_any(
+        datetimes(**ireland, allow_imaginary=True), lambda x: not datetime_exists(x),
+    )
+    # Assert that with allow_imaginary=False we only generate existing datetimes.
+    assert_all_examples(
+        datetimes(**australia, allow_imaginary=False)
+        | datetimes(**ireland, allow_imaginary=False),
+        datetime_exists,
+    )


### PR DESCRIPTION
Closes #2273, so a review from @pganssle would be welcome.

Particular decisions:

- We unconditionally generate a `fold` attribute of either `0` or `1`, *regardless* of other constraints.  This matches the equality and comparison semantics of naive datetimes, and therefore our bounds.

- Previously, imaginary datetimes (i.e. the hours skipped over when DST 'springs forward') were generated *unless* the timezone was supplied by `pytz`.  This has been made consistent by allowing `pytz` timezones to generate imaginary times too.

- A new `allow_imaginary=True` argument to `datetimes()` which when `False` is equivalent to `datetimes(...).filter(dateutil.tz.datetime_exists)`.  This may be inefficient if the bounds mostly span an imaginary period and has some boundary issues near `datetime.min` and `datetime.max`.

  However, I think this is still the best available as it works well for realistic use cases, and the alternative (draw in UTC and convert) can violate important properties like "the timezone could have been generated by the `timezones` strategy" and "the datetime is between the (naive) bounds" due to DST issues and datetime-dependent UTC offsets.

