### PR TITLE
Add new `target(..., allow_noop=True)` argument

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds a ``allow_noop=False`` argument to :func:`~hypothesis.target`.
+If ``True``, calling it outside of an :func:`@given() <hypothesis.given>` test
+becomes a no-op rather than an error, which is useful when writing custom
+assertion helpers (:issue:`2581`).

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -95,6 +95,12 @@ def test_cannot_target_outside_test():
         target(1.0, label="example label")
 
 
+def test_can_target_outside_test_with_allow_noop():
+    target(1.0, label="example label", allow_noop=True)
+    with pytest.raises(InvalidArgument):
+        target(1.0, label="example label", allow_noop=1)  # must be boolean
+
+
 @given(st.none())
 def test_cannot_target_same_label_twice(_):
     target(0.0, label="label")


### PR DESCRIPTION
This new kw-only argument makes it much easier to write helper functions which may be called from traditional or property-based tests.  Closes #2581 - cc @aarchiba.