### PR TITLE
Move transition logic into shrinker

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release is a small internal refactoring to how shrinking interacts with :ref:`targeted property-based testing <targeted-search>` that should have no user user visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -907,13 +907,13 @@ class ConjectureRunner:
                     # of this reason for interestingness.
                     self.settings.database.delete(self.secondary_key, c)
 
-    def shrink(self, example, predicate):
-        s = self.new_shrinker(example, predicate)
+    def shrink(self, example, predicate=None, allow_transition=None):
+        s = self.new_shrinker(example, predicate, allow_transition)
         s.shrink()
         return s.shrink_target
 
-    def new_shrinker(self, example, predicate):
-        return Shrinker(self, example, predicate)
+    def new_shrinker(self, example, predicate=None, allow_transition=None):
+        return Shrinker(self, example, predicate, allow_transition)
 
     def cached_test_function(self, buffer, error_on_discard=False, extend=0):
         """Checks the tree to see if we've tested this buffer, and returns the


### PR DESCRIPTION
This is a small refactoring following on from #2396 that moves the logic that was a little hacky into the shrinker, so we can constrain shrinking by restriction what transitions we allow rather than always accepting transitions to a smaller interesting test case.