### PR TITLE
Infer strategies from `typing_extensions` types

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
         architecture: '$(python.architecture)'
     - script: |
         pip install --upgrade setuptools pip wheel
-        pip install -r requirements/test.txt
+        pip install -r requirements/test.txt typing-extensions
         pip install hypothesis-python/[all]
       displayName: Install dependencies
     - script: |

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This patch adds strategy inference for the ``Literal``, ``NewType``, ``Type``,
+``DefaultDict``, and ``TypedDict`` types from the :pypi:`typing_extensions`
+backport on PyPI.

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -27,6 +27,10 @@ pip install ".[dpcontracts]"
 $PYTEST tests/dpcontracts/
 pip uninstall -y dpcontracts
 
+pip install typing_extensions
+$PYTEST tests/typing_extensions/
+pip uninstall -y typing_extensions
+
 pip install ".[lark]"
 $PYTEST tests/lark/
 pip install lark-parser==0.7.1

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1343,9 +1343,15 @@ def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
 
 
 def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
+    # TODO: We would like to move this to the top level, but pending some major
+    # refactoring it's hard to do without creating circular imports.
+    from hypothesis.strategies._internal import types
+
     if (
         hasattr(typing, "_TypedDictMeta")
         and type(thing) is typing._TypedDictMeta  # type: ignore
+        or hasattr(types.typing_extensions, "_TypedDictMeta")
+        and type(thing) is types.typing_extensions._TypedDictMeta  # type: ignore
     ):  # pragma: no cover
         # The __optional_keys__ attribute may or may not be present, but if there's no
         # way to tell and we just have to assume that everything is required.
@@ -1356,10 +1362,6 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
             mapping={k: v for k, v in anns.items() if k not in optional},
             optional={k: v for k, v in anns.items() if k in optional},
         )
-
-    # TODO: We would like to move this to the top level, but pending some major
-    # refactoring it's hard to do without creating circular imports.
-    from hypothesis.strategies._internal import types
 
     def as_strategy(strat_or_callable, thing, final=True):
         # User-provided strategies need some validation, and callables even more

--- a/hypothesis-python/tests/typing_extensions/__init__.py
+++ b/hypothesis-python/tests/typing_extensions/__init__.py
@@ -1,0 +1,14 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -1,0 +1,96 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import collections
+import sys
+from typing import Union
+
+import pytest
+from typing_extensions import DefaultDict, Literal, NewType, Type
+
+import hypothesis.strategies as st
+from hypothesis import assume, given
+from hypothesis.strategies import from_type
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="lovecraftian implemenation")
+@pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])
+def test_typing_extensions_Literal(value):
+    assert from_type(Literal[value]).example() == value
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="lovecraftian implemenation")
+@given(st.data())
+def test_typing_extensions_Literal_nested(data):
+    lit = Literal
+    values = [
+        (lit["hamster", 0], ("hamster", 0)),
+        (lit[26, False, "bunny", 130], (26, False, "bunny", 130)),
+        (lit[lit[1]], {1}),
+        (lit[lit[1], 2], {1, 2}),
+        (lit[1, lit[2], 3], {1, 2, 3}),
+        (lit[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
+    ]
+    literal_type, flattened_literals = data.draw(st.sampled_from(values))
+    assert data.draw(st.from_type(literal_type)) in flattened_literals
+
+
+@pytest.mark.skipif(sys.version_info[:2] == (3, 5), reason="no attribute annotations")
+def test_simple_typeddict():
+    exec(
+        """
+from hypothesis import given
+from hypothesis.strategies import from_type
+from typing_extensions import TypedDict
+
+class A(TypedDict):
+    a: int
+
+@given(from_type(A))
+def test_simple_typeddict(value):
+    assert type(value) == dict
+    assert set(value) == {"a"}
+    assert isinstance(value["a"], int)
+
+test_simple_typeddict()
+"""
+    )
+
+
+def test_typing_extensions_Type_int():
+    assert from_type(Type[int]).example() is int
+
+
+@given(from_type(Type[Union[str, list]]))
+def test_typing_extensions_Type_Union(ex):
+    assert ex in (str, list)
+
+
+def test_resolves_NewType():
+    typ = NewType("T", int)
+    nested = NewType("NestedT", typ)
+    uni = NewType("UnionT", Union[int, None])
+    assert isinstance(from_type(typ).example(), int)
+    assert isinstance(from_type(nested).example(), int)
+    assert isinstance(from_type(uni).example(), (int, type(None)))
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="new addition")
+@given(from_type(DefaultDict[int, int]))
+def test_defaultdict(ex):
+    assert isinstance(ex, collections.defaultdict)
+    assume(ex)
+    assert all(isinstance(elem, int) for elem in ex)
+    assert all(isinstance(elem, int) for elem in ex.values())


### PR DESCRIPTION
While working on Hypothesmith, I noticed that `LibCST` was using `typing_extensions.Literal` in their type annotations, rather than `typing.Literal`.  As the latter was added in Python 3.8, using a backport is perfectly sensible - but `st.from_type()` had no idea what to do.  After this PR, it will "just work".

Fixes #2413.