### PR TITLE
Improved `get_type_hints()` for classes with forward references

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the internals of :func:`~hypothesis.strategies.builds` type
+inference, to handle recursive forward references in certain dataclasses.
+This is useful for e.g. :pypi:`hypothesmith`'s forthcoming :pypi:`LibCST` mode.

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -29,6 +29,8 @@ run()
 # Skip collection of tests which require the Django test runner,
 # or that don't work on the current version of Python.
 collect_ignore_glob = ["django/*"]
+if sys.version_info < (3, 6):  # Remove after dropping Python 3.5
+    collect_ignore_glob.append("cover/*py36*")
 if sys.version_info < (3, 8):
     collect_ignore_glob.append("cover/*py38*")
 

--- a/hypothesis-python/tests/cover/test_lookup_py36.py
+++ b/hypothesis-python/tests/cover/test_lookup_py36.py
@@ -1,0 +1,33 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import typing
+
+import pytest
+
+from hypothesis import given, strategies as st
+from hypothesis.internal.compat import PYPY
+
+
+class TreeForwardRefs(typing.NamedTuple):
+    val: int
+    l: typing.Optional["TreeForwardRefs"]
+    r: typing.Optional["TreeForwardRefs"]
+
+
+@pytest.mark.skipif(PYPY, reason="pypy36 does not resolve the forward refs")
+@given(st.builds(TreeForwardRefs))
+def test_resolves_forward_references_outside_annotations(t):
+    assert isinstance(t, TreeForwardRefs)

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -13,6 +13,7 @@
 #
 # END HEADER
 
+import dataclasses
 import typing
 
 import pytest
@@ -101,3 +102,14 @@ def test_layered_optional_key_is_optional():
     # Optional keys are not currently supported, as PEP-589 leaves no traces
     # at runtime.  See https://github.com/python/cpython/pull/17214
     find_any(from_type(C), lambda d: "b" not in d)
+
+
+@dataclasses.dataclass()
+class Node:
+    left: typing.Union["Node", int]
+    right: typing.Union["Node", int]
+
+
+@given(st.builds(Node))
+def test_can_resolve_recursive_dataclass(val):
+    assert isinstance(val, Node)


### PR DESCRIPTION
This was prompted by some work on https://github.com/Zac-HD/hypothesmith/issues/2.  Happily, it also fixes #1004 - since I last prodded at that issue the typing ecosystem has improved and we're *mostly* 3.6+ and so a fairly simple approach now works :tada: 