### PR TITLE
Fix/use signature type hints

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -276,6 +276,7 @@ their individual contributions.
 * `Pierre-Jean Campigotto <https://github.com/PJCampi>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
+* `Rónán Carrigan <https://www.github.com/rcarriga`_ (rcarriga@tcd.ie)
 * `Ryan Soklaski <https://www.github.com/rsokl>`_ (rsoklaski@gmail.com)
 * `Ryan Turner <https://github.com/rdturnermtl>`_ (ryan.turner@uber.com)
 * `Sam Bishop (TechDragon) <https://github.com/techdragon>`_ (sam@techdragon.io)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -276,7 +276,7 @@ their individual contributions.
 * `Pierre-Jean Campigotto <https://github.com/PJCampi>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
-* `Rónán Carrigan <https://www.github.com/rcarriga`_ (rcarriga@tcd.ie)
+* `Rónán Carrigan <https://www.github.com/rcarriga>`_ (rcarriga@tcd.ie)
 * `Ryan Soklaski <https://www.github.com/rsokl>`_ (rsoklaski@gmail.com)
 * `Ryan Turner <https://github.com/rdturnermtl>`_ (ryan.turner@uber.com)
 * `Sam Bishop (TechDragon) <https://github.com/techdragon>`_ (sam@techdragon.io)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.builds` will use the `__signature__` attribute of
+the target, if it exists, to retrieve type hints.
+Previously :func:`python:typing.get_type_hints`, was used by default.
+If argument names varied between the `__annotations__` and `__signature__`,
+they would not be supplied to the target.
+
+This was particularily an issue in the case of a `pydantic` model which uses an alias generator.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -140,10 +140,11 @@ else:
             if inspect.isclass(thing) and hasattr(thing, "__signature__"):
                 # It is possible for the signature and annotations attributes to
                 # differ on an object due to renamed arguments.
-                # To prevent missing arguments we use the signature to provide any type hints it has
-                # and then override any common names with the more comprehensive type hint
-                # from get_type_hints
-                # See https://github.com/HypothesisWorks/hypothesis/pull/2580 for more details.
+                # To prevent missing arguments we use the signature to provide any type
+                # hints it has and then override any common names with the more
+                # comprehensive type information from get_type_hints
+                # See https://github.com/HypothesisWorks/hypothesis/pull/2580
+                # for more details.
                 spec = inspect.getfullargspec(thing)
                 hints = {
                     k: v

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -136,7 +136,15 @@ else:
         NameError for unresolvable forward references, just return an empty dict.
         """
         try:
-            hints = typing.get_type_hints(thing)
+            if inspect.isclass(thing) and hasattr(thing, "__signature__"):
+                spec = inspect.getfullargspec(thing)
+                hints = {
+                    k: v
+                    for k, v in spec.annotations.items()
+                    if k in (spec.args + spec.kwonlyargs) and isinstance(v, type)
+                }
+            else:
+                hints = typing.get_type_hints(thing)
         except (TypeError, NameError):
             hints = {}
         if hints or not inspect.isclass(thing):

--- a/hypothesis-python/tests/nocover/test_build_signature.py
+++ b/hypothesis-python/tests/nocover/test_build_signature.py
@@ -45,3 +45,30 @@ def test_builds_uses_signature_attribute(val):
 @given(st.from_type(Model))
 def test_from_type_uses_signature_attribute(val):
     assert isinstance(val, Model)
+
+
+def use_annotations(
+    self, test_a: int, test_b: str = None, *, test_x: float, test_y: str
+):
+    pass
+
+
+def use_signature(self, testA: int, testB: str = None, *, testX: float, testY: str):
+    pass
+
+
+class ModelWithAlias:
+    __annotations__ = get_type_hints(use_annotations)
+    __signature__ = signature(use_signature)
+
+    def __init__(self, **kwargs):
+        # Check that we're being called with the expected arguments
+        assert set(kwargs) == {"testA", "testX", "testY"}
+        assert isinstance(kwargs["testA"], int)
+        assert isinstance(kwargs["testX"], float)
+        assert isinstance(kwargs["testY"], str)
+
+
+@given(st.builds(ModelWithAlias))
+def test_build_using_different_signature_and_annotations(val):
+    assert isinstance(val, ModelWithAlias)


### PR DESCRIPTION
When the target of `builds` defines a `__signature__`, the `builds` function uses it alongside the hints from `typing.get_type_hints`. Normally this is OK but, in the case of Pydantic, a model can define aliases for attributes which are then used in the `__signature__` but not in the `__annotations__` which is used by `typing`. This results in the intersection of the `required` and `hints` variables within `builds` being empty and so no arguments being passed.

This change will use the `__signature__` if it exists by default and then fallback to the `typing` module. The code is taken from directly above in the `get_type_hints` version for Python 3.5. Of course this means there is a small amount of duplication. Happy to extract this to a separate function but wasn't sure which one would suit the Hypothesis code style the best.