### PR TITLE
Ghostwriter upgrade: equivalence heuristic and lots of edge cases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This patch makes the :doc:`ghostwriter <ghostwriter>` much more robust when
+passed unusual modules.
+
+- improved support for non-resolvable type annotations
+- :func:`~hypothesis.extra.ghostwriter.magic` can now write
+  :func:`~hypothesis.extra.ghostwriter.equivalent` tests
+- running :func:`~hypothesis.extra.ghostwriter.magic` on modules where some
+  names in ``__all__`` are undefined skips such names, instead of raising an error
+- :func:`~hypothesis.extra.ghostwriter.magic` now knows to skip mocks
+- improved handling of import-time errors found by the ghostwriter CLI

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -67,6 +67,7 @@ else:
 
     def obj_name(s: str) -> object:
         """This "type" imports whatever object is named by a dotted string."""
+        s = s.strip()
         try:
             return importlib.import_module(s)
         except ImportError:

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -309,7 +309,7 @@ def _get_module(obj):
 def _get_qualname(obj, include_module=False):
     # Replacing angle-brackets for objects defined in `.<locals>.`
     qname = getattr(obj, "__qualname__", obj.__name__)
-    qname = qname.replace("<", "_").replace(">", "_")
+    qname = qname.replace("<", "_").replace(">", "_").replace(" ", "")
     if include_module:
         return _get_module(obj) + "." + qname
     return qname

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -120,7 +120,6 @@ def _check_style(style: str) -> None:
 # take values of a particular type.
 _GUESS_STRATEGIES_BY_NAME = (
     (st.text(), ["name", "filename", "fname"]),
-    (st.integers(min_value=0), ["index"]),
     (st.floats(), ["real", "imag"]),
     (st.functions(), ["function", "func", "f"]),
     (st.iterables(st.integers()) | st.iterables(st.text()), ["iterable"]),
@@ -495,7 +494,13 @@ def magic(
 
     imports = set()
     parts = []
-    by_name = {_get_qualname(f, include_module=True): f for f in functions}
+    by_name = {}
+    for f in functions:
+        try:
+            by_name[_get_qualname(f, include_module=True)] = f
+        except Exception:
+            pass  # e.g. Pandas 'CallableDynamicDoc' object has no attribute '__name__'
+    assert by_name
 
     # Look for pairs of functions that roundtrip, based on known naming patterns.
     for writename, readname in ROUNDTRIP_PAIRS:

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -59,6 +59,7 @@ import black
 from hypothesis import find, strategies as st
 from hypothesis.errors import InvalidArgument, Unsatisfiable
 from hypothesis.internal.compat import get_type_hints
+from hypothesis.internal.reflection import is_mock
 from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal.strategies import OneOfStrategy
 from hypothesis.strategies._internal.types import _global_type_lookup
@@ -485,7 +486,7 @@ def magic(
                 ]
             for f in funcs:
                 try:
-                    if callable(f) and inspect.signature(f).parameters:
+                    if (not is_mock(f)) and callable(f) and _get_params(f):
                         functions.add(f)
                 except ValueError:
                     pass

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -137,7 +137,7 @@ else:
         """
         try:
             hints = typing.get_type_hints(thing)
-        except (TypeError, NameError):
+        except (AttributeError, TypeError, NameError):
             hints = {}
         if hints or not inspect.isclass(thing):
             return hints

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -26,6 +26,7 @@ import os
 import sys
 import typing
 import uuid
+from pathlib import PurePath
 from types import FunctionType
 
 from hypothesis import strategies as st
@@ -361,6 +362,8 @@ _global_type_lookup[type] = st.sampled_from(
     [type(None)] + sorted(_global_type_lookup, key=str)
 )
 
+if sys.version_info[:2] >= (3, 6):  # pragma: no branch
+    _global_type_lookup[os.PathLike] = st.builds(PurePath, st.text())
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
     # subclass of MutableMapping, and in Python 3.9 we resolve to a union
     # which includes this... but we don't actually ever want to build one.

--- a/hypothesis-python/tests/ghostwriter/recorded/addition_op_multimagic.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/addition_op_multimagic.txt
@@ -1,0 +1,16 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import _operator
+import numpy
+import test_expected_output
+from hypothesis import given, strategies as st
+
+
+@given(a=st.floats(), b=st.floats())
+def test_equivalent_add_add_add(a, b):
+    result_0_add = _operator.add(a, b)
+    result_1_add = numpy.add(a, b)
+    result_2_add = test_expected_output.add(a=a, b=b)
+    assert result_0_add == result_1_add, (result_0_add, result_1_add)
+    assert result_0_add == result_2_add, (result_0_add, result_2_add)

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -74,6 +74,7 @@ def add(a: float, b: float) -> float:
         ("eval_equivalent", ghostwriter.equivalent(eval, ast.literal_eval)),
         ("sorted_self_equivalent", ghostwriter.equivalent(sorted, sorted, sorted)),
         ("addition_op_magic", ghostwriter.magic(add)),
+        ("addition_op_multimagic", ghostwriter.magic(add, operator.add, numpy.add)),
         (
             "division_operator",
             ghostwriter.binary_operation(

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -95,6 +95,10 @@ def timsort(seq: Sequence[int]) -> List[int]:
     return sorted(seq)
 
 
+def non_type_annotation(x: 3):  # type: ignore
+    pass
+
+
 def test_flattens_one_of_repr():
     assert repr(from_type(Sequence[int])).count("one_of(") == 2
     assert repr(ghostwriter._get_strategies(timsort)["seq"]).count("one_of(") == 1
@@ -102,7 +106,15 @@ def test_flattens_one_of_repr():
 
 @varied_excepts
 @pytest.mark.parametrize(
-    "func", [re.compile, json.loads, json.dump, timsort, ast.literal_eval]
+    "func",
+    [
+        re.compile,
+        json.loads,
+        json.dump,
+        timsort,
+        ast.literal_eval,
+        non_type_annotation,
+    ],
 )
 def test_ghostwriter_fuzz(func, ex):
     source_code = ghostwriter.fuzz(func, except_=ex)

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -104,8 +104,9 @@ def annotated_any(x: Any):
 
 
 def test_flattens_one_of_repr():
-    assert repr(from_type(Sequence[int])).count("one_of(") == 2
-    assert repr(ghostwriter._get_strategies(timsort)["seq"]).count("one_of(") == 1
+    strat = from_type(Sequence[int])
+    assert repr(strat).count("one_of(") > 1
+    assert ghostwriter._valid_syntax_repr(strat).count("one_of(") == 1
 
 
 @varied_excepts

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -277,3 +277,16 @@ def test_module_with_mock_does_not_break():
     # through the initial validation and then fail when used in more detailed
     # logic in the ghostwriter machinery.
     ghostwriter.magic(unittest.mock)
+
+
+def compose_types(x: type, y: type):
+    pass
+
+
+def test_unrepr_identity_elem():
+    # Works with inferred identity element
+    source_code = ghostwriter.binary_operation(compose_types)
+    exec(source_code, {})
+    # and also works with explicit identity element
+    source_code = ghostwriter.binary_operation(compose_types, identity=type)
+    exec(source_code, {})

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -18,6 +18,7 @@ import enum
 import json
 import re
 import unittest
+import unittest.mock
 from decimal import Decimal
 from types import ModuleType
 from typing import Any, List, Sequence, Set
@@ -255,3 +256,10 @@ def test_overlapping_args_use_union_of_strategies():
 
     source_code = ghostwriter.equivalent(f, g)
     assert "arg=st.one_of(st.integers(), st.floats())" in source_code
+
+
+def test_module_with_mock_does_not_break():
+    # Before we added an explicit check for unspec'd mocks, they would pass
+    # through the initial validation and then fail when used in more detailed
+    # logic in the ghostwriter machinery.
+    ghostwriter.magic(unittest.mock)

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -107,6 +107,15 @@ def annotated_any(x: Any):
 space_in_name = type("a name", (type,), {"__init__": lambda self: None})
 
 
+class NotResolvable:
+    def __init__(self, unannotated_required):
+        pass
+
+
+def non_resolvable_arg(x: NotResolvable):
+    pass
+
+
 def test_flattens_one_of_repr():
     strat = from_type(Sequence[int])
     assert repr(strat).count("one_of(") > 1
@@ -125,6 +134,7 @@ def test_flattens_one_of_repr():
         non_type_annotation,
         annotated_any,
         space_in_name,
+        non_resolvable_arg,
     ],
 )
 def test_ghostwriter_fuzz(func, ex):

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -104,6 +104,9 @@ def annotated_any(x: Any):
     pass
 
 
+space_in_name = type("a name", (type,), {"__init__": lambda self: None})
+
+
 def test_flattens_one_of_repr():
     strat = from_type(Sequence[int])
     assert repr(strat).count("one_of(") > 1
@@ -121,6 +124,7 @@ def test_flattens_one_of_repr():
         ast.literal_eval,
         non_type_annotation,
         annotated_any,
+        space_in_name,
     ],
 )
 def test_ghostwriter_fuzz(func, ex):

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -20,7 +20,7 @@ import re
 import unittest
 from decimal import Decimal
 from types import ModuleType
-from typing import List, Sequence, Set
+from typing import Any, List, Sequence, Set
 
 import pytest
 
@@ -99,6 +99,10 @@ def non_type_annotation(x: 3):  # type: ignore
     pass
 
 
+def annotated_any(x: Any):
+    pass
+
+
 def test_flattens_one_of_repr():
     assert repr(from_type(Sequence[int])).count("one_of(") == 2
     assert repr(ghostwriter._get_strategies(timsort)["seq"]).count("one_of(") == 1
@@ -114,6 +118,7 @@ def test_flattens_one_of_repr():
         timsort,
         ast.literal_eval,
         non_type_annotation,
+        annotated_any,
     ],
 )
 def test_ghostwriter_fuzz(func, ex):

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
@@ -113,3 +113,18 @@ def test_can_import_from_scripts_in_working_dir(tmpdir):
     )
     assert result.returncode == 0
     assert "Error: " not in result.stderr
+
+
+def test_empty_module_is_not_error(tmpdir):
+    (tmpdir / "mycode.py").write("# Nothing to see here\n")
+    result = subprocess.run(
+        "hypothesis write mycode",
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+        cwd=tmpdir,
+    )
+    assert result.returncode == 0
+    assert "Error: " not in result.stderr
+    assert "# Found no testable functions" in result.stdout

--- a/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py
+++ b/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py
@@ -1,0 +1,77 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""Try running `hypothesis write ...` on all available modules.
+
+Prints a list of module names which caused some kind of internal error.
+
+The idea here is to check that we at least don't crash on anything that
+people actually ship, or at least only on the cases we know and don't
+really care about - there are a lot of strange things in a python install.
+Some have import-time side effects or errors so we skip them; others
+just have such weird semantics that we don't _want_ to support them.
+"""
+
+import distutils.sysconfig as sysconfig
+import multiprocessing
+import os
+import subprocess
+
+skip = (
+    "idlelib curses antigravity pip prompt_toolkit IPython .popen_ django. .test. "
+    "execnet.script lib2to3.pgen2.conv tests. Cython. ~ - ._ libcst.codemod. "
+    "modernize flask. sphinx. pyasn1 dbm.ndbm doctest"
+).split()
+
+
+def getmodules():
+    std_lib = sysconfig.get_python_lib(standard_lib=True)
+    for top, _, files in os.walk(std_lib):
+        for nm in files:
+            if nm.endswith(".py") and nm not in ("__init__.py", "__main__.py"):
+                modname = (
+                    os.path.join(top, nm)[len(std_lib) + 1 : -3]
+                    .replace(os.sep, ".")
+                    .replace("site-packages.", "")
+                )
+                if not any(bad in modname for bad in skip):
+                    yield modname
+
+
+def write_for(mod):
+    try:
+        subprocess.run(
+            ["hypothesis", "write", mod],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            universal_newlines=True,
+        )
+    except subprocess.SubprocessError as e:
+        # Only report the error if we could load _but not process_ the module
+        if (
+            "Error: Found the '" not in e.stderr
+            and "Error: Failed to import" not in e.stderr
+        ):
+            return mod
+
+
+if __name__ == "__main__":
+    print("# prints the names of modules for which `hypothesis write` errors out")
+    with multiprocessing.Pool() as pool:
+        for name in pool.imap(write_for, getmodules()):
+            if name is not None:
+                print(name, flush=True)


### PR DESCRIPTION
As the final stage of the ghostwriter saga, I decided that we should really be able to infer that functions with the same qualname and set of args are probably equivalent - unless they have incompatible return type annotations.

Then I ran `hypothesis write` on a wide range of modules to check that it worked reasonably well - and fixed a couple of weird issues for `pandas`... and then got suspicious and [wrote this script](https://github.com/Zac-HD/hypothesis/blob/anyghost/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py) to run it against every Python module I have installed.

As the list of commits might indicate, this revealed *many* odd little issues.  

The general theme is "give decent output for strange modules instead of crashing", and *everything* here occurs in a real module.

- Dynamically constructed type with a space in the name?  Matplot does it for floating axes.
- Callables with no `__name__`, or undefined names in `__all__`?  Pandas does both.
- Un-spec'd mocks as a module global?  `unittest.mock` isn't the only one.
- Import-time side effects?  Let's just say that `import antigravity` is still my favorite.
- Annotations that aren't types?  Historically reasonable, if discouraged these days.

etc...

