### PR TITLE
Document and type-annotate database code

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds type annotations to the :doc:`hypothesis.database <database>`
+module.  There is no runtime change, but your typechecker might notice.

--- a/hypothesis-python/docs/database.rst
+++ b/hypothesis-python/docs/database.rst
@@ -66,3 +66,20 @@ Like everything under ``.hypothesis/``, the examples directory will be
 transparently created on demand.  Unlike the other subdirectories,
 ``examples/`` is designed to handle merges, deletes, etc if you just add the
 directory into git, mercurial, or any similar version control system.
+
+
+---------------------------------
+Defining your own ExampleDatabase
+---------------------------------
+
+You can define your :class:`~hypothesis.database.ExampleDatabase`, for example
+to use a shared datastore, with just a few methods:
+
+.. autoclass:: hypothesis.database.ExampleDatabase
+   :members:
+
+Two concrete :class:`~hypothesis.database.ExampleDatabase` classes ship with
+Hypothesis:
+
+.. autoclass:: hypothesis.database.DirectoryBasedExampleDatabase
+.. autoclass:: hypothesis.database.InMemoryExampleDatabase

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -95,17 +95,12 @@ def test_saving_a_key_twice_fetches_it_once(exampledatabase):
     assert list(exampledatabase.fetch(b"foo")) == [b"bar"]
 
 
-def test_can_close_a_database_without_touching_it(exampledatabase):
-    exampledatabase.close()
-
-
 def test_can_close_a_database_after_saving(exampledatabase):
     exampledatabase.save(b"foo", b"bar")
 
 
 def test_class_name_is_in_repr(exampledatabase):
     assert type(exampledatabase).__name__ in repr(exampledatabase)
-    exampledatabase.close()
 
 
 def test_an_absent_value_is_present_after_it_moves(exampledatabase):

--- a/hypothesis-python/tests/nocover/test_database_agreement.py
+++ b/hypothesis-python/tests/nocover/test_database_agreement.py
@@ -72,8 +72,6 @@ class DatabaseComparison(RuleBasedStateMachine):
             last_db = db
 
     def teardown(self):
-        for d in self.dbs:
-            d.close()
         shutil.rmtree(self.tempd)
 
 

--- a/hypothesis-python/tests/nocover/test_strategy_state.py
+++ b/hypothesis-python/tests/nocover/test_strategy_state.py
@@ -71,7 +71,6 @@ class HypothesisSpec(RuleBasedStateMachine):
     @rule()
     def clear_database(self):
         if self.database is not None:
-            self.database.close()
             self.database = None
 
     @rule()


### PR DESCRIPTION
I've been looking at the database code lately with a view to various fuzzing workflows, and thought that we could make it a lot easier for downstream users to write their own.  To that end, this PR:

- Turns `ExampleDatabase` into an abstract base class, so that subclasses cannot be instantiated unless they define all three of the `save`, `delete`, and `fetch` methods
- Removes the `.close()` method, which we no longer call anywhere
  (I think this was dropped in 4.0, with the SQLite database format)
- Adds some API documentation - [read it here](https://hypothesis--2568.org.readthedocs.build/en/2568/database.html)
- Adds the trivial type annotations (`bytes` and `Iterable[bytes]` only)

If you have e.g. a team who would like to use some networked non-file-system data store to implement a shared database for them and their CI bots, this makes the Hypothesis end of it totally trivial and that's good enough for me.  

I've also dashed off trivial `ReadOnlyDatabase(db)` and `MultiplexedDatabase(*dbs)` wrappers which do the obvious things, but I don't think they really belong upstream - we don't have any need for them and they're equally trivial to implement downstream.