### PR TITLE
Support `Literal` on py36

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This patch fixes :func:`~hypothesis.strategies.from_type` with
+the :pypi:`typing_extensions` ``Literal`` backport on Python 3.6.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -104,7 +104,11 @@ def is_typing_literal(thing):
         hasattr(typing, "Literal")
         and getattr(thing, "__origin__", None) == typing.Literal
         or hasattr(typing_extensions, "Literal")
-        and getattr(thing, "__origin__", None) == typing_extensions.Literal
+        and (
+            getattr(thing, "__origin__", None) == typing_extensions.Literal
+            or sys.version_info[:2] == (3, 6)
+            and isinstance(thing, type(typing_extensions.Literal[None]))
+        )
     )
 
 

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import collections
-import sys
 from typing import Union
 
 import pytest
@@ -24,13 +23,11 @@ from hypothesis import assume, given, strategies as st
 from hypothesis.strategies import from_type
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="lovecraftian implemenation")
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])
 def test_typing_extensions_Literal(value):
     assert from_type(Literal[value]).example() == value
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="lovecraftian implemenation")
 @given(st.data())
 def test_typing_extensions_Literal_nested(data):
     lit = Literal


### PR DESCRIPTION
This turns out to be essential for the Pydantic plugin I'm working on (https://github.com/samuelcolvin/pydantic/pull/2097), so here we go.