### PR TITLE
Recommend using `sampled_from()` when `builds(Enum)` raises an error

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the error message if :func:`~hypothesis.strategies.builds`
+is passed an :class:`~python:enum.Enum` which cannot be called without arguments,
+to suggest using :func:`~hypothesis.strategies.sampled_from` (:issue:`2693`).


### PR DESCRIPTION
This improved error message closes #2693, and is designed to avoid any slowdown if the target to build does not raise a `TypeError`.