### PR TITLE
`st.timezones()` strategy using the stdlib `zoneinfo` module

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release adds new :func:`~hypothesis.strategies.timezones` and
+:func:`~hypothesis.strategies.timezone_keys` strategies (:issue:`2630`)
+based on the new :mod:`python:zoneinfo` module in Python 3.9.
+
+``pip install hypothesis[zoneinfo]`` will ensure that you have the
+appropriate backports installed if you need them.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -78,6 +78,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "django": ("https://django.readthedocs.io/en/stable/", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
     "redis": ("https://redis-py.readthedocs.io/en/stable/", None),
     "attrs": ("https://www.attrs.org/en/stable/", None),
 }

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -19,7 +19,7 @@ PYTEST="python -m pytest -n2"
 $PYTEST tests/cover tests/pytest
 
 # Run tests for each extra module while the requirements are installed
-pip install ".[pytz, dateutil]"
+pip install ".[pytz, dateutil, zoneinfo]"
 $PYTEST tests/datetime/
 pip uninstall -y pytz python-dateutil
 

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -67,6 +67,13 @@ extras = {
     "pytest": ["pytest>=4.3"],
     "dpcontracts": ["dpcontracts>=0.4"],
     "redis": ["redis>=3.0.0"],
+    # zoneinfo is an odd one: every dependency is conditional, because they're
+    # only necessary on old versions of Python or Windows systems.
+    "zoneinfo": [
+        "tzdata>=2020.4 ; sys_platform == 'win32'",
+        "backports.zoneinfo>=0.2.1 ; python_version<'3.9'",
+        "importlib_resources>=3.3.0 ; python_version<'3.7'",
+    ],
     # We only support Django versions with upstream support - see
     # https://www.djangoproject.com/download/#supported-versions
     "django": ["pytz>=2014.1", "django>=2.2"],

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -56,7 +56,14 @@ from hypothesis.strategies._internal.core import (
     tuples,
     uuids,
 )
-from hypothesis.strategies._internal.datetime import dates, datetimes, timedeltas, times
+from hypothesis.strategies._internal.datetime import (
+    dates,
+    datetimes,
+    timedeltas,
+    times,
+    timezone_keys,
+    timezones,
+)
 from hypothesis.strategies._internal.ipaddress import ip_addresses
 
 # The implementation of all of these lives in `_strategies.py`, but we
@@ -107,6 +114,8 @@ __all__ = [
     "text",
     "timedeltas",
     "times",
+    "timezone_keys",
+    "timezones",
     "tuples",
     "uuids",
     "SearchStrategy",

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -34,6 +34,7 @@ from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.compat import ForwardRef, typing_root_type
 from hypothesis.internal.conjecture.utils import many as conjecture_utils_many
+from hypothesis.strategies._internal.datetime import zoneinfo
 from hypothesis.strategies._internal.ipaddress import (
     SPECIAL_IPv4_RANGES,
     SPECIAL_IPv6_RANGES,
@@ -348,6 +349,8 @@ _global_type_lookup = {
     os.PathLike: st.builds(PurePath, st.text()),
     # Pull requests with more types welcome!
 }
+if zoneinfo is not None:  # pragma: no branch
+    _global_type_lookup[zoneinfo.ZoneInfo] = st.timezones()
 
 _global_type_lookup[type] = st.sampled_from(
     [type(None)] + sorted(_global_type_lookup, key=str)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -671,7 +671,7 @@ def test_can_cast():
 @pytest.mark.parametrize("type_", [datetime.timezone, datetime.tzinfo])
 def test_timezone_lookup(type_):
     assert issubclass(type_, datetime.tzinfo)
-    assert_all_examples(st.from_type(type_), lambda t: isinstance(t, datetime.timezone))
+    assert_all_examples(st.from_type(type_), lambda t: isinstance(t, type_))
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -43,6 +43,8 @@ blacklist = [
     "randoms",
     "runner",
     "sampled_from",
+    "timezone_keys",
+    "timezones",
 ]
 types_with_core_strat = set()
 for thing in (

--- a/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
@@ -13,6 +13,8 @@
 #
 # END HEADER
 
+import platform
+
 import pytest
 
 from hypothesis import given, strategies as st
@@ -56,6 +58,24 @@ def test_timezones_argument_validation(kwargs):
 def test_timezone_keys_argument_validation(kwargs):
     with pytest.raises(InvalidArgument):
         st.timezone_keys(**kwargs).validate()
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="platform-specific")
+def test_can_generate_prefixes_if_allowed_and_available():
+    """
+    This is actually kinda fiddly: we may generate timezone keys with the
+    "posix/" or "right/" prefix if-and-only-if they are present on the filesystem.
+
+    This immediately rules out Windows (which uses the tzdata package instead),
+    along with OSX (which doesn't seem to have prefixed keys).  We believe that
+    they are present on at least most Linux distros, but have not done exhaustive
+    testing.
+
+    It's fine to just patch this test out if it fails - passing in the
+    Hypothesis CI demonstrates that the feature works on *some* systems.
+    """
+    find_any(st.timezone_keys(), lambda s: s.startswith("posix/"))
+    find_any(st.timezone_keys(), lambda s: s.startswith("right/"))
 
 
 def test_can_disallow_prefixes():

--- a/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
@@ -1,0 +1,65 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2020 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import pytest
+
+from hypothesis import given, strategies as st
+from hypothesis.errors import InvalidArgument
+from hypothesis.strategies._internal.datetime import zoneinfo
+from tests.common.debug import assert_no_examples, find_any, minimal
+
+
+def test_utc_is_minimal():
+    assert minimal(st.timezones()) is zoneinfo.ZoneInfo("UTC")
+
+
+def test_can_generate_non_utc():
+    find_any(
+        st.datetimes(timezones=st.timezones()).filter(lambda d: d.tzinfo.key != "UTC")
+    )
+
+
+@given(st.data(), st.datetimes(), st.datetimes())
+def test_datetimes_stay_within_naive_bounds(data, lo, hi):
+    if lo > hi:
+        lo, hi = hi, lo
+    out = data.draw(st.datetimes(lo, hi, timezones=st.timezones()))
+    assert lo <= out.replace(tzinfo=None) <= hi
+
+
+@pytest.mark.parametrize("kwargs", [{"no_cache": 1}])
+def test_timezones_argument_validation(kwargs):
+    with pytest.raises(InvalidArgument):
+        st.timezones(**kwargs).validate()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # {"allow_alias": 1},
+        # {"allow_deprecated": 1},
+        {"allow_prefix": 1},
+    ],
+)
+def test_timezone_keys_argument_validation(kwargs):
+    with pytest.raises(InvalidArgument):
+        st.timezone_keys(**kwargs).validate()
+
+
+def test_can_disallow_prefixes():
+    assert_no_examples(
+        st.timezone_keys(allow_prefix=False),
+        lambda s: s.startswith(("posix/", "right/")),
+    )

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -89,6 +89,7 @@ setenv=
     HYPOTHESIS_INTERNAL_COVERAGE=true
 commands =
     rm -f branch-check
+    pip install .[zoneinfo]
     python -m coverage --version
     python -m coverage debug sys
     python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/conjecture tests/datetime tests/numpy tests/pandas tests/lark --ff {posargs}


### PR DESCRIPTION
From one perspective, this is a pretty standard PR adding a new strategy - it's almost identical to the `hypothesis.extra.{dateutil,pytz}.timezones()` strategies, but in the `hypothesis.strategies` namespace because the timezones in question come from the standard library.

On the other hand, they're *only in the latest stdlib*, so we also have some logic to manage backports - mostly through a new `hypothesis[zoneinfo]` extra which has only conditional dependencies.  This is clearly documented and raises nice errors if you don't have the deps; and since it'll be standard eventually I'd prefer to put it in the right place to start with.

Implementation of `allow_aliases` and `allow_deprecated` arguments for `timezone_keys()` has been left to a future PR, along with #2414 - this is just the increment to get a minimal useful API out there.  Closes #2630.