### PR TITLE
Drop Python 3.5 at end of life

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,6 +97,8 @@ jobs:
           TASK: check-nose
         check-pytest43:
           TASK: check-pytest43
+        check-django31:
+          TASK: check-django31
         check-django30:
           TASK: check-django30
         check-django22:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,14 +18,10 @@ jobs:
           TASK: check-coverage
         check-conjecture-coverage:
           TASK: check-conjecture-coverage
-        check-pypy35:
-          TASK: check-pypy35
         check-pypy36:
           TASK: check-pypy36
         check-py36:
           TASK: check-py36
-        check-py35:
-          TASK: check-py35
         check-py37:
           TASK: check-py37
         check-py38:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,18 +101,12 @@ jobs:
           TASK: check-django30
         check-django22:
           TASK: check-django22
-        check-pandas19:
-          TASK: check-pandas19
-        check-pandas22:
-          TASK: check-pandas22
-        check-pandas23:
-          TASK: check-pandas23
-        check-pandas24:
-          TASK: check-pandas24
         check-pandas25:
           TASK: check-pandas25
         check-pandas100:
           TASK: check-pandas100
+        check-pandas111:
+          TASK: check-pandas111
     steps:
     - task: UsePythonVersion@0
       inputs:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release drops support for Python 3.5, which `reached end of life upstream
+<https://devguide.python.org/#status-of-python-branches>`__ on 2020-09-13.

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -47,7 +47,7 @@ Supported versions
 There is quite a lot of variation between pandas versions. We only
 commit to supporting the latest version of pandas, but older minor versions are
 supported on a "best effort" basis.  Hypothesis is currently tested against
-and confirmed working with every Pandas minor version from 0.19 through to 1.0.
+and confirmed working with every Pandas minor version from 0.25 through to 1.1.
 
 Releases that are not the latest patch release of their minor version are not
 tested or officially supported, but will probably also work unless you hit a

--- a/hypothesis-python/docs/supported.rst
+++ b/hypothesis-python/docs/supported.rst
@@ -25,10 +25,10 @@ changes in patch releases.
 Python versions
 ---------------
 
-Hypothesis is supported and tested on CPython 3.5+, i.e.
+Hypothesis is supported and tested on CPython 3.6+, i.e.
 `all versions of CPython with upstream support <https://devguide.python.org/#status-of-python-branches>`_,
 
-Hypothesis also supports the latest PyPy for Python 3.5 and 3.6.
+Hypothesis also supports the latest PyPy for Python 3.6.
 32-bit builds of CPython also work, though they are currently only tested on Windows.
 
 In general Hypothesis does not officially support anything except the latest

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -19,7 +19,7 @@ import warnings
 
 import setuptools
 
