### PR TITLE
Patch out distutils

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch removes an internal use of ``distutils`` in order to avoid
+`this setuptools warning <https://github.com/pypa/setuptools/issues/2261>`__
+for some users.

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-from distutils.version import LooseVersion
 from inspect import signature
 
 import pytest
@@ -44,7 +43,9 @@ class StoringReporter:
         self.results.append(msg)
 
 
-if LooseVersion(pytest.__version__) < "4.3":  # pragma: no cover
+# Avoiding distutils.version.LooseVersion due to
+# https://github.com/HypothesisWorks/hypothesis/issues/2490
+if tuple(map(int, pytest.__version__.split(".")[:2])) < (4, 3):  # pragma: no cover
     import warnings
     from hypothesis.errors import HypothesisWarning
 


### PR DESCRIPTION
Fixes #2490.  This is not a particularly elegant patch, but it *does* mean that we won't need to touch this again regardless of what happens to `setuptools` and `distutils`.

CC @HypothesisWorks/hypothesis-python-contributors - I'd like to ship this ASAP for affected users.