### PR TITLE
Hint about `sampled_from()` when passed a sequence instead of a strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+If you pass a :class:`python:list` or :class:`python:tuple` where a
+strategy was expected, the error message now mentions
+:func:`~hypothesis.strategies.sampled_from` as an example strategy.
+
+Thanks to the enthusiastic participants in the `PyCon Mentored Sprints
+<https://us.pycon.org/2020/hatchery/mentoredsprints/>`__ who suggested
+adding this hint.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -26,7 +26,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import deprecated_posargs, proxies
 from hypothesis.internal.validation import check_type, check_valid_interval
-from hypothesis.strategies._internal import SearchStrategy
+from hypothesis.strategies._internal import SearchStrategy, check_strategy
 from hypothesis.strategies._internal.strategies import T
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 
@@ -400,7 +400,7 @@ def arrays(
                 .flatmap(lambda d: arrays(d, shape=shape, fill=fill, unique=unique))
             )
         elements = from_dtype(dtype)
-    check_type(SearchStrategy, elements, "elements")
+    check_strategy(elements, "elements")
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -1430,7 +1430,7 @@ def integer_array_indices(
         shape and all(isinstance(x, int) and x > 0 for x in shape),
         "shape=%r must be a non-empty tuple of integers > 0" % (shape,),
     )