-if sys.version_info[:3] < (3, 5, 2):
+if sys.version_info[:2] < (3, 6):
     raise Exception(
         "This version of Python is too old to install new versions of Hypothesis.  "
         "Update `pip` and `setuptools`, try again, and you will automatically "
@@ -93,7 +93,7 @@ setuptools.setup(
     zip_safe=False,
     extras_require=extras,
     install_requires=["attrs>=19.2.0", "sortedcontainers>=2.1.0,<3.0.0"],
-    python_requires=">=3.5.2",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Hypothesis",
@@ -106,7 +106,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/hypothesis-python/src/hypothesis/_error_if_old.py
+++ b/hypothesis-python/src/hypothesis/_error_if_old.py
@@ -18,11 +18,11 @@ import sys
 from hypothesis.version import __version__
 
 message = """
-Hypothesis {} requires Python 3.5.2 or later.
+Hypothesis {} requires Python 3.6 or later.
 
 This can only happen if your packaging toolchain is older than python_requires.
 See https://packaging.python.org/guides/distributing-packages-using-setuptools/
 """
 
-if sys.version_info[:3] < (3, 5, 2):  # pragma: no cover
+if sys.version_info[:3] < (3, 6):  # pragma: no cover
     raise Exception(message.format(__version__))

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -385,9 +385,7 @@ def get_random_for_wrapped_test(test, wrapped_test):
         return Random(seed)
 
 
-def process_arguments_to_given(
-    wrapped_test, arguments, kwargs, given_kwargs, argspec,
-):
+def process_arguments_to_given(wrapped_test, arguments, kwargs, given_kwargs, argspec):
     selfy = None
     arguments, kwargs = convert_positional_arguments(wrapped_test, arguments, kwargs)
 
@@ -479,7 +477,7 @@ def new_given_argspec(original_argspec, given_kwargs):
 
 class StateForActualGivenExecution:
     def __init__(
-        self, test_runner, search_strategy, test, settings, random, wrapped_test,
+        self, test_runner, search_strategy, test, settings, random, wrapped_test
     ):
         self.test_runner = test_runner
         self.search_strategy = search_strategy
@@ -1027,7 +1025,7 @@ def given(
                 )
 
             state = StateForActualGivenExecution(
-                test_runner, search_strategy, test, settings, random, wrapped_test,
+                test_runner, search_strategy, test, settings, random, wrapped_test
             )
 
             reproduce_failure = wrapped_test._hypothesis_internal_use_reproduce_failure
@@ -1164,12 +1162,12 @@ def given(
             )
             random = get_random_for_wrapped_test(test, wrapped_test)
             _args, _kwargs, test_runner, search_strategy = process_arguments_to_given(
-                wrapped_test, (), {}, given_kwargs, argspec,
+                wrapped_test, (), {}, given_kwargs, argspec
             )
             assert not _args
             assert not _kwargs
             state = StateForActualGivenExecution(
-                test_runner, search_strategy, test, settings, random, wrapped_test,
+                test_runner, search_strategy, test, settings, random, wrapped_test
             )
             digest = function_digest(test)
 

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -29,8 +29,8 @@ do their best to write you a useful test.
 
 .. note::
 
-    The ghostwriter requires Python 3.6+ and :pypi:`black`, but the generated
-    code supports Python 3.5+ and has no dependencies beyond Hypothesis itself.
+    The ghostwriter requires :pypi:`black`, but the generated code has no
+    dependencies beyond Hypothesis itself.
 
 .. note::
 

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -392,10 +392,11 @@ def _make_test_body(
     # For unittest-style, indent method further into a class body
     if style == "unittest":
         imports.add("unittest")
-        body = "class Test{}{}(unittest.TestCase):\n".format(
+        body = "class Test{}{}(unittest.TestCase):\n{}".format(
             ghost.title(),
             "".join(_get_qualname(f).replace(".", "").title() for f in funcs),
-        ) + indent(body, "    ")
+            indent(body, "    "),
+        )
 
     return imports, body
 
@@ -566,7 +567,7 @@ def magic(
     # be worth the trouble when it's so easy for the user to specify themselves.
     for _, f in sorted(by_name.items()):
         imp, body = _make_test_body(
-            f, test_body=_write_call(f), except_=except_, ghost="fuzz", style=style,
+            f, test_body=_write_call(f), except_=except_, ghost="fuzz", style=style
         )
         imports |= imp
         parts.append(body)

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -52,10 +52,7 @@ def charmap():
         f = charmap_file()
         try:
             with gzip.GzipFile(f, "rb") as i:
-                # When the minimum Python 3 version becomes 3.6, this can be
-                # simplified to `json.load(i)` without needing to decode first.
-                data = i.read().decode()
-                tmp_charmap = dict(json.loads(data))
+                tmp_charmap = dict(json.load(i))
 
         except Exception:
             # This loop is reduced to using only local variables for performance;

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -228,10 +228,10 @@ def get_stream_enc(stream, default=None):
     return getattr(stream, "encoding", None) or default
 
 
-# Under Python 2, math.floor and math.ceil return floats, which cannot
+# Under Python 2, math.floor and math.ceil returned floats, which cannot
 # represent large integers - eg `float(2**53) == float(2**53 + 1)`.
 # We therefore implement them entirely in (long) integer operations.
-# We use the same trick on Python 3, because Numpy values and other
+# We still use the same trick on Python 3, because Numpy values and other
 # custom __floor__ or __ceil__ methods may convert via floats.
 # See issue #1667, Numpy issue 9068.
 def floor(x):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -21,7 +21,6 @@ import sys
 import typing
 
 PYPY = platform.python_implementation() == "PyPy"
-CAN_PACK_HALF_FLOAT = sys.version_info[:2] >= (3, 6)
 WINDOWS = platform.system() == "Windows"
 
 
@@ -96,81 +95,53 @@ def is_typed_named_tuple(cls):
     )
 
 
-if sys.version_info[:2] < (3, 6):
-    # When we drop support for Python 3.5, `get_type_hints` and
-    # `is_typed_named_tuple` should be moved to reflection.py
+def get_type_hints(thing):
+    """Like the typing version, but tries harder and never errors.
 
-    def get_type_hints(thing):
-        if inspect.isclass(thing) and not hasattr(thing, "__signature__"):
-            if is_typed_named_tuple(thing):
-                # Special handling for typing.NamedTuple
-                return thing._field_types  # type: ignore
-            thing = thing.__init__  # type: ignore
-        try:
+    Tries harder: if the thing to inspect is a class but typing.get_type_hints
+    raises an error or returns no hints, then this function will try calling it
+    on the __init__ method. This second step often helps with user-defined
+    classes on older versions of Python. The third step we take is trying
+    to fetch types from the __signature__ property.
+    They override any other ones we found earlier.
+
+    Never errors: instead of raising TypeError for uninspectable objects, or
+    NameError for unresolvable forward references, just return an empty dict.
+    """
+    try:
+        hints = typing.get_type_hints(thing)
+    except (AttributeError, TypeError, NameError):
+        hints = {}
+
+    if not inspect.isclass(thing):
+        return hints
+
+    try:
+        hints.update(typing.get_type_hints(thing.__init__))
+    except (TypeError, NameError, AttributeError):
+        pass
+
+    try:
+        if hasattr(thing, "__signature__"):
+            # It is possible for the signature and annotations attributes to
+            # differ on an object due to renamed arguments.
+            # To prevent missing arguments we use the signature to provide any type
+            # hints it has and then override any common names with the more
+            # comprehensive type information from get_type_hints
+            # See https://github.com/HypothesisWorks/hypothesis/pull/2580
+            # for more details.
             spec = inspect.getfullargspec(thing)
-            hints = {
-                k: v
-                for k, v in spec.annotations.items()
-                if k in (spec.args + spec.kwonlyargs) and isinstance(v, type)
-            }
-        except TypeError:
-            hints = {}
-        try:
-            hints["return"] = typing.get_type_hints(thing)["return"]
-        except Exception:
-            pass
-        return hints
+            hints.update(
+                {
+                    k: v
+                    for k, v in spec.annotations.items()
+                    if k in (spec.args + spec.kwonlyargs) and isinstance(v, type)
+                }
+            )
+    except (AttributeError, TypeError, NameError):
+        pass
 
-
-else:
-
-    def get_type_hints(thing):
-        """Like the typing version, but tries harder and never errors.
-
-        Tries harder: if the thing to inspect is a class but typing.get_type_hints
-        raises an error or returns no hints, then this function will try calling it
-        on the __init__ method. This second step often helps with user-defined
-        classes on older versions of Python. The third step we take is trying
-        to fetch types from the __signature__ property.
-        They override any other ones we found earlier.
-
-        Never errors: instead of raising TypeError for uninspectable objects, or
-        NameError for unresolvable forward references, just return an empty dict.
-        """
-        try:
-            hints = typing.get_type_hints(thing)
-        except (AttributeError, TypeError, NameError):
-            hints = {}
-
-        if not inspect.isclass(thing):
-            return hints
-
-        try:
-            hints.update(typing.get_type_hints(thing.__init__))
-        except (TypeError, NameError, AttributeError):
-            pass
-
-        try:
-            if hasattr(thing, "__signature__"):
-                # It is possible for the signature and annotations attributes to
-                # differ on an object due to renamed arguments.
-                # To prevent missing arguments we use the signature to provide any type
-                # hints it has and then override any common names with the more
-                # comprehensive type information from get_type_hints
-                # See https://github.com/HypothesisWorks/hypothesis/pull/2580
-                # for more details.
-                spec = inspect.getfullargspec(thing)
-                hints.update(
-                    {
-                        k: v
-                        for k, v in spec.annotations.items()
-                        if k in (spec.args + spec.kwonlyargs) and isinstance(v, type)
-                    }
-                )
-        except (AttributeError, TypeError, NameError):
-            pass
-
-        return hints
+    return hints
 
 
 importlib_invalidate_caches = getattr(importlib, "invalidate_caches", lambda: ())

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -16,8 +16,6 @@
 import math
 import struct
 
-from hypothesis.internal.compat import CAN_PACK_HALF_FLOAT
-
 # Format codes for (int, float) sized types, used for byte-wise casts.
 # See https://docs.python.org/3/library/struct.html#format-characters
 STRUCT_FORMATS = {
@@ -32,26 +30,6 @@ STRUCT_FORMATS = {
 # one if Numpy is unavailable too, because it's slightly faster in all cases.
 def reinterpret_bits(x, from_, to):
     return struct.unpack(to, struct.pack(from_, x))[0]
-
-
-if not CAN_PACK_HALF_FLOAT:  # pragma: no cover
-    try:
-        import numpy
-    except ImportError:
-        pass
-    else:
-
-        def reinterpret_bits(x, from_, to):  # noqa: F811
-            if from_ == b"!e":
-                arr = numpy.array([x], dtype=">f2")
-                if numpy.isfinite(x) and not numpy.isfinite(arr[0]):
-                    raise OverflowError("%r too large for float16" % (x,)) from None
-                buf = arr.tobytes()
-            else:
-                buf = struct.pack(from_, x)
-            if to == b"!e":
-                return float(numpy.frombuffer(buf, dtype=">f2")[0])
-            return struct.unpack(to, buf)[0]
 
 
 def float_of(x, width):

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -751,7 +751,7 @@ class RuleStrategy(SearchStrategy):
         self.rules = list(machine.rules())
 
         self.enabled_rules_strategy = st.shared(
-            FeatureStrategy(), key=("enabled rules", machine),
+            FeatureStrategy(), key=("enabled rules", machine)
         )
 
         # The order is a bit arbitrary. Primarily we're trying to group rules

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -117,7 +117,7 @@ def describe_statistics(stats_dict):
         if phase == "shrink":
             lines.append(
                 "    - Tried {} shrinks of which {} were successful".format(
-                    len(cases), d["shrinks-successful"],
+                    len(cases), d["shrinks-successful"]
                 )
             )
         lines.append("")

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1441,13 +1441,6 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         if getattr(thing, "__origin__", None) is typing.Union:
             args = sorted(thing.__args__, key=types.type_sorting_key)
             return one_of([from_type(t) for t in args])
-    # We can't resolve forward references, and under Python 3.5 (only)
-    # a forward reference is an instance of type.  Hence, explicit check:
-    elif type(thing) == getattr(typing, "_ForwardRef", None):  # pragma: no cover
-        raise ResolutionFailed(
-            "thing=%s cannot be resolved.  Upgrading to python>=3.6 may "
-            "fix this problem via improvements to the typing module." % (thing,)
-        )
     if not types.is_a_type(thing):
         raise InvalidArgument("thing=%s must be a type" % (thing,))
     # Now that we know `thing` is a type, the first step is to check for an

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -471,10 +471,6 @@ def floats(
             "Got width=%r, but the only valid values are the integers 16, "
             "32, and 64." % (width,)
         )
-    if width == 16 and sys.version_info[:2] < (3, 6) and "numpy" not in sys.modules:
-        raise InvalidArgument(  # pragma: no cover
-            "width=16 requires either Numpy, or Python >= 3.6"
-        )
 
     check_valid_bound(min_value, "min_value")
     check_valid_bound(max_value, "max_value")
@@ -679,7 +675,7 @@ def sampled_from(elements):
         repr_ = "sampled_from(%s.%s)" % (elements.__module__, elements.__name__)
     else:
         repr_ = "sampled_from(%r)" % (elements,)
-    if hasattr(enum, "Flag") and isclass(elements) and issubclass(elements, enum.Flag):
+    if isclass(elements) and issubclass(elements, enum.Flag):
         # Combinations of enum.Flag members are also members.  We generate
         # these dynamically, because static allocation takes O(2^n) memory.
         # LazyStrategy is used for the ease of force_repr.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -298,12 +298,12 @@ def none() -> SearchStrategy[None]:
 
 @overload
 def one_of(args: Sequence[SearchStrategy[Any]]) -> SearchStrategy[Any]:
-    pass  # pragma: no cover
+    raise NotImplementedError
 
 
 @overload  # noqa: F811
 def one_of(*args: SearchStrategy[Any]) -> SearchStrategy[Any]:
-    pass  # pragma: no cover
+    raise NotImplementedError
 
 
 def one_of(*args):  # noqa: F811
@@ -645,13 +645,13 @@ def tuples(*args: SearchStrategy) -> SearchStrategy[tuple]:
 
 @overload
 def sampled_from(elements: Sequence[T]) -> SearchStrategy[T]:
-    pass  # pragma: no cover
+    raise NotImplementedError
 
 
 @overload  # noqa: F811
 def sampled_from(elements: Type[enum.Enum]) -> SearchStrategy[Any]:
     # `SearchStrategy[Enum]` is unreliable due to metaclass issues.
-    pass  # pragma: no cover
+    raise NotImplementedError
 
 
 @defines_strategy(try_non_lazy=True)  # noqa: F811

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1593,7 +1593,7 @@ def fractions(
 
 
 def _as_finite_decimal(
-    value: Union[Real, str, None], name: str, allow_infinity: Optional[bool],
+    value: Union[Real, str, None], name: str, allow_infinity: Optional[bool]
 ) -> Optional[Decimal]:
     """Convert decimal bounds to decimals, carefully."""
     assert name in ("min_value", "max_value")

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -441,8 +441,6 @@ def floats(
     required to represent the generated float. Valid values are 16, 32, or 64.
     Passing ``width=32`` will still use the builtin 64-bit ``float`` class,
     but always for values which can be exactly represented as a 32-bit float.
-    Half-precision floats (``width=16``) are not supported on Python 3.5,
-    unless :pypi:`Numpy` is installed.
 
     The exclude_min and exclude_max argument can be used to generate numbers
     from open or half-open intervals, by excluding the respective endpoints.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -54,9 +54,7 @@ def replace_tzinfo(value, timezone):
         # WARNING: this is INCORRECT for timezones with negative DST offsets such as
         #       "Europe/Dublin", but it's unclear what we could do instead beyond
         #       documenting the problem and recommending use of `dateutil` instead.
-        #
-        # TODO: after dropping Python 3.5 support we won't need the getattr
-        return timezone.localize(value, is_dst=not getattr(value, "fold", 0))
+        return timezone.localize(value, is_dst=not value.fold)
     return value.replace(tzinfo=timezone)
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -326,8 +326,7 @@ class ArtificialRandom(HypothesisRandom):
             result = self.__data.draw(st.floats(min_value=0.0))
         elif method == "shuffle":
             result = self.__data.draw(st.permutations(range(len(kwargs["x"]))))
-        # This is tested for but only appears in 3.9 so doesn't appear in
-        # coverage.
+        # This is tested for but only appears in 3.9 so doesn't appear in coverage.
         elif method == "randbytes":  # pragma: no cover
             n = kwargs["n"]
             result = self.__data.draw(st.binary(min_size=n, max_size=n))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -142,7 +142,7 @@ def define_copy_method(name):
 
     spec = inspect.getfullargspec(STUBS.get(name, target))
 
-    result = define_function_signature(target.__name__, target.__doc__, spec,)(
+    result = define_function_signature(target.__name__, target.__doc__, spec)(
         implementation
     )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
@@ -17,14 +17,10 @@ import operator
 import re
 import sre_constants as sre
 import sre_parse
-import sys
 
 from hypothesis import reject, strategies as st
 from hypothesis.internal.charmap import as_general_categories, categories
 from hypothesis.internal.compat import int_to_byte
-
-HAS_SUBPATTERN_FLAGS = sys.version_info[:2] >= (3, 6)
-
 
 UNICODE_CATEGORIES = set(categories())
 
@@ -422,9 +418,7 @@ def _strategy(codes, context, is_unicode):
         elif code == sre.SUBPATTERN:
             # Various groups: '(...)', '(:...)' or '(?P<name>...)'
             old_flags = context.flags
-            if HAS_SUBPATTERN_FLAGS:  # pragma: no cover
-                # This feature is available only in specific Python versions
-                context.flags = (context.flags | value[1]) & ~value[2]
+            context.flags = (context.flags | value[1]) & ~value[2]
 
             strat = _strategy(value[-1], context, is_unicode)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -728,7 +728,7 @@ class FilteredStrategy(SearchStrategy):
 
         data.note_event("Aborted test because unable to satisfy %r" % (self,))
         data.mark_invalid()
-        raise AssertionError("Unreachable, for Mypy")  # pragma: no cover
+        raise NotImplementedError("Unreachable, for Mypy")
 
     def note_retried(self, data):
         data.note_event(lazyformat("Retried draw from %r to satisfy filter", self))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -73,9 +73,8 @@ def try_issubclass(thing, superclass):
     superclass = getattr(superclass, "__origin__", None) or superclass
     try:
         return issubclass(thing, superclass)
-    except (AttributeError, TypeError):  # pragma: no cover
-        # Some types can't be the subject or object of an instance or
-        # subclass check under Python 3.5
+    except (AttributeError, TypeError):
+        # Some types can't be the subject or object of an instance or subclass check
         return False
 
 
@@ -85,10 +84,8 @@ def is_a_new_type(thing):
     return (
         hasattr(thing, "__supertype__")
         and (
-            hasattr(typing, "NewType")
-            and getattr(thing, "__module__", None) == "typing"
-            or hasattr(typing_extensions, "NewType")
-            and getattr(thing, "__module__", None) == "typing_extensions"
+            getattr(thing, "__module__", None) == "typing"
+            or getattr(thing, "__module__", None) == "typing_extensions"
         )
         and inspect.isfunction(thing)
     )
@@ -148,9 +145,8 @@ def _try_import_forward_ref(thing, bound):  # pragma: no cover
             and getattr(thing, "__module__", None) == "typing"
         ):
             raise ResolutionFailed(
-                "Looks like you are using python3.6 or any of the previous versions "
-                "together with a TypeVar bound to a ForwardRef. "
-                "It is not supported. Upgrading to python3.7+ will solve this problem."
+                "It looks like you're using a TypeVar bound to a ForwardRef on Python "
+                "3.6, which is not supported - try ugrading to Python 3.7 or later."
             ) from None
         # We fallback to `ForwardRef` instance, you can register it as a type as well:
         # >>> from typing import ForwardRef
@@ -168,15 +164,6 @@ def from_typing_type(thing):
     # information to sensibly resolve to strategies at runtime.
     # Finally, we run a variation of the subclass lookup in `st.from_type`
     # among generic types in the lookup.
-    #
-    # Under 3.6 Union is handled directly in st.from_type, as the argument is
-    # not an instance of `type`. However, under Python 3.5 Union *is* a type
-    # and we have to handle it here, including failing if it has no parameters.
-    if hasattr(thing, "__union_params__"):  # pragma: no cover
-        args = sorted(thing.__union_params__ or (), key=type_sorting_key)
-        if not args:
-            raise ResolutionFailed("Cannot resolve Union of no types.")
-        return st.one_of([st.from_type(t) for t in args])
     if getattr(thing, "__origin__", None) == tuple or isinstance(
         thing, getattr(typing, "TupleMeta", ())
     ):
@@ -229,13 +216,12 @@ def from_typing_type(thing):
         if is_generic_type(k) and try_issubclass(k, thing)
     }
     if typing.Dict in mapping:
-        # The subtype relationships between generic and concrete View types
-        # are sometimes inconsistent under Python 3.5, so we pop them out to
-        # preserve our invariant that all examples of from_type(T) are
-        # instances of type T - and simplify the strategy for abstract types
-        # such as Container
-        for t in (typing.KeysView, typing.ValuesView, typing.ItemsView):
-            mapping.pop(t, None)
+        # ItemsView can cause test_lookup.py::test_specialised_collection_types
+        # to fail, due to weird isinstance behaviour around the elements.
+        mapping.pop(typing.ItemsView, None)
+        if sys.version_info[:2] == (3, 6):  # pragma: no branch
+            # `isinstance(dict().values(), Container) is False` on py36 only -_-
+            mapping.pop(typing.ValuesView, None)
     if len(mapping) > 1:
         # issubclass treats bytestring as a kind of sequence, which it is,
         # but treating it as such breaks everything else when it is presumed
@@ -249,8 +235,6 @@ def from_typing_type(thing):
         elem_type = (getattr(thing, "__args__", None) or ["not int"])[0]
         if getattr(elem_type, "__origin__", None) is typing.Union:
             union_elems = elem_type.__args__
-        elif hasattr(elem_type, "__union_params__"):  # pragma: no cover
-            union_elems = elem_type.__union_params__  # python 3.5 only
         else:
             union_elems = ()
         if not any(
@@ -436,10 +420,8 @@ _global_type_lookup.update(
             # As with Reversible, we tuplize this for compatibility with Hashable.
             st.lists(st.integers(0, 255)).map(tuple),  # type: ignore
         ),
-        # xIO are only available in .io on Python 3.5, but available directly
-        # as typing.*IO from 3.6 onwards and mypy 0.730 errors on the compat form.
-        typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
-        typing.io.TextIO: st.builds(io.StringIO, st.text()),  # type: ignore
+        typing.BinaryIO: st.builds(io.BytesIO, st.binary()),
+        typing.TextIO: st.builds(io.StringIO, st.text()),
     }
 )
 if hasattr(typing, "SupportsIndex"):  # pragma: no cover  # new in Python 3.8
@@ -471,7 +453,7 @@ def register(type_, fallback=None, *, module=typing):
     return inner
 
 
-@register("Type")
+@register(typing.Type)
 @register("Type", module=typing_extensions)
 def resolve_Type(thing):
     if getattr(thing, "__args__", None) is None:
@@ -479,17 +461,14 @@ def resolve_Type(thing):
     args = (thing.__args__[0],)
     if getattr(args[0], "__origin__", None) is typing.Union:
         args = args[0].__args__
-    elif hasattr(args[0], "__union_params__"):  # pragma: no cover
-        args = args[0].__union_params__
-    if isinstance(ForwardRef, type):  # pragma: no cover
-        # Duplicate check from from_type here - only paying when needed.
-        for a in args:
-            if type(a) == ForwardRef:
-                raise ResolutionFailed(
-                    "thing=%s cannot be resolved.  Upgrading to "
-                    "python>=3.6 may fix this problem via improvements "
-                    "to the typing module." % (thing,)
-                )
+    # Duplicate check from from_type here - only paying when needed.
+    for a in args:
+        if type(a) == ForwardRef:
+            raise ResolutionFailed(
+                "thing=%s cannot be resolved.  Upgrading to "
+                "python>=3.6 may fix this problem via improvements "
+                "to the typing module." % (thing,)
+            )
     return st.sampled_from(sorted(args, key=type_sorting_key))
 
 
@@ -541,7 +520,7 @@ def resolve_Dict(thing):
     )
 
 
-@register("DefaultDict", st.builds(collections.defaultdict))
+@register(typing.DefaultDict, st.builds(collections.defaultdict))
 @register("DefaultDict", st.builds(collections.defaultdict), module=typing_extensions)
 def resolve_DefaultDict(thing):
     return resolve_Dict(thing).map(lambda d: collections.defaultdict(None, d))
@@ -601,7 +580,8 @@ def resolve_TypeVar(thing):
         # each part of the union, wraps that in shared so that we only generate
         # from one type per testcase, and flatmaps that back to instances.
         return st.shared(
-            st.sampled_from(strat.original_strategies), key=type_var_key,
+            st.sampled_from(strat.original_strategies),
+            key=type_var_key,
         ).flatmap(lambda s: s)
 
     builtin_scalar_types = [type(None), bool, int, float, str, bytes]

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -580,8 +580,7 @@ def resolve_TypeVar(thing):
         # each part of the union, wraps that in shared so that we only generate
         # from one type per testcase, and flatmaps that back to instances.
         return st.shared(
-            st.sampled_from(strat.original_strategies),
-            key=type_var_key,
+            st.sampled_from(strat.original_strategies), key=type_var_key,
         ).flatmap(lambda s: s)
 
     builtin_scalar_types = [type(None), bool, int, float, str, bytes]

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -29,8 +29,6 @@ run()
 # Skip collection of tests which require the Django test runner,
 # or that don't work on the current version of Python.
 collect_ignore_glob = ["django/*"]
-if sys.version_info < (3, 6):  # Remove after dropping Python 3.5
-    collect_ignore_glob.append("cover/*py36*")
 if sys.version_info < (3, 8):
     collect_ignore_glob.append("cover/*py38*")
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1272,7 +1272,7 @@ def test_database_contains_only_pareto_front():
         runner = ConjectureRunner(
             test,
             settings=settings(
-                max_examples=500, database=db, suppress_health_check=HealthCheck.all(),
+                max_examples=500, database=db, suppress_health_check=HealthCheck.all()
             ),
             database_key=b"stuff",
         )

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -55,7 +55,7 @@ def test_database_contains_only_pareto_front():
         runner = ConjectureRunner(
             test,
             settings=settings(
-                max_examples=500, database=db, suppress_health_check=HealthCheck.all(),
+                max_examples=500, database=db, suppress_health_check=HealthCheck.all()
             ),
             database_key=b"stuff",
         )
@@ -178,7 +178,7 @@ def test_uses_tags_in_calculating_pareto_front():
 
         runner = ConjectureRunner(
             test,
-            settings=settings(max_examples=10, database=InMemoryExampleDatabase(),),
+            settings=settings(max_examples=10, database=InMemoryExampleDatabase()),
             database_key=b"stuff",
         )
 
@@ -197,7 +197,7 @@ def test_optimises_the_pareto_front():
 
     runner = ConjectureRunner(
         test,
-        settings=settings(max_examples=10000, database=InMemoryExampleDatabase(),),
+        settings=settings(max_examples=10000, database=InMemoryExampleDatabase()),
         database_key=b"stuff",
     )
 
@@ -219,7 +219,7 @@ def test_does_not_optimise_the_pareto_front_if_interesting():
 
     runner = ConjectureRunner(
         test,
-        settings=settings(max_examples=10000, database=InMemoryExampleDatabase(),),
+        settings=settings(max_examples=10000, database=InMemoryExampleDatabase()),
         database_key=b"stuff",
     )
 
@@ -243,7 +243,7 @@ def test_stops_optimising_once_interesting():
 
     runner = ConjectureRunner(
         test,
-        settings=settings(max_examples=10000, database=InMemoryExampleDatabase(),),
+        settings=settings(max_examples=10000, database=InMemoryExampleDatabase()),
         database_key=b"stuff",
     )
 

--- a/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
+++ b/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
@@ -199,7 +199,7 @@ def test_learns_to_bridge_only_two():
     )
 
     dfa = dfas.learn_a_new_dfa(
-        runner, [10, 100], [2, 8], lambda d: d.status == Status.INTERESTING,
+        runner, [10, 100], [2, 8], lambda d: d.status == Status.INTERESTING
     )
 
     assert dfa.max_length(dfa.start) == 2
@@ -233,7 +233,7 @@ def test_learns_to_bridge_only_two_with_overlap():
         test_function, settings=settings(database=None), ignore_limits=True
     )
 
-    dfa = dfas.learn_a_new_dfa(runner, u, v, lambda d: d.status == Status.INTERESTING,)
+    dfa = dfas.learn_a_new_dfa(runner, u, v, lambda d: d.status == Status.INTERESTING)
 
     assert list(islice(dfa.all_matching_strings(), 3)) == [b"", bytes(len(v) - len(u))]
 
@@ -258,6 +258,6 @@ def test_learns_to_bridge_only_two_with_suffix():
         test_function, settings=settings(database=None), ignore_limits=True
     )
 
-    dfa = dfas.learn_a_new_dfa(runner, u, v, lambda d: d.status == Status.INTERESTING,)
+    dfa = dfas.learn_a_new_dfa(runner, u, v, lambda d: d.status == Status.INTERESTING)
 
     assert list(islice(dfa.all_matching_strings(), 3)) == [b"", bytes(len(v) - len(u))]

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -469,7 +469,7 @@ def test_example_equality():
 
 @given(st.integers(0, 255), st.randoms(use_true_random=True))
 def test_partial_buffer(n, rnd):
-    data = ConjectureData(prefix=[n], random=rnd, max_length=2,)
+    data = ConjectureData(prefix=[n], random=rnd, max_length=2)
 
     assert data.draw_bytes(2)[0] == n
 

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -200,7 +200,7 @@ def test_center_in_middle_above():
 def test_restricted_bits():
     assert (
         cu.integer_range(
-            ConjectureData.for_buffer([1, 0, 0, 0, 0]), lower=0, upper=2 ** 64 - 1,
+            ConjectureData.for_buffer([1, 0, 0, 0, 0]), lower=0, upper=2 ** 64 - 1
         )
         == 0
     )
@@ -240,7 +240,7 @@ def test_choice():
 
 
 def test_fractional_float():
-    assert cu.fractional_float(ConjectureData.for_buffer([0] * 8),) == 0.0
+    assert cu.fractional_float(ConjectureData.for_buffer([0] * 8)) == 0.0
 
 
 def test_fixed_size_draw_many():

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -64,7 +64,7 @@ def test_copying_preserves_argspec(f):
         ((lambda *, a=1: a), "lambda *, a=1: a"),
     ],
 )
