### PR TITLE
Generate non-tuples if length == 1 from `npst.basic_indices()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+The :func:~hypothesis.extra.numpy.basic_indices strategy can now generate
+bare indexers in place of length-one tuples. Thanks to Andrea for this patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: minor
 
-The :func:~hypothesis.extra.numpy.basic_indices strategy can now generate
+The :func:`~hypothesis.extra.numpy.basic_indices` strategy can now generate
 bare indexers in place of length-one tuples. Thanks to Andrea for this patch!

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1313,9 +1313,9 @@ class BasicIndexStrategy(SearchStrategy):
             while result[-1:] == [slice(None, None)] and data.draw(st.integers(0, 7)):
                 result.pop()
         if len(result) == 1 and data.draw(st.booleans()):
+            # Sometimes generate bare element equivalent to a length-one tuple
             return result[0]
-        else:
-            return tuple(result)
+        return tuple(result)
 
 
 @st.defines_strategy
@@ -1335,6 +1335,8 @@ def basic_indices(
     It generates tuples containing some mix of integers, :obj:`python:slice` objects,
     ``...`` (Ellipsis), and :obj:`numpy:numpy.newaxis`; which when used to index a
     ``shape``-shaped array will produce either a scalar or a shared-memory view.
+    When a length-one tuple would be generated, this strategy may instead return
+    the element which will index the first axis, e.g. `5` instead of `(5,)`.
 
     * ``shape``: the array shape that will be indexed, as a tuple of integers >= 0.
       This must be at least two-dimensional for a tuple to be a valid basic index;

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1312,7 +1312,10 @@ class BasicIndexStrategy(SearchStrategy):
         else:
             while result[-1:] == [slice(None, None)] and data.draw(st.integers(0, 7)):
                 result.pop()
-        return tuple(result)
+        if len(result) == 1 and data.draw(st.booleans()):
+            return result[0]
+        else:
+            return tuple(result)
 
 
 @st.defines_strategy

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1336,7 +1336,7 @@ def basic_indices(
     ``...`` (Ellipsis), and :obj:`numpy:numpy.newaxis`; which when used to index a
     ``shape``-shaped array will produce either a scalar or a shared-memory view.
     When a length-one tuple would be generated, this strategy may instead return
-    the element which will index the first axis, e.g. `5` instead of `(5,)`.
+    the element which will index the first axis, e.g. ``5`` instead of ``(5,)``.
 
     * ``shape``: the array shape that will be indexed, as a tuple of integers >= 0.
       This must be at least two-dimensional for a tuple to be a valid basic index;

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -14,9 +14,9 @@
 # END HEADER
 
 import sys
+from collections.abc import Iterable
 from functools import reduce
 from itertools import zip_longest
-from collections.abc import Iterable
 
 import numpy as np
 import pytest
@@ -1190,7 +1190,8 @@ def test_basic_indices_can_generate_empty_tuple():
 def test_basic_indices_can_generate_non_tuples():
     find_any(
         nps.basic_indices(shape=(0, 0), allow_ellipsis=True),
-        lambda ix: not isinstance(ix, tuple))
+        lambda ix: not isinstance(ix, tuple),
+    )
 
 
 def test_basic_indices_can_generate_long_ellipsis():
@@ -1201,8 +1202,11 @@ def test_basic_indices_can_generate_long_ellipsis():
     )
 
 
-@given(nps.basic_indices(shape=(0, 0, 0, 0, 0)).filter(
-    lambda idx: isinstance(idx, Iterable) and Ellipsis in idx))
+@given(
+    nps.basic_indices(shape=(0, 0, 0, 0, 0)).filter(
+        lambda idx: isinstance(idx, Iterable) and Ellipsis in idx
+    )
+)
 def test_basic_indices_replaces_whole_axis_slices_with_ellipsis(idx):
     # If ... is in the slice, it replaces all ,:, entries for this shape.
     assert slice(None) not in idx

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import sys
-from collections.abc import Iterable
 from functools import reduce
 from itertools import zip_longest
 
@@ -1204,7 +1203,7 @@ def test_basic_indices_can_generate_long_ellipsis():
 
 @given(
     nps.basic_indices(shape=(0, 0, 0, 0, 0)).filter(
-        lambda idx: isinstance(idx, Iterable) and Ellipsis in idx
+        lambda idx: isinstance(idx, tuple) and Ellipsis in idx
     )
 )
 def test_basic_indices_replaces_whole_axis_slices_with_ellipsis(idx):
@@ -1236,7 +1235,7 @@ def test_basic_indices_generate_valid_indexers(
     )
     # Check that disallowed things are indeed absent
     if not allow_newaxis:
-        if hasattr(indexer, "__len__"):
+        if isinstance(indexer, tuple):
             assert 0 <= len(indexer) <= len(shape) + int(allow_ellipsis)
         else:
             assert 1 <= len(shape) + int(allow_ellipsis)


### PR DESCRIPTION
Not sure it's the best way to do it, but here is a first attempt to fix https://github.com/HypothesisWorks/hypothesis/issues/2486