### PR TITLE
Recognise en/de function pairs in the ghostwriter

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This patch teaches the :func:`~hypothesis.extra.ghostwriter.magic` ghostwriter
+to recognise "en/de" function roundtrips other than the common encode/decode
+pattern, such as encrypt/decrypt or, encipher/decipher.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -475,7 +475,7 @@ ROUNDTRIP_PAIRS = (
     (r"dump(.+)", "load{}"),
     (r"to(.+)", "from{}"),
     # Known stem, maybe matching prefixes, maybe matching postfixes.
-    (r"(.*)encode(.*)", "{}decode{}"),
+    (r"(.*)en(.+)", "{}de{}"),
     # Shared postfix, prefix only on "inverse" function
     (r"(.+)", "de{}"),
     (r"(.+)", "un{}"),


### PR DESCRIPTION
This is a totally trivial patch, because a friend tried ghostwriting tests for encrypt/decrypt functions and it didn't work.  But after this PR it will :rocket: 