### PR TITLE
Add logo to HTML documentation

### DIFF
--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -104,6 +104,8 @@ htmlhelp_basename = "Hypothesisdoc"
 
 html_favicon = "../../brand/favicon.ico"
 
+html_logo = "../../brand/dragonfly-rainbow.svg"
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {}


### PR DESCRIPTION
Places the SVG-version of the logo in the top left of the documentation menu.