### PR TITLE
Don't `pip install hypothesis-python/` in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,6 @@ if ! "$TOOL_PYTHON" -m hypothesistooling check-installed ; then
   "$PYTHON" -m pip install --upgrade virtualenv
   "$PYTHON" -m virtualenv "$TOOL_VIRTUALENV"
   "$TOOL_PYTHON" -m pip install --no-warn-script-location -r requirements/tools.txt
-  "$TOOL_PYTHON" -m pip install --no-warn-script-location hypothesis-python/
 fi
 
 "$TOOL_PYTHON" -m hypothesistooling "$@"


### PR DESCRIPTION
According to https://github.com/HypothesisWorks/hypothesis/issues/2734#issuecomment-754002321, this installation line was accidentally introduced in e2e0cf9 (#2656), and does not appear to be needed for anything. It had the undesired effect of causing `./build.sh documentation` to use a stale installed copy of the Hypothesis source, instead of the current source.

Fixes #2734.