### PR TITLE
Fix infinite loop in pareto optimisation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release fixes :issue:`2395`, where under some circumstances targeted property-based testing could cause Hypothesis to get caught in an infinite loop.

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -144,3 +144,13 @@ def test_targeting_can_be_disabled():
         return result[0]
 
     assert score(enabled=True) > score(enabled=False)
+
+
+def test_issue_2395_regression():
+    @given(d=st.floats().filter(lambda x: abs(x) < 1000))
+    @settings(max_examples=1000, database=None)
+    @seed(93962505385993024185959759429298090872)
+    def test_targeting_square_loss(d):
+        target(-((d - 42.5) ** 2.0))
+
+    test_targeting_square_loss()


### PR DESCRIPTION
Fixes #2395 

Because our pareto front data structure is only approximate, we could (rarely) hit an infinite loop when we do pareto optimisation but it fails to evict the original target even though the target is (either as a result of optimisation or always was) dominated. The result was that we would pareto optimise a test case, then we would loop back and try again and again with the same initial test case.

This PR fixes this by:

1. Adding an assertion that would have caught this problem.
2. Explicitly evicting the original test case when this would happen.

This is surprisingly hard to trigger reliably, so I've not added dedicated tests for it beyond the regression test.