### PR TITLE
Move our all our CI to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,135 @@
+name: Hypothesis CI
+
+on:
+  push:
+    branches: [ master , github-actions ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+          - check-whole-repo-tests
+          - lint
+          - check-format
+          - check-coverage
+          - check-conjecture-coverage
+          - check-py38
+          - check-quality
+        python-version: ["3.8"]
+        include:
+          - task: check-py36
+            python-version: "3.6"
+          - task: check-py37
+            python-version: "3.7"
+          - task: check-py39
+            python-version: "3.9"
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh
+
+  test-win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - task: check-py38-x64
+            python.version: "3.8"
+            python.architecture: "x64"
+          - task: check-py38-x86
+            python.version: "3.8"
+            python.architecture: "x86"
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Install dependencies
+      run: |
+        pip install --upgrade setuptools pip wheel
+        pip install -r requirements/test.txt fakeredis typing-extensions
+        pip install hypothesis-python/[all]
+    - name: Run tests
+      run: python -m pytest --numprocesses auto hypothesis-python/tests/
+
+  test-osx:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        task:
+          - check-py38
+        python-version: ["3.8"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh
+
+  specific-deps:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+          - check-nose
+          - check-pytest43
+          - check-django31
+          - check-django30
+          - check-django22
+          - check-pandas111
+          - check-pandas100
+          - check-pandas25
+        python-version: ["3.8"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: TASK=${{ matrix.task }} ./build.sh
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test, test-win, test-osx, specific-deps]
+    strategy:
+      matrix:
+        task:
+          - deploy
+        python-version: ["3.8"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Deploy package
+      run: TASK=${{ matrix.task }} ./build.sh

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ their individual contributions.
 * `David Bonner <https://github.com/rascalking>`_ (dbonner@gmail.com)
 * `David Chudzicki <https://github.com/dchudz>`_ (dchudz@gmail.com)
 * `David Mascharka <https://github.com/davidmascharka>`_
+* `Dawn E. Collett <https://github.com/lisushka>`_
 * `Derek Gustafson <https://www.github.com/degustaf>`_
 * `Dion Misic <https://www.github.com/kingdion>`_ (dion.misic@gmail.com)
 * `Dmitry Dygalo <https://www.github.com/Stranger6667>`_

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,9 @@ if [ -n "${PIPELINE_WORKSPACE-}" ] ; then
 elif [ -n "${TRAVIS-}" ] ; then
     # We're on Travis and already set up a suitable Python
     PYTHON=$(command -v python)
+elif [ -n "${GITHUB_ACTIONS-}" ] ; then
+    # We're on GitHub Actions and already set up a suitable Python
+    PYTHON=$(command -v python)
 else
     # Otherwise, we install it from scratch
     "$SCRIPTS/ensure-python.sh" 3.8.5

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -11,7 +11,7 @@ flake8-bugbear
 flake8-comprehensions
 flake8-docstrings
 flake8-mutable
-ipython
+ipython < 7.17  # drops support for Python 3.6
 isort
 lark-parser
 mypy
@@ -29,4 +29,5 @@ sphinx-rtd-theme
 sphinx-selective-exclude
 toml
 tox
+traitlets < 5.0   # drops support for Python 3.6
 twine

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -44,7 +44,7 @@ idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 iniconfig==1.1.1          # via pytest
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.19.0           # via -r requirements/tools.in
+ipython==7.16.1           # via -r requirements/tools.in
 isort==5.6.4              # via -r requirements/tools.in
 jedi==0.17.2              # via ipython
 jeepney==0.6.0            # via keyring, secretstorage
@@ -111,7 +111,7 @@ tokenize-rt==4.0.0        # via pyupgrade
 toml==0.10.2              # via -r requirements/tools.in, black, dparse, pytest, tox
 tox==3.20.1               # via -r requirements/tools.in
 tqdm==4.54.1              # via pyupio, twine
-traitlets==5.0.5          # via ipython
+traitlets==4.3.3          # via -r requirements/tools.in, ipython
 twine==3.2.0              # via -r requirements/tools.in
 typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.3  # via black, mypy

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -31,7 +31,7 @@ from hypothesistooling.scripts import pip_tool
 TASKS = {}
 BUILD_FILES = tuple(
     os.path.join(tools.ROOT, f)
-    for f in ["tooling", "requirements", ".travis.yml", "hypothesis-python/tox.ini"]
+    for f in ["tooling", "requirements", ".github", "hypothesis-python/tox.ini"]
 )
 
 


### PR DESCRIPTION
As you may know, Travis CI was acquired by private equity a few months ago, and it appears that they are proceeding to the "strip-mine the company" phase - in particular, their open-source offering is slower, flaky, delayed, and now imposes a tight monthly cap.  The Travis blog has [more info here](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) and [an update here](https://blog.travis-ci.com/oss-announcement).  While legitimate, we therefore want to move to a different CI provider.

GitHub Actions runs on the same infrastructure as Azure Pipelines (see #2043), with somewhat cleaner configuration and much better UI integration with GitHub.  In particular secrets management and build status reporting are nice.  So let's transfer everything over to a single provider!

With deep gratitude to @lisushka, this PR closes #2599 (where she did most of the work!), and replaces my previous attempt in #2626.  Remaining action items:

- [ ] @DRMacIver to enable GitHub Actions in the repo settings
- [ ] @DRMacIver to set up the `encrypted_b8618e5d043b_key` and `encrypted_b8618e5d043b_iv` secrets in the repo settings.  This means that GitHub Actions can push fixes to our pyup PRs, push releases to GitHub/Zenodo/PyPI, etc.
- [ ] after merge, @DRMacIver to set GitHub Actions as a "required check" to merge PRs, and unset Azure Pipelines
- [ ] after merge, @Zac-HD to make a follow-up PR removing other CI systems and config files
- [ ] after merge, and a successful release, @sobolevn to make a follow-up PR adding caching for performance

You can see a complete run at https://github.com/Zac-HD/hypothesis/actions/runs/376714822

(I'd be happy to do the remaining config too, but don't have admin access)