### PR TITLE
Add a "tasks" task to print the list of tasks supported by the build system

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -174,7 +174,7 @@ You can also use ``./build.sh check-format``, which will run format and some lin
 git diff. Note: This will error even if you started with a git diff, so if you've got any uncommitted changes
 this will necessarily report an error.
 
-Look in ``.travis.yml`` for a short list of other supported build tasks.
+Run ``./build.sh tasks`` for a list of all supported build task names.
 
 Note: The build requires a lot of different versions of python, so rather than have you install them yourself,
 the build system will install them itself in a local directory. This means that the first time you run a task you

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -487,6 +487,13 @@ def check_rust_tests():
     cr.cargo("test")
 
 
+@task()
+def tasks():
+    """Print a list of all task names supported by the build system."""
+    for task_name in sorted(TASKS.keys()):
+        print(task_name)
+
+
 if __name__ == "__main__":
     if "SNAKEPIT" not in os.environ:
         print(
@@ -505,7 +512,8 @@ if __name__ == "__main__":
     if task_to_run is None:
         print(
             "No task specified. Either pass the task to run as an "
-            "argument or as an environment variable TASK."
+            "argument or as an environment variable TASK. "
+            '(Use "./build.sh tasks" to list all supported task names.)'
         )
         sys.exit(1)
 


### PR DESCRIPTION
I always found it slightly annoying to have to look through `.travis.yml` or `__main__.py` to figure out which tasks are supported by `./build.sh`, especially since some of the task names don't appear directly in the source. So I added a new task that just directly prints a list of all known task names.

I also added a helpful suggestion to the error message that appears when no task is specified.