### PR TITLE
unittest.subTest wrapper should be handled as method

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -226,6 +226,7 @@ their individual contributions.
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
+* `Israel Fruchter <https://github.com/fruch>`_
 * `Jack Massey <https://github.com/massey101>`_
 * `Jakub Nabaglo <https://github.com/nbgl>`_ (j@nab.gl)
 * `Jenny Rouleau <https://github.com/jennyrou>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2462`, a bug in our handling of :meth:`unittest.TestCase.subTest`.
+Thanks to Israel Fruchter for fixing this at the EuroPython sprints!

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -24,6 +24,7 @@ import random as rnd_module
 import sys
 import time
 import traceback
+import types
 import warnings
 import zlib
 from inspect import getfullargspec
@@ -1102,7 +1103,7 @@ def given(
                 if isinstance(runner, TestCase) and hasattr(runner, "subTest"):
                     subTest = runner.subTest
                     try:
-                        runner.subTest = fake_subTest
+                        runner.subTest = types.MethodType(fake_subTest, runner)
                         state.run_engine()
                     finally:
                         runner.subTest = subTest


### PR DESCRIPTION
Fix: #2462

fixed as part of #europython sprints