### PR TITLE
Rm 'setuptools' from azure script line

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
         architecture: '$(python.architecture)'
     - script: |
         pip install --upgrade setuptools pip wheel
-        pip install setuptools -r requirements/test.txt
+        pip install -r requirements/test.txt
         pip install hypothesis-python/[all]
       displayName: Install dependencies
     - script: |


### PR DESCRIPTION
This line of the windows script is either a weird Azure workaround I don't know about, in which case disregard, or a typo.
 `pip install setuptools -r requirements/test.txt`
setuptools was upgraded to the latest version in the previous line so installing it here should be a no-op?

(I know about the requirement to update the changelog but can someone confirm this is right first?)