### PR TITLE
First codemods: fix positional arguments for keyword-only parameters

### DIFF
--- a/guides/review.rst
+++ b/guides/review.rst
@@ -170,6 +170,9 @@ Public API changes must satisfy the following:
 3. If an API is deprecated, the deprecation warning must make it clear
    how the user should modify their code to adapt to this change (
    possibly by referring to documentation).
+   If the required code change could be automated, the deprecation should have either
+   `a codemod to fix it <https://github.com/HypothesisWorks/hypothesis/issues/2705>`__
+   or a tracking issue to write one (see "asking for more work" below).
 4. If it is likely that we will want to make backwards incompatible changes
    to an API later, to whatever extent possible these should be made immediately
    when it is introduced instead.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds the :ref:`codemods` extra, which you can use to
+check for and automatically fix issues such as use of deprecated
+Hypothesis APIs (:issue:`2705`).

--- a/hypothesis-python/docs/extras.rst
+++ b/hypothesis-python/docs/extras.rst
@@ -23,6 +23,8 @@ There are separate pages for :doc:`django` and :doc:`numpy`.
 
 .. automodule:: hypothesis.extra.cli
 
+.. automodule:: hypothesis.extra.codemods
+
 .. automodule:: hypothesis.extra.dpcontracts
    :members:
 

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -44,7 +44,11 @@ pip install lark-parser==0.7.1
 $PYTEST tests/lark/
 pip uninstall -y lark-parser
 
