### PR TITLE
Reverse order of steps in individual reduction passes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release reverses the order in which some operations are tried during shrinking.
+This should generally be a slight performance improvement, but most tests are unlikely to notice much difference.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -44,9 +44,9 @@ class Chooser:
         if depth < len(self.__prefix):
             i = self.__prefix[depth]
             if i >= len(values):
-                i = 0
+                i = len(values) - 1
         else:
-            i = 0
+            i = len(values) - 1
 
         count = 0
         while node.live_child_count > 0:
@@ -61,7 +61,7 @@ class Chooser:
                 else:
                     node.children[i] = DeadNode
                     node.live_child_count -= 1
-            i = (i + 1) % len(values)
+            i = (i - 1) % len(values)
         raise DeadBranch()
 
     def finish(self):
@@ -71,15 +71,12 @@ class Chooser:
         assert len(self.__node_trail) == len(self.__choices) + 1
 
         next_value = list(self.__choices)
-        if next_value:
-            next_value[-1] += 1
-            for i in range(len(next_value) - 1, -1, -1):
-                if next_value[i] >= self.__node_trail[i].n:
-                    next_value[i] = 0
-                    if i > 0:
-                        next_value[i - 1] += 1
-                else:
-                    break
+        while next_value:
+            next_value[-1] -= 1
+            if next_value[-1] < 0:
+                next_value.pop()
+            else:
+                break
 
         self.__node_trail[-1].live_child_count = 0
         while len(self.__node_trail) > 1 and self.__node_trail[-1].exhausted:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -87,9 +87,6 @@ class Chooser:
             target.children[i] = DeadNode
             target.live_child_count -= 1
 
-        while len(next_value) > 0 and next_value[-1] == 0:
-            next_value.pop()
-
         return tuple(next_value)
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1043,6 +1043,7 @@ class Shrinker:
             if a < 0 or b > len(group):
                 return False
             regions = []
+
             for e in group[a:b]:
                 t = (e.start, e.end, replacement)
                 if not regions or t[0] >= regions[-1][1]:

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -39,13 +39,21 @@ def minimal(definition, condition=lambda x: True, settings=None, timeout_after=1
             runtime.append(0.0)
         return result
 
+    if settings is None:
+        settings = Settings(max_examples=50000)
+
+    verbosity = settings.verbosity
+    if verbosity == Verbosity.normal:
+        verbosity = Verbosity.quiet
+
     @given(definition)
     @Settings(
-        parent=settings or Settings(max_examples=50000, verbosity=Verbosity.quiet),
+        parent=settings,
         suppress_health_check=HealthCheck.all(),
         report_multiple_bugs=False,
         derandomize=True,
         database=None,
+        verbosity=verbosity,
     )
     def inner(x):
         if wrapped_condition(x):

--- a/hypothesis-python/tests/conjecture/test_choice_tree.py
+++ b/hypothesis-python/tests/conjecture/test_choice_tree.py
@@ -92,3 +92,12 @@ def test_wraps_around_to_beginning():
     assert tree.step((), f) == (1,)
     assert tree.step((1,), f) == (0,)
     assert tree.step((0,), f) == ()
+
+
+def test_skips_over_exhausted_subtree():
+    def f(chooser):
+        chooser.choose(range(10))
+
+    tree = ChoiceTree()
+    assert tree.step((8,), f) == (7,)
+    assert tree.step((8,), f) == (6,)

--- a/hypothesis-python/tests/conjecture/test_choice_tree.py
+++ b/hypothesis-python/tests/conjecture/test_choice_tree.py
@@ -89,5 +89,6 @@ def test_wraps_around_to_beginning():
         chooser.choose(range(3))
 
     tree = ChoiceTree()
-
-    assert tree.step((2,), f) == ()
+    assert tree.step((), f) == (1,)
+    assert tree.step((1,), f) == (0,)
+    assert tree.step((0,), f) == ()

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -218,19 +218,6 @@ def test_containment(n, seed):
     assert iv == ([n], n)
 
 
-@pytest.mark.parametrize("n", [0, 1, 2])
-def test_text_containment(n):
-    iv = minimal(
-        tuples(lists(text()), text()),
-        lambda x: x[1] in x[0] and len(x[1]) >= n,
-        timeout_after=60,
-    )
-
-    value = "0" * n
-
-    assert iv == ([value], value)
-
-
 def test_duplicate_containment():
     ls, i = minimal(
         tuples(lists(integers()), integers()),


### PR DESCRIPTION
Previously in reduction we iterated over the choice tree from left to right. Now we iterate over it from right to left.

The reasoning behind the change is basically that reductions near the end of the test case are more likely to work because there's less dependent on them. The downside is that reductions towards the left are more likely to have large impacts because there's more dependent on them, but it seems that (at least in our shrink quality test suite) this is a minor performance win.

This is loosely motivated by trying to improve shrink performance in #2340 but it's a relatively minor improvement. I was trying a number of more sweeping changes but this is the only one I found that was convincingly an improvement.

Unrelated test changes in this PR:

* It was annoying me that `minimal` didn't respect `--hypothesis-verbosity=debug`, so I made it do so.
* We had a test in the shrink quality section that we couldn't actually guarantee but that happened to work. I removed it.