### PR TITLE
Make `forced` a kw-only arg

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -189,6 +189,7 @@ their individual contributions.
 * `Alex Gaynor <https://github.com/alex>`_
 * `Alex Stapleton <https://www.github.com/public>`_
 * `Alex Willmer <https://github.com/moreati>`_ (alex@moreati.org.uk)
+* `Andrea Pierré <https://www.github.com/kir0ul>`_
 * `Ben Peterson <https://github.com/killthrush>`_ (killthrush@hotmail.com)
 * `Benjamin Lee <https://github.com/Benjamin-Lee>`_ (benjamindlee@me.com)
 * `Benjamin Palmer <https://github.com/benjpalmer>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch contains a small internal refactoring with no user-visible impact.
+
+Thanks to Andrea for writing this at
+`the SciPy 2020 Sprints <https://www.scipy2020.scipy.org/sprints-schedule>`__!

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -983,7 +983,7 @@ class ConjectureData:
         self.events = frozenset(self.events)
         self.observer.conclude_test(self.status, self.interesting_origin)
 
-    def draw_bits(self, n, forced=None):
+    def draw_bits(self, n, *, forced=None):
         """Return an ``n``-bit integer from the underlying source of
         bytes. If ``forced`` is set to an integer will instead
         ignore the underlying source and simulate a draw as if it had

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -227,7 +227,7 @@ def test_does_not_trigger_health_check_on_simple_strategies(monkeypatch):
     # we need it to pretend to be.
     def draw_bits(self, n, forced=None):
         time.sleep(0.001)
-        return existing_draw_bits(self, n, forced)
+        return existing_draw_bits(self, n, forced=forced)
 
     monkeypatch.setattr(ConjectureData, "draw_bits", draw_bits)
 


### PR DESCRIPTION
Tried to fix https://github.com/HypothesisWorks/hypothesis/issues/2487, let me know if it was the correct intended behavior or if I missed anything :slightly_smiling_face: 