### PR TITLE
Fix binary() docstring backticks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes the rendering of :func:`~hypothesis.strategies.binary`
+docstring by using the proper backticks syntax.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1109,7 +1109,7 @@ def binary(*, min_size: int = 0, max_size: int = None) -> SearchStrategy[bytes]:
     """Generates :class:`python:bytes`.
 
     The generated :class:`python:bytes` will have a length of at least ``min_size``
-    and at most ``max_size`.  If ``max_size is None`` there is no upper limit.
+    and at most ``max_size``.  If ``max_size`` is None there is no upper limit.
 
     Examples from this strategy shrink towards smaller strings and lower byte
     values.


### PR DESCRIPTION
Introduced in #2387.