-def test_py3only_lambda_formatting(lam, source):
+def test_kwonly_lambda_formatting(lam, source):
     # Testing kwonly lambdas, with and without varargs and default values
     assert get_pretty_function_description(lam) == source
 

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-import sys
 from inspect import getfullargspec
 
 import attr
@@ -129,19 +128,11 @@ class Inferrables:
     annot_converter = attr.ib(converter=a_converter)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] <= (3, 5),
-    reason="Too-old typing module can't get return value hint",
-)
 @given(st.builds(Inferrables))
 def test_attrs_inference_builds(c):
     pass
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] <= (3, 5),
-    reason="Too-old typing module can't get return value hint",
-)
 @given(st.from_type(Inferrables))
 def test_attrs_inference_from_type(c):
     pass

--- a/hypothesis-python/tests/cover/test_cathetus.py
+++ b/hypothesis-python/tests/cover/test_cathetus.py
@@ -74,7 +74,7 @@ def test_cathetus_nan(h, a):
 
 
 @pytest.mark.parametrize(
-    "h,a", [(math.inf, 3), (math.inf, -3), (math.inf, 0), (math.inf, math.nan)],
+    "h,a", [(math.inf, 3), (math.inf, -3), (math.inf, 0), (math.inf, math.nan)]
 )
 def test_cathetus_infinite(h, a):
     assert math.isinf(cathetus(h, a))

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import datetime as dt
-import sys
 
 import pytest
 
