### PR TITLE
Add ghostwriter functions for binary ops and Numpy (g)ufuncs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,10 @@ jobs:
           TASK: check-coverage
         check-conjecture-coverage:
           TASK: check-conjecture-coverage
-        check-pypy35:
-          TASK: check-pypy35
-        check-pypy36:
-          TASK: check-pypy36
+        # check-pypy35:
+        #   TASK: check-pypy35
+        # check-pypy36:
+        #   TASK: check-pypy36
         check-py36:
           TASK: check-py36
         check-py35:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This patch adds two new :doc:`ghostwriters <ghostwriter>` to test
+:wikipedia:`binary operations <Binary_operation>`, like :func:`python:operator.add`,
+and Numpy :np-ref:`ufuncs <ufuncs.html>` and :np-ref:`gufuncs
+<c-api/generalized-ufuncs.html>` like :obj:`np.matmul() <numpy:numpy.matmul>`.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -89,6 +89,7 @@ extlinks = {
     "pypi": ("https://pypi.org/project/%s", ""),
     "bpo": ("https://bugs.python.org/issue%s", "bpo-"),
     "np-ref": ("https://docs.scipy.org/doc/numpy/reference/%s", ""),
+    "wikipedia": ("https://en.wikipedia.org/wiki/%s", ""),
 }
 
 # -- Options for HTML output ----------------------------------------------

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -67,7 +67,7 @@ hoverxref_domains = ["py"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "django": ("https://django.readthedocs.io/en/stable/", None),
@@ -88,7 +88,7 @@ extlinks = {
     "pull": (_repo + "pull/%s", "pull request #"),
     "pypi": ("https://pypi.org/project/%s", ""),
     "bpo": ("https://bugs.python.org/issue%s", "bpo-"),
-    "np-ref": ("https://docs.scipy.org/doc/numpy/reference/%s", ""),
+    "np-ref": ("https://numpy.org/doc/stable/reference/%s", ""),
     "wikipedia": ("https://en.wikipedia.org/wiki/%s", ""),
 }
 

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -96,6 +96,7 @@ else:
     @main.command()  # type: ignore  # Click adds the .command attribute
     @click.argument("func", type=obj_name, required=True, nargs=-1)
     @click.option("--idempotent", "writer", flag_value="idempotent")
+    @click.option("--binary-op", "writer", flag_value="binary_operation")
     @click.option("--equivalent", "writer", flag_value="equivalent")
     @click.option("--roundtrip", "writer", flag_value="roundtrip")
     @click.option(
@@ -122,6 +123,7 @@ else:
             hypothesis write gzip
             hypothesis write re.compile --except re.error
             hypothesis write --style=unittest --idempotent sorted
+            hypothesis write --binary-op operator.add
             hypothesis write --equivalent ast.literal_eval eval
             hypothesis write --roundtrip json.dumps json.loads
         """

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -99,6 +99,8 @@ else:
     @click.option("--binary-op", "writer", flag_value="binary_operation")
     @click.option("--equivalent", "writer", flag_value="equivalent")
     @click.option("--roundtrip", "writer", flag_value="roundtrip")
+    # Note: we deliberately omit a --ufunc flag, because the magic()
+    # detection of ufuncs is both precise and complete.
     @click.option(
         "--style",
         type=click.Choice(["pytest", "unittest"]),

--- a/hypothesis-python/tests/ghostwriter/recorded/addition_op_magic.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/addition_op_magic.txt
@@ -1,0 +1,26 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import test_expected_output
+from hypothesis import given, strategies as st
+
+add_operands = st.floats()
+
+
+@given(a=add_operands, b=add_operands, c=add_operands)
+def test_associative_binary_operation_add(a, b, c):
+    left = test_expected_output.add(a=a, b=test_expected_output.add(a=b, b=c))
+    right = test_expected_output.add(a=test_expected_output.add(a=a, b=b), b=c)
+    assert left == right, (left, right)
+
+
+@given(a=add_operands, b=add_operands)
+def test_commutative_binary_operation_add(a, b):
+    left = test_expected_output.add(a=a, b=b)
+    right = test_expected_output.add(a=b, b=a)
+    assert left == right, (left, right)
+
+
+@given(a=add_operands)
+def test_identity_binary_operation_add(a):
+    assert a == test_expected_output.add(a=a, b=0.0)

--- a/hypothesis-python/tests/ghostwriter/recorded/division_operator.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/division_operator.txt
@@ -1,0 +1,14 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import _operator
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with an appropriate strategy
+
+truediv_operands = st.nothing()
+
+
+@given(a=truediv_operands)
+def test_identity_binary_operation_truediv(a):
+    assert a == _operator.truediv(a, "identity element here")

--- a/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
@@ -1,12 +1,23 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
 
+import hypothesis.extra.numpy as npst
 import numpy
 from hypothesis import given, strategies as st
 
-# TODO: replace st.nothing() with appropriate strategies
 
+@given(
+    data=st.data(),
+    shapes=npst.mutually_broadcastable_shapes(signature="(n?,k),(k,m?)->(n?,m?)"),
+    types=st.sampled_from(numpy.matmul.types).filter(lambda sig: "O" not in sig),
+)
+def test_gufunc_matmul(data, shapes, types):
+    input_shapes, expected_shape = shapes
+    input_dtypes, expected_dtype = types.split("->")
+    array_st = [npst.arrays(d, s) for d, s in zip(input_dtypes, input_shapes)]
 
-@given(a=st.nothing(), b=st.nothing())
-def test_fuzz_matmul(a, b):
-    numpy.matmul(a, b)
+    a, b = data.draw(st.tuples(*array_st))
+    result = numpy.matmul(a, b)
+
+    assert result.shape == expected_shape
+    assert result.dtype.char == expected_dtype

--- a/hypothesis-python/tests/ghostwriter/recorded/multiplication_operator.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/multiplication_operator.txt
@@ -1,0 +1,35 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import _operator
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with an appropriate strategy
+
+mul_operands = st.nothing()
+
+
+@given(a=mul_operands, b=mul_operands, c=mul_operands)
+def test_associative_binary_operation_mul(a, b, c):
+    left = _operator.mul(a, _operator.mul(b, c))
+    right = _operator.mul(_operator.mul(a, b), c)
+    assert left == right, (left, right)
+
+
+@given(a=mul_operands, b=mul_operands)
+def test_commutative_binary_operation_mul(a, b):
+    left = _operator.mul(a, b)
+    right = _operator.mul(b, a)
+    assert left == right, (left, right)
+
+
+@given(a=mul_operands)
+def test_identity_binary_operation_mul(a):
+    assert a == _operator.mul(a, 1)
+
+
+@given(a=mul_operands, b=mul_operands, c=mul_operands)
+def test_add_distributes_over_binary_operation_mul(a, b, c):
+    left = _operator.add(_operator.mul(a, b), _operator.mul(a, c))
+    right = _operator.mul(a, _operator.add(b, c))
+    assert left == right, (left, right)

--- a/hypothesis-python/tests/ghostwriter/recorded/multiplication_operator_unittest.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/multiplication_operator_unittest.txt
@@ -1,0 +1,34 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import _operator
+import unittest
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with an appropriate strategy
+
+
+class TestBinaryOperationmul(unittest.TestCase):
+    mul_operands = st.nothing()
+
+    @given(a=mul_operands, b=mul_operands, c=mul_operands)
+    def test_associative_binary_operation_mul(self, a, b, c):
+        left = _operator.mul(a, _operator.mul(b, c))
+        right = _operator.mul(_operator.mul(a, b), c)
+        self.assertEqual(left, right)
+
+    @given(a=mul_operands, b=mul_operands)
+    def test_commutative_binary_operation_mul(self, a, b):
+        left = _operator.mul(a, b)
+        right = _operator.mul(b, a)
+        self.assertEqual(left, right)
+
+    @given(a=mul_operands)
+    def test_identity_binary_operation_mul(self, a):
+        self.assertEqual(a, _operator.mul(a, 1))
+
+    @given(a=mul_operands, b=mul_operands, c=mul_operands)
+    def test_add_distributes_over_binary_operation_mul(self, a, b, c):
+        left = _operator.add(_operator.mul(a, b), _operator.mul(a, c))
+        right = _operator.mul(a, _operator.add(b, c))
+        self.assertEqual(left, right)

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -21,6 +21,7 @@ To update the recorded outputs, run `pytest --hypothesis-update-outputs ...`.
 
 import ast
 import base64
+import operator
 import pathlib
 import re
 from typing import Sequence
@@ -46,6 +47,10 @@ class A_Class:
         pass
 
 
+def add(a: float, b: float) -> float:
+    return a + b
+
+
 # Note: for some of the `expected` outputs, we replace away some small
 #       parts which vary between minor versions of Python.
 @pytest.mark.parametrize(
@@ -68,6 +73,28 @@ class A_Class:
         ("timsort_idempotent", ghostwriter.idempotent(timsort)),
         ("eval_equivalent", ghostwriter.equivalent(eval, ast.literal_eval)),
         ("sorted_self_equivalent", ghostwriter.equivalent(sorted, sorted, sorted)),
+        ("addition_op_magic", ghostwriter.magic(add)),
+        (
+            "division_operator",
+            ghostwriter.binary_operation(
+                operator.truediv, associative=False, commutative=False
+            ),
+        ),
+        (
+            "multiplication_operator",
+            ghostwriter.binary_operation(
+                operator.mul, identity=1, distributes_over=operator.add
+            ),
+        ),
+        (
+            "multiplication_operator_unittest",
+            ghostwriter.binary_operation(
+                operator.mul,
+                identity=1,
+                distributes_over=operator.add,
+                style="unittest",
+            ),
+        ),
     ],
     ids=lambda x: x[0],
 )


### PR DESCRIPTION
As a follow-up to #2118 and #2344, this PR adds ghostwriters for less common but still useful patterns:

- binary operations demonstrate most of the 'classic' properties - associative, commutative, identity element, and distributive.  While these are rarer in Python than roundtrips and IMO less useful, they're still nice to have.
- Numpy-compatible (generalised) universal array functions.  These have surprisingly complex behaviour around the allowed shapes and dtypes of input and output arrays, and provide a lovely chance to show off our high-level strategies for testing numeric code.