### PR TITLE
Avoid importing Django if not needed

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+If you have :pypi:`django` installed but don't use it, this patch will make
+``import hypothesis`` a few hundred milliseconds faster (e.g. 0.704s -> 0.271s).
+
+Thanks to :pypi:`importtime-waterfall` for highlighting this problem and
+`Jake Vanderplas <https://twitter.com/jakevdp/status/1130983439862181888>`__ for
+the solution - it's impossible to misuse code from a module you haven't imported!

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -222,21 +222,12 @@ def ceil(x):
     return y
 
 
-try:
-    from django.test import TransactionTestCase
-
-    def bad_django_TestCase(runner):
-        if runner is None:
-            return False
-        if not isinstance(runner, TransactionTestCase):
-            return False
-
-        from hypothesis.extra.django._impl import HypothesisTestCase
-
-        return not isinstance(runner, HypothesisTestCase)
-
-
-except Exception:
-    # Can't use ImportError, because of e.g. Django config errors
-    def bad_django_TestCase(runner):
+def bad_django_TestCase(runner):
+    if runner is None or "django.test" not in sys.modules:
         return False
+    if not isinstance(runner, sys.modules["django.test"].TransactionTestCase):
+        return False
+
+    from hypothesis.extra.django._impl import HypothesisTestCase
+
+    return not isinstance(runner, HypothesisTestCase)


### PR DESCRIPTION
This is a small but easy performance improvement - and in this case small means avoiding `import django.test` for some users, around 400ms on my machine, using [this one weird trick](1130983439862181888).  You can get your own numbers with `time python -c "import hypothesis"`.

We use the same trick elsewhere to check for Numpy arrays, and for that we wrote an explicit test that `import hypothesis` does not import numpy as a side-effect.  I've skipped that here, because it's much more annoying to write that with the Django test runner than with pytest, and because I think we're at much lower risk of regressions.