### PR TITLE
I heard you like shrinking, so I shrunk the shrinker

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release removes a number of Hypothesis's internal "shrink passes" - transformations
+it makes to a generated test case during shrinking - which appeared to be redundant with
+other transformations.
+
+It is unlikely that you will see much impact from this. If you do, it will likely show up
+as a change in shrinking performance (probably slower, maybe faster), or possibly in
+worse shrunk results. If you encounter the latter, please let us know.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -498,7 +498,6 @@ class Shrinker:
                 block_program("X" * 2),
                 block_program("X" * 1),
                 "pass_to_descendant",
-                "alphabet_minimize",
                 "reorder_examples",
                 "minimize_floats",
                 "minimize_duplicated_blocks",
@@ -1269,81 +1268,6 @@ class Shrinker:
             ),
             random=self.random,
         )
-
-    @derived_value
-    def alphabet(self):
-        return sorted(set(self.buffer))
-
-    @defines_shrink_pass()
-    def alphabet_minimize(self, chooser):
-        """Attempts to minimize the "alphabet" - the set of bytes that
-        are used in the representation of the current buffer. The main
-        benefit of this is that it significantly increases our cache hit rate
-        by making things that are equivalent more likely to have the same
-        representation, but it's also generally a rather effective "fuzzing"
-        step that gives us a lot of good opportunities to slip to a smaller
-        representation of the same bug.
-        """
-        c = chooser.choose(self.alphabet)
-        buf = self.buffer
-
-        def can_replace_with(d):
-            if d < 0:
-                return False
-
-            if self.consider_new_buffer(bytes([d if b == c else b for b in buf])):
-                if d <= 1:
-                    # For small values of d if this succeeds we take this
-                    # as evidence that it is worth doing a a bulk replacement
-                    # where we replace all values which are close
-                    # to c but smaller with d as well. This helps us substantially
-                    # in cases where we have a lot of "dead" bytes that don't really do
-                    # much, as it allows us to replace many of them in one go rather
-                    # than one at a time. An example of where this matters is
-                    # test_minimize_multiple_elements_in_silly_large_int_range_min_is_not_dupe
-                    # in test_shrink_quality.py
-                    def replace_range(k):
-                        if k > c:
-                            return False
-
-                        def should_replace_byte(b):
-                            return c - k <= b <= c and d < b
-
-                        return self.consider_new_buffer(
-                            bytes([d if should_replace_byte(b) else b for b in buf])
-                        )
-
-                    find_integer(replace_range)
-                return True
-
-        if (
-            # If we cannot replace the current byte with its predecessor,
-            # assume it is already minimal and continue on. This ensures
-            # we make no more than one call per distinct byte value in the
-            # event that no shrinks are possible here.
-            not can_replace_with(c - 1)
-            # We next try replacing with 0 or 1. If this works then
-            # there is nothing else to do here.
-            or can_replace_with(0)
-            or can_replace_with(1)
-            # Finally we try to replace with c - 2 before going on to the
-            # binary search so that in cases which were already nearly
-            # minimal we don't do log(n) extra work.
-            or not can_replace_with(c - 2)
-        ):
-            return
-
-        # Now binary search to find a small replacement.
-
-        # Invariant: We cannot replace with lo, we can replace with hi.
-        lo = 1
-        hi = c - 2
-        while lo + 1 < hi:
-            mid = (lo + hi) // 2
-            if can_replace_with(mid):
-                hi = mid
-            else:
-                lo = mid
 
     def run_block_program(self, i, description, original, repeats=1):
         """Block programs are a mini-DSL for block rewriting, defined as a sequence

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1425,14 +1425,5 @@ def non_zero_suffix(b):
     return b[i:]
 
 
-def expand_region(f, a, b):
-    """Attempts to find u, v with u <= a, v >= b such that f(u, v) is true.
-    Assumes that f(a, b) is already true.
-    """
-    b += find_integer(lambda k: f(a, b + k))
-    a -= find_integer(lambda k: f(a - k, b))
-    return (a, b)
-
-
 class StopShrinking(Exception):
     pass

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -831,19 +831,6 @@ def test_handle_size_too_large_during_dependent_lowering():
     shrinker.fixate_shrink_passes(["minimize_individual_blocks"])
 
 
-def test_zero_examples_will_zero_blocks():
-    @shrinking_from([1, 1, 1])
-    def shrinker(data):
-        n = data.draw_bits(1)
-        data.draw_bits(1)
-        m = data.draw_bits(1)
-        if n == m == 1:
-            data.mark_interesting()
-
-    shrinker.fixate_shrink_passes(["zero_examples"])
-    assert list(shrinker.shrink_target.buffer) == [1, 0, 1]
-
-
 def test_block_may_grow_during_lexical_shrinking():
     initial = bytes([2, 1, 1])
 

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -313,18 +313,6 @@ def test_finding_a_minimal_balanced_binary_tree():
     assert list(shrinker.shrink_target.buffer) == [1, 0, 1, 0, 1, 0, 0]
 
 
-def test_alphabet_minimization():
-    @shrink(bytes((10, 11)) * 5, "alphabet_minimize")
-    def x(data):
-        buf = data.draw_bytes(10)
-        if len(set(buf)) > 2:
-            data.mark_invalid()
-        if buf[0] < buf[1] and buf[1] > 1:
-            data.mark_interesting()
-
-    assert x == [0, 2] * 5
-
-
 def test_float_shrink_can_run_when_canonicalisation_does_not_work(monkeypatch):
     # This should be an error when called
     monkeypatch.setattr(Float, "shrink", None)

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -169,13 +169,7 @@ def test_shrinking_blocks_from_common_offset():
     assert sorted(x) == [0, 1]
 
 
-def test_handle_empty_draws(monkeypatch):
-    monkeypatch.setattr(
-        Shrinker,
-        "shrink",
-        lambda self: self.fixate_shrink_passes(["adaptive_example_deletion"]),
-    )
-
+def test_handle_empty_draws():
     @run_to_buffer
     def x(data):
         while True:
@@ -314,7 +308,7 @@ def test_finding_a_minimal_balanced_binary_tree():
         if not b:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["adaptive_example_deletion", "reorder_examples"])
+    shrinker.shrink()
 
     assert list(shrinker.shrink_target.buffer) == [1, 0, 1, 0, 1, 0, 0]
 
@@ -416,19 +410,6 @@ def test_zero_contained_examples():
     assert list(shrinker.shrink_target.buffer) == [1, 0] * 4
 
 
-def test_adaptive_example_deletion_deletes_nothing():
-    @shrinking_from(bytes([1]) * 8 + bytes(1))
-    def shrinker(data):
-        n = 0
-        while data.draw_bits(8):
-            n += 1
-        if n >= 8:
-            data.mark_interesting()
-
-    shrinker.fixate_shrink_passes(["adaptive_example_deletion"])
-    assert list(shrinker.shrink_target.buffer) == [1] * 8 + [0]
-
-
 def test_zig_zags_quickly():
     @shrinking_from(bytes([255]) * 4)
     def shrinker(data):
@@ -478,7 +459,7 @@ def test_retain_end_of_buffer():
         if interesting:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["adaptive_example_deletion"])
+    shrinker.shrink()
     assert list(shrinker.buffer) == [6, 0]
 
 
@@ -524,7 +505,7 @@ def test_can_expand_deleted_region():
         if v1 == (0, 0) or t() == (0, 0):
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["adaptive_example_deletion"])
+    shrinker.shrink()
     assert list(shrinker.buffer) == [0, 0]
 
 
@@ -574,7 +555,7 @@ def test_shrink_pass_method_is_idempotent():
         data.draw_bits(8)
         data.mark_interesting()
 
-    sp = shrinker.shrink_pass("adaptive_example_deletion")
+    sp = shrinker.shrink_pass(block_program("X"))
     assert isinstance(sp, ShrinkPass)
     assert shrinker.shrink_pass(sp) is sp
 


### PR DESCRIPTION
It turns out that our test suite passes without a number of the shrink passes, saving only for some hyper-specific tests that tested specific behaviour of those passes. So I deleted them. The Hypothesis shrinker: Now with less code.

# Motivation

Partly this is just because deleting code that we don't actually need is good and I encourage it, but I had some specific goals in mind for targeting these shrink passes: I have a low-key goal of removing the concept of `examples` from `ConjectureData` and making our code  work purely based on integer values of blocks. Removing things that we don't need that rely on these features is a great first step towards that.

1. We have too many uses of the word "example" in our code and doing a large scale refactoring which requires significant technical research is easier than coming up with a new name.
2. The [minithesis](https://github.com/DRMacIver/minithesis/) reducer has shown you can go remarkably far with this approach.
3. The forthcoming reduction pass learning stuff will probably paper over any problems this causes.
4. A lot of the tracking we do is very high overhead, and it would be nice to improve the performance of generation by removing that overhead.

(We're probably going to keep something like `start_example` and `stop_example` code so that we can use it for discards, but we hopefully won't need to maintain any sort of hierarchical tree of examples)