### PR TITLE
Tidy defines_strategy decorators (#2516)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,6 +41,7 @@ their individual contributions.
 * `El Awbery <https://www.github.com/ElAwbery>`_
 * `Emmanuel Leblond <https://www.github.com/touilleMan>`_
 * `Felix Grünewald <https://www.github.com/fgruen>`_
+* `Felix Sheldon <https://www.github.com/darkpaw>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch contains some internal refactoring.
+Thanks to Felix Sheldon for fixing :issue:`2516`!

--- a/hypothesis-python/src/hypothesis/extra/dateutil.py
+++ b/hypothesis-python/src/hypothesis/extra/dateutil.py
@@ -44,7 +44,7 @@ def __zone_sort_key(zone):
 
 
 @st.cacheable
-@st.defines_strategy
+@st.defines_strategy()
 def timezones() -> st.SearchStrategy[dt.tzinfo]:
     """Any timezone from :pypi:`dateutil <python-dateutil>`.
 

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -54,7 +54,7 @@ class TransactionTestCase(HypothesisTestCase, dt.TransactionTestCase):
     pass
 
 
-@st.defines_strategy
+@st.defines_strategy()
 def from_model(
     *model: Type[dm.Model], **field_strategies: Union[st.SearchStrategy, InferType]
 ) -> st.SearchStrategy:
@@ -146,7 +146,7 @@ def _models_impl(draw, strat):
         reject()
 
 
-@st.defines_strategy
+@st.defines_strategy()
 def from_form(
     form: Type[df.Form],
     form_kwargs: dict = None,

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -193,7 +193,7 @@ def check_explicit(name):
 
 
 @st.cacheable
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def from_lark(
     grammar: lark.lark.Lark,

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -40,7 +40,7 @@ BroadcastableShapes = NamedTuple(
 TIME_RESOLUTIONS = tuple("Y  M  D  h  m  s  ms  us  ns  ps  fs  as".split())
 
 
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 def from_dtype(dtype: np.dtype) -> st.SearchStrategy[Any]:
     """Creates a strategy which can generate any value of the given dtype."""
     check_type(np.dtype, dtype, "dtype")
@@ -297,7 +297,7 @@ def fill_for(elements, unique, fill, name=""):
     return fill
 
 
-@st.defines_strategy
+@st.defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def arrays(
     dtype: Any,
@@ -416,7 +416,7 @@ def arrays(
     return ArrayStrategy(elements, shape, dtype, fill, unique)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def array_shapes(
     *, min_dims: int = 1, max_dims: int = None, min_side: int = 1, max_side: int = None
@@ -448,7 +448,7 @@ def array_shapes(
     ).map(tuple)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 def scalar_dtypes() -> st.SearchStrategy[np.dtype]:
     """Return a strategy that can return any non-flexible scalar dtype."""
     return st.one_of(
@@ -463,7 +463,7 @@ def scalar_dtypes() -> st.SearchStrategy[np.dtype]:
 
 
 def defines_dtype_strategy(strat: T) -> T:
-    @st.defines_strategy
+    @st.defines_strategy()
     @proxies(strat)
     def inner(*args, **kwargs):
         return strat(*args, **kwargs).map(np.dtype)
@@ -703,7 +703,7 @@ def array_dtypes(
     ).filter(_no_title_is_name_of_a_titled_field)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def nested_dtypes(
     subtype_strategy: st.SearchStrategy[np.dtype] = scalar_dtypes(),
@@ -726,7 +726,7 @@ def nested_dtypes(
     ).filter(lambda d: max_itemsize is None or d.itemsize <= max_itemsize)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def valid_tuple_axes(
     ndim: int, *, min_size: int = 0, max_size: int = None
@@ -775,7 +775,7 @@ def valid_tuple_axes(
     ).map(tuple)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def broadcastable_shapes(
     shape: Shape,
@@ -1095,7 +1095,7 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
     return _GUfuncSig(input_shapes=input_shapes, result_shape=result_shape)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 def mutually_broadcastable_shapes(
     *,
     num_shapes: Union[UniqueIdentifier, int] = not_set,
@@ -1321,7 +1321,7 @@ class BasicIndexStrategy(SearchStrategy):
         return tuple(result)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 def basic_indices(
     shape: Shape,
     *,
@@ -1386,7 +1386,7 @@ def basic_indices(
     )
 
 
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def integer_array_indices(
     shape: Shape,

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -152,7 +152,7 @@ DEFAULT_MAX_SIZE = 10
 
 
 @st.cacheable
-@st.defines_strategy
+@st.defines_strategy()
 def range_indexes(
     min_size: int = 0, max_size: int = None
 ) -> st.SearchStrategy[pandas.RangeIndex]:
@@ -174,7 +174,7 @@ def range_indexes(
 
 
 @st.cacheable
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def indexes(
     *,
@@ -215,7 +215,7 @@ def indexes(
     return ValueIndexStrategy(elements, dtype, min_size, max_size, unique)
 
 
-@st.defines_strategy
+@st.defines_strategy()
 @deprecated_posargs
 def series(
     *,
@@ -361,7 +361,7 @@ def columns(
 
 
 @deprecated_posargs
-@st.defines_strategy
+@st.defines_strategy()
 def data_frames(
     columns: Sequence[column] = None,
     *,

--- a/hypothesis-python/src/hypothesis/extra/pytz.py
+++ b/hypothesis-python/src/hypothesis/extra/pytz.py
@@ -36,7 +36,7 @@ __all__ = ["timezones"]
 
 
 @st.cacheable
-@st.defines_strategy
+@st.defines_strategy()
 def timezones() -> st.SearchStrategy[dt.tzinfo]:
     """Any timezone in the Olsen database, as a pytz tzinfo object.
 

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -134,7 +134,7 @@ class DomainNameStrategy(SearchStrategy):
         return domain
 
 
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def domains(
     *, max_length: int = 255, max_element_length: int = 63
@@ -145,7 +145,7 @@ def domains(
     )
 
 
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 def urls() -> SearchStrategy[str]:
     """A strategy for :rfc:`3986`, generating http/https URLs."""
 
@@ -161,7 +161,7 @@ def urls() -> SearchStrategy[str]:
     )
 
 
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 def ip4_addr_strings() -> SearchStrategy[str]:
     note_deprecation(
         "Use `ip_addresses(v=4).map(str)` instead of `ip4_addr_strings()`; "
@@ -171,7 +171,7 @@ def ip4_addr_strings() -> SearchStrategy[str]:
     return ip_addresses(v=4).map(str)
 
 
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 def ip6_addr_strings() -> SearchStrategy[str]:
     note_deprecation(
         "Use `ip_addresses(v=6).map(str)` instead of `ip6_addr_strings()`; "

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -21,7 +21,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal.core import (
-    defines_strategy_with_reusable_values,
+    defines_strategy,
     deprecated_posargs,
     just,
     none,
@@ -148,7 +148,7 @@ class DatetimeStrategy(SearchStrategy):
             data.mark_invalid()
 
 
-@defines_strategy_with_reusable_values
+@defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def datetimes(
     min_value: dt.datetime = dt.datetime.min,
@@ -218,7 +218,7 @@ class TimeStrategy(SearchStrategy):
         return dt.time(**result, tzinfo=tz)
 
 
-@defines_strategy_with_reusable_values
+@defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def times(
     min_value: dt.time = dt.time.min,
@@ -259,7 +259,7 @@ class DateStrategy(SearchStrategy):
         )
 
 
-@defines_strategy_with_reusable_values
+@defines_strategy(force_reusable_values=True)
 def dates(
     min_value: dt.date = dt.date.min, max_value: dt.date = dt.date.max
 ) -> SearchStrategy[dt.date]:
@@ -299,7 +299,7 @@ class TimedeltaStrategy(SearchStrategy):
         return dt.timedelta(**result)
 
 
-@defines_strategy_with_reusable_values
+@defines_strategy(force_reusable_values=True)
 def timedeltas(
     min_value: dt.timedelta = dt.timedelta.min,
     max_value: dt.timedelta = dt.timedelta.max,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -21,7 +21,7 @@ from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal.core import (
     SearchStrategy,
     binary,
-    defines_strategy_with_reusable_values,
+    defines_strategy,
     integers,
     sampled_from,
 )
@@ -78,7 +78,7 @@ SPECIAL_IPv6_RANGES = (
 )
 
 
-@defines_strategy_with_reusable_values
+@defines_strategy(force_reusable_values=True)
 def ip_addresses(
     *, v: int = None, network: Union[str, IPv4Network, IPv6Network] = None
 ) -> SearchStrategy[Union[IPv4Address, IPv6Address]]:

--- a/hypothesis-python/tests/nocover/test_deferred_errors.py
+++ b/hypothesis-python/tests/nocover/test_deferred_errors.py
@@ -59,7 +59,7 @@ def test_errors_on_example():
 def test_does_not_recalculate_the_strategy():
     calls = [0]
 
-    @defines_strategy
+    @defines_strategy()
     def foo():
         calls[0] += 1
         return st.just(1)


### PR DESCRIPTION
Tidied up internal defines_strategy decorators code. Fixes #2516.

The `defines_strategy` decorator now has optional named parameters instead of using a set of decorators with
different options "preset".

`base_defines_strategy` was renamed to `defines_strategy`, which means the decorator is used as `@defines_strategy()`.

Possibly leaving one "overload" in place, `defines_strategy = base_defines_strategy()`, would have allowed the decorator to be `@defines_strategy` but the thinking there is that explicitly indicating that the optional parameters are not wanted is a good thing.

