### PR TITLE
use strings for struct formats

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,11 +1,10 @@
 RELEASE_TYPE: patch
 
-use str for struct module function calls because the struct module is
-documented as accepting only "format strings" and happens to implement
-"format bytes", which can cause Warnings when run with `python -bb`
-in some cases
+This patch changes some internal :obj:`python:struct.Struct.format` strings
+from ``bytes`` to ``str``, to avoid :class:`python:BytesWarning` when running
+`python -bb <https://docs.python.org/3/using/cmdline.html#cmdoption-b>`__.
 
-see https://docs.python.org/3/library/struct.html#struct-format-strings
-and https://bugs.python.org/issue41777
-and https://github.com/pytest-dev/pytest-xdist/issues/596
-and https://bugs.python.org/issue21071#msg292409
+Thanks to everyone involved in `pytest-xdist issue 596
+<https://github.com/pytest-dev/pytest-xdist/issues/596>`__,
+:bpo:`16349`, :bpo:`21071`, and :bpo:`41777` for their work on this -
+it was a remarkably subtle issue!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+use str for struct module function calls because the struct module is
+documented as accepting only "format strings" and happens to implement
+"format bytes", which can cause Warnings when run with `python -bb`
+in some cases
+
+see https://docs.python.org/3/library/struct.html#struct-format-strings
+and https://bugs.python.org/issue41777
+and https://github.com/pytest-dev/pytest-xdist/issues/596
+and https://bugs.python.org/issue21071#msg292409

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -19,15 +19,12 @@ import struct
 # Format codes for (int, float) sized types, used for byte-wise casts.
 # See https://docs.python.org/3/library/struct.html#format-characters
 STRUCT_FORMATS = {
-    16: ("!H", "!e"),  # Note: 'e' is new in Python 3.6, so we have helpers
+    16: ("!H", "!e"),
     32: ("!I", "!f"),
     64: ("!Q", "!d"),
 }
 
 
-# There are two versions of this: the one that uses Numpy to support Python
-# 3.5 and earlier, and the elegant one for new versions.  We use the new
-# one if Numpy is unavailable too, because it's slightly faster in all cases.
 def reinterpret_bits(x, from_, to):
     return struct.unpack(to, struct.pack(from_, x))[0]
 
@@ -46,7 +43,9 @@ def sign(x):
     try:
         return math.copysign(1.0, x)
     except TypeError:
-        raise TypeError("Expected float but got %r of type %s" % (x, type(x).__name__))
+        raise TypeError(
+            "Expected float but got %r of type %s" % (x, type(x).__name__)
+        ) from None
 
 
 def is_negative(x):

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -19,9 +19,9 @@ import struct
 # Format codes for (int, float) sized types, used for byte-wise casts.
 # See https://docs.python.org/3/library/struct.html#format-characters
 STRUCT_FORMATS = {
-    16: (b"!H", b"!e"),  # Note: 'e' is new in Python 3.6, so we have helpers
-    32: (b"!I", b"!f"),
-    64: (b"!Q", b"!d"),
+    16: ("!H", "!e"),  # Note: 'e' is new in Python 3.6, so we have helpers
+    32: ("!I", "!f"),
+    64: ("!Q", "!d"),
 }
 
 
@@ -37,9 +37,9 @@ def float_of(x, width):
     if width == 64:
         return float(x)
     elif width == 32:
-        return reinterpret_bits(float(x), b"!f", b"!f")
+        return reinterpret_bits(float(x), "!f", "!f")
     else:
-        return reinterpret_bits(float(x), b"!e", b"!e")
+        return reinterpret_bits(float(x), "!e", "!e")
 
 
 def sign(x):


### PR DESCRIPTION
the struct module is documented as accepting only "format strings" and only happens to implement "format bytes", which can cause Warnings when run with `python -bb` in some cases

see https://docs.python.org/3/library/struct.html#struct-format-strings
and https://bugs.python.org/issue41777
and https://github.com/pytest-dev/pytest-xdist/issues/596
and https://bugs.python.org/issue21071#msg292409