### PR TITLE
Report targets with falsifying example(s)

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+Failing tests which use :func:`~hypothesis.target` now report the highest
+score observed for each target alongside the failing example(s), even without
+:ref:`explicitly showing test statistics <statistics>`.
+
+This improves the debugging workflow for tests of accuracy, which assert that the
+total imprecision is within some error budget - for example, ``abs(a - b) < 0.5``.
+Previously, shrinking to a minimal failing example could often make errors seem
+smaller or more subtle than they really are (see `the threshold problem
+<https://hypothesis.works/articles/threshold-problem/>`__, and :issue:`2180`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -89,7 +89,7 @@ from hypothesis.reporting import (
     verbose_report,
     with_reporter,
 )
-from hypothesis.statistics import note_engine_for_statistics
+from hypothesis.statistics import describe_targets, note_engine_for_statistics
 from hypothesis.strategies._internal.collections import TupleStrategy
 from hypothesis.strategies._internal.strategies import (
     Ex,
@@ -752,6 +752,11 @@ class StateForActualGivenExecution:
         self.failed_normally = True
 
         flaky = 0
+
+        if runner.best_observed_targets:
+            for line in describe_targets(runner.best_observed_targets):
+                report(line)
+            report("")
 
         for falsifying_example in self.falsifying_examples:
             info = falsifying_example.extra_information

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -105,13 +105,31 @@ class Statistics:
             % (self.draw_time_percentage,),
             "  - Stopped because %s" % (self.exit_reason,),
         ]
-        if self.targets:
-            lines.append("  - Highest target scores:")
-            for label, score in sorted(self.targets.items(), key=lambda x: x[::-1]):
-                lines.append("{:>20g}  ({})".format(score, repr(label)))
+        target_lines = describe_targets(self.targets)
+        if target_lines:
+            lines.append("  - " + target_lines[0])
+            lines.extend("    " + l for l in target_lines[1:])
         if self.events:
             lines.append("  - Events:")
             lines += ["    * %s" % (event,) for event in self.events]
+        return lines
+
+
+def describe_targets(best_targets):
+    """Return a list of lines describing the results of `target`, if any."""
+    # These lines are included in the general statistics description below,
+    # but also printed immediately below failing examples to alleviate the
+    # "threshold problem" where shrinking can make severe bug look trival.
+    # See https://github.com/HypothesisWorks/hypothesis/issues/2180
+    if not best_targets:
+        return []
+    elif len(best_targets) == 1:
+        label, score = next(iter(best_targets.items()))
+        return ["Highest target score: {:g}  (label={!r})".format(score, label)]
+    else:
+        lines = ["Highest target scores:"]
+        for label, score in sorted(best_targets.items(), key=lambda x: x[::-1]):
+            lines.append("{:>16g}  (label={!r})".format(score, label))
         return lines
 
 


### PR DESCRIPTION
Here's an idea that closes #2180  (cc @aarchiba): consider a test which asserts that the largest integer is `100`.  Obviously this will fail, but shrinking will make it look like an off-by-one error!

```python
@given(st.integers(min_value=0))
def test_threshold_problem(x):
    target(float(x))
    # target(float(x * 2), label="another target")
    # assert x <= 100000
    assert x <= 100
```

Fortunately, reporting the highest observation seen by `target` makes it easy to tell that while `x=101` was the minimal counterexample, much larger errors exist:

```python-traceback
Highest target score: 9.14676e+08  (label='')

Falsifying example: test_threshold_problem(
    x=101,
)
Traceback (most recent call last): ...
```

And if we un-comment our other `target` calls and assertions, we can see that this works smoothly with multi-objective optimisation and reporting of multiple errors too:

```python-traceback
Highest target scores:
     3.27686e+06  (label='')
     6.55371e+06  (label='another target')

Falsifying example: test_threshold_problem(
    x=100001,
)
Traceback (most recent call last): ...

Falsifying example: test_threshold_problem(
    x=101,
)
Traceback (most recent call last): ...
```

As in #2234, either there's a threshold (in which case the maximum is always from a failing test) or there isn't (and the score is irrelevant).  For consistency we therefore report the maximum score seen from *any* example and trust that users can skip over those which are not relevant.  While more verbose, I expect this to be a substantial improvement for scientific and data-oriented users where `target()`ing an error budget is a very common style of test.