### PR TITLE
Don't import time methods

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release makes some internal changes for testing purposes and should have no user visible effect.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -22,13 +22,13 @@ import inspect
 import io
 import random as rnd_module
 import sys
+import time
 import traceback
 import warnings
 import zlib
 from inspect import getfullargspec
 from io import StringIO
 from random import Random
-from time import perf_counter
 from typing import Any, BinaryIO, Callable, Hashable, List, Optional, TypeVar, Union
 from unittest import TestCase
 
@@ -524,9 +524,9 @@ class StateForActualGivenExecution:
             def test(*args, **kwargs):
                 self.__test_runtime = None
                 initial_draws = len(data.draw_times)
-                start = perf_counter()
+                start = time.perf_counter()
                 result = self.test(*args, **kwargs)
-                finish = perf_counter()
+                finish = time.perf_counter()
                 internal_draw_time = sum(data.draw_times[initial_draws:])
                 runtime = datetime.timedelta(
                     seconds=finish - start - internal_draw_time

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -13,9 +13,9 @@
 #
 # END HEADER
 
+import time
 from collections import defaultdict
 from enum import IntEnum
-from time import perf_counter
 
 import attr
 
@@ -774,7 +774,7 @@ class ConjectureData:
         global global_test_counter
         self.testcounter = global_test_counter
         global_test_counter += 1
-        self.start_time = perf_counter()
+        self.start_time = time.perf_counter()
         self.events = set()
         self.forced_indices = set()
         self.interesting_origin = None
@@ -866,7 +866,7 @@ class ConjectureData:
             # can be almost arbitrarily slow.  In cases like characters() and text()
             # where we cache something expensive, this led to Flaky deadline errors!
             # See https://github.com/HypothesisWorks/hypothesis/issues/2108
-            start_time = perf_counter()
+            start_time = time.perf_counter()
 
         strategy.validate()
 
@@ -888,7 +888,7 @@ class ConjectureData:
                     try:
                         return strategy.do_draw(self)
                     finally:
-                        self.draw_times.append(perf_counter() - start_time)
+                        self.draw_times.append(time.perf_counter() - start_time)
                 except BaseException as e:
                     mark_for_escalation(e)
                     raise
@@ -967,7 +967,7 @@ class ConjectureData:
         if self.frozen:
             assert isinstance(self.buffer, bytes)
             return
-        self.finish_time = perf_counter()
+        self.finish_time = time.perf_counter()
         assert len(self.buffer) == self.index
 
         # Always finish by closing all remaining examples so that we have a

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -14,11 +14,11 @@
 # END HEADER
 
 import math
+import time
 from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum
 from random import Random, getrandbits
-from time import perf_counter
 from weakref import WeakKeyDictionary
 
 import attr
@@ -136,12 +136,12 @@ class ConjectureRunner:
     @contextmanager
     def _log_phase_statistics(self, phase):
         self.stats_per_test_case.clear()
-        start_time = perf_counter()
+        start_time = time.perf_counter()
         try:
             yield
         finally:
             self.statistics[phase + "-phase"] = {
-                "duration-seconds": perf_counter() - start_time,
+                "duration-seconds": time.perf_counter() - start_time,
                 "test-cases": list(self.stats_per_test_case),
                 "distinct-failures": len(self.interesting_examples),
                 "shrinks-successful": self.shrinks,
@@ -255,7 +255,7 @@ class ConjectureRunner:
 
         if (
             self.finish_shrinking_deadline is not None
-            and self.finish_shrinking_deadline < perf_counter()
+            and self.finish_shrinking_deadline < time.perf_counter()
         ):
             # See https://github.com/HypothesisWorks/hypothesis/issues/2340
             report(
@@ -891,7 +891,7 @@ class ConjectureRunner:
         # a warning.   Many CI systems will kill a build after around ten minutes with
         # no output, and appearing to hang isn't great for interactive use either -
         # showing partially-shrunk examples is better than quitting with no examples!
-        self.finish_shrinking_deadline = perf_counter() + 300
+        self.finish_shrinking_deadline = time.perf_counter() + 300
 
         for prev_data in sorted(
             self.interesting_examples.values(), key=lambda d: sort_key(d.buffer)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -483,7 +483,6 @@ class Shrinker:
         This method iterates to a fixed point and so is idempontent - calling
         it twice will have exactly the same effect as calling it once.
         """
-
         self.fixate_shrink_passes(
             [
                 block_program("X" * 5),

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -20,8 +20,6 @@ import time as time_module
 
 import pytest
 
-from hypothesis import core as core_module
-from hypothesis.internal.conjecture import data as data_module, engine as engine_module
 from hypothesis.internal.detection import is_hypothesis_test
 from tests.common import TIME_INCREMENT
 from tests.common.setup import run
@@ -78,10 +76,6 @@ def consistently_increment_time(monkeypatch):
     monkeypatch.setattr(time_module, "perf_counter", time)
     monkeypatch.setattr(time_module, "sleep", sleep)
     monkeypatch.setattr(time_module, "freeze", freeze, raising=False)
-    # Also monkeypatch the modules which "from time import perf_counter"
-    monkeypatch.setattr(core_module, "perf_counter", time)
-    monkeypatch.setattr(data_module, "perf_counter", time)
-    monkeypatch.setattr(engine_module, "perf_counter", time)
 
 
 random_states_after_tests = {}

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 import re
+import time
 from random import Random
 from unittest.mock import Mock
 
@@ -778,7 +779,7 @@ def test_exit_because_shrink_phase_timeout(monkeypatch):
         if data.draw_bits(64) > 2 ** 33:
             data.mark_interesting()
 
-    monkeypatch.setattr(engine_module, "perf_counter", fast_time)
+    monkeypatch.setattr(time, "perf_counter", fast_time)
     runner = ConjectureRunner(f, settings=settings(database=None))
     runner.run()
     assert runner.exit_reason == ExitReason.very_slow_shrinking


### PR DESCRIPTION
Fixes #2497.

The reason it was often failing was that it was hitting the time limit on shrinks. The reason it was hitting the time limit on shrinks is that our mocking for `perf_counter` wasn't doing anything, which is why this was flaky on CI but not locally - it was timing dependent.

I'm not 100% clear on why this was happening, but I adopted the simpler approach of replacing it with just doing `import time` and calling methods on it, as that's significantly less brittle. 