@@ -139,13 +138,12 @@ def test_naive_times_are_naive(dt):
     assert dt.tzinfo is None
 
 
-# The fold attribute was added in Python 3.6.  It's less clear why this also fails
-# on pypy3.6, but it seems to canonicalise fold to 0 for non-ambiguous times...
-@pytest.mark.skipif(PYPY or sys.version_info[:2] < (3, 6), reason="see comment")
+# pypy3.6 seems to canonicalise fold to 0 for non-ambiguous times?
+@pytest.mark.skipif(PYPY, reason="see comment")
 def test_can_generate_datetime_with_fold_1():
     find_any(datetimes(), lambda d: d.fold)
 
 
-@pytest.mark.skipif(PYPY or sys.version_info[:2] < (3, 6), reason="see comment")
+@pytest.mark.skipif(PYPY, reason="see comment")
 def test_can_generate_time_with_fold_1():
     find_any(times(), lambda d: d.fold)

--- a/hypothesis-python/tests/cover/test_escalation.py
+++ b/hypothesis-python/tests/cover/test_escalation.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import os
-import sys
 
 import pytest
 
@@ -77,12 +76,6 @@ def test_is_hypothesis_file_not_confused_by_prefix(monkeypatch):
     root = os.path.dirname(hypothesis.__file__)
     assert esc.is_hypothesis_file(hypothesis.__file__)
     assert esc.is_hypothesis_file(esc.__file__)
