### PR TITLE
Add heuristic for detecting finished shrinks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release adds a heuristic to detect when shrinking has finished despite the fact
+that there are many more possible transformations to try. This will be particularly
+useful for tests where the minimum failing test case is very large despite there being
+many smaller test cases possible, where it is likely to speed up shrinking dramatically.
+
+In some cases it is likely that this will result in worse shrunk test cases. In those
+cases rerunning the test will result in further shrinking.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -145,6 +145,13 @@ class ConjectureRunner:
         # We ensure that the test has this much stack space remaining, no matter
         # the size of the stack when called, to de-flake RecursionErrors (#2494).
         self.__recursion_limit = sys.getrecursionlimit()
+        self.__pending_call_explanation = None
+
+    def explain_next_call_as(self, explanation):
+        self.__pending_call_explanation = explanation
+
+    def clear_call_explanation(self):
+        self.__pending_call_explanation = None
 
     @contextmanager
     def _log_phase_statistics(self, phase):
@@ -199,6 +206,10 @@ class ConjectureRunner:
             sys.setrecursionlimit(self.__recursion_limit)
 
     def test_function(self, data):
+        if self.__pending_call_explanation is not None:
+            self.debug(self.__pending_call_explanation)
+            self.__pending_call_explanation = None
+
         assert isinstance(data.observer, TreeRecordingObserver)
         self.call_count += 1
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -800,7 +800,7 @@ class Shrinker:
             # trigger this heuristic, so whenever we shrink successfully
             # we give ourselves a bit of breathing room to make sure we
             # would find a shrink that took that long to find the next time.
-            # The case where we're taking a long time but making steady 
+            # The case where we're taking a long time but making steady
             # progress is handled by `finish_shrinking_deadline` in engine.py
             self.max_stall = max(
                 self.max_stall, (self.calls - self.calls_at_last_shrink) * 2

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -308,12 +308,6 @@ class Shrinker:
 
         return accept
 
-    def explain_next_call_as(self, explanation):
-        self.__pending_shrink_explanation = explanation
-
-    def clear_call_explanation(self):
-        self.__pending_shrink_explanation = None
-
     def add_new_pass(self, run):
         """Creates a shrink pass corresponding to calling ``run(self)``"""
 
@@ -387,10 +381,6 @@ class Shrinker:
         that the result is either an Overrun object (if the buffer is
         too short to be a valid test case) or a ConjectureData object
         with status >= INVALID that would result from running this buffer."""
-
-        if self.__pending_shrink_explanation is not None:
-            self.debug(self.__pending_shrink_explanation)
-            self.__pending_shrink_explanation = None
 
         buffer = bytes(buffer)
         result = self.engine.cached_test_function(buffer)
@@ -1514,7 +1504,7 @@ class ShrinkPass:
         initial_shrinks = self.shrinker.shrinks
         initial_calls = self.shrinker.calls
         size = len(self.shrinker.shrink_target.buffer)
-        self.shrinker.explain_next_call_as(self.name)
+        self.shrinker.engine.explain_next_call_as(self.name)
 
         if random_order:
             selection_order = random_selection_order(self.shrinker.random)
@@ -1530,7 +1520,7 @@ class ShrinkPass:
             self.calls += self.shrinker.calls - initial_calls
             self.shrinks += self.shrinker.shrinks - initial_shrinks
             self.deletions += size - len(self.shrinker.shrink_target.buffer)
-            self.shrinker.clear_call_explanation()
+            self.shrinker.engine.clear_call_explanation()
         return True
 
     @property

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -799,8 +799,9 @@ class Shrinker:
             # If we are just taking a long time to shrink we don't want to
             # trigger this heuristic, so whenever we shrink successfully
             # we give ourselves a bit of breathing room to make sure we
-            # would find a shrink that took that long to find the next
-            # time.
+            # would find a shrink that took that long to find the next time.
+            # The case where we're taking a long time but making steady 
+            # progress is handled by `finish_shrinking_deadline` in engine.py
             self.max_stall = max(
                 self.max_stall, (self.calls - self.calls_at_last_shrink) * 2
             )

--- a/hypothesis-python/tests/cover/test_debug_information.py
+++ b/hypothesis-python/tests/cover/test_debug_information.py
@@ -33,7 +33,7 @@ def test_reports_passes():
 
     value = out.getvalue()
 
-    assert "adaptive_example_deletion" in value
+    assert "minimize_individual_blocks" in value
     assert "calls" in value
     assert "shrinks" in value
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -138,6 +138,8 @@ def test_block_programs_fail_efficiently(monkeypatch):
         Shrinker, "run_block_program", counts_calls(Shrinker.run_block_program)
     )
 
+    shrinker.max_stall = 500
+
     shrinker.fixate_shrink_passes([block_program("XX")])
 
     assert shrinker.shrinks == 0


### PR DESCRIPTION
Fixes #2523. 

Basic logic: If it's been at least `N` calls since our last successful shrink, we're probably done. Initially `N = 200` but we raise it if we're still shrinking but getting near to that limit.

I also included an unrelated change in this that just tidies up the debug output a bit because I was finding it really hard to figure out what was going on - we no longer print the shrink pass before a cached test function call, only an actual call.