### PR TITLE
Add special case shrink pass for sums of integers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release improves shrinking quality in some special cases.

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -331,3 +331,9 @@ def test_lists_forced_near_top(n):
     assert minimal(
         lists(integers(), min_size=n, max_size=n + 2), lambda t: len(t) == n + 2
     ) == [0] * (n + 2)
+
+
+def test_sum_of_pair():
+    assert minimal(
+        tuples(integers(0, 1000), integers(0, 1000)), lambda x: sum(x) > 1000
+    ) == (1, 1000)


### PR DESCRIPTION
We don't currently reduce tests that look like the following well:

```python

@given(st.integers(0, 1000), st.integers(0, 1000))
def test(m, n):
    assert m + n <= 1000
```

In that we might end up with basically any pair `(m, n)` with `m + n == 1001`, when ideally we'd always end up with `m = 1, n = 1000`.

It'd be nice to normalise such a simple test. This PR adds a special case shrinking pass for tests that have sum lower bounds like this.

Full disclosure: This is me cheating at a benchmark. https://github.com/jlink/shrinking-challenge/blob/main/challenges/bound5.md