### PR TITLE
Upgrade draft ghostwriter, part 3/4

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds yet more internal functions to support a new feature
+we're working on, like :ref:`version 5.18.3 <v5.18.3>` and
+:ref:`version 5.23.6 <v5.23.6>`.  We promise it's worth the wait!

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -38,9 +38,9 @@ $PYTEST tests/lark/
 pip uninstall -y lark-parser
 
 if [ "$(python -c 'import sys, platform; print(sys.version_info[:2] >= (3, 6) and platform.python_implementation() != "PyPy")')" = "True" ] ; then
-  pip install black
+  pip install black numpy
   $PYTEST tests/ghostwriter/
-  pip uninstall -y black
+  pip uninstall -y black numpy
 fi
 
 if [ "$(python -c 'import sys; print(sys.version_info[:2] == (3, 6))')" = "False" ] ; then

--- a/hypothesis-python/tests/ghostwriter/recorded/base64_magic.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/base64_magic.txt
@@ -1,0 +1,108 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import base64
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with appropriate strategies
+
+
+@given(
+    b=st.nothing(),
+    foldspaces=st.booleans(),
+    adobe=st.booleans(),
+    ignorechars=st.just(b" \t\n\r\x0b"),
+)
+def test_fuzz_a85decode(b, foldspaces, adobe, ignorechars):
+    base64.a85decode(b=b, foldspaces=foldspaces, adobe=adobe, ignorechars=ignorechars)
+
+
+@given(
+    b=st.nothing(),
+    foldspaces=st.booleans(),
+    wrapcol=st.just(0),
+    pad=st.booleans(),
+    adobe=st.booleans(),
+)
+def test_fuzz_a85encode(b, foldspaces, wrapcol, pad, adobe):
+    base64.a85encode(b=b, foldspaces=foldspaces, wrapcol=wrapcol, pad=pad, adobe=adobe)
+
+
+@given(s=st.nothing(), casefold=st.booleans())
+def test_fuzz_b16decode(s, casefold):
+    base64.b16decode(s=s, casefold=casefold)
+
+
+@given(s=st.nothing())
+def test_fuzz_b16encode(s):
+    base64.b16encode(s=s)
+
+
+@given(s=st.nothing(), casefold=st.booleans(), map01=st.none())
+def test_fuzz_b32decode(s, casefold, map01):
+    base64.b32decode(s=s, casefold=casefold, map01=map01)
+
+
+@given(s=st.nothing())
+def test_fuzz_b32encode(s):
+    base64.b32encode(s=s)
+
+
+@given(s=st.nothing(), altchars=st.none(), validate=st.booleans())
+def test_fuzz_b64decode(s, altchars, validate):
+    base64.b64decode(s=s, altchars=altchars, validate=validate)
+
+
+@given(s=st.nothing(), altchars=st.none())
+def test_fuzz_b64encode(s, altchars):
+    base64.b64encode(s=s, altchars=altchars)
+
+
+@given(b=st.nothing())
+def test_fuzz_b85decode(b):
+    base64.b85decode(b=b)
+
+
+@given(b=st.nothing(), pad=st.booleans())
+def test_fuzz_b85encode(b, pad):
+    base64.b85encode(b=b, pad=pad)
+
+
+@given(input=st.nothing(), output=st.nothing())
+def test_fuzz_decode(input, output):
+    base64.decode(input=input, output=output)
+
+
+@given(s=st.nothing())
+def test_fuzz_decodebytes(s):
+    base64.decodebytes(s=s)
+
+
+@given(input=st.nothing(), output=st.nothing())
+def test_fuzz_encode(input, output):
+    base64.encode(input=input, output=output)
+
+
+@given(s=st.nothing())
+def test_fuzz_encodebytes(s):
+    base64.encodebytes(s=s)
+
+
+@given(s=st.nothing())
+def test_fuzz_standard_b64decode(s):
+    base64.standard_b64decode(s=s)
+
+
+@given(s=st.nothing())
+def test_fuzz_standard_b64encode(s):
+    base64.standard_b64encode(s=s)
+
+
+@given(s=st.nothing())
+def test_fuzz_urlsafe_b64decode(s):
+    base64.urlsafe_b64decode(s=s)
+
+
+@given(s=st.nothing())
+def test_fuzz_urlsafe_b64encode(s):
+    base64.urlsafe_b64encode(s=s)

--- a/hypothesis-python/tests/ghostwriter/recorded/fuzz_classmethod.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/fuzz_classmethod.txt
@@ -1,0 +1,9 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+import test_expected_output
+from hypothesis import given, strategies as st
+
+
+@given(arg=st.integers())
+def test_fuzz_A_Class_a_classmethod(arg):
+    test_expected_output.A_Class.a_classmethod(arg=arg)

--- a/hypothesis-python/tests/ghostwriter/recorded/fuzz_classmethod.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/fuzz_classmethod.txt
@@ -1,5 +1,6 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
+
 import test_expected_output
 from hypothesis import given, strategies as st
 

--- a/hypothesis-python/tests/ghostwriter/recorded/fuzz_sorted.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/fuzz_sorted.txt
@@ -1,5 +1,6 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
+
 from hypothesis import given, strategies as st
 
 

--- a/hypothesis-python/tests/ghostwriter/recorded/fuzz_sorted.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/fuzz_sorted.txt
@@ -3,9 +3,10 @@
 from hypothesis import given, strategies as st
 
 
