### PR TITLE
Some small refactoring of choice tree logic in shrinker

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release consists of some internal refactoring to the shrinker in preparation for future work. It has no user visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -70,13 +70,7 @@ class Chooser:
         self.__finished = True
         assert len(self.__node_trail) == len(self.__choices) + 1
 
-        next_value = list(self.__choices)
-        while next_value:
-            next_value[-1] -= 1
-            if next_value[-1] < 0:
-                next_value.pop()
-            else:
-                break
+        result = tuple(self.__choices)
 
         self.__node_trail[-1].live_child_count = 0
         while len(self.__node_trail) > 1 and self.__node_trail[-1].exhausted:
@@ -87,7 +81,7 @@ class Chooser:
             target.children[i] = DeadNode
             target.live_child_count -= 1
 
-        return tuple(next_value)
+        return result
 
 
 class ChoiceTree:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1472,10 +1472,19 @@ class ShrinkPass:
         size = len(self.shrinker.shrink_target.buffer)
         self.shrinker.explain_next_call_as(self.name)
         try:
-            self.next_prefix = tree.step(
+            choices = tree.step(
                 self.next_prefix,
                 lambda chooser: self.run_with_chooser(self.shrinker, chooser),
             )
+
+            next_prefix = list(choices)
+            while next_prefix and next_prefix[-1] == 0:
+                next_prefix.pop()
+
+            if next_prefix:
+                next_prefix[-1] -= 1
+
+            self.next_prefix = next_prefix
         finally:
             self.calls += self.shrinker.calls - initial_calls
             self.shrinks += self.shrinker.shrinks - initial_shrinks

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -571,9 +571,6 @@ class Shrinker:
             if 0 < len(successful_passes) < len(passes):
                 self.fixate_shrink_passes(successful_passes)
 
-        for sp in passes:
-            sp.fixed_point_at = self.shrink_target
-
     @property
     def buffer(self):
         return self.shrink_target.buffer
@@ -1453,16 +1450,12 @@ class ShrinkPass:
     shrinker = attr.ib()
 
     last_prefix = attr.ib(default=())
-    fixed_point_at = attr.ib(default=None)
     successes = attr.ib(default=0)
     calls = attr.ib(default=0)
     shrinks = attr.ib(default=0)
     deletions = attr.ib(default=0)
 
     def step(self):
-        if self.fixed_point_at is self.shrinker.shrink_target:
-            return False
-
         tree = self.shrinker.shrink_pass_choice_trees[self]
         if tree.exhausted:
             return False

--- a/hypothesis-python/tests/conjecture/test_choice_tree.py
+++ b/hypothesis-python/tests/conjecture/test_choice_tree.py
@@ -84,14 +84,12 @@ def test_skips_over_exhausted_children():
     assert results == [(1, 0), (1, 1), (2, 0)]
 
 
-def test_wraps_around_to_beginning():
+def test_starts_from_the_end():
     def f(chooser):
         chooser.choose(range(3))
 
     tree = ChoiceTree()
-    assert tree.step((), f) == (1,)
-    assert tree.step((1,), f) == (0,)
-    assert tree.step((0,), f) == ()
+    assert tree.step((), f) == (2,)
 
 
 def test_skips_over_exhausted_subtree():
@@ -99,5 +97,5 @@ def test_skips_over_exhausted_subtree():
         chooser.choose(range(10))
 
     tree = ChoiceTree()
+    assert tree.step((8,), f) == (8,)
     assert tree.step((8,), f) == (7,)
-    assert tree.step((8,), f) == (6,)

--- a/hypothesis-python/tests/conjecture/test_choice_tree.py
+++ b/hypothesis-python/tests/conjecture/test_choice_tree.py
@@ -15,7 +15,11 @@
 
 import hypothesis.strategies as st
 from hypothesis import given
-from hypothesis.internal.conjecture.choicetree import ChoiceTree
+from hypothesis.internal.conjecture.choicetree import ChoiceTree, prefix_selection_order
+
+
+def select(*args):
+    return prefix_selection_order(args)
 
 
 def exhaust(f):
@@ -26,7 +30,9 @@ def exhaust(f):
     prefix = ()
 
     while not tree.exhausted:
-        prefix = tree.step(prefix, lambda chooser: results.append(f(chooser)))
+        prefix = tree.step(
+            prefix_selection_order(prefix), lambda chooser: results.append(f(chooser))
+        )
     return results
 
 
@@ -77,9 +83,9 @@ def test_skips_over_exhausted_children():
 
     tree = ChoiceTree()
 
-    tree.step((1, 0), f)
-    tree.step((1, 1), f)
-    tree.step((0, 0), f)
+    tree.step(select(1, 0), f)
+    tree.step(select(1, 1), f)
+    tree.step(select(0, 0), f)
 
     assert results == [(1, 0), (1, 1), (2, 0)]
 
@@ -89,7 +95,7 @@ def test_starts_from_the_end():
         chooser.choose(range(3))
 
     tree = ChoiceTree()
-    assert tree.step((), f) == (2,)
+    assert tree.step(select(), f) == (2,)
 
 
 def test_skips_over_exhausted_subtree():
@@ -97,5 +103,5 @@ def test_skips_over_exhausted_subtree():
         chooser.choose(range(10))
 
     tree = ChoiceTree()
-    assert tree.step((8,), f) == (8,)
-    assert tree.step((8,), f) == (7,)
+    assert tree.step(select(8), f) == (8,)
+    assert tree.step(select(8), f) == (7,)


### PR DESCRIPTION
This is just a pull request of small refactoring of the logic involved in running a single step of a shrink pass. In particularly it:

* Abstracts out the logic of how we decide what choice to make a bit
* Removes the logic for computing the next prefix because we implicitly find it anyway through the logic for avoiding exhausted subtrees
* Removes some redundant information on shrink passes that we no longer need

It has no user visible impact.

## Context

I was working on a new shrink pass selection algorithm. Part of this was that I had to be able to run shrink passes where choices were made randomly instead of deterministically, which prompted the refactoring for how we pick individual choices.

I couldn't actually make this work convincingly, but I thought some of the refactoring that happened as part of it was a net improvement.