-
-    # Ignore `Path.resolve` for python 3.5 because it is strict by default
-    # and some paths in this test are made up (this behavior has been changed
-    # since python 3.6)
-    if sys.version_info < (3, 6):
-        monkeypatch.setattr("pathlib.Path.resolve", lambda x: x, raising=False)
 
     assert not esc.is_hypothesis_file(pytest.__file__)
     assert not esc.is_hypothesis_file(root + "-suffix")

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -168,7 +168,7 @@ def test_prints_verbose_output_for_explicit_examples():
         pass
 
     assert_falsifying_output(
-        test_always_passes, x="NOT AN INTEGER", example_type="Trying",
+        test_always_passes, x="NOT AN INTEGER", example_type="Trying"
     )
 
 
@@ -179,9 +179,7 @@ def test_captures_original_repr_of_example():
         x.append(1)
         assert not x
 
-    assert_falsifying_output(
-        test_mutation, x=[],
-    )
+    assert_falsifying_output(test_mutation, x=[])
 
 
 def test_examples_are_tried_in_order():

--- a/hypothesis-python/tests/cover/test_float_nastiness.py
+++ b/hypothesis-python/tests/cover/test_float_nastiness.py
@@ -21,7 +21,7 @@ import pytest
 
 from hypothesis import assume, given, strategies as st
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import CAN_PACK_HALF_FLOAT, WINDOWS
+from hypothesis.internal.compat import WINDOWS
 from hypothesis.internal.floats import (
     float_of,
     float_to_int,
@@ -173,8 +173,7 @@ def test_float32_can_exclude_infinity(x):
     assert not math.isinf(x)
 
 
-@pytest.mark.skipif(not (numpy or CAN_PACK_HALF_FLOAT), reason="dependency")
-@given(st.floats(width=32, allow_infinity=False))
+@given(st.floats(width=16, allow_infinity=False))
 def test_float16_can_exclude_infinity(x):
     assert not math.isinf(x)
 
@@ -193,18 +192,8 @@ def test_float16_can_exclude_infinity(x):
     ],
 )
 def test_out_of_range(kwargs):
