### PR TITLE
Allow datetime subclasses as bounds for `st.datetimes()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2406`, where use of :obj:`pandas:pandas.Timestamp`
+objects as bounds for the :func:`~hypothesis.strategies.datetimes` strategy
+caused an internal error.  This bug was introduced in :ref:`version 5.8.1 <v5.8.2>`.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -78,18 +78,15 @@ def datetime_does_not_exist(value):
     return value != roundtrip
 
 
-def draw_capped_multipart(data, min_value, max_value):
+def draw_capped_multipart(
+    data, min_value, max_value, duration_names=DATENAMES + TIMENAMES
+):
     assert isinstance(min_value, (dt.date, dt.time, dt.datetime))
     assert type(min_value) == type(max_value)
     assert min_value <= max_value
     result = {}
     cap_low, cap_high = True, True
-    duration_names_by_type = {
-        dt.date: DATENAMES,
-        dt.time: TIMENAMES,
-        dt.datetime: DATENAMES + TIMENAMES,
-    }
-    for name in duration_names_by_type[type(min_value)]:
+    for name in duration_names:
         low = getattr(min_value if cap_low else dt.datetime.min, name)
         high = getattr(max_value if cap_high else dt.datetime.max, name)
         if name == "day" and not cap_high:
@@ -216,7 +213,7 @@ class TimeStrategy(SearchStrategy):
         self.tz_strat = timezones_strat
 
     def do_draw(self, data):
-        result = draw_capped_multipart(data, self.min_value, self.max_value)
+        result = draw_capped_multipart(data, self.min_value, self.max_value, TIMENAMES)
         tz = data.draw(self.tz_strat)
         return dt.time(**result, tzinfo=tz)
 
@@ -257,7 +254,9 @@ class DateStrategy(SearchStrategy):
         self.max_value = max_value
 
     def do_draw(self, data):
-        return dt.date(**draw_capped_multipart(data, self.min_value, self.max_value))
+        return dt.date(
+            **draw_capped_multipart(data, self.min_value, self.max_value, DATENAMES)
+        )
 
 
 @defines_strategy_with_reusable_values

--- a/hypothesis-python/tests/pandas/test_argument_validation.py
+++ b/hypothesis-python/tests/pandas/test_argument_validation.py
@@ -13,8 +13,13 @@
 #
 # END HEADER
 
+from datetime import datetime
+
+import pandas as pd
+
 import hypothesis.extra.pandas as pdst
 import hypothesis.strategies as st
+from hypothesis import given
 from tests.common.arguments import argument_validation_test, e
 
 BAD_ARGS = [
@@ -69,3 +74,13 @@ BAD_ARGS = [
 
 
 test_raise_invalid_argument = argument_validation_test(BAD_ARGS)
+
+lo, hi = pd.Timestamp(2017, 1, 1), pd.Timestamp(2084, 12, 21)
+
+
+@given(st.datetimes(min_value=lo, max_value=hi))
+def test_timestamp_as_datetime_bounds(dt):
+    # Would have caught https://github.com/HypothesisWorks/hypothesis/issues/2406
+    assert isinstance(dt, datetime)
+    assert lo <= dt <= hi
+    assert not isinstance(dt, pd.Timestamp)


### PR DESCRIPTION
Notably `pandas.Timestamp`, which we now also have a test for.  Fixes #2406.