### PR TITLE
Python 3.9: Treat missing __args__ on generic types as None

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -266,6 +266,7 @@ their individual contributions.
 * `Paul Lorett Amazona <https://github.com/whatevergeek>`_
 * `Paul Stiverson <https://github.com/thismatters>`_
 * `Peadar Coyle <https://github.com/springcoil>`_ (peadarcoyle@gmail.com)
+* `Petr Viktorin <https://github.com/encukou>`_
 * `Pierre-Jean Campigotto <https://github.com/PJCampi>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,8 @@ jobs:
           TASK: check-py37
         check-py38:
           TASK: check-py38
+        check-py39:
+          TASK: check-py39
         check-quality:
           TASK: check-quality
     steps:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix ``__args__`` handling in inferring strategies for generic types under Python 3.9.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Fix ``__args__`` handling in inferring strategies for generic types under Python 3.9.
+Fix :func:`~hypothesis.strategies.from_type` with generic types under Python 3.9.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -412,7 +412,7 @@ def register(type_, fallback=None):
 
 @register("Type")
 def resolve_Type(thing):
-    if thing.__args__ is None:
+    if getattr(thing, '__args__', None) is None:
         return st.just(type)
     args = (thing.__args__[0],)
     if getattr(args[0], "__origin__", None) is typing.Union:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -412,7 +412,7 @@ def register(type_, fallback=None):
 
 @register("Type")
 def resolve_Type(thing):
-    if getattr(thing, '__args__', None) is None:
+    if getattr(thing, "__args__", None) is None:
         return st.just(type)
     args = (thing.__args__[0],)
     if getattr(args[0], "__origin__", None) is typing.Union:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -22,6 +22,8 @@ import inspect
 import io
 import ipaddress
 import numbers
+import os
+import sys
 import typing
 import uuid
 from types import FunctionType
@@ -309,6 +311,12 @@ _global_type_lookup = {
 _global_type_lookup[type] = st.sampled_from(
     [type(None)] + sorted(_global_type_lookup, key=str)
 )
+
+if sys.version_info[:2] >= (3, 9):  # pragma: no cover
+    # subclass of MutableMapping, and in Python 3.9 we resolve to a union
+    # which includes this... but we don't actually ever want to build one.
+    _global_type_lookup[os._Environ] = st.just(os.environ)
+
 
 try:  # pragma: no cover
     import numpy as np

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -38,6 +38,7 @@ sentinel = object()
 generics = sorted(
     (t for t in types._global_type_lookup if isinstance(t, typing_root_type)), key=str
 )
+xfail_on_39 = () if sys.version_info[:2] < (3, 9) else pytest.mark.xfail
 
 
 @pytest.mark.parametrize("typ", generics)
@@ -56,7 +57,7 @@ def test_resolve_typing_module(typ):
         elif isinstance(typ, typing._ProtocolMeta):
             pass
         elif typ is typing.Type and not isinstance(typing.Type, type):
-            assert isinstance(ex, typing.TypeVar)
+            assert ex is type or isinstance(ex, typing.TypeVar)
         else:
             try:
                 assert isinstance(ex, typ)
@@ -232,7 +233,7 @@ def if_available(name):
 @pytest.mark.parametrize(
     "typ",
     [
-        typing.Sequence,
+        pytest.param(typing.Sequence, marks=xfail_on_39),
         typing.Container,
         typing.Mapping,
         typing.Reversible,

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}-{brief,prettyquick,full,custom}
+envlist = py{35,36,37,38,39}-{brief,prettyquick,full,custom}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -376,6 +376,7 @@ PY35 = "3.5.7"
 PY36 = "3.6.9"
 PY37 = "3.7.4"
 PY38 = "3.8.0"
+PY39 = "3.9-dev"
 PYPY35 = "pypy3.5-7.0.0"
 PYPY36 = "pypy3.6-7.1.1"
 
@@ -388,8 +389,8 @@ def install_core():
 # ALIASES are the executable names for each Python version
 ALIASES = {PYPY35: "pypy3", PYPY36: "pypy3"}
 
-for n in [PY35, PY36, PY37, PY38]:
-    major, minor, patch = n.split(".")
+for n in [PY35, PY36, PY37, PY38, PY39]:
+    major, minor, patch = n.replace("-dev", ".").split(".")
     ALIASES[n] = "python%s.%s" % (major, minor)
 
 
@@ -420,6 +421,11 @@ def check_py37():
 @python_tests
 def check_py38():
     run_tox("py38-full", PY38)
+
+
+@python_tests
+def check_py39():
+    run_tox("py39-full", PY39)
 
 
 @python_tests


### PR DESCRIPTION
In Python 3.9, the `__args__` attribute is unset rather than set to None on types that aren't specialized.

See:
- https://docs.python.org/3.9/whatsnew/changelog.html?highlight=__args__#id2 (search `__args__`)
- https://bugs.python.org/issue40397

Closes #2444.