### PR TITLE
Make `dictionaries(keys=sampled_from(...), ...)` more efficient

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch makes some strategies for collections with a uniqueness constraint
+much more efficient, including ``dictionaries(keys=sampled_from(...), values=..)``
+and ``lists(tuples(sampled_from(...), ...), unique_by=lambda x: x[0])``.
+(related to :issue:`2036`)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -127,9 +127,10 @@ class ListStrategy(SearchStrategy):
 
 
 class UniqueListStrategy(ListStrategy):
-    def __init__(self, elements, min_size, max_size, keys):
+    def __init__(self, elements, min_size, max_size, keys, tuple_suffixes):
         super().__init__(elements, min_size, max_size)
         self.keys = keys
+        self.tuple_suffixes = tuple_suffixes
 
     def do_draw(self, data):
         if self.element_strategy.is_empty:
@@ -161,6 +162,8 @@ class UniqueListStrategy(ListStrategy):
             else:
                 for key, seen in zip(self.keys, seen_sets):
                     seen.add(key(value))
+                if self.tuple_suffixes is not None:
+                    value = (value,) + data.draw(self.tuple_suffixes)
                 result.append(value)
         assert self.max_size >= len(result) >= self.min_size
         return result
@@ -191,6 +194,8 @@ class UniqueSampledListStrategy(UniqueListStrategy):
             ):
                 for key, seen in zip(self.keys, seen_sets):
                     seen.add(key(value))
+                if self.tuple_suffixes is not None:
+                    value = (value,) + data.draw(self.tuple_suffixes)
                 result.append(value)
             else:
                 should_draw.reject()

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -86,6 +86,22 @@ def test_efficient_sets_of_samples(x):
     assert x == set(range(50))
 
 
+@given(st.dictionaries(keys=st.sampled_from(range(50)), values=st.none(), min_size=50))
+def test_efficient_dicts_with_sampled_keys(x):
+    assert set(x) == set(range(50))
+
+
+@given(
+    st.lists(
+        st.tuples(st.sampled_from(range(20)), st.builds(list)),
+        min_size=20,
+        unique_by=lambda asdf: asdf[0],
+    )
+)
+def test_efficient_lists_of_tuples_first_element_sampled_from(x):
+    assert {first for first, *_ in x} == set(range(20))
+
+
 @given(st.lists(st.sampled_from([0] * 100), unique=True))
 def test_does_not_include_duplicates_even_when_duplicated_in_collection(ls):
     assert len(ls) <= 1


### PR DESCRIPTION
This is related to #2036, in that it extends our special-casing of unique lists of elements=sampled_from(), but not strictly part of that issue.  Fortunately it also stands quite nicely alone, to be reviewed and merged separately :grin: 