### PR TITLE
Improve signature of `settings()`, for tab-completion and type checking

### DIFF
--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -19,4 +19,5 @@ exclude_lines =
     def __copy__
     def __deepcopy__
     except ImportError:
+    if TYPE_CHECKING:
     assert all\(.+\)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch refactors :class:`hypothesis.settings` to use type-annotated
+keyword arguments instead of ``**kwargs``, which makes tab-completion
+much more useful - as well as type-checkers like :pypi:`mypy`.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -240,6 +240,13 @@ class settings(metaclass=settingsMeta):
         if options is not None:
             options = tuple(options)
             assert default in options
+
+            def validator(value):
+                if value not in options:
+                    msg = f"Invalid {name}, {value!r}. Valid options: {options!r}"
+                    raise InvalidArgument(msg)
+                return value
+
         else:
             assert validator is not None
 
@@ -247,7 +254,6 @@ class settings(metaclass=settingsMeta):
             name=name,
             description=description.strip(),
             default=default,
-            options=options,
             validator=validator,
         )
         setattr(settings, name, settingsProperty(name, show_default))
@@ -266,12 +272,6 @@ class settings(metaclass=settingsMeta):
                     " after construction."
                 )
             else:
-                setting = all_settings[name]
-                if setting.options is not None and value not in setting.options:
-                    raise InvalidArgument(
-                        "Invalid %s, %r. Valid options: %r"
-                        % (name, value, setting.options)
-                    )
                 return object.__setattr__(self, name, value)
         else:
             raise AttributeError("No such setting %s" % (name,))
@@ -343,7 +343,6 @@ class Setting:
     name = attr.ib()
     description = attr.ib()
     default = attr.ib()
-    options = attr.ib()
     validator = attr.ib()
 
 

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -87,11 +87,6 @@ def test_can_repeatedly_push_the_same_thing():
     assert settings().max_examples == original_default
 
 
-def test_cannot_create_settings_with_invalid_options():
-    with pytest.raises(InvalidArgument):
-        settings(a_setting_with_limited_options="spoon")
-
-
 def test_can_set_verbosity():
     settings(verbosity=Verbosity.quiet)
     settings(verbosity=Verbosity.normal)


### PR DESCRIPTION
The highlight of this PR is improving the signature of the `settings()` class, to use explicit and type-annotated arguments instead of `**kwargs` - and therefore support all the nice developer tooling people use.  Personally I'm more excited about tab-completion working, but type checkers and Sphinx understanding it is nice too :wink:

Best reviewed commit-by-commit, as there's some initial tidying up (this is some of our oldest code) before getting to the main event.