### PR TITLE
Improve performance of DFA methods

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves the performance of some methods in Hypothesis's internal
+automaton library. These are currently only lightly used by user code, but
+this may result in slightly faster shrinking.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -214,7 +214,6 @@ class DFA:
                 for t in self.successor_states(s):
                     key = (t, n - 1)
                     if key not in cache and key not in seen:
-                        assert key not in pending
                         pending.append(key)
                         seen.add(key)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -150,7 +150,7 @@ class DFA:
             the stack set appropriately."""
             assert len(stack) == len(stack_set)
             j = stack.pop()
-            stack_set.discard(j)
+            stack_set.remove(j)
             assert len(stack) == len(stack_set)
 
         while stack:
@@ -168,8 +168,9 @@ class DFA:
             # calculated max_length for.
             for k in self.successor_states(j):
                 if k in stack_set:
-                    # We should never have put a dead node on the
-                    # stack in the first place.
+                    # k is part of a loop and is known to be live
+                    # (since we never push dead states on the stack),
+                    # so it can reach strings of unbounded length.
                     assert not self.is_dead(k)
                     cache[k] = inf
                     break
@@ -178,6 +179,8 @@ class DFA:
                     stack_set.add(k)
                     break
             else:
+                # All of j's successors have a known max_length or are dead,
+                # so we can now compute a max_length for j itself.
                 cache[j] = max(
                     (
                         1 + cache[k]
@@ -270,7 +273,7 @@ class DFA:
 
         # First we find all reachable nodes from i which have not
         # already been cached, noting any which are roots and
-        # populating the backwards graph..
+        # populating the backwards graph.
 
         explored = set()
         queue = deque([state])

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -187,7 +187,7 @@ class DFA:
                     default=0,
                 )
 
-                # j is live so either must be acceptin gor have a live child.
+                # j is live so it must either be accepting or have a live child.
                 assert self.is_accepting(j) or cache[j] > 0
                 pop()
         return cache[i]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -75,7 +75,7 @@ class DFA:
     def transitions(self, i):
         """Iterates over all pairs (byte, state) of transitions
         which do not lead to dead states."""
-        for c, j in self.__raw_transitions(i):
+        for c, j in self.raw_transitions(i):
             if not self.is_dead(j):
                 yield c, j
 
@@ -159,7 +159,7 @@ class DFA:
 
         while queue:
             j = queue.popleft()
-            for _, k in self.__raw_transitions(j):
+            for _, k in self.raw_transitions(j):
                 if k not in reached:
                     reached.add(k)
                     if k != i:
@@ -256,7 +256,7 @@ class DFA:
             yield from self.all_matching_strings_of_length(length)
             length += 1
 
-    def __raw_transitions(self, i):
+    def raw_transitions(self, i):
         for c in self.alphabet:
             j = self.transition(i, c)
             yield c, j
@@ -480,3 +480,18 @@ class ConcreteDFA(DFA):
                     if u <= char <= v:
                         return j
             return DEAD
+
+    def raw_transitions(self, i):
+        if i == DEAD:
+            return
+        transitions = self.__transitions[i]
+        if isinstance(transitions, dict):
+            yield from sorted(transitions.items())
+        else:
+            for t in transitions:
+                if len(t) == 2:
+                    yield t
+                else:
+                    u, v, j = t
+                    for c in range(u, v + 1):
+                        yield c, j

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -35,15 +35,18 @@ class DFA:
     def __init__(self):
         self.__caches = threading.local()
 
+    def __cache(self, name):
+        try:
+            cache = getattr(self.__caches, name)
+        except AttributeError:
+            cache = {}
+            setattr(self.__caches, name, cache)
+        return cache
+
     def cached(fn):
         @proxies(fn)
         def wrapped(self, *args):
-            try:
-                cache = getattr(self.__caches, fn.__name__)
-            except AttributeError:
-                cache = {}
-                setattr(self.__caches, fn.__name__, cache)
-
+            cache = self.__cache(fn.__name__)
             try:
                 return cache[args]
             except KeyError:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -196,8 +196,8 @@ class DFA:
         return cache[i]
 
     def count_strings(self, state, length):
-        """Returns the number of strings of length ``k``
-        that are accepted when starting from state ``i``."""
+        """Returns the number of strings of length ``length``
+        that are accepted when starting from state ``state``."""
         assert length >= 0
         cache = self.__cache("count_strings")
 

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -72,20 +72,7 @@ def dfas(draw):
     start = draw(a_state)
     accepting = draw(st.sets(a_state, min_size=1))
 
-    transitions = [
-        draw(
-            st.one_of(
-                st.lists(
-                    st.tuples(a_byte, a_state)
-                    | st.tuples(a_byte, a_byte, a_state).map(
-                        lambda t: (t[1], t[0], t[2]) if t[0] > t[1] else t
-                    )
-                ),
-                st.dictionaries(a_byte, a_state),
-            )
-        )
-        for _ in range(states)
-    ]
+    transitions = [draw(st.dictionaries(a_byte, a_state)) for _ in range(states)]
 
     return ConcreteDFA(transitions, accepting, start)
 

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -141,3 +141,9 @@ def test_all_matching_regions_include_all_matches(x, y, z):
     s = x + y + z
 
     assert (len(x), len(x) + len(y)) in y_matcher.all_matching_regions(s)
+
+
+def test_max_length_of_long_dfa():
+    dfa = ConcreteDFA([{0: i + 1} for i in range(1000)] + [{}], {1000})
+    assert not dfa.is_dead(dfa.start)
+    assert dfa.max_length(dfa.start) == 1000

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -13,7 +13,11 @@
 #
 # END HEADER
 
+import itertools
 import math
+from math import inf
+
+import pytest
 
 from hypothesis import assume, example, given, note, reject, settings, strategies as st
 from hypothesis.internal.conjecture.dfa import DEAD, ConcreteDFA
@@ -40,6 +44,12 @@ def test_enumeration_of_very_long_strings():
         assert int.from_bytes(s, "big") == i
         if i >= 1000:
             break
+
+
+def test_is_dead_with_cache_reuse():
+    dfa = ConcreteDFA([{0: i + 1, 1: 11} for i in range(10)] + [{}, {}], {10})
+    for n in range(10, -1, -1):
+        assert not dfa.is_dead(n)
 
 
 def test_max_length_of_empty_dfa_is_zero():
@@ -143,7 +153,45 @@ def test_all_matching_regions_include_all_matches(x, y, z):
     assert (len(x), len(x) + len(y)) in y_matcher.all_matching_regions(s)
 
 
-def test_max_length_of_long_dfa():
-    dfa = ConcreteDFA([{0: i + 1} for i in range(1000)] + [{}], {1000})
+@pytest.mark.parametrize("n", [1, 10, 100, 1000])
+def test_max_length_of_long_dfa(n):
+    dfa = ConcreteDFA([{0: i + 1} for i in range(n)] + [{}], {n})
     assert not dfa.is_dead(dfa.start)
-    assert dfa.max_length(dfa.start) == 1000
+    assert dfa.max_length(dfa.start) == n
+
+
+def test_dfa_with_cached_dead():
+    dfa = ConcreteDFA([[{0: 1, 1: 2}], [], []], {2})
+
+    assert dfa.is_dead(1)
+    assert dfa.is_dead(0)
+
+
+@pytest.mark.parametrize("order", itertools.permutations((0, 1, 2)))
+def test_dead_nodes(order):
+    dfa = ConcreteDFA([{0: 1, 1: 2}, {}, {}], {2})
+    for i in order:
+        assert dfa.is_dead(i) == (i == 1)
+
+
+@given(st.permutations(range(5)))
+def test_max_length_of_recursive_dfa(order):
+    dfa = ConcreteDFA([{0: 1, 1: 2, 2: 3}, {0: 2}, {0: 1}, {0: 0, 1: 4}, {}], {4})
+    for i in order:
+        dfa.max_length(i)
+
+    assert dfa.max_length(0) == inf
+    assert dfa.max_length(1) == 0
+    assert dfa.max_length(2) == 0
+    assert dfa.max_length(3) == inf
+    assert dfa.max_length(4) == 0
+
+
+def test_transitions_out_of_dead_are_empty():
+    dfa = ConcreteDFA([{}], {0})
+    assert list(dfa.raw_transitions(DEAD)) == []
+
+
+def test_can_transition_from_dead():
+    dfa = ConcreteDFA([{}], {0})
+    assert dfa.transition(DEAD, 0) == DEAD


### PR DESCRIPTION
In a previous review @Zalathar asked if there was something clever we could do to update all of the cached `is_dead` values at once. We semi-agreed that there probably was and it probably wasn't worth it.

Anyway my experience with trying to get #2525 working on hypothesis-csmith showed just how bad our DFA method performance was on large DFAs and pointed out that for even quite small DFAs `max_length` could easily raise a `RecursionError`.

So, this is that something clever. Non-recursive (Well, explicit recursion in the `max_length` case) implementations which more efficiently calculate `is_dead` and `max_length` for a large swathe of the DFA at once.

Still WIP because some of the changes seem to interact badly with the testing of #2525 and I haven't got to the bottom of that yet, but the actual changes seem to work and I think it's a problem with the tests generating invalid-but-previously-OK data.