### PR TITLE
Improve performance of Random.sample when use_true_random=False

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the performance of the ``sample`` method on objects obtained from :func:`~hypothesis.strategies.randoms`
+when ``use_true_random=False``. This should mostly only be noticeable when the sample size is a large fraction of the population size,
+but may also help avoid health check failures in some other cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -137,6 +137,8 @@ def check_sample(values, strategy_name):
                 values=repr(values), strategy=strategy_name
             )
         )
+    if isinstance(values, range):
+        return values
     return tuple(values)
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -301,14 +301,15 @@ class ArtificialRandom(HypothesisRandom):
                     "Sample size %d not in expected range 0 <= k <= %d" % (k, len(seq))
                 )
 
-            result = []
-            selected = set()
-            while len(result) < k:
-                i = cu.integer_range(self.__data, 0, len(seq) - 1)
-                if i not in selected:
-                    selected.add(i)
-                    result.append(i)
-            assert len(result) == len(selected)
+            result = self.__data.draw(
+                st.lists(
+                    st.sampled_from(range(len(seq))),
+                    min_size=k,
+                    max_size=k,
+                    unique=True,
+                )
+            )
+
         elif method == "getrandbits":
             result = self.__data.draw_bits(kwargs["n"])
         elif method == "triangular":

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -315,3 +315,8 @@ def test_can_draw_arbitrary_fractions(p, b):
         cu.biased_coin(ConjectureData.for_buffer(b), p)
     except StopTest:
         reject()
+
+
+def test_samples_from_a_range_directly():
+    s = cu.check_sample(range(10 ** 1000), "")
+    assert isinstance(s, range)

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -368,3 +368,19 @@ def test_can_find_end_of_range():
         st.randoms(use_true_random=False).map(lambda r: r.randrange(0, 10, 2)),
         lambda n: n == 8,
     )
+
+
+@given(st.randoms(use_true_random=False))
+def test_can_sample_from_whole_range(rnd):
+    xs = list(map(str, range(10)))
+    ys = rnd.sample(xs, len(xs))
+    assert sorted(ys) == sorted(xs)
+
+
+@given(st.randoms(use_true_random=False))
+def test_can_sample_from_large_subset(rnd):
+    xs = list(map(str, range(10)))
+    n = len(xs) // 3
+    ys = rnd.sample(xs, n)
+    assert set(ys).issubset(set(xs))
+    assert len(ys) == len(set(ys)) == n


### PR DESCRIPTION
This improves the performance of sampling mostly by making it fail when the stream is being manipulated in a way that works against it, which happens e.g. when passing all zeroes to a non-zero sample, and can trigger a health check.

This was prompted by #2503 failing due to flaky coverage of this method, and noticing this problem when I went to try to write more precise tests for it. This yak stack is so deep right now...