### PR TITLE
Generate non-UTF-8 unicode for Numpy arrays

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+This release allows :func:`~hypothesis.extra.numpy.from_dtype` to generate
+Unicode strings which cannot be encoded in UTF-8, but are valid in Numpy
+arrays (which use UTF-32).
+
+This logic will only be used with :pypi:`Numpy` >= 1.18.2, because earlier
+versions have `an issue <https://github.com/numpy/numpy/issues/15363>`__
+which led us to revert :ref:`Hypothesis 5.2 <v5.2.0>` last time!

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -325,7 +325,7 @@ def test_can_unicode_strings_without_decode_error(arr):
     pass
 
 
-@pytest.mark.xfail(strict=False, reason="mitigation for issue above")
+@pytest.mark.skipif(not nps.NP_FIXED_UNICODE, reason="workaround for old bug")
 def test_unicode_string_dtypes_need_not_be_utf8():
     def cannot_encode(string):
         try:


### PR DESCRIPTION
1. #2246 tried it, but was deferred until after we dropped Python 2
2. #2307 worked... until we hit numpy/numpy#15363 and reverted the release in #2329
3. Third time's the charm!  Now that Numpy has fixed the upstream bug, this _should_ work :sweat_smile: 