-    check_type(SearchStrategy, result_shape, "result_shape")
+    check_strategy(result_shape, "result_shape")
     check_argument(
         np.issubdtype(dtype, np.integer), "dtype=%r must be an integer dtype" % (dtype,)
     )

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -261,7 +261,7 @@ def series(
     if index is None:
         index = range_indexes()
     else:
-        st.check_strategy(index)
+        st.check_strategy(index, "index")
 
     elements, dtype = elements_and_dtype(elements, dtype)
     index_strategy = index
@@ -473,7 +473,7 @@ def data_frames(
     if index is None:
         index = range_indexes()
     else:
-        st.check_strategy(index)
+        st.check_strategy(index, "index")
 
     index_strategy = index
 

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -31,6 +31,14 @@ def check_type(typ, arg, name=""):
             typ_string = "one of %s" % (", ".join(t.__name__ for t in typ))
         else:
             typ_string = typ.__name__
+
+            if typ_string == "SearchStrategy":
+                from hypothesis.strategies import SearchStrategy
+
+                # Use hypothesis.strategies._internal.strategies.check_strategy
+                # instead, as it has some helpful "did you mean..." logic.
+                assert typ is not SearchStrategy, "use check_strategy instead"
+
         raise InvalidArgument(
             "Expected %s but got %s%r (type=%s)"
             % (typ_string, name, arg, type(arg).__name__)

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -22,9 +22,7 @@ from hypothesis.internal.coverage import check_function
 
 
 @check_function
-def check_type(typ, arg, name=""):
-    if name:
-        name += "="
+def check_type(typ, arg, name):
     if not isinstance(arg, typ):
         if isinstance(typ, tuple):
             assert len(typ) >= 2, "Use bare type instead of len-1 tuple"
@@ -40,20 +38,20 @@ def check_type(typ, arg, name=""):
                 assert typ is not SearchStrategy, "use check_strategy instead"
 
         raise InvalidArgument(
-            "Expected %s but got %s%r (type=%s)"
+            "Expected %s but got %s=%r (type=%s)"
             % (typ_string, name, arg, type(arg).__name__)
         )
 
 
 @check_function
-def check_valid_integer(value):
+def check_valid_integer(value, name):
     """Checks that value is either unspecified, or a valid integer.
 
     Otherwise raises InvalidArgument.
     """
     if value is None:
         return
-    check_type(int, value)
+    check_type(int, value, name)
 
 
 @check_function

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -47,7 +47,11 @@ from hypothesis.internal.reflection import (
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import current_verbosity, report
 from hypothesis.strategies._internal.featureflags import FeatureStrategy
-from hypothesis.strategies._internal.strategies import OneOfStrategy, SearchStrategy
+from hypothesis.strategies._internal.strategies import (
+    OneOfStrategy,
+    SearchStrategy,
+    check_strategy,
+)
 from hypothesis.vendor.pretty import RepresentationPrinter
 
 STATE_MACHINE_RUN_LABEL = cu.calc_label_from_name("another state machine step")
@@ -568,7 +572,7 @@ def rule(*, targets=(), target=None, **kwargs):
     """
     converted_targets = _convert_targets(targets, target)
     for k, v in kwargs.items():
-        check_type(SearchStrategy, v, k)
+        check_strategy(v, name=k)
 
     def accept(f):
         existing_rule = getattr(f, RULE_MARKER, None)
@@ -606,7 +610,7 @@ def initialize(*, targets=(), target=None, **kwargs):
     """
     converted_targets = _convert_targets(targets, target)
     for k, v in kwargs.items():
-        check_type(SearchStrategy, v, k)
+        check_strategy(v, name=k)
 
     def accept(f):
         existing_rule = getattr(f, RULE_MARKER, None)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1495,7 +1495,7 @@ def fractions(
     assert max_value is None or isinstance(max_value, Fraction)
 
     check_valid_interval(min_value, max_value, "min_value", "max_value")
-    check_valid_integer(max_denominator)
+    check_valid_integer(max_denominator, "max_denominator")
 
     if max_denominator is not None:
         if max_denominator < 1:
@@ -1607,7 +1607,7 @@ def decimals(
     try to maximize human readability when shrinking.
     """
     # Convert min_value and max_value to Decimal values, and validate args
-    check_valid_integer(places)
+    check_valid_integer(places, "places")
     if places is not None and places < 0:
         raise InvalidArgument("places=%r may not be negative" % places)
     min_value = _as_finite_decimal(min_value, "min_value", allow_infinity)
@@ -2152,7 +2152,7 @@ def slices(draw: Any, size: int) -> slice:
 
     Examples from this strategy shrink toward 0 and smaller values
     """
-    check_valid_integer(size)
+    check_valid_integer(size, "size")
     if size is None or size < 1:
         raise InvalidArgument("size=%r must be at least one" % size)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -902,8 +902,8 @@ def dictionaries(
     check_valid_sizes(min_size, max_size)
     if max_size == 0:
         return fixed_dictionaries(dict_class())
-    check_strategy(keys)
-    check_strategy(values)
+    check_strategy(keys, "keys")
+    check_strategy(values, "values")
 
     return lists(
         tuples(keys, values),
@@ -1964,7 +1964,7 @@ class DataObject:
         return "data(...)"
 
     def draw(self, strategy: SearchStrategy[Ex], label: Any = None) -> Ex:
-        check_type(SearchStrategy, strategy, "strategy")
+        check_strategy(strategy, "strategy")
         result = self.conjecture_data.draw(strategy)
         self.count += 1
         if label is not None:
@@ -2138,7 +2138,7 @@ def functions(
         hints = get_type_hints(like)
         returns = from_type(hints.get("return", type(None)))
 
-    check_type(SearchStrategy, returns)
+    check_strategy(returns, "returns")
     return FunctionStrategy(like, returns)
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
@@ -14,8 +14,7 @@
 # END HEADER
 
 from hypothesis.internal.reflection import get_pretty_function_description
-from hypothesis.internal.validation import check_type
-from hypothesis.strategies._internal.strategies import SearchStrategy
+from hypothesis.strategies._internal.strategies import SearchStrategy, check_strategy
 
 
 class FlatMapStrategy(SearchStrategy):
@@ -38,7 +37,7 @@ class FlatMapStrategy(SearchStrategy):
     def do_draw(self, data):
         source = data.draw(self.flatmapped_strategy)
         expanded_source = self.expand(source)
-        check_type(SearchStrategy, expanded_source)
+        check_strategy(expanded_source)
         return data.draw(expanded_source)
 
     @property

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -25,6 +25,7 @@ from hypothesis._settings import HealthCheck, Phase, Verbosity, settings
 from hypothesis.control import _current_build_context, assume
 from hypothesis.errors import (
     HypothesisException,
+    InvalidArgument,
     NonInteractiveExampleWarning,
     UnsatisfiedAssumption,
 )
@@ -37,7 +38,6 @@ from hypothesis.internal.conjecture.utils import (
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.lazyformat import lazyformat
 from hypothesis.internal.reflection import get_pretty_function_description
-from hypothesis.internal.validation import check_type
 from hypothesis.utils.conventions import UniqueIdentifier
 
 Ex = TypeVar("Ex", covariant=True)
@@ -767,4 +767,13 @@ class FilteredStrategy(SearchStrategy):
 
 @check_function
 def check_strategy(arg, name=""):
-    check_type(SearchStrategy, arg, name)
+    if not isinstance(arg, SearchStrategy):
+        hint = ""
+        if isinstance(arg, (list, tuple)):
+            hint = ", such as st.sampled_from({}),".format(name or "...")
+        if name:
+            name += "="
+        raise InvalidArgument(
+            "Expected a SearchStrategy%s but got %s%r (type=%s)"
+            % (hint, name, arg, type(arg).__name__)
+        )

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -21,6 +21,7 @@ from hypothesis import find, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.validation import check_type
 from hypothesis.strategies import (
+    SearchStrategy as ActualSearchStrategy,
     binary,
     booleans,
     data,
@@ -247,3 +248,17 @@ def test_validation_happens_on_draw():
 
     with pytest.raises(InvalidArgument, match="has no values"):
         test()
+
+
+class SearchStrategy:
+    """Not the SearchStrategy type you were looking for."""
+
+
+def check_type_(*args):
+    return check_type(*args)
+
+
+def test_check_type_suggests_check_strategy():
+    check_type_(SearchStrategy, SearchStrategy(), "this is OK")
+    with pytest.raises(AssertionError, match="use check_strategy instead"):
+        check_type_(ActualSearchStrategy, None, "SearchStrategy assertion")

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -35,6 +35,7 @@ from hypothesis.strategies import (
     sets,
     text,
 )
+from hypothesis.strategies._internal.strategies import check_strategy
 from tests.common.utils import fails_with
 
 
@@ -262,3 +263,18 @@ def test_check_type_suggests_check_strategy():
     check_type_(SearchStrategy, SearchStrategy(), "this is OK")
     with pytest.raises(AssertionError, match="use check_strategy instead"):
         check_type_(ActualSearchStrategy, None, "SearchStrategy assertion")
+
+
+def check_strategy_(*args):
+    return check_strategy(*args)
+
+
+def test_check_strategy_might_suggest_sampled_from():
+    with pytest.raises(InvalidArgument) as excinfo:
+        check_strategy_("not a strategy")
+    assert "sampled_from" not in str(excinfo.value)
+    with pytest.raises(InvalidArgument, match="such as st.sampled_from"):
+        check_strategy_([1, 2, 3])
+    with pytest.raises(InvalidArgument, match="such as st.sampled_from"):
+        check_strategy_((1, 2, 3))
+    check_strategy_(integers(), "passes for our custom coverage check")


### PR DESCRIPTION
During the [PyCon mentored sprints](https://us.pycon.org/2020/hatchery/mentoredsprints/), two of the people I was working with wrote variations on `st.lists(elements=[1, 2, 3])`, and then had to look up `st.sampled_from()`.  So:

1. if passed a list or tuple when expecting a strategy, the error message is e.g `Expected a SearchStrategy, such as st.sampled_from(elements), but got elements=[1, 2, 3] (type=list)`
2. If we `check_type` with a strategy instead of using our `check_strategy` helper, that's now an internal error.