### PR TITLE
Per-phase statistics reporting

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release upgrades the test statistics available via the
+:ref:`--hypothesis-show-statistics <statistics>` option to include
+separate information on each of the :attr:`~hypothesis.settings.phases`
+(:issue:`1555`).

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -72,11 +72,9 @@ You would see:
 
 .. code-block:: none
 
-  test_integers:
-
-    - 100 passing examples, 0 failing examples, 0 invalid examples
-    - Typical runtimes: ~ 1ms
-    - Fraction of time spent in data generation: ~ 12%
+    - during generate phase (0.06 seconds):
+        - Typical runtimes: < 1ms, ~ 47% in data generation
+        - 100 passing examples, 0 failing examples, 0 invalid examples
     - Stopped because settings.max_examples=100
 
 The final "Stopped because" line is particularly important to note: It tells you the
@@ -102,13 +100,13 @@ You would see something like:
 
   test_even_integers:
 
-      - 100 passing examples, 0 failing examples, 36 invalid examples
-      - Typical runtimes: 0-1 ms
-      - Fraction of time spent in data generation: ~ 16%
-      - Stopped because settings.max_examples=100
-      - Events:
-        * 80.88%, Retried draw from integers().filter(lambda x: <unknown>) to satisfy filter
-        * 26.47%, Aborted test because unable to satisfy integers().filter(lambda x: <unknown>)
+    - during generate phase (0.08 seconds):
+        - Typical runtimes: < 1ms, ~ 57% in data generation
+        - 100 passing examples, 0 failing examples, 12 invalid examples
+        - Events:
+          * 51.79%, Retried draw from integers().filter(lambda x: x % 2 == 0) to satisfy filter
+          * 10.71%, Aborted test because unable to satisfy integers().filter(lambda x: x % 2 == 0)
+    - Stopped because settings.max_examples=100
 
 You can also mark custom events in a test using the ``event`` function:
 
@@ -130,16 +128,16 @@ You will then see output like:
 
   test_even_integers:
 
-    - 100 passing examples, 0 failing examples, 38 invalid examples
-    - Typical runtimes: 0-1 ms
-    - Fraction of time spent in data generation: ~ 16%
+    - during generate phase (0.09 seconds):
+        - Typical runtimes: < 1ms, ~ 59% in data generation
+        - 100 passing examples, 0 failing examples, 32 invalid examples
+        - Events:
+          * 54.55%, Retried draw from integers().filter(lambda x: x % 2 == 0) to satisfy filter
+          * 31.06%, i mod 3 = 2
+          * 28.79%, i mod 3 = 0
+          * 24.24%, Aborted test because unable to satisfy integers().filter(lambda x: x % 2 == 0)
+          * 15.91%, i mod 3 = 1
     - Stopped because settings.max_examples=100
-    - Events:
-      * 80.43%, Retried draw from integers().filter(lambda x: <unknown>) to satisfy filter
-      * 31.88%, i mod 3 = 0
-      * 27.54%, Aborted test because unable to satisfy integers().filter(lambda x: <unknown>)
-      * 21.74%, i mod 3 = 1
-      * 18.84%, i mod 3 = 2
 
 Arguments to ``event`` can be any hashable type, but two events will be considered the same
 if they are the same when converted to a string with :obj:`python:str`.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -89,7 +89,7 @@ from hypothesis.reporting import (
     verbose_report,
     with_reporter,
 )
-from hypothesis.statistics import describe_targets, note_engine_for_statistics
+from hypothesis.statistics import describe_targets, note_statistics
 from hypothesis.strategies._internal.collections import TupleStrategy
 from hypothesis.strategies._internal.strategies import (
     Ex,
@@ -730,7 +730,7 @@ class StateForActualGivenExecution:
         # Use the Conjecture engine to run the test function many times
         # on different inputs.
         runner.run()
-        note_engine_for_statistics(runner)
+        note_statistics(runner.statistics)
 
         if runner.call_count == 0:
             return

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -23,7 +23,7 @@ from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.detection import is_hypothesis_test
 from hypothesis.reporting import default as default_reporter, with_reporter
-from hypothesis.statistics import collector
+from hypothesis.statistics import collector, describe_statistics
 
 LOAD_PROFILE_OPTION = "--hypothesis-profile"
 VERBOSITY_OPTION = "--hypothesis-verbosity"
@@ -177,8 +177,8 @@ else:
             store = StoringReporter(item.config)
 
             def note_statistics(stats):
-                lines = [item.nodeid + ":", ""] + stats.get_description() + [""]
-                item.hypothesis_statistics = lines
+                stats["nodeid"] = item.nodeid
+                item.hypothesis_statistics = describe_statistics(stats)
 
             with collector.with_value(note_statistics):
                 with with_reporter(store):
@@ -205,10 +205,9 @@ else:
         # always be the key for a list of _pytest.reports.TestReport objects
         # (where we stored the statistics data in pytest_runtest_makereport above)
         for test_report in terminalreporter.stats.get("", []):
-            for name, lines in test_report.user_properties:
+            for name, value in test_report.user_properties:
                 if name == "hypothesis-stats" and test_report.when == "teardown":
-                    for li in lines:
-                        terminalreporter.write_line(li)
+                    terminalreporter.write_line(value + "\n\n")
 
     def pytest_collection_modifyitems(items):
         for item in items:

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -35,7 +35,6 @@ from hypothesis.internal.conjecture.pareto import DominanceRelation, dominance
 from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.internal.entropy import deterministic_PRNG
-from hypothesis.statistics import Statistics
 from tests.common.strategies import SLOW, HardToShrink
 from tests.common.utils import no_shrink
 from tests.conjecture.common import (
@@ -436,17 +435,6 @@ class Foo:
         return "stuff"
 
 
-@pytest.mark.parametrize("event", ["hi", Foo()])
-def test_note_events(event):
-    def f(data):
-        data.note_event(event)
-        data.draw_bytes(1)
-
-    runner = ConjectureRunner(f)
-    runner.run()
-    assert runner.event_call_counts[str(event)] == runner.call_count > 0
-
-
 def test_debug_data(capsys):
     buf = [0, 1, 2]
 
@@ -794,7 +782,7 @@ def test_exit_because_shrink_phase_timeout(monkeypatch):
     runner = ConjectureRunner(f, settings=settings(database=None))
     runner.run()
     assert runner.exit_reason == ExitReason.very_slow_shrinking
-    assert Statistics(runner).exit_reason == "shrinking was very slow"
+    assert runner.statistics["stopped-because"] == "shrinking was very slow"
 
 
 def test_dependent_block_pairs_can_lower_to_zero():


### PR DESCRIPTION
Fixes #1555.

I've also gone for a more substantial refactoring than the bare minimum.  Where the old scheme converted attributes directly into report lines, this PR prefers to ship around a blob of JSON and provide a function for converting it to report lines.

Having a machine-readable form that we can dump out makes analysis (c.f. https://github.com/HypothesisWorks/hypothesis/issues/437#issuecomment-288549657) much easier, whether that's to assess a test suite, compare fuzzers, or decide if a proposed change is robustly better than the status quo.  There's no public or supported interface in this PR, but it makes experimentation much easier - for example, I'm planning to use this to assess the effectiveness of targeted PBT and/or swarm testing vs. a baseline :slightly_smiling_face:

To install this branch and try it out, `pip install -U git+https://github.com/Zac-HD/hypothesis.git@better-stats#subdirectory=hypothesis-python`