### PR TITLE
Normalise bytes to common canonical values in L*

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes some changes to internal support code that is not currently used in production Hypothesis.
+It has no user visible effect at present.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -287,8 +287,11 @@ class IntegerNormalizer:
         Returns True if and only if this makes a change to
         the underlying canonical values."""
         canonical = self.normalize(value)
+        if canonical == value:
+            return False
+
         value_test = test(value)
-        if canonical == value or test(canonical) == value_test:
+        if test(canonical) == value_test:
             return False
 
         def can_lower(k):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -95,6 +95,9 @@ class IntList:
     def __delitem__(self, i):
         del self.__underlying[i]
 
+    def insert(self, i, v):
+        self.__underlying.insert(i, v)
+
     def __iter__(self):
         return iter(self.__underlying)
 


### PR DESCRIPTION
So, bytes, there are a lot of them, right? 256, in fact.

In many cases we'll find that most of them don't matter very much. In those cases we would like to be able to treat them as basically the same so as to avoid making quite so many membership queries.

This PR adds a preliminary attempt at this, by maintaining a very basic partition of the integers into contiguous intervals, and splitting that partition up as we discover new inequivalent integers.

How much does this help? Hard to say. It definitely speeds up the scenario where we have a single block whose value we're ignoring, which is currently really unneccessarily slow. Beyond that, I suspect the heuristics will need tinkering with a bit more as we come across specific practical scenarios.