### PR TITLE
Make `fuzz_one_input` ~2.5x times faster

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch precomputes some of the setup logic for our experimental
+:ref:`external fuzzer integration <fuzz_one_input>` and sets
+:obj:`deadline=None <hypothesis.settings.deadline>` in fuzzing mode,
+saving around 150us on each iteration.
+
+This is around two-thirds the runtime to fuzz an empty test with
+``@given(st.none())``, and nice to have even as a much smaller
+fraction of the runtime for non-trivial tests.

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -744,3 +744,24 @@ Note that the interpretation of both input and output bytestrings is specific
 to the exact version of Hypothesis you are using and the strategies given to
 the test, just like the :doc:`example database <database>` and
 :func:`@reproduce_failure <hypothesis.reproduce_failure>` decorator.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Interaction with settings
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``fuzz_one_input`` uses just enough of Hypothesis' internals to drive your
+test function with a fuzzer-provided bytestring, and most settings therefore
+have no effect in this mode.  We recommend running your tests the usual way
+before fuzzing to get the benefits of healthchecks, as well as afterwards to
+replay, shrink, deduplicate, and report whatever errors were discovered.
+
+- The :obj:`~hypothesis.settings.database` setting *is* used by fuzzing mode -
+  adding failures to the database to be replayed when you next run your tests
+  is our preferred reporting mechanism and reponse to
+  `the 'fuzzer taming' problem <https://blog.regehr.org/archives/925>`__.
+- The :obj:`~hypothesis.settings.verbosity` and
+  :obj:`~hypothesis.settings.stateful_step_count` settings work as usual.
+
+The ``deadline``, ``derandomize``, ``max_examples``, ``phases``, ``print_blob``,
+``report_multiple_bugs``, and ``suppress_health_check`` settings do not affect
+fuzzing mode.


### PR DESCRIPTION
...well, if it's hardly doing anything - the two tricks consist of doing less setup, and sharing the cost of creating `StateForActualGivenExecution` across invocations (or moving it before the fork point).

```python
from time import perf_counter
from hypothesis import given, strategies as st


@given(st.none())  # or something more complicated
def test(_):
    pass


loops = 10000
start = perf_counter()

fuzz_one_input = test.hypothesis.fuzz_one_input  # fewer attribute lookups = faster
for _ in range(loops):
    fuzz_one_input(b"look, it's trying to talk to us...  \0\0\0\0\0\0")

end = perf_counter()
print(f"{loops} iterations in {end-start:.3f} seconds, {loops/(end-start):.0f} it/s")
```

On my machine this test script goes from ~3,800 it/s on master to ~10,300 it/s, saving 170 microseconds on each iteration.  That naturally makes this a lot less impressive once you're using nontrivial strategies or doing any real work in the test function, but it's still nice to have!