### PR TITLE
Set no_implicit_optional to True for mypy and align typehints

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,6 +70,7 @@ their individual contributions.
 * `Katrina Durance <https://github.com/kdurance>`_
 * `kbara <https://www.github.com/kbara>`_
 * `Kristian Glass <https://www.github.com/doismellburning>`_
+* `Krzysztof Przybyła <https://github.com/kprzybyla>`_
 * `Kyle Reeve <https://www.github.com/kreeve>`_ (krzw92@gmail.com)
 * `Lampros Mountrakis <https://www.github.com/lmount>`_
 * `Lea Provenzano <https://github.com/leaprovenzano>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch adds explicit :class:`~python:typing.Optional` annotations to our public API,
+to better support users who run :pypi:`mypy` with ``--strict`` or ``no_implicit_optional=True``.
+
+Thanks to Krzysztof Przybyła for bringing this to our attention and writing the patch!

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -75,13 +75,14 @@ this strategy were views.
 5.31.0 - 2020-09-04
 -------------------
 
-:func:`~hypothesis.strategies.builds` will use the `__signature__` attribute of
+:func:`~hypothesis.strategies.builds` will use the ``__signature__`` attribute of
 the target, if it exists, to retrieve type hints.
 Previously :func:`python:typing.get_type_hints`, was used by default.
-If argument names varied between the `__annotations__` and `__signature__`,
+If argument names varied between the ``__annotations__`` and ``__signature__``,
 they would not be supplied to the target.
 
-This was particularily an issue in the case of a `pydantic` model which uses an alias generator.
+This was particularily an issue for :pypi:`pydantic` models which use an
+`alias generator <https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator>`__.
 
 .. _v5.30.1:
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -291,7 +291,9 @@ class settings(metaclass=settingsMeta):
         return ", ".join(sorted(bits, key=len))
 
     @staticmethod
-    def register_profile(name: str, parent: Optional["settings"] = None, **kwargs: Any) -> None:
+    def register_profile(
+        name: str, parent: Optional["settings"] = None, **kwargs: Any
+    ) -> None:
         """Registers a collection of values to be used as a settings profile.
 
         Settings profiles can be loaded by name - for example, you might

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -26,7 +26,7 @@ import os
 import threading
 import warnings
 from enum import Enum, IntEnum, unique
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import attr
 
@@ -140,7 +140,7 @@ class settings(metaclass=settingsMeta):
         else:
             raise AttributeError("settings has no attribute %s" % (name,))
 
-    def __init__(self, parent: "settings" = None, **kwargs: Any) -> None:
+    def __init__(self, parent: Optional["settings"] = None, **kwargs: Any) -> None:
         if parent is not None and not isinstance(parent, settings):
             raise InvalidArgument(
                 "Invalid argument: parent=%r is not a settings instance" % (parent,)
@@ -291,7 +291,7 @@ class settings(metaclass=settingsMeta):
         return ", ".join(sorted(bits, key=len))
 
     @staticmethod
-    def register_profile(name: str, parent: "settings" = None, **kwargs: Any) -> None:
+    def register_profile(name: str, parent: Optional["settings"] = None, **kwargs: Any) -> None:
         """Registers a collection of values to be used as a settings profile.
 
         Settings profiles can be loaded by name - for example, you might

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -292,7 +292,7 @@ class settings(metaclass=settingsMeta):
 
     @staticmethod
     def register_profile(
-        name: str, parent: Optional["settings"] = None, **kwargs: Any
+        name: str, parent: Optional["settings"] = None, **kwargs: Any,
     ) -> None:
         """Registers a collection of values to be used as a settings profile.
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1223,9 +1223,9 @@ def find(
     specifier: SearchStrategy[Ex],
     condition: Callable[[Any], bool],
     *,
-    settings: Settings = None,
-    random: Random = None,
-    database_key: bytes = None
+    settings: Optional[Settings] = None,
+    random: Optional[Random] = None,
+    database_key: Optional[bytes] = None
 ) -> Ex:
     """Returns the minimal example from the given strategy ``specifier`` that
     matches the predicate function ``condition``."""

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 from functools import partial
 from inspect import Parameter, signature
-from typing import Type, Union, Optional
+from typing import Optional, Type, Union
 
 from django import forms as df, test as dt
 from django.core.exceptions import ValidationError

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 from functools import partial
 from inspect import Parameter, signature
-from typing import Type, Union
+from typing import Type, Union, Optional
 
 from django import forms as df, test as dt
 from django.core.exceptions import ValidationError
@@ -149,7 +149,7 @@ def _models_impl(draw, strat):
 @st.defines_strategy()
 def from_form(
     form: Type[df.Form],
-    form_kwargs: dict = None,
+    form_kwargs: Optional[dict] = None,
     **field_strategies: Union[st.SearchStrategy, InferType]
 ) -> st.SearchStrategy[df.Form]:
     """Return a strategy for examples of ``form``.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -852,7 +852,7 @@ def _make_binop_body(
     parts = []
 
     def maker(
-        sub_property: str, args: str, body: str, right: Optional[str] = None
+        sub_property: str, args: str, body: str, right: Optional[str] = None,
     ) -> None:
         if right is not None:
             body = f"left={body}\nright={right}\n" + _assert_eq(style, "left", "right")

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -52,7 +52,7 @@ from collections import OrderedDict, defaultdict
 from itertools import permutations, zip_longest
 from string import ascii_lowercase
 from textwrap import dedent, indent
-from typing import Any, Callable, Dict, Mapping, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Mapping, Set, Tuple, Type, TypeVar, Union, Optional
 
 import black
 
@@ -336,7 +336,7 @@ def _make_test_body(
     test_body: str,
     except_: Tuple[Type[Exception], ...],
     style: str,
-    given_strategies: Mapping[str, Union[str, st.SearchStrategy]] = None,
+    given_strategies: Optional[Mapping[str, Union[str, st.SearchStrategy]]] = None,
 ) -> Tuple[Set[str], str]:
     # Get strategies for all the arguments to each function we're testing.
     with _with_any_registered():
@@ -763,7 +763,7 @@ def binary_operation(
     associative: bool = True,
     commutative: bool = True,
     identity: Union[X, InferType, None] = infer,
-    distributes_over: Callable[[X, X], X] = None,
+    distributes_over: Optional[Callable[[X, X], X]] = None,
     except_: Except = (),
     style: str = "pytest",
 ) -> str:
@@ -825,7 +825,7 @@ def _make_binop_body(
     associative: bool = True,
     commutative: bool = True,
     identity: Union[X, InferType, None] = infer,
-    distributes_over: Callable[[X, X], X] = None,
+    distributes_over: Optional[Callable[[X, X], X]] = None,
     except_: Tuple[Type[Exception], ...],
     style: str,
 ) -> Tuple[Set[str], str]:
@@ -840,7 +840,7 @@ def _make_binop_body(
     all_imports = set()
     parts = []
 
-    def maker(sub_property: str, args: str, body: str, right: str = None) -> None:
+    def maker(sub_property: str, args: str, body: str, right: Optional[str] = None) -> None:
         if right is not None:
             body = f"left={body}\nright={right}\n" + _assert_eq(style, "left", "right")
         imports, body = _make_test_body(

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -52,7 +52,18 @@ from collections import OrderedDict, defaultdict
 from itertools import permutations, zip_longest
 from string import ascii_lowercase
 from textwrap import dedent, indent
-from typing import Any, Callable, Dict, Mapping, Set, Tuple, Type, TypeVar, Union, Optional
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import black
 
@@ -840,7 +851,9 @@ def _make_binop_body(
     all_imports = set()
     parts = []
 
-    def maker(sub_property: str, args: str, body: str, right: Optional[str] = None) -> None:
+    def maker(
+        sub_property: str, args: str, body: str, right: Optional[str] = None
+    ) -> None:
         if right is not None:
             body = f"left={body}\nright={right}\n" + _assert_eq(style, "left", "right")
         imports, body = _make_test_body(

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -35,7 +35,7 @@ Lark, unless someone volunteers to either fund or do the maintainence.
 """
 
 from inspect import getfullargspec
-from typing import Dict
+from typing import Dict, Optional
 
 import attr
 import lark
@@ -198,8 +198,8 @@ def check_explicit(name):
 def from_lark(
     grammar: lark.lark.Lark,
     *,
-    start: str = None,
-    explicit: Dict[str, st.SearchStrategy[str]] = None
+    start: Optional[str] = None,
+    explicit: Optional[Dict[str, st.SearchStrategy[str]]] = None
 ) -> st.SearchStrategy[str]:
     """A strategy for strings accepted by the given context-free grammar.
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -733,7 +733,7 @@ def nested_dtypes(
 @st.defines_strategy()
 @deprecated_posargs
 def valid_tuple_axes(
-    ndim: int, *, min_size: int = 0, max_size: Optional[int] = None
+    ndim: int, *, min_size: int = 0, max_size: Optional[int] = None,
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -15,7 +15,7 @@
 
 import math
 import re
-from typing import Any, NamedTuple, Sequence, Tuple, Union, Optional
+from typing import Any, NamedTuple, Optional, Sequence, Tuple, Union
 
 import numpy as np
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -15,7 +15,7 @@
 
 import math
 import re
-from typing import Any, NamedTuple, Sequence, Tuple, Union
+from typing import Any, NamedTuple, Sequence, Tuple, Union, Optional
 
 import numpy as np
 
@@ -303,8 +303,8 @@ def arrays(
     dtype: Any,
     shape: Union[int, Shape, st.SearchStrategy[Shape]],
     *,
-    elements: st.SearchStrategy[Any] = None,
-    fill: st.SearchStrategy[Any] = None,
+    elements: Optional[st.SearchStrategy[Any]] = None,
+    fill: Optional[st.SearchStrategy[Any]] = None,
     unique: bool = False
 ) -> st.SearchStrategy[np.ndarray]:
     r"""Returns a strategy for generating :class:`numpy:numpy.ndarray`\ s.
@@ -419,7 +419,11 @@ def arrays(
 @st.defines_strategy()
 @deprecated_posargs
 def array_shapes(
-    *, min_dims: int = 1, max_dims: int = None, min_side: int = 1, max_side: int = None
+    *,
+    min_dims: int = 1,
+    max_dims: Optional[int] = None,
+    min_side: int = 1,
+    max_side: Optional[int] = None,
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for array shapes (tuples of int >= 1)."""
     check_type(int, min_dims, "min_dims")
@@ -709,7 +713,7 @@ def nested_dtypes(
     subtype_strategy: st.SearchStrategy[np.dtype] = scalar_dtypes(),
     *,
     max_leaves: int = 10,
-    max_itemsize: int = None
+    max_itemsize: Optional[int] = None
 ) -> st.SearchStrategy[np.dtype]:
     """Return the most-general dtype strategy.
 
@@ -729,7 +733,7 @@ def nested_dtypes(
 @st.defines_strategy()
 @deprecated_posargs
 def valid_tuple_axes(
-    ndim: int, *, min_size: int = 0, max_size: int = None
+    ndim: int, *, min_size: int = 0, max_size: Optional[int] = None
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.
@@ -781,9 +785,9 @@ def broadcastable_shapes(
     shape: Shape,
     *,
     min_dims: int = 0,
-    max_dims: int = None,
+    max_dims: Optional[int] = None,
     min_side: int = 1,
-    max_side: int = None
+    max_side: Optional[int] = None
 ) -> st.SearchStrategy[Shape]:
     """Return a strategy for generating shapes that are broadcast-compatible
     with the provided shape.
@@ -1102,9 +1106,9 @@ def mutually_broadcastable_shapes(
     signature: Union[UniqueIdentifier, str] = not_set,
     base_shape: Shape = (),
     min_dims: int = 0,
-    max_dims: int = None,
+    max_dims: Optional[int] = None,
     min_side: int = 1,
-    max_side: int = None
+    max_side: Optional[int] = None
 ) -> st.SearchStrategy[BroadcastableShapes]:
     """Return a strategy for generating a specified number of shapes, N, that are
     mutually-broadcastable with one another and with the provided "base-shape".
@@ -1326,7 +1330,7 @@ def basic_indices(
     shape: Shape,
     *,
     min_dims: int = 0,
-    max_dims: int = None,
+    max_dims: Optional[int] = None,
     allow_newaxis: bool = False,
     allow_ellipsis: bool = True
 ) -> st.SearchStrategy[BasicIndex]:

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -15,7 +15,7 @@
 
 from collections import OrderedDict, abc
 from copy import copy
-from typing import Any, List, Sequence, Set, Union
+from typing import Any, List, Sequence, Set, Union, Optional
 
 import attr
 import numpy as np
@@ -154,7 +154,7 @@ DEFAULT_MAX_SIZE = 10
 @st.cacheable
 @st.defines_strategy()
 def range_indexes(
-    min_size: int = 0, max_size: int = None
+    min_size: int = 0, max_size: Optional[int] = None
 ) -> st.SearchStrategy[pandas.RangeIndex]:
     """Provides a strategy which generates an :class:`~pandas.Index` whose
     values are 0, 1, ..., n for some n.
@@ -178,10 +178,10 @@ def range_indexes(
 @deprecated_posargs
 def indexes(
     *,
-    elements: st.SearchStrategy[Ex] = None,
+    elements: Optional[st.SearchStrategy[Ex]] = None,
     dtype: Any = None,
     min_size: int = 0,
-    max_size: int = None,
+    max_size: Optional[int] = None,
     unique: bool = True
 ) -> st.SearchStrategy[pandas.Index]:
     """Provides a strategy for producing a :class:`pandas.Index`.
@@ -219,10 +219,10 @@ def indexes(
 @deprecated_posargs
 def series(
     *,
-    elements: st.SearchStrategy[Ex] = None,
+    elements: Optional[st.SearchStrategy[Ex]] = None,
     dtype: Any = None,
-    index: st.SearchStrategy[Union[Sequence, pandas.Index]] = None,
-    fill: st.SearchStrategy[Ex] = None,
+    index: Optional[st.SearchStrategy[Union[Sequence, pandas.Index]]] = None,
+    fill: Optional[st.SearchStrategy[Ex]] = None,
     unique: bool = False
 ) -> st.SearchStrategy[pandas.Series]:
     """Provides a strategy for producing a :class:`pandas.Series`.
@@ -337,8 +337,8 @@ def columns(
     names_or_number: Union[int, Sequence[str]],
     *,
     dtype: Any = None,
-    elements: st.SearchStrategy[Ex] = None,
-    fill: st.SearchStrategy[Ex] = None,
+    elements: Optional[st.SearchStrategy[Ex]] = None,
+    fill: Optional[st.SearchStrategy[Ex]] = None,
     unique: bool = False
 ) -> List[column]:
     """A convenience function for producing a list of :class:`column` objects
@@ -363,10 +363,10 @@ def columns(
 @deprecated_posargs
 @st.defines_strategy()
 def data_frames(
-    columns: Sequence[column] = None,
+    columns: Optional[Sequence[column]] = None,
     *,
-    rows: st.SearchStrategy[Union[dict, Sequence[Any]]] = None,
-    index: st.SearchStrategy[Ex] = None
+    rows: Optional[st.SearchStrategy[Union[dict, Sequence[Any]]]] = None,
+    index: Optional[st.SearchStrategy[Ex]] = None
 ) -> st.SearchStrategy[pandas.DataFrame]:
     """Provides a strategy for producing a :class:`pandas.DataFrame`.
 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -15,7 +15,7 @@
 
 from collections import OrderedDict, abc
 from copy import copy
-from typing import Any, List, Sequence, Set, Union, Optional
+from typing import Any, List, Optional, Sequence, Set, Union
 
 import attr
 import numpy as np

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -154,7 +154,7 @@ DEFAULT_MAX_SIZE = 10
 @st.cacheable
 @st.defines_strategy()
 def range_indexes(
-    min_size: int = 0, max_size: Optional[int] = None
+    min_size: int = 0, max_size: Optional[int] = None,
 ) -> st.SearchStrategy[pandas.RangeIndex]:
     """Provides a strategy which generates an :class:`~pandas.Index` whose
     values are 0, 1, ..., n for some n.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1137,7 +1137,9 @@ def from_regex(
 @cacheable
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
-def binary(*, min_size: int = 0, max_size: Optional[int] = None) -> SearchStrategy[bytes]:
+def binary(
+    *, min_size: int = 0, max_size: Optional[int] = None
+) -> SearchStrategy[bytes]:
     """Generates :class:`python:bytes`.
 
     The generated :class:`python:bytes` will have a length of at least ``min_size``
@@ -1909,7 +1911,9 @@ def complex_numbers(
 
 
 @deprecated_posargs
-def shared(base: SearchStrategy[Ex], *, key: Optional[Hashable] = None) -> SearchStrategy[Ex]:
+def shared(
+    base: SearchStrategy[Ex], *, key: Optional[Hashable] = None
+) -> SearchStrategy[Ex]:
     """Returns a strategy that draws a single shared value per run, drawn from
     base. Any two shared instances with the same key will share the same value,
     otherwise the identity of this strategy will be used. That is:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -344,7 +344,9 @@ def one_of(*args):  # noqa: F811
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-def integers(min_value: int = None, max_value: int = None) -> SearchStrategy[int]:
+def integers(
+    min_value: Optional[int] = None, max_value: Optional[int] = None
+) -> SearchStrategy[int]:
     """Returns a strategy which generates integers.
 
     If min_value is not None then all values will be >= min_value. If
@@ -414,11 +416,11 @@ def booleans() -> SearchStrategy[bool]:
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def floats(
-    min_value: Real = None,
-    max_value: Real = None,
+    min_value: Optional[Real] = None,
+    max_value: Optional[Real] = None,
     *,
-    allow_nan: bool = None,
-    allow_infinity: bool = None,
+    allow_nan: Optional[bool] = None,
+    allow_infinity: Optional[bool] = None,
     width: int = 64,
     exclude_min: bool = False,
     exclude_max: bool = False
@@ -693,8 +695,8 @@ def lists(
     elements: SearchStrategy[Ex],
     *,
     min_size: int = 0,
-    max_size: int = None,
-    unique_by: UniqueBy = None,
+    max_size: Optional[int] = None,
+    unique_by: Optional[UniqueBy] = None,
     unique: bool = False
 ) -> SearchStrategy[List[Ex]]:
     """Returns a list containing values drawn from elements with length in the
@@ -781,7 +783,7 @@ def lists(
 @defines_strategy()
 @deprecated_posargs
 def sets(
-    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: int = None
+    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: Optional[int] = None
 ) -> SearchStrategy[Set[Ex]]:
     """This has the same behaviour as lists, but returns sets instead.
 
@@ -801,7 +803,7 @@ def sets(
 @defines_strategy()
 @deprecated_posargs
 def frozensets(
-    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: int = None
+    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: Optional[int] = None
 ) -> SearchStrategy[FrozenSet[Ex]]:
     """This is identical to the sets function but instead returns
     frozensets."""
@@ -831,8 +833,8 @@ def iterables(
     elements: SearchStrategy[Ex],
     *,
     min_size: int = 0,
-    max_size: int = None,
-    unique_by: UniqueBy = None,
+    max_size: Optional[int] = None,
+    unique_by: Optional[UniqueBy] = None,
     unique: bool = False
 ) -> SearchStrategy[Iterable[Ex]]:
     """This has the same behaviour as lists, but returns iterables instead.
@@ -855,7 +857,7 @@ def iterables(
 def fixed_dictionaries(
     mapping: Dict[T, SearchStrategy[Ex]],
     *,
-    optional: Dict[T, SearchStrategy[Ex]] = None
+    optional: Optional[Dict[T, SearchStrategy[Ex]]] = None
 ) -> SearchStrategy[Dict[T, Ex]]:
     """Generates a dictionary of the same type as mapping with a fixed set of
     keys mapping to strategies. ``mapping`` must be a dict subclass.
@@ -901,7 +903,7 @@ def dictionaries(
     *,
     dict_class: type = dict,
     min_size: int = 0,
-    max_size: int = None
+    max_size: Optional[int] = None
 ) -> SearchStrategy[Dict[Ex, T]]:
     # Describing the exact dict_class to Mypy drops the key and value types,
     # so we report Dict[K, V] instead of Mapping[Any, Any] for now.  Sorry!
@@ -933,12 +935,12 @@ def dictionaries(
 @deprecated_posargs
 def characters(
     *,
-    whitelist_categories: Sequence[str] = None,
-    blacklist_categories: Sequence[str] = None,
-    blacklist_characters: Sequence[str] = None,
-    min_codepoint: int = None,
-    max_codepoint: int = None,
-    whitelist_characters: Sequence[str] = None
+    whitelist_categories: Optional[Sequence[str]] = None,
+    blacklist_categories: Optional[Sequence[str]] = None,
+    blacklist_characters: Optional[Sequence[str]] = None,
+    min_codepoint: Optional[int] = None,
+    max_codepoint: Optional[int] = None,
+    whitelist_characters: Optional[Sequence[str]] = None
 ) -> SearchStrategy[str]:
     r"""Generates characters, length-one :class:`python:str`\ ings,
     following specified filtering rules.
@@ -1044,7 +1046,7 @@ def text(
     ),
     *,
     min_size: int = 0,
-    max_size: int = None
+    max_size: Optional[int] = None
 ) -> SearchStrategy[str]:
     """Generates strings with characters drawn from ``alphabet``, which should
     be a collection of length one strings or a strategy generating such strings.
@@ -1135,7 +1137,7 @@ def from_regex(
 @cacheable
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
-def binary(*, min_size: int = 0, max_size: int = None) -> SearchStrategy[bytes]:
+def binary(*, min_size: int = 0, max_size: Optional[int] = None) -> SearchStrategy[bytes]:
     """Generates :class:`python:bytes`.
 
     The generated :class:`python:bytes` will have a length of at least ``min_size``
@@ -1155,7 +1157,7 @@ def binary(*, min_size: int = 0, max_size: int = None) -> SearchStrategy[bytes]:
 @cacheable
 @defines_strategy()
 def randoms(
-    *, note_method_calls: bool = False, use_true_random: bool = None
+    *, note_method_calls: bool = False, use_true_random: Optional[bool] = None
 ) -> SearchStrategy[random.Random]:
     """Generates instances of ``random.Random``. The generated Random instances
     are of a special HypothesisRandom subclass.
@@ -1509,10 +1511,10 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def fractions(
-    min_value: Union[Real, str] = None,
-    max_value: Union[Real, str] = None,
+    min_value: Optional[Union[Real, str]] = None,
+    max_value: Optional[Union[Real, str]] = None,
     *,
-    max_denominator: int = None
+    max_denominator: Optional[int] = None
 ) -> SearchStrategy[Fraction]:
     """Returns a strategy which generates Fractions.
 
@@ -1619,12 +1621,12 @@ def _as_finite_decimal(
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def decimals(
-    min_value: Union[Real, str] = None,
-    max_value: Union[Real, str] = None,
+    min_value: Optional[Union[Real, str]] = None,
+    max_value: Optional[Union[Real, str]] = None,
     *,
-    allow_nan: bool = None,
-    allow_infinity: bool = None,
-    places: int = None
+    allow_nan: Optional[bool] = None,
+    allow_infinity: Optional[bool] = None,
+    places: Optional[int] = None
 ) -> SearchStrategy[Decimal]:
     """Generates instances of :class:`python:decimal.Decimal`, which may be:
 
@@ -1824,9 +1826,9 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
 def complex_numbers(
     *,
     min_magnitude: Real = 0,
-    max_magnitude: Real = None,
-    allow_infinity: bool = None,
-    allow_nan: bool = None
+    max_magnitude: Optional[Real] = None,
+    allow_infinity: Optional[bool] = None,
+    allow_nan: Optional[bool] = None
 ) -> SearchStrategy[complex]:
     """Returns a strategy that generates complex numbers.
 
@@ -1907,7 +1909,7 @@ def complex_numbers(
 
 
 @deprecated_posargs
-def shared(base: SearchStrategy[Ex], *, key: Hashable = None) -> SearchStrategy[Ex]:
+def shared(base: SearchStrategy[Ex], *, key: Optional[Hashable] = None) -> SearchStrategy[Ex]:
     """Returns a strategy that draws a single shared value per run, drawn from
     base. Any two shared instances with the same key will share the same value,
     otherwise the identity of this strategy will be used. That is:
@@ -1930,7 +1932,7 @@ def shared(base: SearchStrategy[Ex], *, key: Hashable = None) -> SearchStrategy[
 @cacheable
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
-def uuids(*, version: int = None) -> SearchStrategy[UUID]:
+def uuids(*, version: Optional[int] = None) -> SearchStrategy[UUID]:
     """Returns a strategy that generates :class:`UUIDs <uuid.UUID>`.
 
     If the optional version argument is given, value is passed through
@@ -2179,7 +2181,7 @@ def emails() -> SearchStrategy[str]:
 def functions(
     *,
     like: Callable[..., Any] = lambda: None,
-    returns: SearchStrategy[Any] = None,
+    returns: Optional[SearchStrategy[Any]] = None,
     pure: bool = False
 ) -> SearchStrategy[Callable[..., Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -345,7 +345,7 @@ def one_of(*args):  # noqa: F811
 @cacheable
 @defines_strategy(force_reusable_values=True)
 def integers(
-    min_value: Optional[int] = None, max_value: Optional[int] = None
+    min_value: Optional[int] = None, max_value: Optional[int] = None,
 ) -> SearchStrategy[int]:
     """Returns a strategy which generates integers.
 
@@ -783,7 +783,7 @@ def lists(
 @defines_strategy()
 @deprecated_posargs
 def sets(
-    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: Optional[int] = None
+    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: Optional[int] = None,
 ) -> SearchStrategy[Set[Ex]]:
     """This has the same behaviour as lists, but returns sets instead.
 
@@ -803,7 +803,7 @@ def sets(
 @defines_strategy()
 @deprecated_posargs
 def frozensets(
-    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: Optional[int] = None
+    elements: SearchStrategy[Ex], *, min_size: int = 0, max_size: Optional[int] = None,
 ) -> SearchStrategy[FrozenSet[Ex]]:
     """This is identical to the sets function but instead returns
     frozensets."""
@@ -1138,7 +1138,7 @@ def from_regex(
 @defines_strategy(force_reusable_values=True)
 @deprecated_posargs
 def binary(
-    *, min_size: int = 0, max_size: Optional[int] = None
+    *, min_size: int = 0, max_size: Optional[int] = None,
 ) -> SearchStrategy[bytes]:
     """Generates :class:`python:bytes`.
 
@@ -1159,7 +1159,7 @@ def binary(
 @cacheable
 @defines_strategy()
 def randoms(
-    *, note_method_calls: bool = False, use_true_random: Optional[bool] = None
+    *, note_method_calls: bool = False, use_true_random: Optional[bool] = None,
 ) -> SearchStrategy[random.Random]:
     """Generates instances of ``random.Random``. The generated Random instances
     are of a special HypothesisRandom subclass.
@@ -1912,7 +1912,7 @@ def complex_numbers(
 
 @deprecated_posargs
 def shared(
-    base: SearchStrategy[Ex], *, key: Optional[Hashable] = None
+    base: SearchStrategy[Ex], *, key: Optional[Hashable] = None,
 ) -> SearchStrategy[Ex]:
     """Returns a strategy that draws a single shared value per run, drawn from
     base. Any two shared instances with the same key will share the same value,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -14,7 +14,7 @@
 # END HEADER
 
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
-from typing import Union, Optional
+from typing import Optional, Union
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.validation import check_type
@@ -80,7 +80,9 @@ SPECIAL_IPv6_RANGES = (
 
 @defines_strategy(force_reusable_values=True)
 def ip_addresses(
-    *, v: Optional[int] = None, network: Optional[Union[str, IPv4Network, IPv6Network]] = None
+    *,
+    v: Optional[int] = None,
+    network: Optional[Union[str, IPv4Network, IPv6Network]] = None
 ) -> SearchStrategy[Union[IPv4Address, IPv6Address]]:
     r"""Generate IP addresses - ``v=4`` for :class:`~python:ipaddress.IPv4Address`\ es,
     ``v=6`` for :class:`~python:ipaddress.IPv6Address`\ es, or leave unspecified

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -14,7 +14,7 @@
 # END HEADER
 
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
-from typing import Union
+from typing import Union, Optional
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.validation import check_type
@@ -80,7 +80,7 @@ SPECIAL_IPv6_RANGES = (
 
 @defines_strategy(force_reusable_values=True)
 def ip_addresses(
-    *, v: int = None, network: Union[str, IPv4Network, IPv6Network] = None
+    *, v: Optional[int] = None, network: Optional[Union[str, IPv4Network, IPv6Network]] = None
 ) -> SearchStrategy[Union[IPv4Address, IPv6Address]]:
     r"""Generate IP addresses - ``v=4`` for :class:`~python:ipaddress.IPv4Address`\ es,
     ``v=6`` for :class:`~python:ipaddress.IPv6Address`\ es, or leave unspecified

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ platform = linux
 
 disallow_untyped_decorators = True
 disallow_incomplete_defs = True
+no_implicit_optional = True
 
 follow_imports = silent
 ignore_missing_imports = True


### PR DESCRIPTION
When using `mypy` with `--strict` flag and `hypothesis` together I stumbled upon a problem where defining custom composite strategies with optional parameters which will be later passed to other `hypothesis` strategies makes `mypy` raise errors because `hypothesis` does not have `no_implicit_optional` option set to `True`.

```python
from hypothesis import strategies as st

@st.composite
def st_value(
    draw: Callable[[st.SearchStrategy[int]], int],
    max_value: Optional[int] = None,
) -> int:
    return draw(st.integers(max_value=max_value))
```

Enabling `no_implicit_optional` does not break anything for users that does not use `--strict` flag but it also makes it work for those who do use it. So I prepared a quick PR which does enable `no_implicit_optional` option and fixes all typehints.

Please forgive me if there is a reason why `no_implicit_optional` was not set to `True` in the first place and I somehow missed it. Hopefully this change will make life easier for those who use `hypothesis` and `mypy` with `--strict` and does not complicate anything for `hypothesis` developers.