### PR TITLE
Add "hypothesis" entry point

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds support for :ref:`entry-points`, which allows for smoother
+integration of third-party Hypothesis extensions and external libraries.
+Unless you're publishing a library with Hypothesis integration, you'll
+probably only ever use this indirectly!

--- a/hypothesis-python/src/hypothesis/__init__.py
+++ b/hypothesis-python/src/hypothesis/__init__.py
@@ -24,6 +24,7 @@ import hypothesis._error_if_old  # noqa  # imported for side-effect of nice erro
 from hypothesis._settings import HealthCheck, Phase, Verbosity, settings
 from hypothesis.control import assume, event, note, reject, target
 from hypothesis.core import example, find, given, reproduce_failure, seed
+from hypothesis.entry_points import run
 from hypothesis.internal.entropy import register_random
 from hypothesis.utils.conventions import infer
 from hypothesis.version import __version__, __version_info__
@@ -48,3 +49,6 @@ __all__ = [
     "__version__",
     "__version_info__",
 ]
+
+run()
+del run

--- a/hypothesis-python/src/hypothesis/entry_points.py
+++ b/hypothesis-python/src/hypothesis/entry_points.py
@@ -1,0 +1,28 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""Run all functions registered for the "hypothesis" entry point.
+
+This can be used with `st.register_type_strategy` to register strategies for your
+custom types, running the relevant code when *hypothesis* is imported instead of
+your package.
+"""
+
+import pkg_resources
+
+
+def run():
+    for entry_point in pkg_resources.iter_entry_points("hypothesis"):
+        entry_point.load()  # pragma: no cover


### PR DESCRIPTION
[Entry points](https://amir.rachum.com/blog/2017/07/28/python-entry-points/) are a nice way for downstream extensions to have Hypothesis run some of their code on import.

The most common uses of this are probably to set up `console_scripts` - followed by pytest plugins - but in our case it's really just a way to get the side effect of `st.register_type_strategy` without requiring upstream libraries to speculatively import Hypothesis.  More docs in the PR, which you can see has a *very* simple implementation!

Possible users include projects like `hypothesis-networkx` registering a strategy for various graph types, or `xarray` registering strategies for their own types from an unimported-by-default submodule.