-    if kwargs.get("width") == 16 and not (CAN_PACK_HALF_FLOAT or numpy):
-        pytest.skip()
     with pytest.raises(OverflowError):
         st.floats(**kwargs).validate()
-
-
-def test_invalidargument_iff_half_float_unsupported():
-    if numpy is None and not CAN_PACK_HALF_FLOAT:
-        with pytest.raises(InvalidArgument):
-            st.floats(width=16).validate()
-    else:
-        st.floats(width=16).validate()
 
 
 def test_disallowed_width():
@@ -279,9 +268,7 @@ def test_cannot_exclude_endpoint_with_zero_interval(lo, hi, exmin, exmax):
         st.floats(lo, hi, exclude_min=exmin, exclude_max=exmax).validate()
 
 
-WIDTHS = (64, 32)
-if numpy or CAN_PACK_HALF_FLOAT:
-    WIDTHS += (16,)
+WIDTHS = (64, 32, 16)
 
 
 @pytest.mark.parametrize("nonfloat", [st.nothing(), st.none()])

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -73,10 +73,8 @@ def _test_matching_pattern(pattern, isvalidchar, is_unicode=False):
     codepoints = range(0, sys.maxunicode + 1) if is_unicode else range(1, 128)
     for c in [chr(x) for x in codepoints]:
         if isvalidchar(c):
