### PR TITLE
Improve error when generating a dataframe from `rows` and `columns` with `fill=None`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves the error message from the
+:func:`~hypothesis.extra.pandas.data_frames` strategy when both the ``rows``
+and ``columns`` arguments are given, but there is a missing entry in ``rows``
+and the corresponding column has no ``fill`` value (:issue:`2678`).

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -648,6 +648,11 @@ def data_frames(
                                 try:
                                     as_list[i] = fills[i]
                                 except KeyError:
+                                    if c.fill.is_empty:
+                                        raise InvalidArgument(
+                                            f"Empty fill strategy in {c!r} cannot "
+                                            f"complete row {original_row!r}"
+                                        ) from None
                                     fills[i] = draw(c.fill)
                                     as_list[i] = fills[i]
                         for k in row:
@@ -679,7 +684,13 @@ def data_frames(
                             % (original_row, len(row), len(rewritten_columns))
                         )
                     while len(row) < len(rewritten_columns):
-                        row.append(draw(rewritten_columns[len(row)].fill))
+                        c = rewritten_columns[len(row)]
+                        if c.fill.is_empty:
+                            raise InvalidArgument(
+                                f"Empty fill strategy in {c!r} cannot "
+                                f"complete row {original_row!r}"
+                            )
+                        row.append(draw(c.fill))
                     result.iloc[row_index] = row
                     break
                 else:

--- a/hypothesis-python/tests/pandas/test_argument_validation.py
+++ b/hypothesis-python/tests/pandas/test_argument_validation.py
@@ -50,6 +50,18 @@ BAD_ARGS = [
     e(pdst.data_frames, rows=st.integers(), index=pdst.range_indexes(0, 0)),
     e(pdst.data_frames, rows=st.integers(), index=pdst.range_indexes(1, 1)),
     e(pdst.data_frames, pdst.columns(1, dtype=int), rows=st.integers()),
+    e(
+        pdst.data_frames,
+        columns=pdst.columns(["a", "b"], dtype=str, elements=st.text()),
+        rows=st.just({"a": "x"}),
+        index=pdst.indexes(dtype=int, min_size=1),
+    ),
+    e(
+        pdst.data_frames,
+        columns=pdst.columns(["a", "b"], dtype=str, elements=st.text()),
+        rows=st.just(["x"]),
+        index=pdst.indexes(dtype=int, min_size=1),
+    ),
     e(pdst.indexes),
     e(pdst.indexes, dtype="category"),
     e(pdst.indexes, dtype="not a dtype"),


### PR DESCRIPTION
This PR fixes #2678: generating [`pdst.data_frames()`](https://hypothesis.readthedocs.io/en/latest/numpy.html#hypothesis.extra.pandas.data_frames) with interacting `rows` and `columns` arguments gave a very confusing error message because one of the columns was missing a `fill` value:

```python-traceback
hypothesis.errors.FailedHealthCheck: It looks like your strategy is filtering out a lot of data.
    Health check found 50 filtered examples but only 0 good ones. ...
```

After this patch, you instead get:

```python-traceback
hypothesis.errors.InvalidArgument: Empty fill strategy in 
    column(name='b', elements=text().map(convert_element), dtype=dtype('<U'), fill=nothing(), unique=False)
    cannot complete row {'a': 'x'}
```

which I think is a *lot* more helpful than the staus quo :slightly_smiling_face: 