### PR TITLE
Small `from_type()` performance upgrade

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch teaches the :func:`~hypothesis.strategies.from_type` internals to
+return slightly more efficient strategies for some generic sets and mappings.


### PR DESCRIPTION
https://github.com/HypothesisWorks/hypothesis/pull/2344#issuecomment-623386133 prompted me to look at whether our internal `_can_hash` filter was really necessary.  It's a small performance overhead, but whitelisting a few builtins wins most of that back with minimal complications to the code.