### PR TITLE
Don't test paretovariate with alpha < 1

### DIFF
--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -71,7 +71,7 @@ define_method_strategy(
 define_method_strategy(
     "vonmisesvariate", mu=st.floats(0, math.pi * 2), kappa=beta_param
 )
-define_method_strategy("paretovariate", alpha=beta_param)
+define_method_strategy("paretovariate", alpha=st.floats(1.0))
 define_method_strategy("shuffle", x=st.lists(st.integers()))
 define_method_strategy("randbytes", n=st.integers(0, 100))
 

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -71,7 +71,8 @@ define_method_strategy(
 define_method_strategy(
     "vonmisesvariate", mu=st.floats(0, math.pi * 2), kappa=beta_param
 )
-define_method_strategy("paretovariate", alpha=st.floats(1.0))
+# Small alpha may raise ZeroDivisionError, see https://bugs.python.org/issue41421
+define_method_strategy("paretovariate", alpha=st.floats(min_value=1.0))
 define_method_strategy("shuffle", x=st.lists(st.integers()))
 define_method_strategy("randbytes", n=st.integers(0, 100))
 


### PR DESCRIPTION
Our tests are occasionally hitting (and discovered) [Python bug 41421](https://bugs.python.org/issue41421?@ok_message=msg%20374517%20created%0Aissue%2041421%20message_count%2C%20messages%20edited%20ok&@template=item).

It's unclear what the correct behaviour here is but given that our tests exposed a bug in the code that is old enough to drink (outside the USA anyway) it's also clear that nobody uses this code so it's better to just shrug and stick to the known good region.