-# TODO: replace st.nothing() with an appropriate strategy
-
-
-@given(iterable=st.nothing(), key=st.none(), reverse=st.booleans())
+@given(
+    iterable=st.one_of(st.iterables(st.integers()), st.iterables(st.text())),
+    key=st.none(),
+    reverse=st.booleans(),
+)
 def test_fuzz_sorted(iterable, key, reverse):
     sorted(iterable, key=key, reverse=reverse)

--- a/hypothesis-python/tests/ghostwriter/recorded/fuzz_ufunc.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/fuzz_ufunc.txt
@@ -1,0 +1,12 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import numpy
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with appropriate strategies
+
+
+@given(a=st.nothing(), b=st.nothing())
+def test_fuzz_add(a, b):
+    numpy.add(a, b)

--- a/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
@@ -1,0 +1,12 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import numpy
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with appropriate strategies
+
+
+@given(a=st.nothing(), b=st.nothing())
+def test_fuzz_matmul(a, b):
+    numpy.matmul(a, b)

--- a/hypothesis-python/tests/ghostwriter/recorded/re_compile.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/re_compile.txt
@@ -1,8 +1,8 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
+
 import re
 from hypothesis import given, strategies as st
-
 
 # TODO: replace st.nothing() with an appropriate strategy
 

--- a/hypothesis-python/tests/ghostwriter/recorded/re_compile_except.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/re_compile_except.txt
@@ -1,8 +1,8 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
+
 import re
 from hypothesis import given, reject, strategies as st
-
 
 # TODO: replace st.nothing() with an appropriate strategy
 

--- a/hypothesis-python/tests/ghostwriter/recorded/re_compile_unittest.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/re_compile_unittest.txt
@@ -1,14 +1,14 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
+
 import re
 import unittest
 from hypothesis import given, strategies as st
 
+# TODO: replace st.nothing() with an appropriate strategy
+
 
 class TestFuzzCompile(unittest.TestCase):
-
-    # TODO: replace st.nothing() with an appropriate strategy
-
     @given(pattern=st.nothing(), flags=st.just(0))
     def test_fuzz_compile(self, pattern, flags):
         re.compile(pattern=pattern, flags=flags)

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -37,12 +37,19 @@ def timsort(seq: Sequence[int]) -> Sequence[int]:
     return sorted(seq)
 
 
+class A_Class:
+    @classmethod
+    def a_classmethod(cls, arg: int):
+        pass
+
+
 # Note: for some of the `expected` outputs, we replace away some small
 #       parts which vary between minor versions of Python.
 @pytest.mark.parametrize(
     "data",
     [
         ("fuzz_sorted", ghostwriter.fuzz(sorted)),
+        ("fuzz_classmethod", ghostwriter.fuzz(A_Class.a_classmethod)),
         ("re_compile", ghostwriter.fuzz(re.compile)),
         (
             "re_compile_except",

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -19,6 +19,7 @@
 To update the recorded outputs, run `pytest --hypothesis-update-outputs ...`.
 """
 
+import base64
 import pathlib
 import re
 from typing import Sequence
@@ -58,6 +59,7 @@ class A_Class:
             .replace("import sre_constants\n", "").replace("sre_constants.", "re."),
         ),
         ("re_compile_unittest", ghostwriter.fuzz(re.compile, style="unittest")),
+        ("base64_magic", ghostwriter.magic(base64)),
     ],
     ids=lambda x: x[0],
 )

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -24,6 +24,7 @@ import pathlib
 import re
 from typing import Sequence
 
+import numpy
 import pytest
 
 from hypothesis.extra import ghostwriter
@@ -51,6 +52,8 @@ class A_Class:
     [
         ("fuzz_sorted", ghostwriter.fuzz(sorted)),
         ("fuzz_classmethod", ghostwriter.fuzz(A_Class.a_classmethod)),
+        ("fuzz_ufunc", ghostwriter.fuzz(numpy.add)),
+        ("magic_gufunc", ghostwriter.magic(numpy.matmul)),
         ("re_compile", ghostwriter.fuzz(re.compile)),
         (
             "re_compile_except",

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -24,7 +24,7 @@ from typing import List, Sequence, Set
 
 import pytest
 
-from hypothesis.errors import InvalidArgument, Unsatisfiable
+from hypothesis.errors import InvalidArgument
 from hypothesis.extra import ghostwriter
 from hypothesis.strategies import from_type, just
 
@@ -149,14 +149,10 @@ def test_invalid_func_inputs(gw, args):
 
 
 def test_run_ghostwriter_fuzz():
-    # This test covers the whole lifecycle: first, we get the default code.
-    # The first argument is unknown, so we fail to draw from st.nothing()
+    # Our strategy-guessing code works for all the arguments to sorted,
+    # and we handle positional-only arguments in calls correctly too.
     source_code = ghostwriter.fuzz(sorted)
-    with pytest.raises(Unsatisfiable):
-        get_test_function(source_code)()
-    # Replacing that nothing() with a strategy for sequences of integers makes the
-    # test pass, incidentally checking our handling of positional-only arguments.
-    source_code = source_code.replace("st.nothing()", "st.lists(st.integers())")
+    assert "st.nothing()" not in source_code
     get_test_function(source_code)()
 
 


### PR DESCRIPTION
Part of #2344 split out for easier review; follows #2449 and #2501.  In this installment, we have (commit-by-commit):

- Using qualified names so that we correctly handle non-module-scoped objects like classmethods
- Avoiding catching any redundant exceptions (i.e. subclasses of others we catch), like flake8-bugbear
- Guess a strategy for well-known argument names if there is no annotation or default value
- A `magic()` ghostwriter which can write a test for every function in a module with one pass, without duplicated imports or header comments

Good luck @rsokl!