### PR TITLE
Fix regex case bug

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2657`, where passing unicode patterns compiled with
+:obj:`python:re.IGNORECASE` to :func:`~hypothesis.strategies.from_regex` could
+trigger an internal error when casefolding a character creates a longer string
+(e.g. ``"\u0130".lower() -> "i\u0370"``).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2228,7 +2228,7 @@ def functions(
 ) -> SearchStrategy[Callable[..., Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737
-    """functions(*, like=lambda: None, returns=none())
+    """functions(*, like=lambda: None, returns=none(), pure=False)
 
     A strategy for functions, which can be used in callbacks.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
@@ -316,14 +316,8 @@ def _strategy(codes, context, is_unicode):
                     j += 1
 
                 if i + 1 < j:
-                    strategies.append(
-                        st.just(
-                            empty.join(
-                                [to_char(charcode) for (_, charcode) in codes[i:j]]
-                            )
-                        )
-                    )
-
+                    chars = (to_char(charcode) for _, charcode in codes[i:j])
+                    strategies.append(st.just(empty.join(chars)))
                     i = j
                     continue
 

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -453,3 +453,12 @@ def test_fullmatch_must_be_bool():
 
 def test_issue_1786_regression():
     st.from_regex(re.compile("\\\\", flags=re.IGNORECASE)).validate()
+
+
+def test_sets_allow_multichar_output_in_ignorecase_mode():
+    # CharacterBuilder.strategy includes logic to add multi-character strings
+    # via sampled_from(), if any are whitelisted as matching.  See issue #2657.
+    find_any(
+        st.from_regex(re.compile("[\u0130_]", re.IGNORECASE)),
+        lambda s: len(s) > 1,
+    )

--- a/hypothesis-python/tests/nocover/test_regex.py
+++ b/hypothesis-python/tests/nocover/test_regex.py
@@ -85,3 +85,22 @@ def test_fuzz_stuff(data):
 
     ex = data.draw(st.from_regex(regex))
     assert regex.search(ex)
+
+
+# Some preliminaries, to establish what's happening:
+I_WITH_DOT = "\u0130"
+assert I_WITH_DOT.swapcase() == "i\u0307"  # note: string of length two!
+assert re.compile(I_WITH_DOT, flags=re.IGNORECASE).match(I_WITH_DOT.swapcase())
+
+
+@given(st.data())
+def test_case_insensitive_not_literal_never_constructs_multichar_match(data):
+    # So our goal is to confirm that we can never accidentally create a non-matching
+    # string by assembling individually allowed characters.
+    pattern = re.compile(f"[^{I_WITH_DOT}]+", flags=re.IGNORECASE)
+    strategy = st.from_regex(pattern, fullmatch=True)
+    for _ in range(5):
+        s = data.draw(strategy)
+        assert pattern.fullmatch(s) is not None
+        # And to be on the safe side, we implment this stronger property:
+        assert set(s).isdisjoint(I_WITH_DOT.swapcase())

--- a/hypothesis-python/tests/nocover/test_regex.py
+++ b/hypothesis-python/tests/nocover/test_regex.py
@@ -104,3 +104,10 @@ def test_case_insensitive_not_literal_never_constructs_multichar_match(data):
         assert pattern.fullmatch(s) is not None
         # And to be on the safe side, we implment this stronger property:
         assert set(s).isdisjoint(I_WITH_DOT.swapcase())
+
+
+@given(st.from_regex(re.compile(f"[^{I_WITH_DOT}_]", re.IGNORECASE), fullmatch=True))
+def test_no_error_converting_negated_sets_to_strategy(s):
+    # CharactersBuilder no longer triggers an internal error converting sets
+    # or negated sets to a strategy when multi-char strings are whitelisted.
+    pass


### PR DESCRIPTION
Closes #2657 - turns out we weren't quite careful enough about `.swapcase()` on unicode characters: it turns out there there's at least one character where this changes the length, but still matches the longer string in case-insensitive mode.  So now we check for length as well as a match.