### PR TITLE
Allow simultaneously lowering two nearby blocks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the quality of shrunk test cases in some special cases.
+Specifically, it should get shrinking unstuck in some scenarios which require
+simultaneously changing two parts of the generated test case.


### PR DESCRIPTION
Currently we only simultaneously lower blocks if they have the same value, and we do so for all blocks of the same value. This modifies our shrinking to subtract from any nearby pair of non-zero blocks at once.

This is another shrink pass that, while reasonably general purpose and justifiable, is mostly motivated to do better on a benchmark.

Specifically this is for the [calculator benchmark](https://github.com/jlink/shrinking-challenge/blob/f21a9633892c748622cd5ff3e270d46584ecde78/pbt-libraries/hypothesis/challenges/calculator.md), where this change allows us to shrink the expression `('/', 0, 1)` to `('+', 0, 0)`, which requires us to lower two nearby blocks by one. I've included a test based on this in the shrink quality tests.