### PR TITLE
Doc fix: The database setting doesn't actually allow string values

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This change fixes a documentation error in the
+:obj:`~hypothesis.settings.database` setting.
+
+The previous documentation suggested that callers could specify a database
+path string, or the special string ``":memory:"``, but this setting has
+never actually allowed string arguments.
+
+Permitted values are ``None``, and instances of
+:class:`~hypothesis.database.ExampleDatabase`.

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -33,7 +33,10 @@ pip uninstall -y redis fakeredis
 
 pip install typing_extensions
 $PYTEST tests/typing_extensions/
-pip uninstall -y typing_extensions
+if [ "$(python -c 'import sys; print(sys.version_info[:2] <= (3, 7))')" = "False" ] ; then
+  # Required by importlib_metadata backport, which we don't want to break
+  pip uninstall -y typing_extensions
+fi
 
 pip install ".[lark]"
 $PYTEST tests/lark/

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -419,8 +419,10 @@ settings._define_setting(
     description="""
 An instance of :class:`~hypothesis.database.ExampleDatabase` that will be
 used to save examples to and load previous examples from. May be ``None``
-in which case no storage will be used, ``":memory:"`` for an in-memory
-database, or any path for a directory-based example database.
+in which case no storage will be used.
+
+See the :doc:`example database documentation <database>` for a list of built-in
+example database implementations, and how to define custom implementations.
 """,
     validator=_validate_database,
 )

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -26,12 +26,12 @@ hypothesis[cli]
     Usage: hypothesis [OPTIONS] COMMAND [ARGS]...
 
     Options:
-    --version   Show the version and exit.
-    -h, --help  Show this message and exit.
+      --version   Show the version and exit.
+      -h, --help  Show this message and exit.
 
     Commands:
-    fuzz   [hypofuzz] runs tests with an adaptive coverage-guided fuzzer.
-    write  `hypothesis write` writes property-based tests for you! Type...
+      fuzz     [hypofuzz] runs tests with an adaptive coverage-guided fuzzer.
+      write    `hypothesis write` writes property-based tests for you!
 
 This module requires the :pypi:`click` package, and provides Hypothesis' command-line
 interface, for e.g. :doc:`'ghostwriting' tests <ghostwriter>` via the terminal.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -30,28 +30,28 @@ generally do their best to write you a useful test.  You can also use
     $ hypothesis write --help
     Usage: hypothesis write [OPTIONS] FUNC...
 
-    `hypothesis write` writes property-based tests for you!
+      `hypothesis write` writes property-based tests for you!
 
-    Type annotations are helpful but not required for our advanced
-    introspection and templating logic.  Try running the examples below to see
-    how it works:
+      Type annotations are helpful but not required for our advanced
+      introspection and templating logic.  Try running the examples below to see
+      how it works:
 
-        hypothesis write gzip
-        hypothesis write numpy.matmul
-        hypothesis write re.compile --except re.error
-        hypothesis write --equivalent ast.literal_eval eval
-        hypothesis write --roundtrip json.dumps json.loads
-        hypothesis write --style=unittest --idempotent sorted
-        hypothesis write --binary-op operator.add
+          hypothesis write gzip
+          hypothesis write numpy.matmul
+          hypothesis write re.compile --except re.error
+          hypothesis write --equivalent ast.literal_eval eval
+          hypothesis write --roundtrip json.dumps json.loads
+          hypothesis write --style=unittest --idempotent sorted
+          hypothesis write --binary-op operator.add
 
     Options:
-    --roundtrip                start by testing write/read or encode/decode!
-    --equivalent               very useful when optimising or refactoring code
-    --idempotent
-    --binary-op
-    --style [pytest|unittest]  pytest-style function, or unittest-style method?
-    -e, --except OBJ_NAME      dotted name of exception(s) to ignore
-    -h, --help                 Show this message and exit.
+      --roundtrip                start by testing write/read or encode/decode!
+      --equivalent               very useful when optimising or refactoring code
+      --idempotent
+      --binary-op
+      --style [pytest|unittest]  pytest-style function, or unittest-style method?
+      -e, --except OBJ_NAME      dotted name of exception(s) to ignore
+      -h, --help                 Show this message and exit.
 
 .. note::
 

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -187,11 +187,12 @@ def test_can_have_none_database():
 
 
 @pytest.mark.parametrize("db", [None, ExampleDatabase(":memory:")])
-def test_database_type_must_be_ExampleDatabase(db):
+@pytest.mark.parametrize("bad_db", [":memory:", ".hypothesis/examples"])
+def test_database_type_must_be_ExampleDatabase(db, bad_db):
     with local_settings(settings(database=db)):
         settings_property_db = settings.database
         with pytest.raises(InvalidArgument):
-            settings(database=".hypothesis/examples")
+            settings(database=bad_db)
         assert settings.database is settings_property_db
 
 


### PR DESCRIPTION
This docstring suggests that callers can pass a database path string or the special string `":memory:"`, but those arguments are not actually permitted by the implementation.

It seems that an early draft of #1196 did allow string arguments (to match the now-removed `database_file` setting). The feature was then removed after review feedback, but unfortunately the docstring was not
updated.

In-memory DBs and custom DB paths can still be specified by explicitly instantiating a subclass of `ExampleDatabase`, or by calling `ExampleDatabase` with a string argument (currently under-documented?).