-            assert r.search(c), (
-                '"%s" supposed to match "%s" (%r, category "%s"), '
-                "but it doesn't" % (pattern, c, c, unicodedata.category(c))
-            )
+            msg = "%r supposed to match %r (%r, category %r), but it doesn't"
+            assert r.search(c), msg % (pattern, c, c, unicodedata.category(c))
         else:
             assert not r.search(c), (
                 '"%s" supposed not to match "%s" (%r, category "%s"), '
@@ -244,7 +242,7 @@ def test_end():
 
 def test_groupref_exists():
     assert_all_examples(
-        st.from_regex("^(<)?a(?(1)>)$"), lambda s: s in ("a", "a\n", "<a>", "<a>\n"),
+        st.from_regex("^(<)?a(?(1)>)$"), lambda s: s in ("a", "a\n", "<a>", "<a>\n")
     )
     assert_all_examples(
         st.from_regex("^(a)?(?(1)b|c)$"), lambda s: s in ("ab", "ab\n", "c", "c\n")

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -323,7 +323,6 @@ def test_group_backref_may_not_be_present(s):
     assert s[0] == s[1]
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="requires Python 3.6")
 def test_subpattern_flags():
     strategy = st.from_regex("(?i)\\Aa(?-i:b)\\Z")
 

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -189,14 +189,8 @@ def test_shrinks_both_failures():
             test()
 
     output = o.getvalue()
-
-    assert_output_contains_failure(
-        output, test, i=10000,
-    )
-
-    assert_output_contains_failure(
-        output, test, i=second_target[0],
-    )
+    assert_output_contains_failure(output, test, i=10000)
+    assert_output_contains_failure(output, test, i=second_target[0])
 
 
 def test_handles_flaky_tests_where_only_one_is_flaky():

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -280,7 +280,6 @@ def test_generic_origin_without_type_args(generic):
         pass
 
 
-@pytest.mark.skipif(sys.version_info[:2] <= (3, 5), reason="typing on 3.5 is wild")
 def test_generic_origin_from_type():
     with temp_registered(MyGeneric, st.builds(MyGeneric)):
         find_any(st.from_type(MyGeneric[T]))

--- a/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
@@ -69,7 +69,7 @@ def test_bound_correct_forward_ref(built):
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] != (3, 6), reason="typing in python3.6 is partially working",
+    sys.version_info[:2] != (3, 6), reason="typing in python3.6 is partially working"
 )
 def test_bound_correct_forward_ref_python36():
     """

--- a/hypothesis-python/tests/nocover/test_from_type_recipe.py
+++ b/hypothesis-python/tests/nocover/test_from_type_recipe.py
@@ -30,7 +30,7 @@ def everything_except(excluded_types):
 
 @given(
     excluded_types=st.lists(
-        st.sampled_from(TYPES), min_size=1, max_size=3, unique=True,
+        st.sampled_from(TYPES), min_size=1, max_size=3, unique=True
     ).map(tuple),
     data=st.data(),
 )

--- a/hypothesis-python/tests/nocover/test_simple_numbers.py
+++ b/hypothesis-python/tests/nocover/test_simple_numbers.py
@@ -137,9 +137,7 @@ def is_integral(value):
 
 
 def test_can_minimal_float_far_from_integral():
-    minimal(
-        floats(), lambda x: math.isfinite(x) and not is_integral(x * (2 ** 32)),
-    )
+    minimal(floats(), lambda x: math.isfinite(x) and not is_integral(x * (2 ** 32)))
 
 
 def test_list_of_fractional_float():

--- a/hypothesis-python/tests/numpy/test_lazy_import.py
+++ b/hypothesis-python/tests/numpy/test_lazy_import.py
@@ -13,8 +13,6 @@
 #
 # END HEADER
 
-from hypothesis.internal.compat import CAN_PACK_HALF_FLOAT
-
 SHOULD_NOT_IMPORT_NUMPY = """
 import sys
 from hypothesis import given, strategies as st
@@ -26,10 +24,6 @@ def test_no_numpy_import(x):
 
 
 def test_hypothesis_is_not_the_first_to_import_numpy(testdir):
+    # We only import numpy if the user did so first.
     result = testdir.runpytest(testdir.makepyfile(SHOULD_NOT_IMPORT_NUMPY))
-    # OK, we import numpy on Python < 3.6 to get 16-bit float support.
-    # But otherwise we only import it if the user did so first.
-    if CAN_PACK_HALF_FLOAT:
-        result.assert_outcomes(passed=1, failed=0)
-    else:
-        result.assert_outcomes(passed=0, failed=1)
+    result.assert_outcomes(passed=1, failed=0)

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -59,9 +59,7 @@ class HypothesisFalsified(AssertionError):
     pass
 
 
-def define_test(
-    specifier, predicate, condition=None, p=0.5, suppress_health_check=(),
-):
+def define_test(specifier, predicate, condition=None, p=0.5, suppress_health_check=()):
     required_runs = int(RUNS * p)
 
     def run_test():
@@ -366,5 +364,5 @@ for i in range(4):
 
 
 test_long_duplicates_strings = define_test(
-    tuples(text(), text()), lambda s: len(s[0]) >= 5 and s[0] == s[1],
+    tuples(text(), text()), lambda s: len(s[0]) >= 5 and s[0] == s[1]
 )