-if [ "$(python -c 'import sys, platform; print(sys.version_info[:2] >= (3, 6) and platform.python_implementation() != "PyPy")')" = "True" ] ; then
+if [ "$(python -c 'import platform; print(platform.python_implementation() != "PyPy")')" = "True" ] ; then
+  pip install ".[codemods,cli]"
+  $PYTEST tests/codemods/
+  pip uninstall -y libcst click
+
   pip install black numpy
   $PYTEST tests/ghostwriter/
   pip uninstall -y black numpy

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -58,6 +58,7 @@ assert __version__ is not None
 
 extras = {
     "cli": ["click>=7.0", "black>=19.10b0"],
+    "codemods": ["libcst>=0.3.16"],
     "ghostwriter": ["black>=19.10b0"],
     "pytz": ["pytz>=2014.1"],
     "dateutil": ["python-dateutil>=1.4"],

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -639,10 +639,15 @@ The default is ``True`` if the ``CI`` or ``TF_BUILD`` env vars are set, ``False`
 settings.lock_further_definitions()
 
 
-def note_deprecation(message: str, *, since: str) -> None:
+def note_deprecation(message: str, *, since: str, has_codemod: bool) -> None:
     if since != "RELEASEDAY":
         date = datetime.datetime.strptime(since, "%Y-%m-%d").date()
         assert datetime.date(2016, 1, 1) <= date
+    if has_codemod:
+        message += (
+            "\n    The `hypothesis codemod` command-line tool can automatically "
+            "refactor your code to fix this warning."
+        )
     warnings.warn(HypothesisDeprecationWarning(message), stacklevel=2)
 
 

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -30,7 +30,7 @@ hypothesis[cli]
       -h, --help  Show this message and exit.
 
     Commands:
-      codemod  `hypothesis codemod` refactors deprecated or inefficent code.
+      codemod  `hypothesis codemod` refactors deprecated or inefficient code.
       fuzz     [hypofuzz] runs tests with an adaptive coverage-guided fuzzer.
       write    `hypothesis write` writes property-based tests for you!
 
@@ -122,7 +122,7 @@ else:
     @main.command()  # type: ignore  # Click adds the .command attribute
     @click.argument("path", type=str, required=True, nargs=-1)
     def codemod(path):
-        """`hypothesis codemod` refactors deprecated or inefficent code.
+        """`hypothesis codemod` refactors deprecated or inefficient code.
 
         It adapts `python -m libcst.tool`, removing many features and config options
         which are rarely relevant for this purpose.  If you need more control, we
@@ -144,7 +144,7 @@ else:
             sys.exit(1)
 
         # Special case for stdin/stdout usage
-        if any(p == "-" for p in path):
+        if "-" in path:
             if len(path) > 1:
                 raise Exception(
                     "Cannot specify multiple paths when reading from stdin!"

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -30,6 +30,7 @@ hypothesis[cli]
       -h, --help  Show this message and exit.
 
     Commands:
+      codemod  `hypothesis codemod` refactors deprecated or inefficent code.
       fuzz     [hypofuzz] runs tests with an adaptive coverage-guided fuzzer.
       write    `hypothesis write` writes property-based tests for you!
 
@@ -43,6 +44,8 @@ import builtins
 import importlib
 import sys
 from difflib import get_close_matches
+from functools import partial
+from multiprocessing import Pool
 
 MESSAGE = """
 The Hypothesis command-line interface requires the `{}` package,
@@ -103,6 +106,68 @@ else:
                 f"{funcname!r} attribute."
                 + (f"  Closest matches: {matches!r}" if matches else "")
             )
+
+    def _refactor(func, fname):
+        try:
+            with open(fname) as f:
+                oldcode = f.read()
+        except (OSError, UnicodeError) as err:
+            # Permissions or encoding issue, or file deleted, etc.
+            return f"skipping {fname!r} due to {err}"
+        newcode = func(oldcode)
+        if newcode != oldcode:
+            with open(fname, mode="w") as f:
+                f.write(newcode)
+
+    @main.command()  # type: ignore  # Click adds the .command attribute
+    @click.argument("path", type=str, required=True, nargs=-1)
+    def codemod(path):
+        """`hypothesis codemod` refactors deprecated or inefficent code.
+
+        It adapts `python -m libcst.tool`, removing many features and config options
+        which are rarely relevant for this purpose.  If you need more control, we
+        encourage you to use the libcst CLI directly; if not this one is easier.
+
+        PATH is the file(s) or directories of files to format in place, or
+        "-" to read from stdin and write to stdout.
+        """
+        try:
+            from libcst.codemod import gather_files
+
+            from hypothesis.extra import codemods
+        except ImportError:
+            sys.stderr.write(
+                "You are missing required dependencies for this option.  Run:\n\n"
+                "    python -m pip install --upgrade hypothesis[codemods]\n\n"
+                "and try again."
+            )
+            sys.exit(1)
+
+        # Special case for stdin/stdout usage
+        if any(p == "-" for p in path):
+            if len(path) > 1:
+                raise Exception(
+                    "Cannot specify multiple paths when reading from stdin!"
+                )
+            print("Codemodding from stdin", file=sys.stderr)
+            print(codemods.refactor(sys.stdin.read()))
+            return 0
+
+        # Find all the files to refactor, and then codemod them
+        files = gather_files(path)
+        errors = set()
+        if len(files) <= 1:
+            errors.add(_refactor(codemods.refactor, *files))
+        else:
+            with Pool() as pool:
+                for msg in pool.imap_unordered(
+                    partial(_refactor, codemods.refactor), files
+                ):
+                    errors.add(msg)
+        errors.discard(None)
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        return 1 if errors else 0
 
     @main.command()  # type: ignore  # Click adds the .command attribute
     @click.argument("func", type=obj_name, required=True, nargs=-1)

--- a/hypothesis-python/src/hypothesis/extra/codemods.py
+++ b/hypothesis-python/src/hypothesis/extra/codemods.py
@@ -29,7 +29,7 @@ You can run the codemods via our CLI::
     $ hypothesis codemod --help
     Usage: hypothesis codemod [OPTIONS] PATH...
 
-      `hypothesis codemod` refactors deprecated or inefficent code.
+      `hypothesis codemod` refactors deprecated or inefficient code.
 
       It adapts `python -m libcst.tool`, removing many features and config
       options which are rarely relevant for this purpose.  If you need more

--- a/hypothesis-python/src/hypothesis/extra/codemods.py
+++ b/hypothesis-python/src/hypothesis/extra/codemods.py
@@ -1,0 +1,88 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""
+.. _codemods:
+
+--------------------
+hypothesis[codemods]
+--------------------
+
+This module provides codemods based on the :pypi:`LibCST` library, which can
+both detect *and automatically fix* issues with code that uses Hypothesis,
+including upgrading from deprecated features to our recommended style.
+
+.. autofunction:: refactor
+"""
+
+from typing import List
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.codemod import VisitorBasedCodemodCommand
+
+
+def refactor(code: str) -> str:
+    """Update a source code string from deprecated to modern Hypothesis APIs.
+
+    This may not fix *all* the deprecation warnings in your code, but we're
+    confident that it will be easier than doing it all by hand.
+
+    We recommend using the CLI, but if you want a Python function here it is.
+    """
+    context = cst.codemod.CodemodContext()
+    mod = cst.parse_module(code)
+    transforms: List[VisitorBasedCodemodCommand] = [
+        HypothesisFixPositionalKeywonlyArgs(context),
+        HypothesisFixComplexMinMagnitude(context),
+    ]
+    for transform in transforms:
+        mod = transform.transform_module(mod)
+    return mod.code
+
+
+def match_qualname(name):
+    # We use the metadata to get qualname instead of matching directly on function
+    # name, because this handles some scope and "from x import y as z" issues.
+    return m.MatchMetadataIfTrue(
+        cst.metadata.QualifiedNameProvider,
+        # If there are multiple possible qualnames, e.g. due to conditional imports,
+        # be conservative.  Better to leave the user to fix a few things by hand than
+        # to break their code while attempting to refactor it!
+        lambda qualnames: all(n.name == name for n in qualnames),
+    )
+
+
+class HypothesisFixComplexMinMagnitude(VisitorBasedCodemodCommand):
+    """Fix a deprecated min_magnitude=None argument for complex numbers::
+
+        st.complex_numbers(min_magnitude=None) -> st.complex_numbers(min_magnitude=0)
+
+    Note that this should be run *after* ``HypothesisFixPositionalKeywonlyArgs``,
+    in order to handle ``st.complex_numbers(None)``.
+    """
+
+    DESCRIPTION = "Fix a deprecated min_magnitude=None argument for complex numbers."
+    METADATA_DEPENDENCIES = (cst.metadata.QualifiedNameProvider,)
+
+    @m.call_if_inside(
+        m.Call(metadata=match_qualname("hypothesis.strategies.complex_numbers"))
+    )
+    def leave_Arg(self, original_node, updated_node):
+        if m.matches(
+            updated_node, m.Arg(keyword=m.Name("min_magnitude"), value=m.Name("None"))
+        ):
+            return updated_node.with_changes(value=cst.Integer("0"))
+        return updated_node

--- a/hypothesis-python/src/hypothesis/extra/codemods.py
+++ b/hypothesis-python/src/hypothesis/extra/codemods.py
@@ -24,6 +24,29 @@ This module provides codemods based on the :pypi:`LibCST` library, which can
 both detect *and automatically fix* issues with code that uses Hypothesis,
 including upgrading from deprecated features to our recommended style.
 
+You can run the codemods via our CLI::
+
+    $ hypothesis codemod --help
+    Usage: hypothesis codemod [OPTIONS] PATH...
+
+      `hypothesis codemod` refactors deprecated or inefficent code.
+
+      It adapts `python -m libcst.tool`, removing many features and config
+      options which are rarely relevant for this purpose.  If you need more
+      control, we encourage you to use the libcst CLI directly; if not this one
+      is easier.
+
+      PATH is the file(s) or directories of files to format in place, or "-" to
+      read from stdin and write to stdout.
+
+    Options:
+      -h, --help  Show this message and exit.
+
+Alternatively you can use ``python -m libcst.tool``, which offers more control
+at the cost of additional configuration (adding ``'hypothesis.extra'`` to the
+``modules`` list in ``.libcst.codemod.yaml``) and `some issues on Windows
+<https://github.com/Instagram/LibCST/issues/435>`__.
+
 .. autofunction:: refactor
 """
 

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -96,6 +96,7 @@ def from_model(
             note_deprecation(
                 "The `model` argument will be positional-only in a future version",
                 since="2020-03-18",
+                has_codemod=False,
             )
 
     if not issubclass(m_type, dm.Model):

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -168,7 +168,9 @@ else:
                         active_fx = item._request._get_active_fixturedef(fx.argname)
                         if active_fx.scope == "function":
                             note_deprecation(
-                                msg % (item.nodeid, fx.argname), since="2020-02-29"
+                                msg % (item.nodeid, fx.argname),
+                                since="2020-02-29",
+                                has_codemod=False,
                             )
 
             if item.get_closest_marker("parametrize") is not None:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -649,6 +649,7 @@ def deprecated_posargs(func: C) -> C:
                 "keyword-only argument in a future version."
                 % (qualname(func), param.name, pos),
                 since="2020-02-07",
+                has_codemod=True,
             )
             bound.arguments[param.name] = pos
         return func(*bound.args, **bound.kwargs)

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -85,6 +85,7 @@ def check_valid_magnitude(value, name):
             "min_magnitude=None is deprecated; use min_magnitude=0 "
             "or omit the argument entirely.",
             since="2020-05-13",
+            has_codemod=True,
         )
 
 

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -167,6 +167,7 @@ def ip4_addr_strings() -> SearchStrategy[str]:
         "Use `ip_addresses(v=4).map(str)` instead of `ip4_addr_strings()`; "
         "the provisional strategy is less flexible and will be removed.",
         since="2020-01-21",
+        has_codemod=False,
     )
     return ip_addresses(v=4).map(str)
 
@@ -177,5 +178,6 @@ def ip6_addr_strings() -> SearchStrategy[str]:
         "Use `ip_addresses(v=6).map(str)` instead of `ip6_addr_strings()`; "
         "the provisional strategy is less flexible and will be removed.",
         since="2020-01-21",
+        has_codemod=False,
     )
     return ip_addresses(v=6).map(str)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1235,6 +1235,7 @@ def randoms(
             want the new behaviour (which will become the default in future),
             set use_true_random=False.""",
             since="2020-06-30",
+            has_codemod=False,
         )
         use_true_random = True
 
