### PR TITLE
Fix Iterable type annotation handling

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -550,6 +550,11 @@ def resolve_Iterator(thing):
     return st.iterables(st.from_type(thing.__args__[0]))
 
 
+@register(typing.Iterable, st.iterables(st.nothing()))
+def resolve_Iterable(thing):
+    return st.iterables(st.from_type(thing.__args__[0]))
+
+
 @register(typing.Callable, st.functions())
 def resolve_Callable(thing):
     # Generated functions either accept no arguments, or arbitrary arguments.


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/2645.

I am not sure where and how to include additional tests, can you please provide guidance?

The only place where already correctly-working `Iterator` is mentioned in tests is this: https://github.com/HypothesisWorks/hypothesis/blob/c8d926284818767799f618a17866767e91d298ab/hypothesis-python/tests/cover/test_lookup.py#L105

But `Iterable` is also mentioned in the same spot a few lines below, even though it didn't work properly.