### PR TITLE
Refactor pytest plugin statistics handling for strict JUnit xml validation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes an interaction where our :ref:`test statistics <statistics>`
+handling made Pytest's ``--junit-xml`` output fail to validate against the
+strict ``xunit2`` schema (:issue:`1975`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -590,7 +590,7 @@ class ConcreteDFA(DFA):
           (in which case they map characters to other states) or lists. If they
           are a list they may contain tuples of length 2 or 3. A tuple ``(c, j)``
           indicates that this state transitions to state ``j`` given ``c``. A
-          tuple ``(u, v, j)`` indicates this state transitiosn to state ``j``
+          tuple ``(u, v, j)`` indicates this state transitions to state ``j``
           given any ``c`` with ``u <= c <= v``.
         * ``accepting`` is a set containing the integer labels of accepting
           states.

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -89,6 +89,13 @@ def dfas(draw):
 
 @settings(max_examples=20)
 @given(dfas(), st.booleans())
+@example(
+    ConcreteDFA(
+        transitions=[[(0, 2), (1, 255, 1)], [(0, 2), (1, 255, 0)], []],
+        accepting={2},
+    ),
+    False,
+)
 def test_canonicalised_matches_same_strings(dfa, via_repr):
     canon = dfa.canonicalise()
     note(canon)


### PR DESCRIPTION
Closes #1975, by the inelegant but effective expedient of using a valid-for-junitxml if the `--junit-xml` argument has been passed, and base64-encoding everything to avoid XML escaping problems with arbitrary user-supplied events, `target` labels, etc.

Ping @danilomendesdias @tadeu @arthursoprana @ggrbill @prusse-martin @thisch - you each 👍'd the issue and I'd appreciate any feedback you might have on this PR, especially confirming whether or not it fixes the problem for you!