### PR TITLE
Make all sections use consistent case style.

### DIFF
--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -14,7 +14,7 @@ features, such as how they simplify, but the data they can generate is the only
 public part of their API.
 
 ~~~~~~~~~~~~~~~
-Core Strategies
+Core strategies
 ~~~~~~~~~~~~~~~
 
 Functions for building strategies are all available in the hypothesis.strategies
@@ -25,7 +25,7 @@ module. The salient functions from it are as follows:
   :exclude-members: SearchStrategy
 
 ~~~~~~~~~~~~~~~~~~~~~~
-Provisional Strategies
+Provisional strategies
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: hypothesis.provisional

--- a/hypothesis-python/docs/database.rst
+++ b/hypothesis-python/docs/database.rst
@@ -1,5 +1,5 @@
 ===============================
-The Hypothesis Example Database
+The Hypothesis example database
 ===============================
 
 When Hypothesis finds a bug it stores enough information in its database to reproduce it. This

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -49,7 +49,7 @@ additional information you might need in your test.
 .. _statistics:
 
 ---------------
-Test Statistics
+Test statistics
 ---------------
 
 If you are using :pypi:`pytest` you can see a number of statistics about the executed tests
@@ -545,7 +545,7 @@ random number generators for you, and you can register others:
 .. _type-inference:
 
 -------------------
-Inferred Strategies
+Inferred strategies
 -------------------
 
 In some cases, Hypothesis can work out what to do when you omit arguments.
@@ -606,7 +606,7 @@ updating to a newer version of Python as a workaround.
 .. _our-type-hints:
 
 ------------------------------
-Type Annotations in Hypothesis
+Type annotations in Hypothesis
 ------------------------------
 
 If you install Hypothesis and use :pypi:`mypy` 0.590+, or another
@@ -668,7 +668,7 @@ it creates.  For example:
 .. _pytest-plugin:
 
 ----------------------------
-The Hypothesis pytest Plugin
+The Hypothesis pytest plugin
 ----------------------------
 
 Hypothesis includes a tiny plugin to improve integration with :pypi:`pytest`,

--- a/hypothesis-python/docs/development.rst
+++ b/hypothesis-python/docs/development.rst
@@ -1,5 +1,5 @@
 ==============================
-Ongoing Hypothesis Development
+Ongoing Hypothesis development
 ==============================
 
 Hypothesis development is managed by me, `David R. MacIver <https://www.drmaciver.com>`_.
@@ -23,7 +23,7 @@ details and :pull:`154` for an example of how the process goes). This isn't
 
 .. _release-policy:
 
-Release Policy
+Release policy
 ==============
 
 Hypothesis releases follow `semantic versioning <https://semver.org/>`_.
@@ -39,7 +39,7 @@ published on PyPI as soon as it's merged onto master, after code review and
 passing our extensive test suite.
 
 
-Project Roadmap
+Project roadmap
 ===============
 
 Hypothesis does not have a long-term release plan.  We respond to bug reports

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -236,7 +236,7 @@ Hypothesis, and how the :func:`~hypothesis.strategies.datetimes` strategy works.
     >>> test_adding_a_day_commutes()
 
 -------------------
-Condorcet's Paradox
+Condorcet's paradox
 -------------------
 
 A classic paradox in voting theory, called Condorcet's paradox, is that

--- a/hypothesis-python/docs/manifesto.rst
+++ b/hypothesis-python/docs/manifesto.rst
@@ -1,5 +1,5 @@
 =========================
-The Purpose of Hypothesis
+The purpose of Hypothesis
 =========================
 
 What is Hypothesis for?

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -1,5 +1,5 @@
 ===================================
-Hypothesis for the Scientific Stack
+Hypothesis for the scientific stack
 ===================================
 
 .. _hypothesis-numpy:
@@ -41,7 +41,7 @@ a strategy for generating elements for it).
    :members:
 
 ~~~~~~~~~~~~~~~~~~
-Supported Versions
+Supported versions
 ~~~~~~~~~~~~~~~~~~
 
 There is quite a lot of variation between pandas versions. We only

--- a/hypothesis-python/docs/packaging.rst
+++ b/hypothesis-python/docs/packaging.rst
@@ -1,5 +1,5 @@
 ====================
-Packaging Guidelines
+Packaging guidelines
 ====================
 
 Downstream packagers often want to package Hypothesis. Here are some guidelines.

--- a/hypothesis-python/docs/reproducing.rst
+++ b/hypothesis-python/docs/reproducing.rst
@@ -1,5 +1,5 @@
 ====================
-Reproducing Failures
+Reproducing failures
 ====================
 
 One of the things that is often concerning for people using randomized testing

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -49,7 +49,7 @@ Available settings
 .. _phases:
 
 ~~~~~~~~~~~~~~~~~~~~~
-Controlling What Runs
+Controlling what runs
 ~~~~~~~~~~~~~~~~~~~~~
 
 Hypothesis divides tests into four logically distinct phases:
@@ -167,7 +167,7 @@ You can change the defaults by using profiles.
 .. _settings_profiles:
 
 ~~~~~~~~~~~~~~~~~
-settings Profiles
+Settings profiles
 ~~~~~~~~~~~~~~~~~
 
 Depending on your environment you may want different default settings.

--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -45,7 +45,7 @@ though, where a higher level API comes into it's own, keep reading!
 .. _rulebasedstateful:
 
 -------------------------
-Rule based state machines
+Rule-based state machines
 -------------------------
 
 .. autoclass:: hypothesis.stateful.RuleBasedStateMachine

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -15,7 +15,7 @@ If there's something missing which you think should be here, let us know!
     maintainers endorse a package.
 
 -------------------
-External Strategies
+External strategies
 -------------------
 
 Some packages provide strategies directly:
@@ -44,7 +44,7 @@ Others provide a function to infer a strategy from some other schema:
 
 
 -----------------
-Other Cool Things
+Other cool things
 -----------------
 
 :pypi:`schemathesis` is a tool for testing web applications built with `Open API / Swagger specifications <https://swagger.io/>`_.
@@ -79,7 +79,7 @@ approach to be combined with traditional pythonic code.
 
 
 --------------------
-Writing an Extension
+Writing an extension
 --------------------
 
 *See* :gh-file:`CONTRIBUTING.rst` *for more information.*

--- a/hypothesis-python/docs/support.rst
+++ b/hypothesis-python/docs/support.rst
@@ -1,5 +1,5 @@
 ================
-Help and Support
+Help and support
 ================
 
 For questions you are happy to ask in public, the :doc:`Hypothesis community <community>` is a

--- a/hypothesis-python/docs/supported.rst
+++ b/hypothesis-python/docs/supported.rst
@@ -87,7 +87,7 @@ In terms of what's actually *known* to work:
     100% branch coverage.
 
 -----------------
-Optional Packages
+Optional packages
 -----------------
 
 The supported versions of optional packages, for strategies in ``hypothesis.extra``,

--- a/hypothesis-python/docs/usage.rst
+++ b/hypothesis-python/docs/usage.rst
@@ -1,5 +1,5 @@
 =====================================
-Open Source Projects using Hypothesis
+Open source projects using Hypothesis
 =====================================
 
 The following is a non-exhaustive list of open source projects I know are


### PR DESCRIPTION
A majority of section headings in the Python documentation used "Sentence Case" i.e. capitalise the first word, proper nouns and initials.

A minority used Title Case (i.e. capitalise all major words).

This edit made them all conform to the former style, which makes the Table of Contents look much neater.