### PR TITLE
Framework to migrate CI/CD pipelines to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,17 +16,17 @@ jobs:
           - check-coverage
           - check-conjecture-coverage
           - check-py36
+          - check-quality
         python-version: ["3.6"]
         include:
+          - task: check-py35
+            python-version: "3.5"
           - task: check-py37
             python-version: "3.7"
           - task: check-py38
             python-version: "3.8"
           - task: check-py39
             python-version: "3.9-dev"
-          # - task: check-py310
-          #   python-version: "3.10-dev"
-          #   continue-on-error: true
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -36,3 +36,76 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh
+#   test-win:
+#     runs-on: windows-latest
+#     strategy:
+#       matrix:
+#         task:
+#           - check-whole-repo-tests
+#           - lint
+#           - check-format
+#           - check-coverage
+#           - check-conjecture-coverage
+#           - check-py36
+#           - check-quality
+#         python-version: ["3.6"]
+#         include:
+#           - task: check-py35
+#             python-version: "3.5"
+#           - task: check-py37
+#             python-version: "3.7"
+#           - task: check-py38
+#             python-version: "3.8"
+#           - task: check-py39
+#             python-version: "3.9-dev"
+#       fail-fast: false
+#     steps:
+#     - uses: actions/checkout@v2
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Run tests
+#       run: TASK=${{ matrix.task }} ./build.sh
+  test-osx:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        task:
+          - check-py36
+        python-version: ["3.6"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh
+  specific-deps:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+          - check-nose
+          - check-pytest43
+          - check-django30
+          - check-django22
+          - check-pandas19
+          - check-pandas22
+          - check-pandas23
+          - check-pandas24
+          - check-pandas25
+          - check-pandas100
+        python-version: ["3.6"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh
+      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Hypothesis CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+          - check-whole-repo-tests
+          - lint
+          - check-format
+          - check-coverage
+          - check-conjecture-coverage
+          - check-py36
+        python-version: ["3.6"]
+        include:
+          - task: check-py37
+            python-version: "3.7"
+          - task: check-py38
+            python-version: "3.8"
+          - task: check-py39
+            python-version: "3.9-dev"
+          # - task: check-py310
+          #   python-version: "3.10-dev"
+          #   continue-on-error: true
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,25 +38,29 @@ jobs:
       run: TASK=${{ matrix.task }} ./build.sh
   test-win:
     runs-on: windows-latest
-#     strategy:
-#       matrix:
-#         include:
-#           - task: check-py36-x64
-#             python.version: '3.6'
-#             python.architecture: 'x64'
-#           - task: check-py36-x86
-#             python.version: '3.6'
-#             python.architecture: 'x86'
-#       fail-fast: false
+    strategy:
+      matrix:
+        include:
+          - task: check-py36-x64
+            python.version: '3.6'
+            python.architecture: 'x64'
+          - task: check-py36-x86
+            python.version: '3.6'
+            python.architecture: 'x86'
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#         architecture: ${{ matrix.python-architecture }}
-#     - name: Run tests
-#       run: TASK=${{ matrix.task }} cd hypothesis-python && pytest --numprocesses auto
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Install dependencies
+      run: pip install --upgrade setuptools pip wheel
+           pip install -r requirements/test.txt typing-extensions black
+           pip install hypothesis-python/[all]
+    - name: Run tests
+      run: cd hypothesis-python && pytest --numprocesses auto
   test-osx:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,11 +50,11 @@ jobs:
 #       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.python-architecture }}
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#         architecture: ${{ matrix.python-architecture }}
 #     - name: Run tests
 #       run: TASK=${{ matrix.task }} cd hypothesis-python && pytest --numprocesses auto
   test-osx:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
     - name: Run tests
-      run: TASK=${{ matrix.task }} ./build.sh
+      run: TASK=${{ matrix.task }} cd hypothesis-python && pytest --numprocesses auto
   test-osx:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,16 +38,16 @@ jobs:
       run: TASK=${{ matrix.task }} ./build.sh
   test-win:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        include:
-          - task: check-py36-x64
-            python.version: '3.6'
-            python.architecture: 'x64'
-          - task: check-py36-x86
-            python.version: '3.6'
-            python.architecture: 'x86'
-      fail-fast: false
+#     strategy:
+#       matrix:
+#         include:
+#           - task: check-py36-x64
+#             python.version: '3.6'
+#             python.architecture: 'x64'
+#           - task: check-py36-x86
+#             python.version: '3.6'
+#             python.architecture: 'x86'
+#       fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -55,8 +55,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
-    - name: Run tests
-      run: TASK=${{ matrix.task }} cd hypothesis-python && pytest --numprocesses auto
+#     - name: Run tests
+#       run: TASK=${{ matrix.task }} cd hypothesis-python && pytest --numprocesses auto
   test-osx:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,4 +98,20 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh
-      
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test, test-win, test-osx, specific-deps]
+    strategy:
+      matrix:
+        task:
+          - deploy
+        python-version: ["3.6"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Deploy package
+      run: TASK=${{ matrix.task }} ./build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,37 +36,27 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh
-#   test-win:
-#     runs-on: windows-latest
-#     strategy:
-#       matrix:
-#         task:
-#           - check-whole-repo-tests
-#           - lint
-#           - check-format
-#           - check-coverage
-#           - check-conjecture-coverage
-#           - check-py36
-#           - check-quality
-#         python-version: ["3.6"]
-#         include:
-#           - task: check-py35
-#             python-version: "3.5"
-#           - task: check-py37
-#             python-version: "3.7"
-#           - task: check-py38
-#             python-version: "3.8"
-#           - task: check-py39
-#             python-version: "3.9-dev"
-#       fail-fast: false
-#     steps:
-#     - uses: actions/checkout@v2
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Run tests
-#       run: TASK=${{ matrix.task }} ./build.sh
+  test-win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - task: check-py36-x64
+            python.version: '3.6'
+            python.architecture: 'x64'
+          - task: check-py36-x86
+            python.version: '3.6'
+            python.architecture: 'x86'
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh
   test-osx:
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
This pull request migrates the Linux and macOS tests from Azure Pipelines to Github Actions, as well as the deploy steps from Travis CI.  It also adds a shell task for migrating the Windows tests.