### PR TITLE
Adds `pure` argument to `functions` strategy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -266,6 +266,7 @@ their individual contributions.
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Nick Anyos <https://www.github.com/NickAnyos>`_
+* `Nikita Sobolev <https://github.com/sobolevn>`_ (mail@sobolevn.me)
 * `Paul Ganssle <https://ganssle.io>`_ (paul@ganssle.io)
 * `Paul Kehrer <https://github.com/reaperhulk>`_
 * `Paul Lorett Amazona <https://github.com/whatevergeek>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+The :func:`~hypothesis.strategies.functions` strategy has a new argument
+``pure=True``, which ensures that the same return value is generated for
+identical calls to the generated function (:issue:`2538`).
+
+Thanks to Zac Hatfield-Dodds and Nikita Sobolev for this feature!

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2158,7 +2158,10 @@ def emails() -> SearchStrategy[str]:
 @defines_strategy
 @deprecated_posargs
 def functions(
-    *, like: Callable[..., Any] = lambda: None, returns: SearchStrategy[Any] = None
+    *,
+    like: Callable[..., Any] = lambda: None,
+    returns: SearchStrategy[Any] = None,
+    pure: bool = False
 ) -> SearchStrategy[Callable[..., Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737
@@ -2171,12 +2174,17 @@ def functions(
     for the function is drawn from the ``returns`` argument, which must be a
     strategy.
 
-    Note that the generated functions do not validate their arguments, and
+    If ``pure=True``, all arguments passed to the generated function must be
+    hashable, and if passed identical arguments the original return value will
+    be returned again - *not* regenerated, so beware mutable values.
+
+    If ``pure=False``, generated functions do not validate their arguments, and
     may return a different value if called again with the same arguments.
 
     Generated functions can only be called within the scope of the ``@given``
     which created them.  This strategy does not support ``.example()``.
     """
+    check_type(bool, pure, "pure")
     if not callable(like):
         raise InvalidArgument(
             "The first argument to functions() must be a callable to imitate, "
@@ -2188,7 +2196,7 @@ def functions(
         returns = from_type(hints.get("return", type(None)))
 
     check_strategy(returns, "returns")
-    return FunctionStrategy(like, returns)
+    return FunctionStrategy(like, returns, pure)
 
 
 @composite

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -136,7 +136,7 @@ def pure_func(arg1, arg2):
 
 
 @given(
-    f=functions(like=pure_func, pure=True),
+    f=functions(like=pure_func, returns=integers(), pure=True),
     arg1=integers(),
     arg2=integers()
 )
@@ -145,19 +145,20 @@ def test_functions_pure_with_same_args(f, arg1, arg2):
 
 
 @given(
-    f=functions(like=pure_func, pure=True),
+    f=functions(like=pure_func, returns=integers(), pure=True),
     arg1=integers(),
     arg2=integers()
 )
 def test_functions_pure_with_different_args(f, arg1, arg2):
     r1 = f(arg1, arg2)
     r2 = f(arg2, arg1)
-    assert r1 != r2 or r1 == r2
+    assume(r1 != r2)
+    assert r1 != r2
 
 
 @given(
-    f1=functions(like=pure_func, pure=True),
-    f2=functions(like=pure_func, pure=True)
+    f1=functions(like=pure_func, returns=integers(), pure=True),
+    f2=functions(like=pure_func, returns=integers(), pure=True)
 )
 def test_functions_pure_two_functions_different_args_same_result(f1, f2):
     r1 = f1(1, 2)
@@ -167,8 +168,8 @@ def test_functions_pure_two_functions_different_args_same_result(f1, f2):
 
 
 @given(
-    f1=functions(like=pure_func, pure=True),
-    f2=functions(like=pure_func, pure=True)
+    f1=functions(like=pure_func, returns=integers(), pure=True),
+    f2=functions(like=pure_func, returns=integers(), pure=True)
 )
 def test_functions_pure_two_functions_same_args_same_result(f1, f2):
     r1 = f1(0, 0)
@@ -178,10 +179,11 @@ def test_functions_pure_two_functions_same_args_same_result(f1, f2):
 
 
 @given(
-    f1=functions(like=pure_func, pure=True),
-    f2=functions(like=pure_func, pure=True)
+    f1=functions(like=pure_func, returns=integers(), pure=True),
+    f2=functions(like=pure_func, returns=integers(), pure=True)
 )
 def test_functions_pure_two_functions_different_args_different_result(f1, f2):
     r1 = f1(1, 2)
     r2 = f2(3, 4)
-    assert r1 != r2 or r1 == r2
+    assume(r1 != r2)
+    assert r1 != r2

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -76,11 +76,12 @@ def test_functions_lambda_with_arg(f):
 
 
 @pytest.mark.parametrize(
-    "like,returns,pure", [
+    "like,returns,pure",
+    [
         (None, booleans(), False),
         (lambda: None, "not a strategy", True),
-        (lambda: None, booleans(), None)
-    ]
+        (lambda: None, booleans(), None),
+    ],
 )
 def test_invalid_arguments(like, returns, pure):
     with pytest.raises(InvalidArgument):
@@ -138,7 +139,7 @@ def pure_func(arg1, arg2):
 @given(
     f=functions(like=pure_func, returns=integers(), pure=True),
     arg1=integers(),
-    arg2=integers()
+    arg2=integers(),
 )
 def test_functions_pure_with_same_args(f, arg1, arg2):
     # Same regardless of calling convention, unlike functools.lru_cache()
@@ -152,7 +153,7 @@ def test_functions_pure_with_same_args(f, arg1, arg2):
 @given(
     f=functions(like=pure_func, returns=integers(), pure=True),
     arg1=integers(),
-    arg2=integers()
+    arg2=integers(),
 )
 def test_functions_pure_with_different_args(f, arg1, arg2):
     r1 = f(arg1, arg2)
@@ -163,10 +164,23 @@ def test_functions_pure_with_different_args(f, arg1, arg2):
 
 @given(
     f1=functions(like=pure_func, returns=integers(), pure=True),
-    f2=functions(like=pure_func, returns=integers(), pure=True)
+    f2=functions(like=pure_func, returns=integers(), pure=True),
 )
 def test_functions_pure_two_functions_different_args_different_result(f1, f2):
     r1 = f1(1, 2)
     r2 = f2(3, 4)
+    assume(r1 != r2)
+    # If this is never true, the test will fail with Unsatisfiable
+
+
+@given(
+    f1=functions(like=pure_func, returns=integers(), pure=True),
+    f2=functions(like=pure_func, returns=integers(), pure=True),
+    arg1=integers(),
+    arg2=integers(),
+)
+def test_functions_pure_two_functions_same_args_different_result(f1, f2, arg1, arg2):
+    r1 = f1(arg1, arg2)
+    r2 = f2(arg1, arg2)
     assume(r1 != r2)
     # If this is never true, the test will fail with Unsatisfiable

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -132,7 +132,7 @@ def test_functions_strategy_with_kwonly_args(f):
 
 
 def pure_func(arg1, arg2):
-    ...
+    pass
 
 
 @given(
@@ -165,30 +165,8 @@ def test_functions_pure_with_different_args(f, arg1, arg2):
     f1=functions(like=pure_func, returns=integers(), pure=True),
     f2=functions(like=pure_func, returns=integers(), pure=True)
 )
-def test_functions_pure_two_functions_different_args_same_result(f1, f2):
-    r1 = f1(1, 2)
-    r2 = f2(0, 0)
-    assume(r1 == r2)
-    assert r1 == r2
-
-
-@given(
-    f1=functions(like=pure_func, returns=integers(), pure=True),
-    f2=functions(like=pure_func, returns=integers(), pure=True)
-)
-def test_functions_pure_two_functions_same_args_same_result(f1, f2):
-    r1 = f1(0, 0)
-    r2 = f2(0, 0)
-    assume(r1 == r2)
-    assert r1 == r2
-
-
-@given(
-    f1=functions(like=pure_func, returns=integers(), pure=True),
-    f2=functions(like=pure_func, returns=integers(), pure=True)
-)
 def test_functions_pure_two_functions_different_args_different_result(f1, f2):
     r1 = f1(1, 2)
     r2 = f2(3, 4)
     assume(r1 != r2)
-    assert r1 != r2
+    # If this is never true, the test will fail with Unsatisfiable

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -141,7 +141,12 @@ def pure_func(arg1, arg2):
     arg2=integers()
 )
 def test_functions_pure_with_same_args(f, arg1, arg2):
-    assert f(arg1, arg2) == f(arg1, arg2)
+    # Same regardless of calling convention, unlike functools.lru_cache()
+    expected = f(arg1, arg2)
+    assert f(arg1, arg2) == expected
+    assert f(arg1, arg2=arg2) == expected
+    assert f(arg1=arg1, arg2=arg2) == expected
+    assert f(arg2=arg2, arg1=arg1) == expected
 
 
 @given(

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -158,7 +158,7 @@ def test_functions_pure_with_different_args(f, arg1, arg2):
     r1 = f(arg1, arg2)
     r2 = f(arg2, arg1)
     assume(r1 != r2)
-    assert r1 != r2
+    # If this is never true, the test will fail with Unsatisfiable
 
 
 @given(


### PR DESCRIPTION
Adds some tests for pure functions. Needs further work.

Closes #2538 

Questions right now (https://github.com/HypothesisWorks/hypothesis/issues/2538#issuecomment-671288387 for the context):

> passing kwargs in different orders, or an arg positionally vs by keyword, does not affect the caching

How can I test this? Didn't find any `cache` references in `test_cover`

> can generate non-identical return value for non-identical arguments

I have a problem with this one. Because my code `assert r1 != r2 or r1 == r2` does not really make much sence.
What is the best way to handle it?

> arg1=numbers()

I can probably improve this part:

```python
@given(
    f=functions(like=pure_func, pure=True),
    arg1=integers(),
    arg2=integers()
)
```

Currently `arg1` and `arg2` are just numbers. I can use `.one_of` and multiple strategies. Or leave this as is.