### PR TITLE
Changes how TypeVar is registered, refs #2572

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,8 +1,8 @@
 RELEASE_TYPE: minor
 
-:func:`~hypothesis.strategies.register_type_strategy` now supports 
-:class:`python:typing.TypeVar`, which was previously hard-coded, and allows a 
-variety of types to be generated for unconstrained :class:`~python:typing.TypeVar`s 
+:func:`~hypothesis.strategies.register_type_strategy` now supports
+:class:`python:typing.TypeVar`, which was previously hard-coded, and allows a
+variety of types to be generated for an unconstrained :class:`~python:typing.TypeVar`
 instead of just :func:`~hypothesis.strategies.text`.
 
 Thanks again to Nikita Sobolev for all your work on advanced types!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,8 @@
 RELEASE_TYPE: minor
 
-This release adds support for overriding default ``TypeVar`` strategy,
-it also enhances the default strategy for ``TypeVar``s
-that now includes a lot of types instead of just ``st.text()``.
+:func:`~hypothesis.strategies.register_type_strategy` now supports 
+:class:`python:typing.TypeVar`, which was previously hard-coded, and allows a 
+variety of types to be generated for unconstrained :class:`~python:typing.TypeVar`s 
+instead of just :func:`~hypothesis.strategies.text`.
+
+Thanks again to Nikita Sobolev for all your work on advanced types!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds support for overriding default ``TypeVar`` strategy,
+it also enhances the default strategy for ``TypeVar``s
+that now includes a lot of types instead of just ``st.text()``.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1471,13 +1471,14 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # We also have a special case for TypeVars.
     # They are represented as instances like `~T` when they come here.
     # We need to work with their type instead.
-    if isinstance(thing, TypeVar) and type(thing) in types._global_type_lookup:
+    if isinstance(thing, TypeVar) and type(thing) in types._global_type_lookup:  # type: ignore
         return as_strategy(types._global_type_lookup[type(thing)], thing)
     # If there's no explicitly registered strategy, maybe a subtype of thing
     # is registered - if so, we can resolve it to the subclass strategy.
     # We'll start by checking if thing is from from the typing module,
     # because there are several special cases that don't play well with
     # subclass and instance checks.
+    print("root", isinstance(thing, typing_root_type))
     if isinstance(thing, typing_root_type):
         return types.from_typing_type(thing)
     # If it's not from the typing module, we get all registered types that are

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1478,7 +1478,6 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # We'll start by checking if thing is from from the typing module,
     # because there are several special cases that don't play well with
     # subclass and instance checks.
-    print("root", isinstance(thing, typing_root_type))
     if isinstance(thing, typing_root_type):
         return types.from_typing_type(thing)
     # If it's not from the typing module, we get all registered types that are

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1468,6 +1468,11 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # convert empty results into an explicit error.
     if thing in types._global_type_lookup:
         return as_strategy(types._global_type_lookup[thing], thing)
+    # We also have a special case for TypeVars.
+    # They are represented as instances like `~T` when they come here.
+    # We need to work with their type instead.
+    if isinstance(thing, TypeVar) and type(thing) in types._global_type_lookup:
+        return as_strategy(types._global_type_lookup[type(thing)], thing)
     # If there's no explicitly registered strategy, maybe a subtype of thing
     # is registered - if so, we can resolve it to the subclass strategy.
     # We'll start by checking if thing is from from the typing module,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -601,7 +601,7 @@ def resolve_TypeVar(thing):
             st.sampled_from(strat.original_strategies), key=type_var_key,
         ).flatmap(lambda s: s)
 
