### PR TITLE
Adding pytester plugin

### DIFF
--- a/hypothesis-python/tests/numpy/test_lazy_import.py
+++ b/hypothesis-python/tests/numpy/test_lazy_import.py
@@ -15,6 +15,8 @@
 
 from hypothesis.internal.compat import CAN_PACK_HALF_FLOAT
 
+pytest_plugins = "pytester"
+
 SHOULD_NOT_IMPORT_NUMPY = """
 import sys
 from hypothesis import given, strategies as st


### PR DESCRIPTION
According to the documentation [0] the line `pytest_plugins = pytester`
must be added on the top of conftest.py.

In this case I added to tests/numpy/test_lazy_import.py.

[0] https://docs.pytest.org/en/latest/reference.html?highlight=pytester#testdir