### PR TITLE
Fix `target()` / `database=None` bug

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where :func:`~hypothesis.target` was accidentally
+disabled if :attr:`~hypothesis.settings.database` setting was ``None``.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -121,11 +121,9 @@ class ConjectureRunner:
         # is only marginally useful at present, but speeds up local development
         # because it means that large targets will be quickly surfaced in your
         # testing.
+        self.pareto_front = ParetoFront(self.random)
         if self.database_key is not None and self.settings.database is not None:
-            self.pareto_front = ParetoFront(self.random)
             self.pareto_front.on_evict(self.on_pareto_evict)
-        else:
-            self.pareto_front = None
 
         # We want to be able to get the ConjectureData object that results
         # from running a buffer without recalculating, especially during
@@ -200,7 +198,7 @@ class ConjectureRunner:
 
         self.debug_data(data)
 
-        if self.pareto_front is not None and self.pareto_front.add(data.as_result()):
+        if self.pareto_front.add(data.as_result()):
             self.save_buffer(data.buffer, sub_key=b"pareto")
 
         assert len(data.buffer) <= BUFFER_SIZE
@@ -847,8 +845,7 @@ class ConjectureRunner:
                 break
 
     def pareto_optimise(self):
-        if self.pareto_front is not None:
-            ParetoOptimiser(self).run()
+        ParetoOptimiser(self).run()
 
     def _run(self):
         with self._log_phase_statistics("reuse"):

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -17,7 +17,7 @@ from operator import itemgetter
 
 import pytest
 
-from hypothesis import Phase, example, given, seed, settings, strategies as st, target
+from hypothesis import example, given, seed, settings, strategies as st, target
 from hypothesis.errors import InvalidArgument
 
 
@@ -121,29 +121,6 @@ def test_targeting_with_many_empty(_):
     # This exercises some logic in the optimiser that prevents it from trying
     # to mutate empty examples in the middle of the test case.
     target(1.0)
-
-
-def test_targeting_can_be_disabled():
-    strat = st.lists(st.integers(0, 255))
-
-    def score(enabled):
-        result = [0]
-        phases = [Phase.generate]
-        if enabled:
-            phases.append(Phase.target)
-
-        @seed(0)
-        @settings(database=None, max_examples=200, phases=phases)
-        @given(strat)
-        def test(ls):
-            score = float(sum(ls))
-            result[0] = max(result[0], score)
-            target(score)
-
-        test()
-        return result[0]
-
-    assert score(enabled=True) > score(enabled=False)
 
 
 def test_issue_2395_regression():


### PR DESCRIPTION
While exploring the behaviour of the pareto optimiser, I noticed that setting `database=None` would disable the `target` phase entirely.  This in turn means that our slowest test - per https://github.com/HypothesisWorks/hypothesis/issues/852#issuecomment-628505527 - *wasn't testing anything at all*.

Suggestions for a performant test that would have caught this welcome :sweat_smile: 