### PR TITLE
Fix bug caused by variable name reuse in DFA transitions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a small internal bug in Hypothesis's internal automaton library.
+Fortunately this bug was currently impossible to hit in user facing code, so this
+has no user visible impact.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -440,13 +440,13 @@ class ConcreteDFA(DFA):
     def is_accepting(self, i):
         return i in self.__accepting
 
-    def transition(self, i, c):
+    def transition(self, state, char):
         """Returns the state that i transitions to on reading
         character c from a string."""
-        if i == DEAD:
-            return i
+        if state == DEAD:
+            return DEAD
 
-        table = self.__transitions[i]
+        table = self.__transitions[state]
 
         # Given long transition tables we convert them to
         # dictionaries for more efficient lookup.
@@ -459,21 +459,21 @@ class ConcreteDFA(DFA):
                     u, v, j = t
                     for c in range(u, v + 1):
                         new_table[c] = j
-            self.__transitions[i] = new_table
+            self.__transitions[state] = new_table
             table = new_table
 
         if isinstance(table, dict):
             try:
-                return self.__transitions[i][c]
+                return self.__transitions[state][char]
             except KeyError:
                 return DEAD
         else:
             for t in table:
                 if len(t) == 2:
-                    if t[0] == c:
+                    if t[0] == char:
                         return t[1]
                 else:
                     u, v, j = t
-                    if u <= c <= v:
+                    if u <= char <= v:
                         return j
             return DEAD

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -124,10 +124,14 @@ def test_has_string_of_max_length(dfa):
 
 
 def test_converts_long_tables_to_dicts():
-    dfa = ConcreteDFA([[(0, 0), (1, 1), (2, 2), (3, 1), (4, 0)], [(0, 0)], []], {2})
-    list(dfa.transitions(0))
+    dfa = ConcreteDFA(
+        [[(0, 0), (1, 1), (2, 2), (3, 1), (4, 0), (7, 10, 1)], [(0, 0)], []], {2}
+    )
+    assert dfa.transition(0, 2) == 2
+    assert dfa.transition(1, 0) == 0
 
     assert isinstance(dfa._ConcreteDFA__transitions[0], dict)
+    assert isinstance(dfa._ConcreteDFA__transitions[1], list)
 
 
 @settings(max_examples=20)


### PR DESCRIPTION
In which @DRMacIver is reminded that having single letter variable names might be fine but single variable function arguments are the worst. Possibly this should be in our style guide to prevent me from having to learn this again? Not sure.

Anyway, this fixes a bug where we may get the wrong answer the first time we call `transition` on a state on `ConcreteDFA` because I accidentally changed the character we were reading in a loop.