### PR TITLE
WIP: Make block programs operate on blocks as integers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release makes some internal changes to the shrinker. Under some circumstances this
+will result in better shrinking, but those should be fairly rare and this is primarily
+refactoring in preparation for future changes.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -64,7 +64,7 @@ from hypothesis.internal.compat import (
     int_from_bytes,
     qualname,
 )
-from hypothesis.internal.conjecture.data import ConjectureData, StopTest
+from hypothesis.internal.conjecture.data import ConjectureData, EmptyBitSource, StopTest
 from hypothesis.internal.conjecture.engine import ConjectureRunner, sort_key
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
@@ -296,7 +296,7 @@ class ArtificialDataForExample(ConjectureData):
     def __init__(self, kwargs):
         self.__draws = 0
         self.__kwargs = kwargs
-        super().__init__(max_length=0, prefix=b"", random=None)
+        super().__init__(EmptyBitSource())
 
     def draw_bits(self, n):
         raise NotImplementedError("Dummy object should never be asked for bits.")

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -747,6 +747,11 @@ class BitSource:
         raise NotImplementedError()
 
 
+class EmptyBitSource:
+    def draw_bits(self, n):
+        raise OutOfBits()
+
+
 class BitSourceFromPrefix(BitSource):
     """Main implementation of BitSource. Draws from a fixed sequence
     of bytes, then uniformly at random from some random source,
@@ -793,24 +798,22 @@ class ConjectureData:
     @classmethod
     def for_buffer(self, buffer, observer=None):
         return ConjectureData(
-            prefix=buffer, max_length=len(buffer), random=None, observer=observer,
+            BitSourceFromPrefix(prefix=buffer, max_length=len(buffer), random=None),
+            observer=observer,
         )
 
-    def __init__(self, max_length, prefix, random, observer=None):
+    def __init__(self, bit_source, observer=None):
         if observer is None:
             observer = DataObserver()
         assert isinstance(observer, DataObserver)
         self.__bytes_drawn = 0
         self.observer = observer
-        self.max_length = max_length
         self.is_find = False
         self.overdraw = 0
         self.__block_starts = defaultdict(list)
         self.__block_starts_calculated_to = 0
 
-        self.__bit_source = BitSourceFromPrefix(
-            prefix=prefix, random=random, max_length=max_length,
-        )
+        self.__bit_source = bit_source
 
         self.blocks = Blocks(self)
         self.buffer = bytearray()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -727,10 +727,19 @@ class ConjectureResult:
     examples = attr.ib(repr=False)
 
     index = attr.ib(init=False)
+    __choices = attr.ib(init=False, default=None)
 
     def __attrs_post_init__(self):
         self.index = len(self.buffer)
         self.forced_indices = frozenset(self.forced_indices)
+
+    @property
+    def choices(self):
+        if self.__choices is None:
+            self.__choices = IntList(
+                [int_from_bytes(self.buffer[u:v]) for u, v in self.blocks.all_bounds()]
+            )
+        return self.__choices
 
     def as_result(self):
         return self

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -797,6 +797,23 @@ class BitSourceFromPrefix(BitSource):
         return int_from_bytes(buf)
 
 
+class BitSourceFromChoices(BitSource):
+    def __init__(self, choices):
+        self.choices = choices
+        self.choices_made = 0
+
+    def draw_bits(self, n):
+        try:
+            result = self.choices[self.choices_made]
+        except IndexError:
+            raise OutOfBits()
+        self.choices_made += 1
+
+        if result.bit_length() > n:
+            result &= (1 << n) - 1
+        return result
+
+
 # Masks for masking off the first byte of an n-bit buffer.
 # The appropriate mask is stored at position n % 8.
 BYTE_MASKS = [(1 << n) - 1 for n in range(8)]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -811,6 +811,7 @@ class BitSourceFromChoices(BitSource):
 
         if result.bit_length() > n:
             result &= (1 << n) - 1
+
         return result
 
 
@@ -1072,6 +1073,10 @@ class ConjectureData:
         try:
             result = self.__bit_source.draw_bits(n)
         except OutOfBits:
+            # Note that this will give a value of None if forced is None and
+            # that is correct behaviour (the tree interprets it as "we've
+            # seen a draw here but we've never seen a value for it")
+            self.observer.draw_bits(n, forced=forced is not None, value=forced)
             self.mark_overrun()
 
         # Note that we always draw the underlying source of bits

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -28,6 +28,7 @@ from hypothesis._settings import local_settings
 from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.compat import ceil, int_from_bytes
 from hypothesis.internal.conjecture.data import (
+    BitSourceFromPrefix,
     ConjectureData,
     ConjectureResult,
     DataObserver,
@@ -866,9 +867,9 @@ class ConjectureRunner:
 
     def new_conjecture_data(self, prefix, max_length=BUFFER_SIZE, observer=None):
         return ConjectureData(
-            prefix=prefix,
-            max_length=max_length,
-            random=self.random,
+            BitSourceFromPrefix(
+                prefix=prefix, max_length=max_length, random=self.random
+            ),
             observer=observer or self.tree.new_observer(),
         )
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -134,6 +134,8 @@ class ConjectureRunner:
         # executed test case.
         self.__data_cache = LRUReusedCache(CACHE_SIZE)
 
+        self.__pending_call_explanation = None
+
     @contextmanager
     def _log_phase_statistics(self, phase):
         self.stats_per_test_case.clear()
@@ -173,6 +175,10 @@ class ConjectureRunner:
                 raise
 
     def test_function(self, data):
+        if self.__pending_call_explanation is not None:
+            self.debug(self.__pending_call_explanation)
+            self.__pending_call_explanation = None
+
         assert isinstance(data.observer, TreeRecordingObserver)
         self.call_count += 1
 
@@ -964,6 +970,12 @@ class ConjectureRunner:
 
     def new_shrinker(self, example, predicate=None, allow_transition=None):
         return Shrinker(self, example, predicate, allow_transition)
+
+    def explain_next_call_as(self, explanation):
+        self.__pending_call_explanation = explanation
+
+    def clear_call_explanation(self):
+        self.__pending_call_explanation = None
 
     def cached_test_function(self, buffer, error_on_discard=False, extend=0):
         """Checks the tree to see if we've tested this buffer, and returns the

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -104,6 +104,7 @@ def assert_all_examples(strategy, predicate):
     :param predicate: (callable) Predicate that takes example and returns bool
     """
 
+    @Settings(database=None)
     @given(strategy)
     def assert_examples(s):
         msg = "Found %r using strategy %s which does not match" % (s, strategy)

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -572,3 +572,17 @@ def test_block_programs_adjust_to_block_size():
     shrinker.fixate_shrink_passes([block_program("-")])
 
     assert list(shrinker.buffer) == [1, 1]
+
+
+def test_caching_of_choice_based_calls():
+    @shrinking_from([1] * 5)
+    def shrinker(d):
+        for _ in range(5):
+            d.draw_bits(8)
+        d.mark_interesting()
+
+    initial = shrinker.calls
+    shrinker.consider_choices([0] * 4)
+    assert shrinker.calls == initial + 1
+    shrinker.consider_choices([0] * 4)
+    assert shrinker.calls == initial + 1

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -559,3 +559,16 @@ def test_zero_coverage_edge_case():
     shrinker.fixate_shrink_passes(["zero_examples"])
 
     assert list(shrinker.buffer) == [255] + [0] * (len(shrinker.buffer) - 1)
+
+
+def test_block_programs_adjust_to_block_size():
+    @shrinking_from([64] + [0] * 7 + [1])
+    def shrinker(data):
+        n = data.draw_bits(8)
+        m = data.draw_bits(n)
+        if m == 1:
+            data.mark_interesting()
+
+    shrinker.fixate_shrink_passes([block_program("-")])
+
+    assert list(shrinker.buffer) == [1, 1]

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -21,6 +21,7 @@ from hypothesis import given, strategies as st
 from hypothesis.errors import Frozen, InvalidArgument
 from hypothesis.internal.conjecture.data import (
     MAX_DEPTH,
+    BitSourceFromPrefix,
     ConjectureData,
     DataObserver,
     Overrun,
@@ -469,7 +470,7 @@ def test_example_equality():
 
 @given(st.integers(0, 255), st.randoms(use_true_random=True))
 def test_partial_buffer(n, rnd):
-    data = ConjectureData(prefix=[n], random=rnd, max_length=2,)
+    data = ConjectureData(BitSourceFromPrefix(prefix=[n], random=rnd, max_length=2,))
 
     assert data.draw_bytes(2)[0] == n
 

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -24,6 +24,7 @@ from hypothesis.internal.conjecture.data import (
     BitSourceFromPrefix,
     ConjectureData,
     DataObserver,
+    EmptyBitSource,
     Overrun,
     Status,
     StopTest,
@@ -504,3 +505,10 @@ def test_children_of_discarded_examples_do_not_create_structural_coverage():
     data.freeze()
     assert structural_coverage(42) not in data.tags
     assert structural_coverage(10) not in data.tags
+
+
+def test_empty_immediately_raises():
+    data = ConjectureData(EmptyBitSource())
+    with pytest.raises(StopTest):
+        data.draw_bits(1)
+    assert data.status == Status.OVERRUN

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 import itertools
+from random import Random
 
 import pytest
 
@@ -25,6 +26,7 @@ from hypothesis.internal.conjecture.data import (
     ConjectureData,
     DataObserver,
     EmptyBitSource,
+    OutOfBits,
     Overrun,
     Status,
     StopTest,
@@ -512,3 +514,13 @@ def test_empty_immediately_raises():
     with pytest.raises(StopTest):
         data.draw_bits(1)
     assert data.status == Status.OVERRUN
+
+
+def test_respects_max_length():
+    source = BitSourceFromPrefix(max_length=3, random=Random(0), prefix=())
+
+    source.draw_bits(1)
+    source.draw_bits(9)
+
+    with pytest.raises(OutOfBits):
+        source.draw_bits(1)


### PR DESCRIPTION
I had important things I was supposed to be working on today so I decided to do something else instead and start work on a longstanding vague intention of mine, which is to move our basic representation of data from sequences of bytes to sequences of integer choices (partly prompted by the fact that this is how it works in Conjecture-for-Rust and [minithesis](https://github.com/DRMacIver/minithesis/)). We will probably still retain the buffer representation (it's needed for the database and is very useful in a few other places) but it would be nice to be able to use both on equal footing.

This is a first pass at that which does it in the place where it's least intrusive and also most useful, which is the block programs in the shrinker. This PR modifies block programs to operate on blocks as integer values rather than as sequences of bytes.

This is mainly visible in effect when block sizes change. e.g. you can see an example of this happening in the test I added: The size of a block depends on the value of a previous block. Previously this would cause us to get confused and read the left-most bytes of the second block, while now we retain its value.