### PR TITLE
Fix test issue, add missing changelog line

### DIFF
--- a/guides/api-style.rst
+++ b/guides/api-style.rst
@@ -64,8 +64,14 @@ We have a reasonably distinctive style when it comes to handling arguments:
   internal exception.
 * We make extensive use of default arguments. If an argument could reasonably
   have a default, it should.
-* Exception to the above: Strategies for collection types should *not* have a
+* Exception to the above: strategies for collection types should *not* have a
   default argument for element strategies.
+* Arguments which have a default value should also be keyword-only, with the
+  exception of ``min_value`` and ``max_value`` (see "Argument Names" below).
+* ``min_value`` and ``max_value`` should default to None for unbounded types
+  such as integers, and the minimal or maximal values for bounded types such
+  as datetimes.  ``floats()`` is an explicit exception to this rule due to
+  special handling for infinities and not-a-number.
 * Interacting arguments (e.g. arguments that must be in a particular order, or
   where at most one is valid, or where one argument restricts the valid range
   of the other) are fine, but when this happens the behaviour of defaults
@@ -77,13 +83,6 @@ We have a reasonably distinctive style when it comes to handling arguments:
 * It's worth thinking about the order of arguments: the first one or two
   arguments are likely to be passed positionally, so try to put values there
   where this is useful and not too confusing.
-* Arguments which have a default value should also be keyword-only.
-  For example, the ideal signature for lists would be
-  ``lists(elements, *, min_size=0, max_size=None, unique_by=None, unique=False)``.
-  We are part-way through a deprecation cycle to convert existing APIs to
-  keyword-only arguments; all new APIs should use them natively.
-  New functions or arguments can implement a forward-compatible signature with
-  ``hypothesis.internal.reflection.reserved_to_kwonly``.
 * When adding arguments to strategies, think carefully about whether the user
   is likely to want that value to vary often. If so, make it a strategy instead
   of a value. In particular if it's likely to be common that they would want to

--- a/guides/strategies-that-shrink.rst
+++ b/guides/strategies-that-shrink.rst
@@ -142,9 +142,9 @@ The exact behaviour of the shrinking is a topic of active research and
 development, so if you are interested in the details we recommend reading
 the `internals guide <https://github.com/HypothesisWorks/hypothesis/blob/master/guides/internals.rst>`_
 and the well-commented source code in
-``hypothesis.internal.conjecture``.  An earlier (mid-2018) version is
-illustrated in David's draft paper *Test-Case Reduction for Free*,
-along with an extensive evaluation.  Contact him if you would like a copy.
+``hypothesis.internal.conjecture`` as well as David's ECOOP 2020 paper
+`Test-Case Reduction via Test-Case Generation: Insights From the Hypothesis Reducer
+<https://2020.ecoop.org/details/ecoop-2020-papers/13/Test-Case-Reduction-via-Test-Case-Generation-Insights-From-the-Hypothesis-Reducer>`__.
 
 
 -------------------------------------

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -1635,6 +1635,9 @@ Miscellaneous
 ~~~~~~~~~~~~~
 - The ``.example()`` method of strategies (intended for interactive
   exploration) no longer takes a ``random`` argument.
+- It is now an error to apply :func:`@example <hypothesis.example>`,
+  :func:`@seed <hypothesis.seed>`, or :func:`@reproduce_failure <hypothesis.reproduce_failure>`
+  without also applying :func:`@given <hypothesis.given>`.
 - You may pass either the ``target`` or ``targets`` argument to stateful rules, but not both.
 - :obj:`~hypothesis.settings.deadline` must be ``None`` (to disable), a
   :class:`~python:datetime.timedelta`, or an integer or float number of milliseconds.

--- a/hypothesis-python/tests/cover/test_unittest.py
+++ b/hypothesis-python/tests/cover/test_unittest.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
 def test_subTest_no_self(testdir, err):
     # https://github.com/HypothesisWorks/hypothesis/issues/2462
     # for some reason this issue happens only when running unittest from commandline
-    fname = testdir.makefile("tests.py", SUBTEST_SUITE)
+    fname = testdir.makepyfile(tests=SUBTEST_SUITE)
     result = testdir.run(sys.executable, *err, str(fname))
     expected = pytest.ExitCode.TESTS_FAILED if err else pytest.ExitCode.OK
     assert result.ret == expected, result.stderr.str()


### PR DESCRIPTION
- Fixes #2716 (which we'll encounter as soon as we move to GitHub Actions, #2674, and re-enable dependency updates).
- Adds a line to the changelog that I discovered was missing while working on #2705.
- Our shrinking guide now [links to the published paper](https://2020.ecoop.org/details/ecoop-2020-papers/13/Test-Case-Reduction-via-Test-Case-Generation-Insights-From-the-Hypothesis-Reducer) instead of suggesting you ask David for a draft.
- Our API style guide notes that 
  - `min_value` and `max_value` need not be keyword-only despite having default values,
  - their default values should be None only for unbounded types (integers yes, datetimes no), and
  - `floats()` is special because of `inf` and `nan` interactions.