@@ -2205,6 +2206,7 @@ def register_type_strategy(
             "%s will be registered for any type arguments."
             % (custom_type, origin, strategy_repr),
             since="2020-08-17",
+            has_codemod=False,
         )
         if origin in types._global_type_lookup:
             raise InvalidArgument(

--- a/hypothesis-python/tests/codemods/test_codemod_cli.py
+++ b/hypothesis-python/tests/codemods/test_codemod_cli.py
@@ -1,0 +1,74 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import subprocess
+
+BEFORE = """
+from hypothesis.strategies import complex_numbers, complex_numbers as cn
+
+complex_numbers(min_magnitude=None)  # simple call to fix
+complex_numbers(min_magnitude=None, max_magnitude=1)  # plus arg after
+complex_numbers(allow_infinity=False, min_magnitude=None)  # plus arg before
+cn(min_magnitude=None)  # imported as alias
+"""
+AFTER = BEFORE.replace("None", "0")
+_unchanged = """
+complex_numbers(min_magnitude=1)  # value OK
+
+class Foo:
+    def complex_numbers(self, **kw): pass
+
+    complex_numbers(min_magnitude=None)  # defined in a different scope
+"""
+BEFORE += _unchanged
+AFTER += _unchanged
+del _unchanged
+
+
+def run(command, tmpdir=None, input=None):
+    return subprocess.run(
+        command,
+        input=input,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+        cwd=tmpdir,
+    )
+
+
+def test_codemod_single_file(tmpdir):
+    fname = tmpdir / "mycode.py"
+    fname.write(BEFORE)
+    result = run("hypothesis codemod mycode.py", tmpdir)
+    assert result.returncode == 0
+    assert fname.read() == AFTER
+
+
+def test_codemod_multiple_files(tmpdir):
+    # LibCST had some trouble with multiprocessing on Windows
+    files = [tmpdir / "mycode1.py", tmpdir / "mycode2.py"]
+    for f in files:
+        f.write(BEFORE)
+    result = run("hypothesis codemod mycode1.py mycode2.py", tmpdir)
+    assert result.returncode == 0
+    for f in files:
+        assert f.read() == AFTER
+
+
+def test_codemod_from_stdin():
+    result = run("hypothesis codemod -", input=BEFORE)
+    assert result.returncode == 0
+    assert result.stdout.rstrip() == AFTER.rstrip()

--- a/hypothesis-python/tests/codemods/test_codemods.py
+++ b/hypothesis-python/tests/codemods/test_codemods.py
@@ -1,0 +1,47 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from libcst.codemod import CodemodTest
+
+from hypothesis.extra import codemods
+
+
+class TestFixComplexMinMagnitude(CodemodTest):
+    TRANSFORM = codemods.HypothesisFixComplexMinMagnitude
+
+    def test_noop(self) -> None:
+        before = """
+            from hypothesis.strategies import complex_numbers, complex_numbers as cn
+
+            complex_numbers(min_magnitude=1)  # value OK
+            complex_numbers(max_magnitude=None)  # different argument
+
+            class Foo:
+                def complex_numbers(self, **kw): pass
+
+                complex_numbers(min_magnitude=None)  # defined in a different scope
+        """
+        self.assertCodemod(before=before, after=before)
+
+    def test_substitution(self) -> None:
+        before = """
+            from hypothesis.strategies import complex_numbers, complex_numbers as cn
+
+            complex_numbers(min_magnitude=None)  # simple call to fix
+            complex_numbers(min_magnitude=None, max_magnitude=1)  # plus arg after
+            complex_numbers(allow_infinity=False, min_magnitude=None)  # plus arg before
+            cn(min_magnitude=None)  # imported as alias
+        """
+        self.assertCodemod(before=before, after=before.replace("None", "0"))

--- a/hypothesis-python/tests/codemods/test_codemods.py
+++ b/hypothesis-python/tests/codemods/test_codemods.py
@@ -18,6 +18,16 @@ from libcst.codemod import CodemodTest
 from hypothesis.extra import codemods
 
 
+def test_refactor_function_is_idempotent():
+    before = (
+        "from hypothesis.strategies import complex_numbers\n\n"
+        + "complex_numbers(None)\n"
+    )
+    after = codemods.refactor(before)
+    assert before.replace("None", "min_magnitude=0") == after
+    assert codemods.refactor(after) == after
+
+
 class TestFixComplexMinMagnitude(CodemodTest):
     TRANSFORM = codemods.HypothesisFixComplexMinMagnitude
 
@@ -45,3 +55,66 @@ class TestFixComplexMinMagnitude(CodemodTest):
             cn(min_magnitude=None)  # imported as alias
         """
         self.assertCodemod(before=before, after=before.replace("None", "0"))
+
+
+class TestFixPositionalKeywonlyArgs(CodemodTest):
+    TRANSFORM = codemods.HypothesisFixPositionalKeywonlyArgs
+
+    def test_substitution(self) -> None:
+        before = """
+            import hypothesis.strategies as st
+
+            st.floats(0, 1, False, False, 32)
+            st.fractions(0, 1, 9)
+        """
+        after = """
+            import hypothesis.strategies as st
+
+            st.floats(0, 1, allow_nan=False, allow_infinity=False, width=32)
+            st.fractions(0, 1, max_denominator=9)
+        """
+        self.assertCodemod(before=before, after=after)
+
+    def test_noop_if_unsure(self) -> None:
+        before = """
+            import random
+
+            if random.getrandbits(1):
+                from hypothesis import target
+                from hypothesis.strategies import lists as sets
+
+                def fractions(*args):
+                    pass
+
+            else:
+                from hypothesis import target
+                from hypothesis.strategies import fractions, sets
+
+            fractions(0, 1, 9)
+            sets(None, 1)
+            target(0, 'label')
+        """
+        after = before.replace("'label'", "label='label'")
+        self.assertCodemod(before=before, after=after)
+
+    def test_stateful_rule_noop(self):
+        # `rule()(lambda self: None)` is a call with a positional argument, and
+        # so we need an additional check that the "func" node is a Name rather than
+        # itself being a Call, lest we rewrite the outer instead of the inner.
+        # (this may be an upstream bug in metadata processing)
+        before = """
+            from hypothesis.stateful import RuleBasedStateMachine, rule
+
+            class MultipleRulesSameFuncMachine(RuleBasedStateMachine):
+                rule1 = rule()(lambda self: None)
+        """
+        self.assertCodemod(before=before, after=before)
+
+    def test_kwargs_noop(self):
+        before = """
+            from hypothesis import target
+
+            kwargs = {"observation": 1, "label": "foobar"}
+            target(**kwargs)
+        """
+        self.assertCodemod(before=before, after=before)

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -470,7 +470,7 @@ def test_show_changed():
 
 def test_note_deprecation_checks_date():
     with pytest.warns(None) as rec:
-        note_deprecation("This is bad", since="RELEASEDAY")
+        note_deprecation("This is bad", since="RELEASEDAY", has_codemod=False)
     assert len(rec) == 1
     with pytest.raises(AssertionError):
-        note_deprecation("This is way too old", since="1999-12-31")
+        note_deprecation("This is way too old", since="1999-12-31", has_codemod=False)

--- a/hypothesis-python/tests/nocover/test_regressions.py
+++ b/hypothesis-python/tests/nocover/test_regressions.py
@@ -26,7 +26,7 @@ def test_note_deprecation_blames_right_code_issue_652():
     @st.composite
     def deprecated_strategy(draw):
         draw(st.none())
-        note_deprecation(msg, since="RELEASEDAY")
+        note_deprecation(msg, since="RELEASEDAY", has_codemod=False)
 
     @given(deprecated_strategy())
     def f(x):

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -14,6 +14,7 @@ flake8-mutable
 ipython < 7.17  # drops support for Python 3.6
 isort
 lark-parser
+libcst
 mypy
 numpy
 pip-tools

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -51,6 +51,7 @@ jeepney==0.6.0            # via keyring, secretstorage
 jinja2==2.11.2            # via pyupio, sphinx
 keyring==21.5.0           # via twine
 lark-parser==0.11.1       # via -r requirements/tools.in
+libcst==0.3.16            # via -r requirements/tools.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mypy-extensions==0.4.3    # via black, mypy


### PR DESCRIPTION
This is an MVP pull request to get us started on #2705 🎉 

It creates the extra dependency, tests, docs,... and uses that for the smallest possible refactoring: robustly replacing the deprecated `st.complex_numbers(min_magnitude=None)` with the non-deprecated equivalent `st.complex_numbers(min_magnitude=0)` (correctly handling shadowed names, importing as an alias, multiple arguments in any order, etc.).

I thought it would be easiest to review if I posted this as-is, and then had a follow-up (TBA) which handles our positional-or-keyword to keyword-only deprecation pathway.  However the latter part turned out to be easier than I expected, so I've included that as well 😎