### PR TITLE
Stop pareto optimisation once interesting examples have been found

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release (potentially very significantly) improves the performance of failing tests in some rare cases,
+mostly only relevant when using :ref:`targeted property-based testing <targeted-search>`,
+by stopping further optimisation of unrelated test cases once a failing example is found.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -299,7 +299,7 @@ class ParetoOptimiser:
         # bits that we haven't covered yet.
         i = len(self.front) - 1
         prev = None
-        while i >= 0:
+        while i >= 0 and not self.__engine.interesting_examples:
             assert self.front
             i = min(i, len(self.front) - 1)
             target = self.front[i]

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -230,3 +230,25 @@ def test_does_not_optimise_the_pareto_front_if_interesting():
     runner.optimise_targets()
 
     assert runner.interesting_examples
+
+
+def test_stops_optimising_once_interesting():
+    hi = 2 ** 16 - 1
+
+    def test(data):
+        n = data.draw_bits(16)
+        data.target_observations[""] = n
+        if n < hi:
+            data.mark_interesting()
+
+    runner = ConjectureRunner(
+        test,
+        settings=settings(max_examples=10000, database=InMemoryExampleDatabase(),),
+        database_key=b"stuff",
+    )
+
+    data = runner.cached_test_function([255] * 2)
+    assert data.status == Status.VALID
+    runner.pareto_optimise()
+    assert runner.call_count <= 10
+    assert runner.interesting_examples


### PR DESCRIPTION
While I was in the area I thought I'd also fix the other pareto optimisation issue that @Zalathar and I discussed in #2395. 

We currently deliberately don't run pareto optimisation in the presence of interesting examples, but there's some possibility that pareto optimisation itself will discover an interesting example. If this happens then pareto optimisation can potentially take a very long time, because once we have interesting examples we no longer limit how many valid test cases we see before stopping the run.

This PR fixes that problem by stopping the pareto optimisation loop once there are interesting examples.