### PR TITLE
Add shrink pass for pairs of bytes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the quality of shrinking in some edge cases which could
+cause it to occasionally get stuck in non-optimal solutions. It has no other
+user-visible impact.

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -29,14 +29,13 @@ class Timeout(BaseException):
 
 def minimal(definition, condition=lambda x: True, settings=None, timeout_after=10):
     def wrapped_condition(x):
-        if timeout_after is not None:
-            if runtime:
-                runtime[0] += TIME_INCREMENT
-                if runtime[0] >= timeout_after:
-                    raise Timeout()
         result = condition(x)
         if result and not runtime:
             runtime.append(0.0)
+        if timeout_after is not None and runtime:
+            runtime[0] += TIME_INCREMENT
+            if runtime[0] >= timeout_after:
+                raise Timeout()
         return result
 
     if settings is None:


### PR DESCRIPTION
A thing I've been noticing in recent work is that we don't do very well at lexicographic shrinks that are obvious if we ignore the block structure but cross block boundaries. In particular there's a common pattern where we have a pair of adjacent bytes that would be trivial to shrink but we never try.

In particular the reason #2482 is currently failing is because of a failure to apply such a reduction.

This PR adds a shrink pass that applies lexicographic shrinks to pairs of bytes, which will get us unstuck in those cases. We're mainly interested in *adjacent* pairs of bytes, but it turns out that there are a number of special cases to worry about here where the shrinker will just take forever and a day to complete if you only focus on adjacent pairs of bytes, so we have some additional logic to skip over sequences of zeroes.