### PR TITLE
Speed up DFA with new iteration algorithm

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release improves the performance of some internal support code. It has no user visible impact,
+as that code is not currently run during normal Hypothesis operation.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -15,6 +15,7 @@
 
 import threading
 from collections import deque
+from math import inf
 
 from hypothesis.internal.reflection import proxies
 
@@ -64,6 +65,10 @@ class DFA:
         character c from a string."""
         raise NotImplementedError()
 
+    @property
+    def alphabet(self):
+        return range(256)
+
     def transitions(self, i):
         """Iterates over all pairs (byte, state) of transitions
         which do not lead to dead states."""
@@ -80,47 +85,179 @@ class DFA:
         return self.is_accepting(i)
 
     @cached
+    def max_length(self, i):
+        """Returns the maximum length of a string that is
+        accepted when starting from i."""
+        if self.is_dead(i):
+            return 0
+        if i in self.reachable(i):
+            return inf
+        next_states = {self.max_length(j) for _, j in self.transitions(i)}
+        if next_states:
+            return 1 + max(next_states)
+        else:
+            assert self.is_accepting(i)
+            return 0
+
+    @cached
+    def count_strings(self, i, k):
+        """Returns the number of strings of length ``k``
+        that are accepted when starting from state ``i``."""
+        assert k >= 0
+        if k == 0:
+            if self.is_accepting(i):
+                return 1
+            else:
+                return 0
+        if k > self.max_length(i):
+            return 0
+        return sum(self.count_strings(j, k - 1) for _, j in self.transitions(i))
+
+    @cached
+    def reachable(self, i):
+        """Returns the set of all states reachable
+        by traversing some non-empty string starting from
+        state i."""
+        reached = set()
+
+        queue = deque([i])
+
+        while queue:
+            j = queue.popleft()
+            for _, k in self.__raw_transitions(j):
+                if k not in reached:
+                    reached.add(k)
+                    if k != i:
+                        queue.append(k)
+        return frozenset(reached)
+
+    @cached
     def is_dead(self, i):
         """Returns True if no strings can be accepted
         when starting from state ``i``."""
         if self.is_accepting(i):
             return False
 
-        cache = self.__caches.is_dead
+        return not any(self.is_accepting(j) for j in self.reachable(i))
 
-        seen = set()
-        pending = deque([i])
-        result = True
-        while pending:
-            j = pending.popleft()
-            if j in seen:
-                continue
-            seen.add(j)
-            if self.is_accepting(j):
-                result = False
-                break
-            else:
-                for _, k in self.__raw_transitions(j):
-                    pending.append(k)
-        if result:
-            for j in seen:
-                cache[j] = True
-        else:
-            cache[i] = False
-        return result
+    def all_matching_strings_of_length(self, k):
+        """Yields all matching strings whose length is ``k``, in ascending
+        lexicographic order."""
+        if self.count_strings(self.start, k) == 0:
+            return
+
+        # This tracks a path through the DFA. We alternate between growing
+        # it until it has length ``k`` and is in an accepting state, then
+        # yielding that as a result, then modifying it so that the next
+        # time we do that it will yield the lexicographically next matching
+        # string.
+        path = bytearray()
+
+        # Tracks the states that are visited by following ``path`` from the
+        # starting point.
+        states = [self.start]
+
+        while True:
+            # First we build up our current best prefix to the lexicographically
+            # first string starting with it.
+            while len(path) < k:
+                state = states[-1]
+                for c, j in self.transitions(state):
+                    if self.count_strings(j, k - len(path) - 1) > 0:
+                        states.append(j)
+                        path.append(c)
+                        break
+                else:  # pragma: no cover
+                    assert False
+            assert self.is_accepting(states[-1])
+            assert len(states) == len(path) + 1
+            yield bytes(path)
+
+            # Now we want to replace this string with the prefix that will
+            # cause us to extend to its lexicographic successor. This can
+            # be thought of as just repeatedly moving to the next lexicographic
+            # successor until we find a matching string, but we're able to
+            # use our length counts to jump over long sequences where there
+            # cannot be a match.
+            while True:
+                # As long as we are in this loop we are trying to move to
+                # the successor of the current string.
+
+                # If we've removed the entire prefix then we're done - no
+                # successor is possible.
+                if not path:
+                    return
+
+                if path[-1] == 255:
+                    # If our last element is maximal then the we have to "carry
+                    # the one" - our lexicographic successor must be incremented
+                    # earlier than this.
+                    path.pop()
+                    states.pop()
+                else:
+                    # Otherwise increment by one.
+                    path[-1] += 1
+                    states[-1] = self.transition(states[-2], path[-1])
+
+                    # If there are no strings of the right length starting from
+                    # this prefix we need to keep going. Otherwise, this is
+                    # the right place to be and we break out of our loop of
+                    # trying to find the successor because it starts here.
+                    if self.count_strings(states[-1], k - len(path)) > 0:
+                        break
 
     def all_matching_strings(self):
         """Iterate over all strings matched by this automaton
         in shortlex-ascending order."""
-        queue = deque([(self.start, b"")])
-        while queue:
-            i, path = queue.popleft()
-            if self.is_accepting(i):
-                yield path
-            for c, j in self.transitions(i):
-                queue.append((j, path + bytes([c])))
+        if self.is_accepting(self.start):
+            yield b""
+
+        # max_length might be infinite, hence the while loop
+        max_length = self.max_length(self.start)
+        length = 1
+        while length <= max_length:
+            yield from self.all_matching_strings_of_length(length)
+            length += 1
 
     def __raw_transitions(self, i):
-        for c in range(256):
+        for c in self.alphabet:
             j = self.transition(i, c)
             yield c, j
+
+
+DEAD = "DEAD"
+
+
+class ConcreteDFA(DFA):
+    def __init__(self, transitions, accepting, start=0):
+        super().__init__()
+        self.__start = start
+        self.__accepting = accepting
+        self.__transitions = transitions
+
+    def __repr__(self):
+        if self.__start != 0:
+            return "ConcreteDFA(%r, %r, start=%r)" % (
+                self.__transitions,
+                self.__accepting,
+                self.__start,
+            )
+        else:
+            return "ConcreteDFA(%r, %r)" % (self.__transitions, self.__accepting,)
+
+    @property
+    def start(self):
+        return self.__start
+
+    def is_accepting(self, i):
+        return i in self.__accepting
+
+    def transition(self, i, c):
+        """Returns the state that i transitions to on reading
+        character c from a string."""
+        if i == DEAD:
+            return i
+        try:
+            return self.__transitions[i][c]
+        except KeyError:
+            return DEAD

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -1,0 +1,44 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from hypothesis.internal.conjecture.dfa import ConcreteDFA
+
+
+def test_enumeration_when_sizes_do_not_agree():
+    dfa = ConcreteDFA([{0: 1, 1: 2}, {}, {1: 3}, {}], {1, 3})  # 0  # 1  # 2  # 3
+
+    assert list(dfa.all_matching_strings()) == [b"\0", b"\1\1"]
+
+
+def test_enumeration_of_very_long_strings():
+    """This test is mainly testing that it terminates. If we were
+    to use a naive breadth first search for this it would take
+    forever to run because it would run in time roughly 256 ** 50.
+    """
+    size = 50
+    dfa = ConcreteDFA(
+        [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
+    )
+
+    for i, s in enumerate(dfa.all_matching_strings()):
+        assert len(s) == size
+        assert int.from_bytes(s, "big") == i
+        if i >= 1000:
+            break
+
+
+def test_max_length_of_empty_dfa_is_zero():
+    dfa = ConcreteDFA([{}], {0})
+    assert dfa.max_length(dfa.start) == 0

--- a/hypothesis-python/tests/conjecture/test_lstar.py
+++ b/hypothesis-python/tests/conjecture/test_lstar.py
@@ -171,3 +171,18 @@ def test_normalizing_can_be_made_to_distinguish_values():
     assert normalizer.distinguish(10, lambda n: n >= 5)
     assert normalizer.normalize(10) == 5
     assert normalizer.normalize(4) == 0
+
+
+def test_learning_large_dfa():
+    """Mostly the thing this is testing is actually that this runs in reasonable
+    time. A naive breadth first search will run ~forever when trying to find this
+    because it will have to explore all strings of length 19 before it finds one
+    of length 20."""
+
+    learner = LStar(lambda s: len(s) == 20)
+
+    learner.learn(bytes(20))
+
+    for i, s in enumerate(itertools.islice(learner.dfa.all_matching_strings(), 500)):
+        assert len(s) == 20
+        assert i == int.from_bytes(s, "big")


### PR DESCRIPTION
So we're iterating over a regular language in shortlex order as part of our tests. That's fine, right? It's just breadth first search. The whole internet loves this adorable Computer Science 101 algorithm. (five minutes pass) we regret to inform you that breadth first search has exponential complexity on this problem.

The problem is this: In order to explore all strings of length `n`, we first need to explore all *paths* of length `n - 1`. For certain easy to generate DFAs that would be all strings of length `n - 1` which is, you know, a lot.

This PR switches us over to an as-far-as-I-know novel (i.e. probably an independent reinvention) algorithm for iterating over a DFA's language which uses a memoized calculation of the number of strings of length `k` accepted from each state `i`. We can then iterate over the whole language by using these calculations to guide us to the lexicographically next string, for much more reasonable behaviour and time complexity.

This does not currently affect any production performance, but I ran into this problem basically as soon as I tried to use DFAs for the next steps of my Cunning Plan, and this includes some of the machinery we'll need in production.