### PR TITLE
Support indexing language matched by a DFA

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release adds some internal functionality that is not currently used in normal operation,
+and as such has no user-visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/index.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/index.py
@@ -1,0 +1,104 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import math
+
+
+class DFAIndex:
+    """Represents the language matched by some DFA as a random
+    access collection sorted in shortlex order."""
+
+    def __init__(self, dfa):
+        self.dfa = dfa
+
+        self.__length = None
+
+    def __iter__(self):
+        return self.dfa.all_matching_strings()
+
+    def length(self):
+        """Like len(self) but will return math.inf when the collection
+        is infinite rather than raising an error."""
+        if self.__length is None:
+            if not math.isfinite(self.dfa.max_length(self.dfa.start)):
+                self.__length = math.inf
+            else:
+                self.__length = sum(
+                    self.dfa.count_strings(self.dfa.start, k)
+                    for k in range(self.dfa.max_length(self.dfa.start) + 1)
+                )
+        return self.__length
+
+    def __len__(self):
+        return self.length()
+
+    def __getitem__(self, i):
+        if i < 0:
+            raise IndexError("Negative indices not supported")
+
+        running_index = i
+
+        length = 0
+        while True:
+            n = self.dfa.count_strings(self.dfa.start, length)
+            if n > running_index:
+                break
+            running_index -= n
+            length += 1
+            if length > self.dfa.max_length(self.dfa.start):
+                assert i >= self.length()
+                raise IndexError("Index %d out of range [0, %d)" % (i, self.length()))
+
+        result = bytearray()
+        state = self.dfa.start
+        while len(result) < length:
+            for c, next_state in self.dfa.transitions(state):
+                n_to_skip = self.dfa.count_strings(next_state, length - len(result) - 1)
+                if running_index < n_to_skip:
+                    result.append(c)
+                    state = next_state
+                    break
+                else:
+                    running_index -= n_to_skip
+            else:  # pragma: no cover
+                assert False, "Count mismatch"
+        assert len(result) == length
+        return bytes(result)
+
+    def index(self, string):
+        """Return the index of string in this collection, so that
+        self[self.index(string)] == string. Raises ValueError if
+        string is not in this collection."""
+
+        if not self.dfa.matches(string):
+            raise ValueError("%r not in language" % (string,))
+
+        if not string:
+            return 0
+
+        result = 0
+        for k in range(len(string)):
+            result += self.dfa.count_strings(self.dfa.start, k)
+
+        state = self.dfa.start
+        for i, c in enumerate(string):
+            remainder = len(string) - i - 1
+            assert remainder >= 0
+            for d in range(c):
+                result += self.dfa.count_strings(
+                    self.dfa.transition(state, d), remainder
+                )
+            state = self.dfa.transition(state, c)
+        return result

--- a/hypothesis-python/tests/conjecture/test_dfa_indexing.py
+++ b/hypothesis-python/tests/conjecture/test_dfa_indexing.py
@@ -1,0 +1,122 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import math
+
+import pytest
+
+from hypothesis import assume, given, strategies as st
+from hypothesis.internal.conjecture.dfa import ConcreteDFA
+from hypothesis.internal.conjecture.dfa.index import DFAIndex
+from hypothesis.internal.conjecture.shrinker import sort_key
+
+
+@st.composite
+def dfas(draw):
+    states = draw(st.integers(1, 5))
+
+    a_state = st.integers(0, states - 1)
+    a_byte = st.integers(0, 255)
+
+    start = draw(a_state)
+    accepting = draw(st.sets(a_state, min_size=1))
+
+    transitions = [draw(st.dictionaries(a_byte, a_state),) for _ in range(states)]
+
+    return ConcreteDFA(transitions, accepting, start)
+
+
+def test_dfa_index_of_self_loop():
+    # Matches strings of all zeroes of any length
+    dfa = ConcreteDFA([{0: 0}], {0})
+
+    index = DFAIndex(dfa)
+    assert index.length() == math.inf
+
+    for i in range(10):
+        assert index[i] == bytes(i)
+        assert index.index(bytes(i)) == i
+
+
+def test_negative_index_not_supported():
+    index = DFAIndex(ConcreteDFA([{}], {0}))
+    with pytest.raises(IndexError):
+        index[-1]
+
+
+def test_value_error_for_non_matching():
+    index = DFAIndex(ConcreteDFA([{0: 1}, {}], {1}))
+    with pytest.raises(ValueError):
+        index.index(b"")
+
+
+def test_dfa_index_only_of_empty_string():
+    dfa = ConcreteDFA([{}], {0})
+
+    index = DFAIndex(dfa)
+
+    assert len(index) == 1
+    assert index[0] == b""
+
+
+def test_eg_1():
+    x = ConcreteDFA([{0: 1, 1: 1}, {0: 0}], {0})
+    index = DFAIndex(x)
+
+    assert index.length() == math.inf
+    assert index[0] == b""
+    assert index[1] == b"\0\0"
+    assert index[2] == b"\1\0"
+    assert index[3] == b"\0\0\0\0"
+    assert index[4] == b"\0\0\1\0"
+
+
+@given(dfas())
+def test_dfa_iteration_order_agrees(dfa):
+    assume(not dfa.is_dead(dfa.start))
+
+    indexer = DFAIndex(dfa)
+
+    assert indexer.length() > 0
+
+    for i, x in enumerate(indexer):
+        assert indexer[i] == x
+        assert indexer.index(x) == i
+        if i == 10:
+            break
+
+
+def test_raises_index_error_for_out_of_index():
+    dfa = ConcreteDFA([{0: 1, 1: 1}, {}], {1})
+
+    with pytest.raises(IndexError):
+        DFAIndex(dfa)[2]
+
+
+@given(dfas(), st.data())
+def test_indexer_is_in_shortlex_order(dfa, data):
+    assume(not dfa.is_dead(dfa.start))
+    indexer = DFAIndex(dfa)
+
+    assert indexer.length() > 0
+
+    n = min(100, indexer.length() - 1)
+    i = data.draw(st.integers(0, n))
+    j = data.draw(st.integers(0, n))
+    assume(i != j)
+
+    i, j = sorted((i, j))
+
+    assert sort_key(indexer[i]) < sort_key(indexer[j])


### PR DESCRIPTION
This adds some (currently unused) internal code for navigating the language of a DFA. It is currently unused, but it's a nice self-contained chunk of work so I thought I'd make it a pull request in its own right.

This is currently a very low priority review, as until #2525 is merged this code has no useful function at all.

## Motivation

This basically allows us to generalise the shrink passes we learn as a result of #2525 to be more useful, because instead of just replacing a string with the minimal string matching the DFA, we can convert it to and from an integer and minimize the integer. This gives us small step reductions in a way that we do not currently get from this - we can learn those small step reductions, but this potentially requires us to learn one DFA per string matched by the original DFA, while being able to make small reductions within the DFA lets us handle a wide range of test functions from one learned DFA.