### PR TITLE
remove instanceof type check for signature hints

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-:func:`~hypothesis.interal.compat.get_type_hints` now accepts any hints present
+:func:`~hypothesis.internal.compat.get_type_hints` now accepts any hints present
 in `thing.__signature__`, not just instances of `type`. This allows for the use
 of types from the `typing` module.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+:func:`~hypothesis.interal.compat.get_type_hints` now accepts any hints present
+in `thing.__signature__`, not just instances of `type`. This allows for the use
+of types from the `typing` module.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,8 @@
 RELEASE_TYPE: patch
 
-:func:`~hypothesis.internal.compat.get_type_hints` now accepts any hints present
-in `thing.__signature__`, not just instances of `type`. This allows for the use
-of types from the `typing` module.
+This patch improves :func:`~hypothesis.strategies.builds` and
+:func:`~hypothesis.strategies.from_type` support for explicitly defined ``__signature__``
+attributes, from :ref:`version 5.8.3 <v5.8.3>`, to support generic types from the
+:mod:`python:typing` module.
+
+Thanks to Rónán Carrigan for identifying and fixing this problem!

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -135,7 +135,7 @@ def get_type_hints(thing):
                 {
                     k: v
                     for k, v in spec.annotations.items()
-                    if k in (spec.args + spec.kwonlyargs) and isinstance(v, type)
+                    if k in (spec.args + spec.kwonlyargs)
                 }
             )
     except (AttributeError, TypeError, NameError):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -130,12 +130,13 @@ def get_type_hints(thing):
             # comprehensive type information from get_type_hints
             # See https://github.com/HypothesisWorks/hypothesis/pull/2580
             # for more details.
+            from hypothesis.strategies._internal.types import is_a_type
             spec = inspect.getfullargspec(thing)
             hints.update(
                 {
                     k: v
                     for k, v in spec.annotations.items()
-                    if k in (spec.args + spec.kwonlyargs)
+                    if k in (spec.args + spec.kwonlyargs) and is_a_type(v)
                 }
             )
     except (AttributeError, TypeError, NameError):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -131,6 +131,7 @@ def get_type_hints(thing):
             # See https://github.com/HypothesisWorks/hypothesis/pull/2580
             # for more details.
             from hypothesis.strategies._internal.types import is_a_type
+
             spec = inspect.getfullargspec(thing)
             hints.update(
                 {

--- a/hypothesis-python/tests/nocover/test_build_signature.py
+++ b/hypothesis-python/tests/nocover/test_build_signature.py
@@ -14,7 +14,7 @@
 # END HEADER
 
 from inspect import signature
-from typing import get_type_hints
+from typing import get_type_hints, Literal
 
 from hypothesis import given, strategies as st
 
@@ -53,7 +53,7 @@ def use_annotations(
     pass
 
 
-def use_signature(self, testA: int, testB: str = None, *, testX: float, testY: str):
+def use_signature(self, testA: int, testB: str = None, *, testX: float, testY: Literal["value"]):
     pass
 
 
@@ -66,7 +66,7 @@ class ModelWithAlias:
         assert set(kwargs) == {"testA", "testX", "testY"}
         assert isinstance(kwargs["testA"], int)
         assert isinstance(kwargs["testX"], float)
-        assert isinstance(kwargs["testY"], str)
+        assert kwargs["testY"] == "value"
 
 
 @given(st.builds(ModelWithAlias))

--- a/hypothesis-python/tests/nocover/test_build_signature.py
+++ b/hypothesis-python/tests/nocover/test_build_signature.py
@@ -14,7 +14,7 @@
 # END HEADER
 
 from inspect import signature
-from typing import get_type_hints, List
+from typing import List, get_type_hints
 
 from hypothesis import given, strategies as st
 
@@ -53,7 +53,9 @@ def use_annotations(
     pass
 
 
-def use_signature(self, testA: int, testB: str = None, *, testX: float, testY: List[str]):
+def use_signature(
+    self, testA: int, testB: str = None, *, testX: float, testY: List[str]
+):
     pass
 
 
@@ -75,7 +77,7 @@ def test_build_using_different_signature_and_annotations(val):
     assert isinstance(val, ModelWithAlias)
 
 
-def use_bad_signature(self, testA: 1, testB: "not_a_type", *, testX: float):
+def use_bad_signature(self, testA: 1, *, testX: float):
     pass
 
 
@@ -86,6 +88,7 @@ class ModelWithBadAliasSignature:
     def __init__(self, **kwargs):
         assert set(kwargs) == {"testX"}
         assert isinstance(kwargs["testX"], float)
+
 
 @given(st.builds(ModelWithBadAliasSignature))
 def test_build_with_non_types_in_signature(val):


### PR DESCRIPTION
The code #2580 was taken from existing code that was intended for an older Python version which didn't take the `typing` module into account. This patch removes the check for `type` instance, to allow the `typing` types such as `Literal`, `Union`, etc.

As the signature is only manually created, I don't see an issue with the complete removal of the check. The alternative is to ensure it is from the `typing` module but I can't find an easy way to do this without using the private types. 