### PR TITLE
Hover-tooltips for xrefs in docs

### DIFF
--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
+    "hoverxref.extension",
 ]
 
 templates_path = ["_templates"]
@@ -59,6 +60,10 @@ exclude_patterns = ["_build"]
 pygments_style = "sphinx"
 
 todo_include_todos = False
+
+# See https://sphinx-hoverxref.readthedocs.io/en/latest/configuration.html
+hoverxref_auto_ref = True
+hoverxref_domains = ["py"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -24,6 +24,7 @@ requests
 restructuredtext-lint
 sortedcontainers
 sphinx
+sphinx-hoverxref
 sphinx-rtd-theme
 toml
 tox

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -95,6 +95,7 @@ six==1.15.0               # via bandit, bleach, cryptography, packaging, pip-too
 smmap==3.0.4              # via gitdb
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sortedcontainers==2.2.2   # via -r requirements/tools.in
+sphinx-hoverxref==0.5b1   # via -r requirements/tools.in
 sphinx-rtd-theme==0.5.0   # via -r requirements/tools.in
 sphinx==3.1.1             # via -r requirements/tools.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx


### PR DESCRIPTION
Via https://sphinx-hoverxref.readthedocs.io/en/latest/index.html

(hopefully this also does readthedocs preview builds for the PR...)