### PR TITLE
Update pip-tools version

### DIFF
--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -62,7 +62,7 @@ pathspec==0.8.0           # via black
 pbr==5.4.5                # via stevedore
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==5.3.0          # via -r requirements/tools.in
+pip-tools==5.3.1          # via -r requirements/tools.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via pytest, tox
 prompt-toolkit==3.0.5     # via ipython


### PR DESCRIPTION
We're getting regular `RuntimeError`s in CI right now because of https://github.com/jazzband/pip-tools/issues/1192 - updating will supposedly fix this problem.