### PR TITLE
Run individual shrink pass steps in a semi-random order

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes some performance improvements to shrinking. They should
+only be noticeable for tests that are currently particularly slow to shrink.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -15,6 +15,8 @@
 
 from collections import defaultdict
 
+from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy, pop_random
+
 
 def prefix_selection_order(prefix):
     """Select choices starting from ``prefix```,
@@ -30,6 +32,17 @@ def prefix_selection_order(prefix):
             yield from range(n - 1, i, -1)
         else:
             yield from range(n - 1, -1, -1)
+
+    return selection_order
+
+
+def random_selection_order(random):
+    """Select choices uniformly at random."""
+
+    def selection_order(depth, n):
+        pending = LazySequenceCopy(range(n))
+        while pending:
+            yield pop_random(random, pending)
 
     return selection_order
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -271,3 +271,11 @@ def find_integer(f):
         else:
             hi = mid
     return lo
+
+
+def pop_random(random, seq):
+    """Remove and return a random element of seq. This runs in O(1) but leaves
+    the sequence in an arbitrary order."""
+    i = random.randrange(0, len(seq))
+    swap(seq, i, len(seq) - 1)
+    return seq.pop()

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -18,7 +18,7 @@ import pytest
 from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture import floats as flt
 from hypothesis.internal.conjecture.engine import ConjectureRunner
-from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
+from hypothesis.internal.conjecture.shrinker import Shrinker, ShrinkPass, block_program
 from hypothesis.internal.conjecture.shrinking import Float
 from hypothesis.internal.conjecture.utils import Sampler
 from tests.conjecture.common import SOME_LABEL, run_to_buffer, shrinking_from
@@ -559,3 +559,14 @@ def test_zero_coverage_edge_case():
     shrinker.fixate_shrink_passes(["zero_examples"])
 
     assert list(shrinker.buffer) == [255] + [0] * (len(shrinker.buffer) - 1)
+
+
+def test_shrink_pass_method_is_idempotent():
+    @shrinking_from([255])
+    def shrinker(data):
+        data.draw_bits(8)
+        data.mark_interesting()
+
+    sp = shrinker.shrink_pass("adaptive_example_deletion")
+    assert isinstance(sp, ShrinkPass)
+    assert shrinker.shrink_pass(sp) is sp

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -187,7 +187,6 @@ def test_minimize_multiple_elements_in_silly_large_int_range_min_is_not_dupe():
     assert x == target
 
 
-@pytest.mark.skip  # See https://github.com/HypothesisWorks/hypothesis/issues/2497
 def test_find_large_union_list():
     size = 10
 


### PR DESCRIPTION
Supplants #2478 - I picked up the code again to try to use it to fix the flaky large union shrink test, and then pulled on a thread and it turned that the more time was spent in selecting the shrink passes the better the code ran.

Causes a modest speedup on our shrink quality tests. Not huge - around 10% maybe - but it's enough to get the union list rnning reliably.

Basic idea is to use a hybrid approach where when nothing seems to be working we randomly bounce a shrink pass around until we find a good point to run from and then go back to running backwards. The large union test actually works best in purely random mode, but some of the other tests work less well and this seems to be an adequate compromise.

I'm not sure how convincingly I can justify this PR other than "ad hoc benchmarking plus it makes that test that was previously failing pass" but uh I guess that's better than nothing?