### PR TITLE
Don't use a buffer we've extended as a cache key

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a small caching bug in Hypothesis internals that may under
+some circumstances have resulted in a less diverse set of test cases being
+generated than was intended.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,3 +3,6 @@ RELEASE_TYPE: patch
 This release fixes a small caching bug in Hypothesis internals that may under
 some circumstances have resulted in a less diverse set of test cases being
 generated than was intended.
+
+Fixing this problem revealed some performance problems that could occur during targeted property based testing, so this release also fixes those. Targeted property-based testing should now be significantly faster in some cases,
+but this may be at the cost of reduced effectiveness.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1033,7 +1033,8 @@ class ConjectureRunner:
         )
         self.test_function(data)
         result = check_result(data.as_result())
-        self.__data_cache[buffer] = result
+        if extend == 0 or len(result.buffer) <= len(buffer):
+            self.__data_cache[buffer] = result
         return result
 
     def event_to_string(self, event):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -989,7 +989,9 @@ class ConjectureRunner:
             return result
 
         try:
-            return check_result(self.__data_cache[buffer])
+            cached = check_result(self.__data_cache[buffer])
+            if cached.status > Status.OVERRUN or extend == 0:
+                return cached
         except KeyError:
             pass
 
@@ -1033,7 +1035,7 @@ class ConjectureRunner:
         )
         self.test_function(data)
         result = check_result(data.as_result())
-        if extend == 0 or len(result.buffer) <= len(buffer):
+        if extend == 0 or (result is not Overrun and len(result.buffer) <= len(buffer)):
             self.__data_cache[buffer] = result
         return result
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -124,8 +124,10 @@ class Optimiser:
                 # component we want to give it a couple of tries to succeed.
                 for _ in range(3):
                     attempt = self.engine.cached_test_function(
-                        prefix + v_as_bytes + self.current_data.buffer[block.end :],
-                        extend=BUFFER_SIZE,
+                        prefix
+                        + v_as_bytes
+                        + self.current_data.buffer[block.end :]
+                        + bytes(BUFFER_SIZE),
                     )
 
                     if self.consider_new_test_data(attempt):


### PR DESCRIPTION
I noticed that the `extend` parameter that I added to `cached_test_function` had a bit of a problem with it: Once you'd extended a buffer it would deterministically always extend it with the same thing. This turns out to be a trivial bug in our caching (we put the original buffer in as a cache key).

~My guess is that we were never hitting this in the wild but it tripped me up in some experimental code and seems worth fixing.~

It turns out that fixing this bug caused massive performance problems in optimisation, so I've also changed the optimiser to only extend the buffer with zeroes rather than randomly. This seems to pass all our tests and should be a lot faster even than the version with the caching bug.