### PR TITLE
Make `sampled_from()` non-lazy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes :issue:`2507`, where lazy evaluation meant that the
+values drawn from a :func:`~hypothesis.strategies.sampled_from` strategy
+could depend on mutations of the sampled sequence that happened after
+the strategy was constructed.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-import enum
 import sys
 import warnings
 from collections import defaultdict
@@ -434,21 +433,14 @@ class SampledFromStrategy(SearchStrategy):
     non-empty subset of the elements.
     """
 
-    def __init__(self, elements):
+    def __init__(self, elements, repr_=None):
         SearchStrategy.__init__(self)
-        self.raw_elements = elements
         self.elements = cu.check_sample(elements, "sampled_from")
         assert self.elements
+        self.repr_ = repr_
 
     def __repr__(self):
-        if isinstance(self.raw_elements, type) and issubclass(
-            self.raw_elements, enum.Enum
-        ):
-            return "sampled_from(%s.%s)" % (
-                self.raw_elements.__module__,
-                self.raw_elements.__name__,
-            )
-        return "sampled_from([%s])" % ", ".join(map(repr, self.elements))
+        return self.repr_ or "sampled_from(%r)" % (list(self.elements),)
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/hypothesis-python/tests/cover/test_custom_reprs.py
+++ b/hypothesis-python/tests/cover/test_custom_reprs.py
@@ -23,6 +23,11 @@ def test_includes_non_default_args_in_repr():
     assert repr(st.integers(min_value=1)) == "integers(min_value=1)"
 
 
+def test_sampled_repr_leaves_range_as_range():
+    huge = 10 ** 100
+    assert repr(st.sampled_from(range(huge))) == "sampled_from(range(0, %s))" % (huge,)
+
+
 def hi(there, stuff):
     return there
 
@@ -35,7 +40,8 @@ def test_supports_positional_and_keyword_args_in_builds():
 
 
 def test_preserves_sequence_type_of_argument():
-    assert repr(st.sampled_from([0])) == "sampled_from([0])"
+    assert repr(st.sampled_from([0, 1])) == "sampled_from([0, 1])"
+    assert repr(st.sampled_from((0, 1))) == "sampled_from((0, 1))"
 
 
 class IHaveABadRepr:

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -86,3 +86,21 @@ def test_max_size_is_respected_with_unique_sampled_from(ls):
 @given(st.lists(st.sampled_from([0, 0.0]), unique=True, min_size=1))
 def test_issue_2247_regression(ls):
     assert len(ls) == 1
+
+
+@given(st.data())
+def test_mutability_1(data):
+    # See https://github.com/HypothesisWorks/hypothesis/issues/2507
+    x = [1]
+    s = st.sampled_from(x)
+    x.append(2)
+    assert data.draw(s) != 2
+
+
+@given(st.data())
+def test_mutability_2(data):
+    x = [1]
+    s = st.sampled_from(x)
+    assert data.draw(s) != 2
+    x.append(2)
+    assert data.draw(s) != 2

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -26,6 +26,7 @@ from hypothesis.errors import (
 from hypothesis.strategies._internal import types
 from hypothesis.strategies._internal.core import _strategies
 from hypothesis.strategies._internal.types import _global_type_lookup
+from tests.common.utils import fails_with
 
 # Build a set of all types output by core strategies
 blacklist = [
@@ -188,9 +189,10 @@ class EmptyEnum(enum.Enum):
     pass
 
 
-def test_error_if_enum_is_empty():
-    with pytest.raises(InvalidArgument):
-        assert st.from_type(EmptyEnum).is_empty
+@fails_with(InvalidArgument)
+@given(st.from_type(EmptyEnum))
+def test_error_if_enum_is_empty(x):
+    pass
 
 
 class BrokenClass:

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -77,11 +77,17 @@ class AnEnum(enum.Enum):
 
 
 def test_enum_repr_uses_class_not_a_list():
-    strat = st.sampled_from(AnEnum)
-    # Our lazy repr looks exactly like our call
-    lazy_repr = repr(strat)
-    assert lazy_repr == "sampled_from(AnEnum)"
-    # The inner repr should have enough detail to find the class again
+    # The repr should have enough detail to find the class again
     # (which is very useful for the ghostwriter logic we're working on)
-    inner_repr = repr(strat.wrapped_strategy)
-    assert inner_repr == "sampled_from(tests.nocover.test_sampled_from.AnEnum)"
+    lazy_repr = repr(st.sampled_from(AnEnum))
+    assert lazy_repr == "sampled_from(tests.nocover.test_sampled_from.AnEnum)"
+
+
+class AFlag(enum.Flag):
+    a = enum.auto()
+    b = enum.auto()
+
+
+def test_flag_enum_repr_uses_class_not_a_list():
+    lazy_repr = repr(st.sampled_from(AFlag))
+    assert lazy_repr == "sampled_from(tests.nocover.test_sampled_from.AFlag)"


### PR DESCRIPTION
Closes #2507.  This is kinda fiddly, but not as bad as I expected... all we really lose is the "repr preserves sequence type" thing and there's no good way to do that without storing a shallow copy of whatever we're sampling just for the repr.