### PR TITLE
Remove shrinking exemption for errors inside strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Hypothesis now shrinks examples where the error is raised while drawing from
+a strategy.  This makes complicated custom strategies *much* easier to debug,
+at the cost of a slowdown for use-cases where you catch and ignore such errors.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -23,7 +23,6 @@ from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import bit_length, int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
 from hypothesis.internal.conjecture.utils import calc_label_from_name
-from hypothesis.internal.escalation import mark_for_escalation
 
 TOP_LABEL = calc_label_from_name("top")
 DRAW_BYTES_LABEL = calc_label_from_name("draw_bytes() in ConjectureData")
@@ -883,15 +882,11 @@ class ConjectureData:
             if not at_top_level:
                 return strategy.do_draw(self)
             else:
+                strategy.validate()
                 try:
-                    strategy.validate()
-                    try:
-                        return strategy.do_draw(self)
-                    finally:
-                        self.draw_times.append(time.perf_counter() - start_time)
-                except BaseException as e:
-                    mark_for_escalation(e)
-                    raise
+                    return strategy.do_draw(self)
+                finally:
+                    self.draw_times.append(time.perf_counter() - start_time)
         finally:
             self.stop_example()
 

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -65,11 +65,6 @@ is_hypothesis_file = belongs_to(hypothesis)
 HYPOTHESIS_CONTROL_EXCEPTIONS = (DeadlineExceeded, StopTest, UnsatisfiedAssumption)
 
 
-def mark_for_escalation(e):
-    if not isinstance(e, HYPOTHESIS_CONTROL_EXCEPTIONS):
-        e.hypothesis_internal_always_escalate = True
-
-
 def escalate_hypothesis_internal_error():
     if PREVENT_ESCALATION:
         return
@@ -79,8 +74,6 @@ def escalate_hypothesis_internal_error():
     if getattr(e, "hypothesis_internal_never_escalate", False):
         return
 
-    if getattr(e, "hypothesis_internal_always_escalate", False):
-        raise
     filepath = traceback.extract_tb(tb)[-1][0]
     if is_hypothesis_file(filepath) and not isinstance(
         e, (HypothesisException,) + HYPOTHESIS_CONTROL_EXCEPTIONS

--- a/hypothesis-python/tests/cover/test_escalation.py
+++ b/hypothesis-python/tests/cover/test_escalation.py
@@ -18,7 +18,6 @@ import os
 import pytest
 
 import hypothesis
-from hypothesis import given, strategies as st
 from hypothesis.internal import escalation as esc
 
 
@@ -47,23 +46,6 @@ def test_does_not_escalate_errors_in_hypothesis_file_if_disabled(monkeypatch):
         assert False
     except AssertionError:
         esc.escalate_hypothesis_internal_error()
-
-
-def test_immediately_escalates_errors_in_generation():
-    count = [0]
-
-    def explode(s):
-        count[0] += 1
-        raise ValueError()
-
-    @given(st.integers().map(explode))
-    def test(i):
-        pass
-
-    with pytest.raises(ValueError):
-        test()
-
-    assert count == [1]
 
 
 def test_is_hypothesis_file_not_confused_by_prefix(monkeypatch):


### PR DESCRIPTION
Since b8e837ef42ce2e5faba2dfb7504143fd790f9444, [version 3.37](https://hypothesis.readthedocs.io/en/latest/changes.html#v3-37-0) in 2017, we've had special handling for exceptions raised while drawing from a strategy and don't attempt to minimise them.

I've opened this PR because I think that we *should* shrink them, just like we shrink everything else and for basically the same reasons: it makes debugging immeasurably easier.  As a concrete example, the lack of in-strategy shrinking has been really really painful while working on Hypothesmith - my "is this source code valid" oracle is built on top of `compile()`.  When the bug is inside the reference compiler, getting long high-unicode strings as a failing input *which doesn't replicate after copy-paste* is not much fun.

CC @DRMacIver - you'll remember the history better than me, but I think the exemption was added because errors in strategies had previously been a healthcheck-warning instead of an error, and at the time it made sense to keep treating them differently from test failures.  IMO with the range of more complex strategies we see now (e.g. `schemathesis`), we should just shrink everything.