### PR TITLE
Deprecate min_magnitude=None

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -207,6 +207,7 @@ their individual contributions.
 * `Daniel J. West <https://github.com/danieljwest>`_
 * `David Bonner <https://github.com/rascalking>`_ (dbonner@gmail.com)
 * `David Chudzicki <https://github.com/dchudz>`_ (dchudz@gmail.com)
+* `David Mascharka <https://github.com/davidmascharka>`_
 * `Derek Gustafson <https://www.github.com/degustaf>`_
 * `Dion Misic <https://www.github.com/kingdion>`_ (dion.misic@gmail.com)
 * `Eduardo Enriquez <https://www.github.com/eduzen>`_ (eduardo.a.enriquez@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch updates the type annotation of the "complex_numbers()" strategy for consistency.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch updates the type annotation of the :func:`~hypothesis.strategies.complex_numbers` strategy for consistency.
+This release deprecates the use of ``min_magnitude=None``, setting the default ``min_magnitude`` to 0.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,4 @@
 RELEASE_TYPE: minor
 
-This release deprecates the use of ``min_magnitude=None``, setting the default ``min_magnitude`` to 0.
+Passing ``min_magnitude=None`` to :func:`~hypothesis.strategies.complex_numbers` is now
+deprecated - you can explicitly pass ``min_magnitude=0``, or omit the argument entirely.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch updates the type annotation of the "complex_numbers()" strategy for consistency.
+This patch updates the type annotation of the :func:`~hypothesis.strategies.complex_numbers` strategy for consistency.

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -76,7 +76,8 @@ def check_valid_magnitude(value, name):
         from hypothesis._settings import note_deprecation
 
         note_deprecation(
-            "min_magnitude=None is deprecated; use min_magnitude=0 instead.",
+            "min_magnitude=None is deprecated; use min_magnitude=0 ",
+            "or omit the argument entirely.",
             since="RELEASEDAY",
         )
 

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -72,6 +72,13 @@ def check_valid_magnitude(value, name):
     check_valid_bound(value, name)
     if value is not None and value < 0:
         raise InvalidArgument("%s=%r must not be negative." % (name, value))
+    if value is None and name == "min_magnitude":
+        from hypothesis._settings import note_deprecation
+
+        note_deprecation(
+            "min_magnitude=None is deprecated; use min_magnitude=0 instead.",
+            since="RELEASEDAY",
+        )
 
 
 @check_function

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -76,7 +76,7 @@ def check_valid_magnitude(value, name):
         from hypothesis._settings import note_deprecation
 
         note_deprecation(
-            "min_magnitude=None is deprecated; use min_magnitude=0 ",
+            "min_magnitude=None is deprecated; use min_magnitude=0 "
             "or omit the argument entirely.",
             since="RELEASEDAY",
         )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1842,7 +1842,7 @@ def complex_numbers(
         # Order of conditions carefully tuned so that for a given pair of
         # magnitude arguments, we always either draw or do not draw the bool
         # (crucial for good shrinking behaviour) but only invert when needed.
-        if min_magnitude != 0 and draw(booleans()) and math.fabs(zi) <= min_magnitude:
+        if min_magnitude > 0 and draw(booleans()) and math.fabs(zi) <= min_magnitude:
             zr = -zr
         return complex(zr, zi)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1799,6 +1799,8 @@ def complex_numbers(
     check_valid_magnitude(min_magnitude, "min_magnitude")
     check_valid_magnitude(max_magnitude, "max_magnitude")
     check_valid_interval(min_magnitude, max_magnitude, "min_magnitude", "max_magnitude")
+    if min_magnitude is None:
+        min_magnitude = 0
     if max_magnitude == math.inf:
         max_magnitude = None
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1768,7 +1768,7 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
 @deprecated_posargs
 def complex_numbers(
     *,
-    min_magnitude: Real = None,
+    min_magnitude: Optional[Real] = 0,
     max_magnitude: Real = None,
     allow_infinity: bool = None,
     allow_nan: bool = None

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1768,7 +1768,7 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
 @deprecated_posargs
 def complex_numbers(
     *,
-    min_magnitude: Optional[Real] = 0,
+    min_magnitude: Real = 0,
     max_magnitude: Real = None,
     allow_infinity: bool = None,
     allow_nan: bool = None
@@ -1777,8 +1777,8 @@ def complex_numbers(
 
     This strategy draws complex numbers with constrained magnitudes.
     The ``min_magnitude`` and ``max_magnitude`` parameters should be
-    non-negative :class:`~python:numbers.Real` numbers; values
-    of ``None`` correspond to zero and infinite values respectively.
+    non-negative :class:`~python:numbers.Real` numbers; a value
+    of ``None`` corresponds an infinite upper bound.
 
     If ``min_magnitude`` is positive or ``max_magnitude`` is finite, it
     is an error to enable ``allow_nan``.  If ``max_magnitude`` is finite,
@@ -1801,8 +1801,6 @@ def complex_numbers(
     check_valid_interval(min_magnitude, max_magnitude, "min_magnitude", "max_magnitude")
     if max_magnitude == math.inf:
         max_magnitude = None
-    if min_magnitude == 0:
-        min_magnitude = None
 
     if allow_infinity is None:
         allow_infinity = bool(max_magnitude is None)
@@ -1812,15 +1810,15 @@ def complex_numbers(
             % (allow_infinity, max_magnitude)
         )
     if allow_nan is None:
-        allow_nan = bool(min_magnitude is None and max_magnitude is None)
-    elif allow_nan and not (min_magnitude is None and max_magnitude is None):
+        allow_nan = bool(min_magnitude == 0 and max_magnitude is None)
+    elif allow_nan and not (min_magnitude == 0 and max_magnitude is None):
         raise InvalidArgument(
             "Cannot have allow_nan=%r, min_magnitude=%r max_magnitude=%r"
             % (allow_nan, min_magnitude, max_magnitude)
         )
     allow_kw = {"allow_nan": allow_nan, "allow_infinity": allow_infinity}
 
-    if min_magnitude is None and max_magnitude is None:
+    if min_magnitude == 0 and max_magnitude is None:
         # In this simple but common case, there are no constraints on the
         # magnitude and therefore no relationship between the real and
         # imaginary parts.
@@ -1837,18 +1835,14 @@ def complex_numbers(
             zi = draw(floats(-max_magnitude, max_magnitude, **allow_kw))
             rmax = cathetus(max_magnitude, zi)
         # Draw the real part from the allowed range given the imaginary part
-        if min_magnitude is None or math.fabs(zi) >= min_magnitude:
+        if min_magnitude == 0 or math.fabs(zi) >= min_magnitude:
             zr = draw(floats(None if rmax is None else -rmax, rmax, **allow_kw))
         else:
             zr = draw(floats(cathetus(min_magnitude, zi), rmax, **allow_kw))
         # Order of conditions carefully tuned so that for a given pair of
         # magnitude arguments, we always either draw or do not draw the bool
         # (crucial for good shrinking behaviour) but only invert when needed.
-        if (
-            min_magnitude is not None
-            and draw(booleans())
-            and math.fabs(zi) <= min_magnitude
-        ):
+        if min_magnitude != 0 and draw(booleans()) and math.fabs(zi) <= min_magnitude:
             zr = -zr
         return complex(zr, zi)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1780,7 +1780,7 @@ def complex_numbers(
     non-negative :class:`~python:numbers.Real` numbers; a value
     of ``None`` corresponds an infinite upper bound.
 
-    If ``min_magnitude`` is positive or ``max_magnitude`` is finite, it
+    If ``min_magnitude`` is nonzero or ``max_magnitude`` is finite, it
     is an error to enable ``allow_nan``.  If ``max_magnitude`` is finite,
     it is an error to enable ``allow_infinity``.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1768,8 +1768,8 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
 @deprecated_posargs
 def complex_numbers(
     *,
-    min_magnitude: Optional[Real] = 0,
-    max_magnitude: Optional[Real] = None,
+    min_magnitude: Real = None,
+    max_magnitude: Real = None,
     allow_infinity: bool = None,
     allow_nan: bool = None
 ) -> SearchStrategy[complex]:

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -20,6 +20,7 @@ import hypothesis.strategies as st
 from hypothesis import given, reject
 from hypothesis.strategies import complex_numbers
 from tests.common.debug import minimal
+from tests.common.utils import checks_deprecated_behaviour
 
 
 def test_minimal():
@@ -75,6 +76,7 @@ def test_minimal_min_magnitude_zero():
     assert minimal(complex_numbers(min_magnitude=0), lambda x: True) == 0
 
 
+@checks_deprecated_behaviour
 def test_minimal_min_magnitude_none():
     assert minimal(complex_numbers(min_magnitude=None), lambda x: True) == 0
 


### PR DESCRIPTION
Closes #2424 by removing the explicit `Optional` from the `complex_numbers` strategy. Replaces the default `min_magnitude=0` with `min_magnitude=None` since these are equivalent and the latter allows you to use implicit `Optional`