### PR TITLE
Add a way to get the strategy used for an `@given`-wrapped test

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch tracks some additional information in Hypothesis internals,
+and has no user-visible impact.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -382,7 +382,7 @@ def get_random_for_wrapped_test(test, wrapped_test):
 
 
 def process_arguments_to_given(
-    wrapped_test, arguments, kwargs, given_kwargs, argspec, settings,
+    wrapped_test, arguments, kwargs, given_kwargs, argspec,
 ):
     selfy = None
     arguments, kwargs = convert_positional_arguments(wrapped_test, arguments, kwargs)
@@ -999,7 +999,7 @@ def given(
             random = get_random_for_wrapped_test(test, wrapped_test)
 
             processed_args = process_arguments_to_given(
-                wrapped_test, arguments, kwargs, given_kwargs, argspec, settings,
+                wrapped_test, arguments, kwargs, given_kwargs, argspec
             )
             arguments, kwargs, test_runner, search_strategy = processed_args
 
@@ -1159,7 +1159,7 @@ def given(
             )
             random = get_random_for_wrapped_test(test, wrapped_test)
             _args, _kwargs, test_runner, search_strategy = process_arguments_to_given(
-                wrapped_test, (), {}, given_kwargs, argspec, settings,
+                wrapped_test, (), {}, given_kwargs, argspec,
             )
             assert not _args
             assert not _kwargs

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -887,6 +887,7 @@ class HypothesisHandle:
 
     inner_test = attr.ib()
     _get_fuzz_target = attr.ib()
+    _given_kwargs = attr.ib()
 
     @property
     def fuzz_one_input(
@@ -1209,7 +1210,7 @@ def given(
         wrapped_test._hypothesis_internal_use_reproduce_failure = getattr(
             test, "_hypothesis_internal_use_reproduce_failure", None
         )
-        wrapped_test.hypothesis = HypothesisHandle(test, _get_fuzz_target)
+        wrapped_test.hypothesis = HypothesisHandle(test, _get_fuzz_target, given_kwargs)
         return wrapped_test
 
     return run_test_as_given

--- a/hypothesis-python/tests/cover/test_fuzz_one_input.py
+++ b/hypothesis-python/tests/cover/test_fuzz_one_input.py
@@ -108,3 +108,21 @@ def test_autopruning_of_returned_buffer():
     # Unused portions of the input buffer are discarded from output.
     # (and canonicalised, but that's a no-op for fixed-length `binary()`)
     assert test.hypothesis.fuzz_one_input(b"deadbeef") == b"dead"
+
+
+STRAT = st.builds(object)
+
+
+@given(x=STRAT)
+def addx(x, y):
+    pass
+
+
+@given(STRAT)
+def addy(x, y):
+    pass
+
+
+def test_can_access_strategy_for_wrapped_test():
+    assert addx.hypothesis._given_kwargs == {"x": STRAT}
+    assert addy.hypothesis._given_kwargs == {"y": STRAT}


### PR DESCRIPTION
This is the last integration point I need to get an external fuzzing engine working.

Having run it in my local fork for a fortnight or so now, after a fairly wide range of failed designs, I'm also confident that this will serve well for the long term and is not too specialised to my particular use-case.  The main thing to note is that unlike our existing [`fuzz_one_input()` hook](https://hypothesis.readthedocs.io/en/latest/details.html#use-with-external-fuzzers), this will allow for some arguments to come from strategies and others from e.g. `@pytest.mark.parametrize(...)`.