### PR TITLE
Reuse up to `max_examples` from database when `Phase.generate` is disabled

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,6 +10,7 @@ their individual contributions.
 
 * `Adam Johnson <https://github.com/adamchainz>`_
 * `Adam Sven Johnson <https://www.github.com/pkqk>`_
+* `Afrida Tabassum <https://github.com/oxfordhalfblood>`_ (afrida@gmail.com)
 * `Akash Suresh <https://www.github.com/akash-suresh>`_ (akashsuresh36@gmail.com)
 * `Alex Gaynor <https://github.com/alex>`_
 * `Alex Stapleton <https://www.github.com/public>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch ensures that, when the ``generate`` :obj:`~hypothesis.settings.phases`
+is disabled, we can replay up to :obj:`~hypothesis.settings.max_examples` examples
+from the database - which is very useful when
+:ref:`using Hypothesis with a fuzzer <fuzz_one_input>`.
+
+Thanks to Afrida Tabassum for fixing :issue:`2585`!

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -541,7 +541,8 @@ class ConjectureRunner:
             corpus = sorted(
                 self.settings.database.fetch(self.database_key), key=sort_key
             )
-            desired_size = max(2, ceil(0.1 * self.settings.max_examples))
+            factor = 0.1 if (Phase.generate in self.settings.phases) else 1
+            desired_size = max(2, ceil(factor * self.settings.max_examples))
 
             if len(corpus) < desired_size:
                 extra_corpus = list(self.settings.database.fetch(self.secondary_key))

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -311,6 +311,25 @@ def test_phases_can_disable_shrinking():
     assert len(seen) == MIN_TEST_CALLS
 
 
+def test_reuse_phase_runs_for_max_examples_if_generation_is_disabled():
+    with deterministic_PRNG():
+        db = InMemoryExampleDatabase()
+        for i in range(256):
+            db.save(b"key", bytes([i]))
+        seen = set()
+
+        def test(data):
+            seen.add(data.draw_bits(8))
+
+        ConjectureRunner(
+            test,
+            settings=settings(max_examples=100, database=db, phases=[Phase.reuse]),
+            database_key=b"key",
+        ).run()
+
+        assert len(seen) == 100
+
+
 def test_erratic_draws():
     n = [0]
 

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -13,11 +13,13 @@
 #
 # END HEADER
 
+import pytest
+
 from hypothesis import HealthCheck, Phase, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture.data import Status
-from hypothesis.internal.conjecture.engine import ConjectureRunner
+from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
 
 
@@ -133,9 +135,10 @@ def test_down_samples_the_pareto_front():
         for i in range(10000):
             db.save(runner.pareto_key, int_to_bytes(i, 2))
 
-        runner.reuse_existing_examples()
+        with pytest.raises(RunIsComplete):
+            runner.reuse_existing_examples()
 
-        assert 0 < runner.valid_examples <= 100
+        assert runner.valid_examples == 1000
 
 
 def test_stops_loading_pareto_front_if_interesting():


### PR DESCRIPTION
Fixes #2585.