### PR TITLE
Adds dry-python/returns to the list of open-source projects

### DIFF
--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -73,11 +73,9 @@ fail - by trying all kinds of inputs and reporting whatever happens.
 
 :pypi:`pytest-subtesthack` functions as a workaround for :issue:`377`.
 
-:pypi:`returns` uses Hypothesis as an addition to Higher Kinded Types 
-to proove functor, applicative, monad, and other laws. 
-The interesting part of it is that laws themself are represented as values.
-This approach combines fully declarative approach 
-with very high level of correctness and traditional pythonic code.
+:pypi:`returns` uses Hypothesis to verify that Higher Kinded Types correctly
+implement functor, applicative, monad, and other laws; allowing a declarative
+approach to be combined with traditional pythonic code.
 
 
 --------------------

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -73,6 +73,12 @@ fail - by trying all kinds of inputs and reporting whatever happens.
 
 :pypi:`pytest-subtesthack` functions as a workaround for :issue:`377`.
 
+:pypi:`returns` uses Hypothesis as an addition to Higher Kinded Types 
+to proove functor, applicative, monad, and other laws. 
+The interesting part of it is that laws themself are represented as values.
+This approach combines fully declarative approach 
+with very high level of correctness and traditional pythonic code.
+
 
 --------------------
 Writing an Extension

--- a/hypothesis-python/docs/usage.rst
+++ b/hypothesis-python/docs/usage.rst
@@ -25,6 +25,7 @@ and was used by `more than 4% of Python users surveyed by the PSF in 2018
 * `cmph-cffi <https://github.com/URXtech/cmph-cffi>`_
 * `cryptography <https://github.com/pyca/cryptography>`_
 * `dbus-signature-pyparsing <https://github.com/stratis-storage/dbus-signature-pyparsing>`_
+* `dry-python/returns <https://github.com/dry-python/returns>`_
 * `fastnumbers <https://github.com/SethMMorton/fastnumbers>`_
 * `flocker <https://github.com/ClusterHQ/flocker>`_
 * `flownetpy <https://github.com/debsankha/flownetpy>`_


### PR DESCRIPTION
Since https://github.com/dry-python/returns/pull/543 is merged, it is now official! 