--- a/hypothesis-python/tests/quality/test_normalization.py
+++ b/hypothesis-python/tests/quality/test_normalization.py
@@ -61,9 +61,7 @@ def test_common_strategies_normalize_small_values(strategy, n, normalize_kwargs)
     dfas.normalize(repr(strategy), test_function, **normalize_kwargs)
 
 
-@pytest.mark.parametrize(
-    "strategy", [st.emails(), st.complex_numbers()], ids=repr,
-)
+@pytest.mark.parametrize("strategy", [st.emails(), st.complex_numbers()], ids=repr)
 def test_harder_strategies_normalize_to_minimal(strategy, normalize_kwargs):
     import random
 

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -18,7 +18,7 @@ import sys
 from typing import Union
 
 import pytest
-from typing_extensions import DefaultDict, Literal, NewType, Type
+from typing_extensions import DefaultDict, Literal, NewType, Type, TypedDict
 
 from hypothesis import assume, given, strategies as st
 from hypothesis.strategies import from_type
@@ -46,26 +46,15 @@ def test_typing_extensions_Literal_nested(data):
     assert data.draw(st.from_type(literal_type)) in flattened_literals
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 5), reason="no attribute annotations")
-def test_simple_typeddict():
-    exec(
-        """
-from hypothesis import given
-from hypothesis.strategies import from_type
-from typing_extensions import TypedDict
-
 class A(TypedDict):
     a: int
+
 
 @given(from_type(A))
 def test_simple_typeddict(value):
     assert type(value) == dict
     assert set(value) == {"a"}
     assert isinstance(value["a"], int)
-
-test_simple_typeddict()
-"""
-    )
 
 
 def test_typing_extensions_Type_int():
@@ -86,7 +75,6 @@ def test_resolves_NewType():
     assert isinstance(from_type(uni).example(), (int, type(None)))
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="new addition")
 @given(from_type(DefaultDict[int, int]))
 def test_defaultdict(ex):
     assert isinstance(ex, collections.defaultdict)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -56,7 +56,13 @@ commands =
 [testenv:django30]
 commands =
     pip install .[pytz]
-    pip install django~=3.0.0
+    pip install django~=3.0.10
+    python -m tests.django.manage test tests.django
+
+[testenv:django31]
+commands =
+    pip install .[pytz]
+    pip install django~=3.1.1
     python -m tests.django.manage test tests.django
 
 [testenv:nose]

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39}-{brief,prettyquick,full,custom}
+envlist = py{36,37,38,39}-{brief,prettyquick,full,custom}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -26,49 +26,6 @@ deps=
 commands=
     python -m pytest tests/quality/ -n2
 
-[testenv:pandas19]
-deps =
-    -r../requirements/test.txt
-    pandas~=0.19.2
-    numpy~=1.17.4
-commands =
-    python -m pytest tests/pandas -n2
-
-[testenv:pandas20]
-deps =
-    -r../requirements/test.txt
-    pandas~=0.20.3
-commands =
-    python -m pytest tests/pandas -n2
-
-[testenv:pandas21]
-deps =
-    -r../requirements/test.txt
-    pandas~=0.21.0
-commands =
-    python -m pytest tests/pandas -n2
-
-[testenv:pandas22]
-deps =
-    -r../requirements/test.txt
-    pandas~=0.22.0
-commands =
-    python -m pytest tests/pandas -n2
-
-[testenv:pandas23]
-deps =
-    -r../requirements/test.txt
-    pandas~=0.23.0
-commands =
-    python -m pytest tests/pandas -n2
-
-[testenv:pandas24]
-deps =
-    -r../requirements/test.txt
-    pandas~=0.24.0
-commands =
-    python -m pytest tests/pandas -n2
-
 [testenv:pandas25]
 deps =
     -r../requirements/test.txt
@@ -80,6 +37,13 @@ commands =
 deps =
     -r../requirements/test.txt
     pandas~=1.0.0
+commands =
+    python -m pytest tests/pandas -n2
+
+[testenv:pandas111]
+deps =
+    -r../requirements/test.txt
+    pandas~=1.1.1
 commands =
     python -m pytest tests/pandas -n2
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -437,7 +437,7 @@ def standard_tox_task(name):
 standard_tox_task("nose")
 standard_tox_task("pytest43")
 
-for n in [22, 30]:
+for n in [22, 30, 31]:
     standard_tox_task("django%d" % (n,))
 for n in [25, 100, 111]:
     standard_tox_task("pandas%d" % (n,))

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -439,7 +439,7 @@ standard_tox_task("pytest43")
 
 for n in [22, 30]:
     standard_tox_task("django%d" % (n,))
-for n in [19, 20, 21, 22, 23, 24, 25, 100]:
+for n in [25, 100, 111]:
     standard_tox_task("pandas%d" % (n,))
 
 standard_tox_task("coverage")

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -376,12 +376,10 @@ def run_tox(task, version):
 
 
 # Via https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
-PY35 = "3.5.7"
 PY36 = "3.6.9"
 PY37 = "3.7.4"
 PY38 = "3.8.0"
 PY39 = "3.9-dev"
-PYPY35 = "pypy3.5-7.0.0"
 PYPY36 = "pypy3.6-7.1.1"
 
 
@@ -391,9 +389,9 @@ def install_core():
 
 
 # ALIASES are the executable names for each Python version
-ALIASES = {PYPY35: "pypy3", PYPY36: "pypy3"}
+ALIASES = {PYPY36: "pypy3"}
 
-for n in [PY35, PY36, PY37, PY38, PY39]:
+for n in [PY36, PY37, PY38, PY39]:
     major, minor, patch = n.replace("-dev", ".").split(".")
     ALIASES[n] = "python%s.%s" % (major, minor)
 
@@ -405,11 +403,6 @@ python_tests = task(
         os.path.join(hp.HYPOTHESIS_PYTHON, "scripts"),
     )
 )
-
-
-@python_tests
-def check_py35():
-    run_tox("py35-full", PY35)
 
 
 @python_tests
@@ -430,11 +423,6 @@ def check_py38():
 @python_tests
 def check_py39():
     run_tox("py39-full", PY39)
-
-
-@python_tests
-def check_pypy35():
-    run_tox("pypy3-full", PYPY35)
 
 
 @python_tests


### PR DESCRIPTION
The last-ever release of Python 3.5 was [made a few days ago](https://www.python.org/downloads/release/python-3510/), and [the end-of-life date](https://devguide.python.org/#status-of-python-branches) (September 13) is very close.  We *could* drag this out to the end of the month, but given that this is now blocking #2613 and has strong overlap with #2599 and #2610, I'd rather get it out of the way sooner rather than later.

Running `black --target-version=py36`, `pyupgrade --py36-plus`, etc. is left for a future PR.