-    builtin_scalar_types = [type(None), bool, int, float, str, bytes, list, dict]
+    builtin_scalar_types = [type(None), bool, int, float, str, bytes]
     return st.shared(
         st.sampled_from(
             # Constraints may be None or () on various Python versions.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -161,11 +161,11 @@ def _try_import_forward_ref(thing, bound):  # pragma: no cover
 def from_typing_type(thing):
     # We start with special-case support for Union and Tuple - the latter
     # isn't actually a generic type. Then we handle Literal since it doesn't
-    # support `isinstance`. Support for Callable may be added to this section
-    # later.
+    # support `isinstance`.
+    #
     # We then explicitly error on non-Generic types, which don't carry enough
     # information to sensibly resolve to strategies at runtime.
-    # Finally, we run a variation of the subclass lookup in st.from_type
+    # Finally, we run a variation of the subclass lookup in `st.from_type`
     # among generic types in the lookup.
     #
     # Under 3.6 Union is handled directly in st.from_type, as the argument is
@@ -204,28 +204,6 @@ def from_typing_type(thing):
             else:
                 literals.append(arg)
         return st.sampled_from(literals)
-    if isinstance(thing, typing.TypeVar):
-        if getattr(thing, "__bound__", None) is not None:
-            bound = thing.__bound__
-            if isinstance(bound, ForwardRef):
-                bound = _try_import_forward_ref(thing, bound)
-            strat = unwrap_strategies(st.from_type(bound))
-            if not isinstance(strat, OneOfStrategy):
-                return strat
-            # The bound was a union, or we resolved it as a union of subtypes,
-            # so we need to unpack the strategy to ensure consistency across uses.
-            # This incantation runs a sampled_from over the strategies inferred for
-            # each part of the union, wraps that in shared so that we only generate
-            # from one type per testcase, and flatmaps that back to instances.
-            return st.shared(
-                st.sampled_from(strat.original_strategies), key="typevar=%r" % (thing,)
-            ).flatmap(lambda s: s)
-        if getattr(thing, "__constraints__", None):
-            return st.shared(
-                st.sampled_from(thing.__constraints__), key="typevar=%r" % (thing,)
-            ).flatmap(st.from_type)
-        # Constraints may be None or () on various Python versions.
-        return st.text()  # An arbitrary type for the typevar
     # Now, confirm that we're dealing with a generic type as we expected
     if not isinstance(thing, typing_root_type):  # pragma: no cover
         raise ResolutionFailed("Cannot resolve %s to a strategy" % (thing,))
@@ -601,3 +579,34 @@ def resolve_Callable(thing):
         like=(lambda: None) if len(thing.__args__) == 1 else (lambda *a, **k: None),
         returns=st.from_type(thing.__args__[-1]),
     )
+
+
+@register(typing.TypeVar)
+def resolve_TypeVar(thing):
+    type_var_key = "typevar=%r" % (thing,)
+
+    if getattr(thing, "__bound__", None) is not None:
+        bound = thing.__bound__
+        if isinstance(bound, ForwardRef):
+            bound = _try_import_forward_ref(thing, bound)
+        strat = unwrap_strategies(st.from_type(bound))
+        if not isinstance(strat, OneOfStrategy):
+            return strat
+        # The bound was a union, or we resolved it as a union of subtypes,
+        # so we need to unpack the strategy to ensure consistency across uses.
+        # This incantation runs a sampled_from over the strategies inferred for
+        # each part of the union, wraps that in shared so that we only generate
+        # from one type per testcase, and flatmaps that back to instances.
+        return st.shared(
+            st.sampled_from(strat.original_strategies), key=type_var_key,
+        ).flatmap(lambda s: s)
+
+    builtin_scalar_types = [type(None), bool, int, float, str, bytes, list, dict]
+    return st.shared(
+        st.sampled_from(
+            # Constraints may be None or () on various Python versions.
+            getattr(thing, "__constraints__", None)
+            or builtin_scalar_types,
+        ),
+        key=type_var_key,
+    ).flatmap(st.from_type)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -284,6 +284,43 @@ def test_distinct_typevars_same_constraint():
     )
 
 
+def test_distinct_typevars_distinct_type():
+    """Ensures that two different type vars have at least one different type in their strategies."""
+    A = typing.TypeVar("A")
+    B = typing.TypeVar("B")
+    find_any(
+        st.tuples(st.from_type(A), st.from_type(B)),
+        lambda ab: type(ab[0]) != type(ab[1]),  # noqa
+    )
+
+
+@given(st.data())
+def test_same_typevars_same_type(data):
+    """Ensures that single type argument will always have the same type in a single context."""
+    A = typing.TypeVar("A")
+
+    def same_type_args(a: A, b: A):
+        assert type(a) == type(b)
+
+    data.draw(st.builds(same_type_args))
+
+
+def test_typevars_can_be_redefined():
+    """We test that one can register a custom strategy for all type vars."""
+    A = typing.TypeVar("A")
+
+    with temp_registered(typing.TypeVar, st.just(1)):
+        assert_all_examples(st.from_type(A), lambda obj: obj == 1)
+
+
+def test_typevars_can_be_redefine_with_factory():
+    """We test that one can register a custom strategy for all type vars."""
+    A = typing.TypeVar("A")
+
+    with temp_registered(typing.TypeVar, lambda thing: st.just(thing.__name__)):
+        assert_all_examples(st.from_type(A), lambda obj: obj == "A")
+
+
 def annotated_func(a: int, b: int = 2, *, c: int, d: int = 4):
     return a + b + c + d
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -300,6 +300,7 @@ def test_distinct_typevars_distinct_type():
     )
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="python3.5 is weird")
 @given(st.data())
 def test_same_typevars_same_type(data):
     """Ensures that single type argument will always have the same type in a single context."""

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -35,7 +35,13 @@ from tests.common.utils import fails_with, temp_registered
 
 sentinel = object()
 generics = sorted(
-    (t for t in types._global_type_lookup if isinstance(t, typing_root_type)), key=str
+    (
+        t
+        for t in types._global_type_lookup
+        # We ignore TypeVar, because it is not a Generic type:
+        if isinstance(t, typing_root_type) and t != typing.TypeVar
+    ),
+    key=str,
 )
 xfail_on_39 = () if sys.version_info[:2] < (3, 9) else pytest.mark.xfail
 


### PR DESCRIPTION
Closes #2572 

Things to review:
- [ ] new default strategies for `TypeVar`s
- [ ] my hacky approach to handle `TypeVar` in `core.py`, it is hacky because it is an explicit corner case
- [ ] testing, I have covered new registration process and all type-guarantees for a single context, what else?