### PR TITLE
Cache fewer inputs when fuzzing

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds a performance optimisation to avoid saving redundant
+seeds when using :ref:`the .fuzz_one_input hook <fuzz_one_input>`.

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -708,7 +708,8 @@ Use with external fuzzers
       and find more bugs without more tests!
 
 Sometimes, you might want to point a traditional fuzzer such as
-`python-afl <https://github.com/jwilk/python-afl>`__ or :pypi:`pythonfuzz`
+`python-afl <https://github.com/jwilk/python-afl>`__, :pypi:`pythonfuzz`,
+or Google's :pypi:`atheris` (for Python *and* native extensions)
 at your code. Wouldn't it be nice if you could use any of your
 :func:`@given <hypothesis.given>` tests as fuzz targets, instead of
 converting bytestrings into your objects by hand?

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -52,7 +52,7 @@ Available settings
 Controlling what runs
 ~~~~~~~~~~~~~~~~~~~~~
 
-Hypothesis divides tests into four logically distinct phases:
+Hypothesis divides tests into five logically distinct phases:
 
 1. Running explicit examples :ref:`provided with the @example decorator <providing-explicit-examples>`.
 2. Rerunning a selection of previously failing examples to reproduce a previously seen error

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -44,7 +44,7 @@ Available settings
 
 .. autoclass:: hypothesis.settings
     :members:
-    :exclude-members: register_profile, get_profile, load_profile, buffer_size
+    :exclude-members: register_profile, get_profile, load_profile
 
 .. _phases:
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -23,7 +23,6 @@ import contextlib
 import datetime
 import inspect
 import os
-import threading
 import warnings
 from enum import Enum, IntEnum, unique
 from typing import Any, Dict, List, Optional
@@ -167,7 +166,6 @@ class settings(metaclass=settingsMeta):
                     "Invalid argument: %r is not a valid setting" % (name,)
                 )
             setattr(self, name, value)
-        self.storage = threading.local()
         self._construction_complete = True
 
     def __call__(self, test):

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -373,6 +373,9 @@ If you are writing one-off tests, running tens of thousands of examples is
 quite reasonable as Hypothesis may miss uncommon bugs with default settings.
 For very complex code, we have observed Hypothesis finding novel bugs after
 *several million* examples while testing :pypi:`SymPy`.
+If you are running more than 100k examples for a test, consider using our
+:ref:`integration for coverage-guided fuzzing <fuzz_one_input>` - it really
+shines when given minutes or hours to run.
 """,
 )
 
@@ -413,7 +416,7 @@ settings._define_setting(
     default=not_set,
     show_default=False,
     description="""
-An instance of hypothesis.database.ExampleDatabase that will be
+An instance of :class:`~hypothesis.database.ExampleDatabase` that will be
 used to save examples to and load previous examples from. May be ``None``
 in which case no storage will be used, ``":memory:"`` for an in-memory
 database, or any path for a directory-based example database.
@@ -607,7 +610,7 @@ allowed to exceed. Tests which take longer than that may be converted into
 errors (but will not necessarily be if close to the deadline, to allow some
 variability in test run time).
 
-Set this to None to disable this behaviour entirely.
+Set this to ``None`` to disable this behaviour entirely.
 """,
 )
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -64,7 +64,7 @@ class settingsProperty:
                     result = ExampleDatabase(not_set)
                 return result
             except KeyError:
-                raise AttributeError(self.name)
+                raise AttributeError(self.name) from None
 
     def __set__(self, obj, value):
         obj.__dict__[self.name] = value
@@ -316,7 +316,7 @@ class settings(metaclass=settingsMeta):
         try:
             return settings._profiles[name]
         except KeyError:
-            raise InvalidArgument("Profile %r is not registered" % (name,))
+            raise InvalidArgument(f"Profile {name!r} is not registered") from None
 
     @staticmethod
     def load_profile(name: str) -> None:

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -92,14 +92,6 @@ def test_cannot_create_settings_with_invalid_options():
         settings(a_setting_with_limited_options="spoon")
 
 
-def test_cannot_register_with_parent_and_settings_args():
-    with pytest.raises(InvalidArgument):
-        settings.register_profile(
-            "conflicted", settings.default, settings=settings.default
-        )
-    assert "conflicted" not in settings._profiles
-
-
 def test_can_set_verbosity():
     settings(verbosity=Verbosity.quiet)
     settings(verbosity=Verbosity.normal)
@@ -439,11 +431,6 @@ def test_assigning_to_settings_attribute_on_state_machine_raises_error():
     state_machine_instance.settings = "any value"
 
 
-def test_can_not_set_timeout_to_time():
-    with pytest.raises(InvalidArgument):
-        settings(timeout=60)
-
-
 def test_derandomise_with_explicit_database_is_invalid():
     with pytest.raises(InvalidArgument):
         settings(derandomize=True, database=ExampleDatabase(":memory:"))
@@ -454,7 +441,6 @@ def test_derandomise_with_explicit_database_is_invalid():
     [
         {"max_examples": -1},
         {"max_examples": 2.5},
-        {"buffer_size": -1},
         {"stateful_step_count": -1},
         {"stateful_step_count": 2.5},
         {"deadline": -1},


### PR DESCRIPTION
The core idea here is that if we've previously seen some buffer that produces a particular failure, we only want to save the new buffer if it is shortlex smaller.  In practice this means that long fuzzing runs saturate and saves a lot of time clearing out irrelevant entries from the database later.

Inspired by fiddling with [Atheris](https://github.com/google/atheris), Google's new fuzzer for Python, and realising that we didn't already have this logic :sweat_smile: 