### PR TITLE
New `RedisExampleDatabase`, `MultiplexedDatabase`, and `ReadOnlyDatabase` for team workflows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
         architecture: '$(python.architecture)'
     - script: |
         pip install --upgrade setuptools pip wheel
-        pip install -r requirements/test.txt typing-extensions black
+        pip install -r requirements/test.txt typing-extensions black fakeredis
         pip install hypothesis-python/[all]
       displayName: Install dependencies
     - script: |

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release adds a new :class:`~hypothesis.extra.redis.RedisExampleDatabase`,
+along with the :class:`~hypothesis.database.ReadOnlyDatabase`
+and :class:`~hypothesis.database.MultiplexedDatabase` helpers, to support
+team workflows where failing examples can be seamlessly shared between everyone
+on the team - and your CI servers or buildbots.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -71,10 +71,11 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "django": ("https://django.readthedocs.io/en/stable/", None),
+    "redis": ("https://redis-py.readthedocs.io/en/stable/", None),
     "attrs": ("https://www.attrs.org/en/stable/", None),
 }
 
-autodoc_mock_imports = ["pandas"]
+autodoc_mock_imports = ["pandas", "redis"]
 
 # This config value must be a dictionary of external sites, mapping unique
 # short alias names to a base URL and a prefix.

--- a/hypothesis-python/docs/database.rst
+++ b/hypothesis-python/docs/database.rst
@@ -20,20 +20,6 @@ workflow considerably by making sure that the examples you've just found are rep
 The database also records examples that exercise less-used parts of your
 code, so the database may update even when no failing examples were found.
 
---------------
-File locations
---------------
-
-The default storage format is as a fairly opaque directory structure. Each test
-corresponds to a directory, and each example to a file within that directory.
-The standard location for it is ``.hypothesis/examples`` in your current working
-directory. You can override this by setting the
-:obj:`~hypothesis.settings.database` setting.
-
-If you have not configured a database and the default location is unusable
-(e.g. because you do not have read/write permission), Hypothesis will issue
-a warning and then fall back to an in-memory database.
-
 --------------------------------------------
 Upgrading Hypothesis and changing your tests
 --------------------------------------------
@@ -43,30 +29,20 @@ and not get wrong behaviour. When you upgrade Hypothesis, old data *might* be in
 this should happen transparently. It can never be the case that e.g. changing the strategy
 that generates an argument gives you data from the old strategy.
 
------------------------------
-Sharing your example database
------------------------------
+-------------------------------
+ExampleDatabase implementations
+-------------------------------
 
-.. note::
-    If specific examples are important for correctness you should use the
-    :func:`@example <hypothesis.example>` decorator, as the example database may discard entries due to
-    changes in your code or dependencies.  For most users, we therefore
-    recommend using the example database locally and possibly persisting it
-    between CI builds, but not tracking it under version control.
+Hypothesis' default :obj:`~hypothesis.settings.database` setting creates a
+:class:`~hypothesis.database.DirectoryBasedExampleDatabase` in your current working directory,
+under ``.hypothesis/examples``.  If this location is unusable, e.g. because you do not have
+read or write permissions, Hypothesis will emit a warning and fall back to an
+:class:`~hypothesis.database.InMemoryExampleDatabase`.
 
-The examples database can be shared simply by checking the directory into
-version control, for example with the following ``.gitignore``::
+Hypothesis provides the following :class:`~hypothesis.database.ExampleDatabase` implementations:
 
