### PR TITLE
Use biased_coin in FeatureFlags

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,5 @@
 RELEASE_TYPE: patch
 
-This release slightly improves the shrinking of stateful tests, and has no
-other user visible impact.
+This release slightly improves shrinking behaviour. This should mainly only
+impact stateful tests, but may have some minor positive impact on shrinking
+collections (lists, sets, etc).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release slightly improves the shrinking of stateful tests, and has no
+other user visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -155,9 +155,11 @@ def boolean(data):
     return bool(data.draw_bits(1))
 
 
-def biased_coin(data, p):
+def biased_coin(data, p, forced=None):
     """Return True with probability p (assuming a uniform generator),
-    shrinking towards False."""
+    shrinking towards False. If ``forced`` is set to a non-None value, this
+    will always return that value but will write choices appropriate to having
+    drawn that value randomly."""
     data.start_example(BIASED_COIN_LABEL)
     while True:
         # The logic here is a bit complicated and special cased to make it
@@ -205,7 +207,10 @@ def biased_coin(data, p):
                 bits = 8
                 partial = True
 
-            i = data.draw_bits(bits)
+            if forced is None:
+                i = data.draw_bits(bits)
+            else:
+                i = data.draw_bits(bits, forced=int(forced))
 
             # We always label the region that causes us to repeat the loop as
             # 255 so that shrinking this byte never causes us to need to draw

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -155,7 +155,7 @@ def boolean(data):
     return bool(data.draw_bits(1))
 
 
-def biased_coin(data, p, forced=None):
+def biased_coin(data, p, *, forced=None):
     """Return True with probability p (assuming a uniform generator),
     shrinking towards False. If ``forced`` is set to a non-None value, this
     will always return that value but will write choices appropriate to having

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -374,16 +374,17 @@ class many:
 
         if self.min_size == self.max_size:
             should_continue = self.count < self.min_size
-        elif self.force_stop:
-            should_continue = False
         else:
-            if self.count < self.min_size:
-                p_continue = 1.0
+            forced_result = None
+            if self.force_stop:
+                forced_result = False
+            elif self.count < self.min_size:
+                forced_result = True
             elif self.count >= self.max_size:
-                p_continue = 0.0
-            else:
-                p_continue = self.stopping_value
-            should_continue = biased_coin(self.data, p_continue)
+                forced_result = False
+            should_continue = biased_coin(
+                self.data, self.stopping_value, forced=forced_result
+            )
 
         if should_continue:
             self.count += 1

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -58,9 +58,9 @@ def test_coin_biased_towards_truth():
     p = 1 - 1.0 / 500
 
     for i in range(1, 255):
-        assert cu.biased_coin(ConjectureData.for_buffer([0, i]), p)
+        assert cu.biased_coin(ConjectureData.for_buffer([0, i, 0, 0]), p)
 
-    assert not cu.biased_coin(ConjectureData.for_buffer([0, 0]), p)
+    assert not cu.biased_coin(ConjectureData.for_buffer([0, 0, 0, 1]), p)
 
 
 def test_coin_biased_towards_falsehood():
@@ -68,8 +68,8 @@ def test_coin_biased_towards_falsehood():
 
     for i in range(255):
         if i != 1:
-            assert not cu.biased_coin(ConjectureData.for_buffer([0, i]), p)
-    assert cu.biased_coin(ConjectureData.for_buffer([0, 1]), p)
+            assert not cu.biased_coin(ConjectureData.for_buffer([0, i, 0, 1]), p)
+    assert cu.biased_coin(ConjectureData.for_buffer([0, 1, 0, 0]), p)
 
 
 def test_unbiased_coin_has_no_second_order():
@@ -106,7 +106,7 @@ def test_drawing_an_exact_fraction_coin():
     for i in range(4):
         for j in range(4):
             total += 1
-            if cu.biased_coin(ConjectureData.for_buffer([i, j]), p):
+            if cu.biased_coin(ConjectureData.for_buffer([i, j, 0]), p):
                 count += 1
     assert p == Fraction(count, total)
 

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -297,3 +297,8 @@ def test_many_with_max_size():
     assert many.more()
     assert many.more()
     assert not many.more()
+
+
+def test_biased_coin_can_be_forced():
+    assert cu.biased_coin(ConjectureData.for_buffer([0]), p=0.5, forced=True)
+    assert not cu.biased_coin(ConjectureData.for_buffer([1]), p=0.5, forced=False)


### PR DESCRIPTION
Part of why #2483 was so fiddly was that it turns out that our feature flags implementation shrinks very badly. On the one hand this was good in that it revealed problems with the pass that it was useful to catch, on the other hand it'd be nicer if it just didn't shrink badly.

The problem is basically that it leaves high bytes in the choice sequence as an intrinsic feature, so the shrinker potentially has to do a lot of work repeatedly checking if it can lower those. Ideally all bytes would be 0 or 1 after a successful shrink. This is easy to achieve by swapping over the implementation to `biased_coin`, which already has optimisations for this.

In order to enable this more elegantly this caused me to add a feature to `biased_coin` which allows you to force the value it returns. Once I'd done that it made sense to make use of that in the `many` utils class which essentially faked that feature badly on its own.