### PR TITLE
Support PEP 585 parametrized standard types

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.from_type` now knows how to resolve :pep:`585`
+parameterized standard collection types, which are new in Python 3.9
+(:issue:`2629`).

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -29,6 +29,8 @@ run()
 # Skip collection of tests which require the Django test runner,
 # or that don't work on the current version of Python.
 collect_ignore_glob = ["django/*"]
+if sys.version_info < (3, 7):
+    collect_ignore_glob.append("cover/*py37*")
 if sys.version_info < (3, 8):
     collect_ignore_glob.append("cover/*py38*")
 

--- a/hypothesis-python/tests/cover/test_lookup_py37.py
+++ b/hypothesis-python/tests/cover/test_lookup_py37.py
@@ -1,0 +1,200 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import annotations
+
+import collections
+import collections.abc
+import contextlib
+import sys
+
+import pytest
+
+from hypothesis import assume, given, infer
+
+# This test file is skippped on Python <= 3.6, where `list[Elem]` is always a
+# SyntaxError.  On Python 3.7 and 3.8, `from __future__ import annotations` means
+# that the syntax is supported; but the feature fails at runtime.  On Python
+# 3.9 and later, it should all work.
+#
+# For details, see https://www.python.org/dev/peps/pep-0585/
+
+if sys.version_info < (3, 9):
+    pytestmark = pytest.mark.xfail(
+        raises=Exception, strict=True, reason="Requires Python 3.9 (PEP 585) or later."
+    )
+
+
+class Elem:
+    pass
+
+
+class Value:
+    pass
+
+
+def check(t, ex):
+    assert isinstance(ex, t)
+    assert all(isinstance(e, Elem) for e in ex)
+    assume(ex)
+
+
+@given(x=infer)
+def test_resolving_standard_tuple1_as_generic(x: tuple[Elem]):
+    check(tuple, x)
+
+
+@given(x=infer)
+def test_resolving_standard_tuple2_as_generic(x: tuple[Elem, Elem]):
+    check(tuple, x)
+
+
+@given(x=infer)
+def test_resolving_standard_tuple_variadic_as_generic(x: tuple[Elem, ...]):
+    check(tuple, x)
+
+
+@given(x=infer)
+def test_resolving_standard_list_as_generic(x: list[Elem]):
+    check(list, x)
+
+
+@given(x=infer)
+def test_resolving_standard_dict_as_generic(x: dict[Elem, Value]):
+    check(dict, x)
+    assert all(isinstance(e, Value) for e in x.values())
+
+
+@given(x=infer)
+def test_resolving_standard_set_as_generic(x: set[Elem]):
+    check(set, x)
+
+
+@given(x=infer)
+def test_resolving_standard_frozenset_as_generic(x: frozenset[Elem]):
+    check(frozenset, x)
+
+
+@given(x=infer)
+def test_resolving_standard_defaultdict_as_generic(
+    x: collections.defaultdict[Elem, Value]
+):
+    check(collections.defaultdict, x)
+    assert all(isinstance(e, Value) for e in x.values())
+
+
+@given(x=infer)
+def test_resolving_standard_iterable_as_generic(x: collections.abc.Iterable[Elem]):
+    check(collections.abc.Iterable, x)
+
+
+@given(x=infer)
+def test_resolving_standard_iterator_as_generic(x: collections.abc.Iterator[Elem]):
+    check(collections.abc.Iterator, x)
+
+
+@given(x=infer)
+def test_resolving_standard_reversible_as_generic(x: collections.abc.Reversible[Elem]):
+    check(collections.abc.Reversible, x)
+
+
+@given(x=infer)
+def test_resolving_standard_container_as_generic(x: collections.abc.Container[Elem]):
+    check(collections.abc.Container, x)
+
+
+@given(x=infer)
+def test_resolving_standard_collection_as_generic(x: collections.abc.Collection[Elem]):
+    check(collections.abc.Collection, x)
+
+
+@given(x=infer)
+def test_resolving_standard_callable_ellipsis(x: collections.abc.Callable[..., Elem]):
+    assert isinstance(x, collections.abc.Callable)
+    assert callable(x)
+    # ... implies *args, **kwargs; as would any argument types
+    assert isinstance(x(), Elem)
+    assert isinstance(x(1, 2, 3, a=4, b=5, c=6), Elem)
+
+
+@given(x=infer)
+def test_resolving_standard_callable_no_args(x: collections.abc.Callable[[], Elem]):
+    assert isinstance(x, collections.abc.Callable)
+    assert callable(x)
+    # [] implies that no arguments are accepted
+    assert isinstance(x(), Elem)
+    with pytest.raises(TypeError):
+        x(1)
+    with pytest.raises(TypeError):
+        x(a=1)
+
+
+@given(x=infer)
+def test_resolving_standard_collections_mutableset_as_generic(
+    x: collections.abc.MutableSet[Elem],
+):
+    check(collections.abc.MutableSet, x)
+
+
+@given(x=infer)
+def test_resolving_standard_mapping_as_generic(x: collections.abc.Mapping[Elem, Value]):
+    check(collections.abc.Mapping, x)
+    assert all(isinstance(e, Value) for e in x.values())
+
+
+@given(x=infer)
+def test_resolving_standard_mutable_mapping_as_generic(
+    x: collections.abc.MutableMapping[Elem, Value],
+):
+    check(collections.abc.MutableMapping, x)
+    assert all(isinstance(e, Value) for e in x.values())
+
+
+@given(x=infer)
+def test_resolving_standard_sequence_as_generic(x: collections.abc.Sequence[Elem]):
+    check(collections.abc.Sequence, x)
+
+
+@given(x=infer)
+def test_resolving_standard_mutable_sequence_as_generic(
+    x: collections.abc.MutableSequence[Elem],
+):
+    check(collections.abc.MutableSequence, x)
+
+
+@given(x=infer)
+def test_resolving_standard_keysview_as_generic(x: collections.abc.KeysView[Elem]):
+    check(collections.abc.KeysView, x)
+
+
+@given(x=infer)
+def test_resolving_standard_itemsview_as_generic(
+    x: collections.abc.ItemsView[Elem, Value]
+):
+    assert isinstance(x, collections.abc.ItemsView)
+    assert all(isinstance(e, Elem) and isinstance(v, Value) for e, v in x)
+    assume(x)
+
+
+@given(x=infer)
+def test_resolving_standard_valuesview_as_generic(x: collections.abc.ValuesView[Elem]):
+    check(collections.abc.ValuesView, x)
+
+
+@given(x=infer)
+def test_resolving_standard_contextmanager_as_generic(
+    x: contextlib.AbstractContextManager[Elem],
+):
+    assert isinstance(x, contextlib.AbstractContextManager)


### PR DESCRIPTION
[PEP 585](https://www.python.org/dev/peps/pep-0585/), the new-in-Python 3.9 feature that enables type annotations like `list[int]` rather than `typing.List[int]`,  turns out to require some minor patches in `st.from_type()`.  

This PR makes those changes, and closes #2629 by adding all the tests needed to prove it.  

CC @sobolevn for another typing review :grin: 