-    # Ignore files cached by Hypothesis...
-    .hypothesis/*
-    # except for the examples directory
-    !.hypothesis/examples/
-
-Like everything under ``.hypothesis/``, the examples directory will be
-transparently created on demand.  Unlike the other subdirectories,
-``examples/`` is designed to handle merges, deletes, etc if you just add the
-directory into git, mercurial, or any similar version control system.
-
+.. autoclass:: hypothesis.database.InMemoryExampleDatabase
+.. autoclass:: hypothesis.database.DirectoryBasedExampleDatabase
 
 ---------------------------------
 Defining your own ExampleDatabase
@@ -77,9 +53,3 @@ to use a shared datastore, with just a few methods:
 
 .. autoclass:: hypothesis.database.ExampleDatabase
    :members:
-
-Two concrete :class:`~hypothesis.database.ExampleDatabase` classes ship with
-Hypothesis:
-
-.. autoclass:: hypothesis.database.DirectoryBasedExampleDatabase
-.. autoclass:: hypothesis.database.InMemoryExampleDatabase

--- a/hypothesis-python/docs/database.rst
+++ b/hypothesis-python/docs/database.rst
@@ -45,6 +45,7 @@ Hypothesis provides the following :class:`~hypothesis.database.ExampleDatabase` 
 .. autoclass:: hypothesis.database.DirectoryBasedExampleDatabase
 .. autoclass:: hypothesis.database.ReadOnlyDatabase
 .. autoclass:: hypothesis.database.MultiplexedDatabase
+.. autoclass:: hypothesis.extra.redis.RedisExampleDatabase
 
 ---------------------------------
 Defining your own ExampleDatabase

--- a/hypothesis-python/docs/database.rst
+++ b/hypothesis-python/docs/database.rst
@@ -43,6 +43,8 @@ Hypothesis provides the following :class:`~hypothesis.database.ExampleDatabase` 
 
 .. autoclass:: hypothesis.database.InMemoryExampleDatabase
 .. autoclass:: hypothesis.database.DirectoryBasedExampleDatabase
+.. autoclass:: hypothesis.database.ReadOnlyDatabase
+.. autoclass:: hypothesis.database.MultiplexedDatabase
 
 ---------------------------------
 Defining your own ExampleDatabase

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -27,6 +27,10 @@ pip install ".[dpcontracts]"
 $PYTEST tests/dpcontracts/
 pip uninstall -y dpcontracts
 
+pip install fakeredis
+$PYTEST tests/redis/
+pip uninstall -y redis fakeredis
+
 pip install typing_extensions
 $PYTEST tests/typing_extensions/
 pip uninstall -y typing_extensions

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -66,6 +66,7 @@ extras = {
     "pandas": ["pandas>=0.19"],
     "pytest": ["pytest>=4.3"],
     "dpcontracts": ["dpcontracts>=0.4"],
+    "redis": ["redis>=3.0.0"],
     # We only support Django versions with upstream support - see
     # https://www.djangoproject.com/download/#supported-versions
     "django": ["pytz>=2014.1", "django>=2.2"],

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -28,6 +28,8 @@ __all__ = [
     "DirectoryBasedExampleDatabase",
     "ExampleDatabase",
     "InMemoryExampleDatabase",
+    "MultiplexedDatabase",
+    "ReadOnlyDatabase",
 ]
 
 
@@ -148,10 +150,9 @@ def _hash(key):
 class DirectoryBasedExampleDatabase(ExampleDatabase):
     """Use a directory to store Hypothesis examples as files.
 
-    The default storage format is as a fairly opaque directory structure. Each test
-    corresponds to a directory, and each example to a file within that directory.
-
-    A ``DirectoryBasedExampleDatabase`` can be shared by checking the directory
+    Each test corresponds to a directory, and each example to a file within that
+    directory.  While the contents are fairly opaque, a
+    ``DirectoryBasedExampleDatabase`` can be shared by checking the directory
     into version control, for example with the following ``.gitignore``::
 
         # Ignore files cached by Hypothesis...
@@ -227,3 +228,85 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
             os.unlink(self._value_path(key, value))
         except OSError:
             pass
+
+
+class ReadOnlyDatabase(ExampleDatabase):
+    """A wrapper to make the given database read-only.
+
+    The implementation passes through ``fetch``, and turns ``save``, ``delete``, and
+    ``move`` into silent no-ops.
+
+    Note that this disables Hypothesis' automatic discarding of stale examples.
+    It is designed to allow local machines to access a shared database (e.g. from CI
+    servers), without propagating changes back from a local or in-development branch.
+    """
+
+    def __init__(self, db: ExampleDatabase) -> None:
+        assert isinstance(db, ExampleDatabase)
+        self._wrapped = db
+
+    def __repr__(self) -> str:
+        return f"ReadOnlyDatabase({self._wrapped!r})"
+
+    def fetch(self, key: bytes) -> Iterable[bytes]:
+        yield from self._wrapped.fetch(key)
+
+    def save(self, key: bytes, value: bytes) -> None:
+        pass
+
+    def delete(self, key: bytes, value: bytes) -> None:
+        pass
+
+
+class MultiplexedDatabase(ExampleDatabase):
+    """A wrapper around multiple databases.
+
+    Each ``save``, ``fetch``, ``move``, or ``delete`` operation will be run against
+    all of the wrapped databases.  ``fetch`` does not yield duplicate values, even
+    if the same value is present in two or more of the wrapped databases.
+
+    This combines well with a :class:`ReadOnlyDatabase`, as follows:
+
+    .. code-block:: python
+
+        local = DirectoryBasedExampleDatabase("/tmp/hypothesis/examples/")
+        shared = CustomNetworkDatabase()
+
+        settings.register_profile("ci", database=shared)
+        settings.register_profile(
+            "dev", database=MultiplexedDatabase(local, ReadOnlyDatabase(shared))
+        )
+        settings.load_profile("ci" if os.environ.get("CI") else "dev")
+
+    So your CI system or fuzzing runs can populate a central shared database;
+    while local runs on development machines can reproduce any failures from CI
+    but will only cache their own failures locally and cannot remove examples
+    from the shared database.
+    """
+
+    def __init__(self, *dbs: ExampleDatabase) -> None:
+        assert all(isinstance(db, ExampleDatabase) for db in dbs)
+        self._wrapped = dbs
+
+    def __repr__(self) -> str:
+        return "MultiplexedDatabase({})".format(", ".join(map(repr, self._wrapped)))
+
+    def fetch(self, key: bytes) -> Iterable[bytes]:
+        seen = set()
+        for db in self._wrapped:
+            for value in db.fetch(key):
+                if value not in seen:
+                    yield value
+                    seen.add(value)
+
+    def save(self, key: bytes, value: bytes) -> None:
+        for db in self._wrapped:
+            db.save(key, value)
+
+    def delete(self, key: bytes, value: bytes) -> None:
+        for db in self._wrapped:
+            db.delete(key, value)
+
+    def move(self, src: bytes, dest: bytes, value: bytes) -> None:
+        for db in self._wrapped:
+            db.move(src, dest, value)

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -148,9 +148,21 @@ def _hash(key):
 class DirectoryBasedExampleDatabase(ExampleDatabase):
     """Use a directory to store Hypothesis examples as files.
 
-    This is the default database for Hypothesis; see above for details.
+    The default storage format is as a fairly opaque directory structure. Each test
+    corresponds to a directory, and each example to a file within that directory.
 
-    .. i.e. see the documentation in database.rst
+    A ``DirectoryBasedExampleDatabase`` can be shared by checking the directory
+    into version control, for example with the following ``.gitignore``::
+
+        # Ignore files cached by Hypothesis...
+        .hypothesis/*
+        # except for the examples directory
+        !.hypothesis/examples/
+
+    Note however that this only makes sense if you also pin to an exact version of
+    Hypothesis, and we would usually recommend implementing a shared database with
+    a network datastore - see :class:`~hypothesis.database.ExampleDatabase`, and
+    the :class:`~hypothesis.database.MultiplexedDatabase` helper.
     """
 
     def __init__(self, path: str) -> None:

--- a/hypothesis-python/src/hypothesis/extra/redis.py
+++ b/hypothesis-python/src/hypothesis/extra/redis.py
@@ -1,0 +1,83 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from contextlib import contextmanager
+from datetime import timedelta
+from typing import Iterable
+
+from redis import Redis
+
+from hypothesis.database import ExampleDatabase
+from hypothesis.internal.validation import check_type
+
+
+class RedisExampleDatabase(ExampleDatabase):
+    """Store Hypothesis examples as sets in the given :class:`redis.Redis` datastore.
+
+    This is particularly useful for shared databases, as per the recipe
+    for a :class:`~hypothesis.database.MultiplexedDatabase`.
+
+    .. note::
+
+        If a test has not been run for ``expire_after``, those examples will be allowed
+        to expire.  The default time-to-live persists examples between weekly runs.
+    """
+
+    def __init__(
+        self,
+        redis: Redis,
+        *,
+        expire_after: timedelta = timedelta(days=8),
+        key_prefix: bytes = b"hypothesis-example:",
+    ):
+        check_type(Redis, redis, "redis")
+        check_type(timedelta, expire_after, "expire_after")
+        check_type(bytes, key_prefix, "key_prefix")
+        self.redis = redis
+        self._expire_after = expire_after
+        self._prefix = key_prefix
+
+    def __repr__(self) -> str:
+        return (
+            f"RedisExampleDatabase({self.redis!r}, expire_after={self._expire_after!r})"
+        )
+
+    @contextmanager
+    def _pipeline(self, *reset_expire_keys, transaction=False, auto_execute=True):
+        # Context manager to batch updates and expiry reset, reducing TCP roundtrips
+        pipe = self.redis.pipeline(transaction=transaction)
+        yield pipe
+        for key in reset_expire_keys:
+            pipe.expire(self._prefix + key, self._expire_after)
+        if auto_execute:
+            pipe.execute()
+
+    def fetch(self, key: bytes) -> Iterable[bytes]:
+        with self._pipeline(key, auto_execute=False) as pipe:
+            pipe.smembers(self._prefix + key)
+        yield from pipe.execute()[0]
+
+    def save(self, key: bytes, value: bytes) -> None:
+        with self._pipeline(key) as pipe:
+            pipe.sadd(self._prefix + key, value)
+
+    def delete(self, key: bytes, value: bytes) -> None:
+        with self._pipeline(key) as pipe:
+            pipe.srem(self._prefix + key, value)
+
+    def move(self, src: bytes, dest: bytes, value: bytes) -> None:
+        with self._pipeline(src, dest) as pipe:
+            pipe.srem(self._prefix + src, value)
+            pipe.sadd(self._prefix + dest, value)

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -22,6 +22,8 @@ from hypothesis.database import (
     DirectoryBasedExampleDatabase,
     ExampleDatabase,
     InMemoryExampleDatabase,
+    MultiplexedDatabase,
+    ReadOnlyDatabase,
 )
 from hypothesis.strategies import binary, lists, tuples
 
@@ -133,3 +135,34 @@ def test_can_handle_disappearing_files(tmpdir, monkeypatch):
         os, "listdir", lambda d: base_listdir(d) + ["this-does-not-exist"]
     )
     assert list(db.fetch(b"foo")) == [b"bar"]
+
+
+def test_readonly_db_is_not_writable():
+    inner = InMemoryExampleDatabase()
+    wrapped = ReadOnlyDatabase(inner)
+    inner.save(b"key", b"value")
+    inner.save(b"key", b"value2")
+    wrapped.delete(b"key", b"value")
+    wrapped.move(b"key", b"key2", b"value2")
+    wrapped.save(b"key", b"value3")
+    assert set(wrapped.fetch(b"key")) == {b"value", b"value2"}
+    assert set(wrapped.fetch(b"key2")) == set()
+
+
+def test_multiplexed_dbs_read_and_write_all():
+    a = InMemoryExampleDatabase()
+    b = InMemoryExampleDatabase()
+    multi = MultiplexedDatabase(a, b)
+    a.save(b"a", b"aa")
+    b.save(b"b", b"bb")
+    multi.save(b"c", b"cc")
+    multi.move(b"a", b"b", b"aa")
+    for db in (a, b, multi):
+        assert set(db.fetch(b"a")) == set()
+        assert set(db.fetch(b"c")) == {b"cc"}
+    got = list(multi.fetch(b"b"))
+    assert len(got) == 2
+    assert set(got) == {b"aa", b"bb"}
+    multi.delete(b"c", b"cc")
+    for db in (a, b, multi):
+        assert set(db.fetch(b"c")) == set()

--- a/hypothesis-python/tests/redis/__init__.py
+++ b/hypothesis-python/tests/redis/__init__.py
@@ -1,0 +1,14 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER

--- a/hypothesis-python/tests/redis/test_redis_exampledatabase.py
+++ b/hypothesis-python/tests/redis/test_redis_exampledatabase.py
@@ -1,0 +1,70 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from fakeredis import FakeRedis
+
+from hypothesis import strategies as st
+from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.extra.redis import RedisExampleDatabase
+from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
+
+
+class DatabaseComparison(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        self.dbs = [
+            InMemoryExampleDatabase(),
+            RedisExampleDatabase(FakeRedis()),
+        ]
+
+    keys = Bundle("keys")
+    values = Bundle("values")
+
+    @rule(target=keys, k=st.binary())
+    def k(self, k):
+        return k
+
+    @rule(target=values, v=st.binary())
+    def v(self, v):
+        return v
+
+    @rule(k=keys, v=values)
+    def save(self, k, v):
+        for db in self.dbs:
+            db.save(k, v)
+
+    @rule(k=keys, v=values)
+    def delete(self, k, v):
+        for db in self.dbs:
+            db.delete(k, v)
+
+    @rule(k1=keys, k2=keys, v=values)
+    def move(self, k1, k2, v):
+        for db in self.dbs:
+            db.move(k1, k2, v)
+
+    @rule(k=keys)
+    def values_agree(self, k):
+        last = None
+        last_db = None
+        for db in self.dbs:
+            keys = set(db.fetch(k))
+            if last is not None:
+                assert last == keys, (last_db, db)
+            last = keys
+            last_db = db
+
+
+TestDBs = DatabaseComparison.TestCase


### PR DESCRIPTION
Our `ExampleDatabase` is a lovely thing - and persisting failing examples is great - but our story for *sharing* them is historically not amazing.  "Sync files or put them in version control" does *work*, but gets painful to set up or very noisy, respectively.  This PR is because after sketching out my ideal fuzzing workflow for teams, I realised it was just as useful for CI .  In short:

- The CI server (and/or fuzz server) saves any failing examples to a *network* datastore.
- Developer machines read from the shared datastore, maintain a local copy, and may or may not write to it.
- To reproduce failing examples locally, *just run the tests*.

And while of course this is optional and doesn't change the default directory-based DB, if you have a Redis server it's now ~ten lines of setup code to get the workflow above.  [Here's the new docs](https://hypothesis--2622.org.readthedocs.build/en/2622/database.html).