### PR TITLE
Ensure spacing tokens between other tokens.

### DIFF
--- a/hypothesis-python/examples/test_lark.py
+++ b/hypothesis-python/examples/test_lark.py
@@ -1,0 +1,32 @@
+
+from lark import Lark
+from hypothesis.extra.lark import from_lark
+import hypothesis
+
+grammar_source = r"""
+
+prog: stmt+
+stmt: typ id "=" num ";"
+typ: "int"
+   | "float"
+id: /[a-z]+/
+num: /[0-9]+/
+
+%ignore /[ ]+/
+
+"""
+
+grammar = Lark(grammar_source, start='prog')
+
+@hypothesis.given(from_lark(grammar, start='prog'))
+def test_lark_token_concatenation(prog):
+    print('===========')
+    print(prog)
+    print('----')
+    p = grammar.parse(prog)
+    print(p)
+    print('===========')
+
+
+if __name__ == "__main__":
+    test_lark_token_concatenation()

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -85,13 +85,14 @@ class LarkStrategy(SearchStrategy):
     See ``from_lark`` for details.
     """
 
-    def __init__(self, grammar, start, explicit):
+    def __init__(self, grammar, start, explicit, seperator):
         assert isinstance(grammar, lark.lark.Lark)
         if start is None:
             start = grammar.options.start
         if not isinstance(start, list):
             start = [start]
         self.grammar = grammar
+        self.seperator = seperator
 
         if "start" in getfullargspec(grammar.grammar.compile).args:
             terminals, rules, ignore_names = grammar.grammar.compile(start)
@@ -145,7 +146,7 @@ class LarkStrategy(SearchStrategy):
         state = DrawState()
         start = data.draw(self.start)
         self.draw_symbol(data, start, state)
-        return "".join(state.result)
+        return self.seperator.join(state.result)
 
     def rule_label(self, name):
         try:
@@ -200,7 +201,8 @@ def from_lark(
     grammar: lark.lark.Lark,
     *,
     start: str = None,
-    explicit: Dict[str, st.SearchStrategy[str]] = None
+    explicit: Dict[str, st.SearchStrategy[str]] = None,
+    seperator: str = ""
 ) -> st.SearchStrategy[str]:
     """A strategy for strings accepted by the given context-free grammar.
 
@@ -234,4 +236,4 @@ def from_lark(
             k: v.map(check_explicit("explicit[%r]=%r" % (k, v)))
             for k, v in explicit.items()
         }
-    return LarkStrategy(grammar, start, explicit)
+    return LarkStrategy(grammar, start, explicit, seperator)

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -177,7 +177,7 @@ class LarkStrategy(SearchStrategy):
             data.stop_example()
 
     def gen_ignore(self, data, draw_state):
-        if self.ignored_symbols and data.draw_bits(2) == 3:
+        if self.ignored_symbols:
             emit = data.draw(st.sampled_from(self.ignored_symbols))
             self.draw_symbol(data, emit, draw_state)
 


### PR DESCRIPTION
This pull request attempts to address #2437 .

This attempts to generate parse able from the lark strategy.

There might be better options on how to implement this, for example passing a token seperator as a keyword argument.