### PR TITLE
None-aware signature override

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.strategies.builds`, so that when passed
+:obj:`~hypothesis.infer` for an argument with a non-:class:`~python:typing.Optional`
+type annotation and a default value of ``None`` to build a class which defines
+an explicit ``__signature__`` attribute, either ``None`` or that type may be
+generated.
+
+This is unlikely to happen unless you are using :pypi:`pydantic` (:issue:`2648`).

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -10,6 +10,14 @@ on `PyPI <https://pypi.org/project/hypothesis/>`__.
 Hypothesis 5.x
 ==============
 
+.. only:: has_release_file
+
+    --------------------
+    Current pull request
+    --------------------
+
+    .. include:: ../RELEASE.rst
+
 .. _v5.38.0:
 
 -------------------

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "hoverxref.extension",
+    "sphinx_selective_exclude.eager_only",
 ]
 
 templates_path = ["_templates"]
@@ -52,6 +53,12 @@ with open(
     exec(f.read(), _d)
     version = _d["__version__"]
     release = _d["__version__"]
+
+
+def setup(app):
+    if os.path.isfile(os.path.join(os.path.dirname(__file__), "..", "RELEASE.rst")):
+        app.tags.add("has_release_file")
+
 
 language = None
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -132,14 +132,13 @@ def get_type_hints(thing):
             # for more details.
             from hypothesis.strategies._internal.types import is_a_type
 
-            spec = inspect.getfullargspec(thing)
-            hints.update(
-                {
-                    k: v
-                    for k, v in spec.annotations.items()
-                    if k in (spec.args + spec.kwonlyargs) and is_a_type(v)
-                }
-            )
+            vkinds = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+            for p in inspect.signature(thing).parameters.values():
+                if p.kind not in vkinds and is_a_type(p.annotation):
+                    if p.default is None:
+                        hints[p.name] = typing.Optional[p.annotation]
+                    else:
+                        hints[p.name] = p.annotation
     except (AttributeError, TypeError, NameError):
         pass
 

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -26,6 +26,7 @@ restructuredtext-lint
 sphinx
 sphinx-hoverxref
 sphinx-rtd-theme
+sphinx-selective-exclude
 toml
 tox
 twine

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -97,6 +97,7 @@ snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sortedcontainers==2.2.2   # via hypothesis (hypothesis-python/setup.py)
 sphinx-hoverxref==0.5b1   # via -r requirements/tools.in
 sphinx-rtd-theme==0.5.0   # via -r requirements/tools.in
+sphinx-selective-exclude==1.0.3  # via -r requirements/tools.in
 sphinx==3.2.1             # via -r requirements/tools.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx


### PR DESCRIPTION
The typing.get_type_hints function has equivalent logic, and since this has bitten people in the wild we'd better add it to ours.

Fixes #2648, related to or follows #2388, #2580, #2606, #2640.  CC @rcarriga FYI :slightly_smiling_face: 

----------

And `RELEASE.rst` is now [included in the changelog for PR docs builds](https://hypothesis--2649.org.readthedocs.build/en/2649/changes.html#current-pull-request) if it exists, so you can see how it renders.