### PR TITLE
Improve error messages for misused APIs

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds some helpful suggestions to error messages you might see
+while learning to use the :func:`@example() <hypothesis.example>` decorator
+(:issue:`2611`) or the :func:`~hypothesis.strategies.one_of` strategy.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -339,6 +339,11 @@ def one_of(*args):  # noqa: F811
         # without incurring any performance overhead when there is only one
         # strategy, and keeps our reprs simple.
         return args[0]
+    if args and not any(isinstance(a, SearchStrategy) for a in args):
+        raise InvalidArgument(
+            f"Did you mean st.sampled_from({list(args)!r})?  st.one_of() is used "
+            "to combine strategies, but all of the arguments were of other types."
+        )
     return OneOfStrategy(args)
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -340,6 +340,9 @@ def one_of(*args):  # noqa: F811
         # strategy, and keeps our reprs simple.
         return args[0]
     if args and not any(isinstance(a, SearchStrategy) for a in args):
+        # And this special case is to give a more-specific error message if it
+        # seems that the user has confused `one_of()` for  `sampled_from()`;
+        # the remaining validation is left to OneOfStrategy.  See PR #2627.
         raise InvalidArgument(
             f"Did you mean st.sampled_from({list(args)!r})?  st.one_of() is used "
             "to combine strategies, but all of the arguments were of other types."

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -266,7 +266,11 @@ def test_produces_valid_examples_from_keyword(fn, kwargs):
     fn(**kwargs).example()
 
 
-@fn_test((ds.one_of, (1,)), (ds.tuples, (1,)))
+@fn_test(
+    (ds.one_of, (1,)),
+    (ds.one_of, (1, ds.integers())),
+    (ds.tuples, (1,)),
+)
 def test_validates_args(fn, args):
     with pytest.raises(InvalidArgument):
         fn(*args).example()

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -28,7 +28,12 @@ from hypothesis import (
     reporting,
     settings,
 )
-from hypothesis.errors import DeadlineExceeded, InvalidArgument, MultipleFailures
+from hypothesis.errors import (
+    DeadlineExceeded,
+    HypothesisWarning,
+    InvalidArgument,
+    MultipleFailures,
+)
 from hypothesis.strategies import floats, integers, nothing, text
 from tests.common.utils import assert_falsifying_output, capture_out
 
@@ -258,3 +263,23 @@ def test_multiple_example_reporting(exc):
 
     with pytest.raises(exc):
         inner_test_multiple_failing_examples()
+
+
+@example(text())
+@given(text())
+def test_example_decorator_accepts_strategies(s):
+    """The custom error message only happens when the test has already failed."""
+
+
+def test_helpful_message_when_example_fails_because_it_was_passed_a_strategy():
+    @example(text())
+    @given(text())
+    def t(s):
+        assert isinstance(s, str)
+
+    try:
+        t()
+    except HypothesisWarning as err:
+        assert isinstance(err.__cause__, AssertionError)
+    else:
+        raise NotImplementedError("should be unreachable")

--- a/hypothesis-python/tests/cover/test_one_of.py
+++ b/hypothesis-python/tests/cover/test_one_of.py
@@ -13,7 +13,12 @@
 #
 # END HEADER
 
+import re
+
+import pytest
+
 from hypothesis import given, strategies as st
+from hypothesis.errors import InvalidArgument
 from tests.common.debug import assert_no_examples
 
 
@@ -37,3 +42,11 @@ def test_one_of_single_strategy_is_noop():
     s = st.integers()
     assert st.one_of(s) is s
     assert st.one_of([s]) is s
+
+
+def test_one_of_without_strategies_suggests_sampled_from():
+    with pytest.raises(
+        InvalidArgument,
+        match=re.escape("Did you mean st.sampled_from([1, 2, 3])?"),
+    ):
+        st.one_of(1, 2, 3)


### PR DESCRIPTION
While not all problems admit a technical solution, helpful error messages have a complementary role to documentation.  This PR adds two context-specific messages that can help with certain confusions I've seen lately - closing #2611 and pointing `one_of(1, 2, 3)` to `sampled_from(1, 2, 3)`.