### PR TITLE
Hypothesis 6.0: starting 2021 as we mean to go on

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -15,3 +15,5 @@ Changes
 - :func:`hypothesis.extra.django.from_model` no longer accepts ``model`` as a
   keyword argument, where it could conflict with fields named "model".
 - :func:`~hypothesis.strategies.randoms` now defaults to ``use_true_random=False``.
+- :func:`~hypothesis.strategies.complex_numbers` no longer accepts
+  ``min_magnitude=None``; either use ``min_magnitude=0`` or just omit the argument.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -17,3 +17,5 @@ Changes
 - :func:`~hypothesis.strategies.randoms` now defaults to ``use_true_random=False``.
 - :func:`~hypothesis.strategies.complex_numbers` no longer accepts
   ``min_magnitude=None``; either use ``min_magnitude=0`` or just omit the argument.
+- ``hypothesis.provisional.ip4_addr_strings`` and ``ip6_addr_strings`` are removed
+  in favor of :func:`ip_addresses(v=...).map(str) <hypothesis.strategies.ip_addresses>`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -14,3 +14,4 @@ Changes
 ~~~~~~~
 - :func:`hypothesis.extra.django.from_model` no longer accepts ``model`` as a
   keyword argument, where it could conflict with fields named "model".
+- :func:`~hypothesis.strategies.randoms` now defaults to ``use_true_random=False``.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -19,3 +19,5 @@ Changes
   ``min_magnitude=None``; either use ``min_magnitude=0`` or just omit the argument.
 - ``hypothesis.provisional.ip4_addr_strings`` and ``ip6_addr_strings`` are removed
   in favor of :func:`ip_addresses(v=...).map(str) <hypothesis.strategies.ip_addresses>`.
+- :func:`~hypothesis.strategies.register_type_strategy` no longer accepts generic
+  types with type arguments, which were always pretty badly broken.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -12,6 +12,8 @@ Hypothesis deprecation warnings*, this will be a very boring upgrade.
 
 Changes
 ~~~~~~~
+- Many functions now use :pep:`3102` keyword-only arguments where passing positional
+  arguments :ref:`was deprecated since 5.5 <v5.5.0>`.
 - :func:`hypothesis.extra.django.from_model` no longer accepts ``model`` as a
   keyword argument, where it could conflict with fields named "model".
 - :func:`~hypothesis.strategies.randoms` now defaults to ``use_true_random=False``.
@@ -22,3 +24,8 @@ Changes
 - :func:`~hypothesis.strategies.register_type_strategy` no longer accepts generic
   types with type arguments, which were always pretty badly broken.
 - Using function-scoped pytest fixtures is now a health-check error, instead of a warning.
+
+.. tip::
+    The :command:`hypothesis codemod` command can automatically refactor your code,
+    particularly to convert positional to keyword arguments where those are now
+    required.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -12,3 +12,5 @@ Hypothesis deprecation warnings*, this will be a very boring upgrade.
 
 Changes
 ~~~~~~~
+- :func:`hypothesis.extra.django.from_model` no longer accepts ``model`` as a
+  keyword argument, where it could conflict with fields named "model".

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,14 @@
+RELEASE_TYPE: major
+
+Welcome to the next major version of Hypothesis!
+
+There are no new features here, as we release those in minor versions.
+Instead, 6.0 is a chance for us to remove deprecated features (many already
+converted into no-ops), and turn a variety of warnings into errors.
+
+If you were running on the last version of Hypothesis 5.x *without any
+Hypothesis deprecation warnings*, this will be a very boring upgrade.
+**In fact, nothing will change for you at all.**
+
+Changes
+~~~~~~~

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -21,3 +21,4 @@ Changes
   in favor of :func:`ip_addresses(v=...).map(str) <hypothesis.strategies.ip_addresses>`.
 - :func:`~hypothesis.strategies.register_type_strategy` no longer accepts generic
   types with type arguments, which were always pretty badly broken.
+- Using function-scoped pytest fixtures is now a health-check error, instead of a warning.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -20,7 +20,6 @@ from typing import NoReturn, Union
 from hypothesis import Verbosity, settings
 from hypothesis.errors import CleanupFailed, InvalidArgument, UnsatisfiedAssumption
 from hypothesis.internal.conjecture.data import ConjectureData
-from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import report, verbose_report
 from hypothesis.utils.dynamicvariables import DynamicVariable
@@ -136,7 +135,6 @@ def event(value: str) -> None:
     context.data.note_event(value)
 
 
-@deprecated_posargs
 def target(observation: Union[int, float], *, label: str = "") -> None:
     """Calling this function with an ``int`` or ``float`` observation gives it feedback
     with which to guide our search for inputs that will cause an error, in

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -77,7 +77,6 @@ from hypothesis.internal.reflection import (
     arg_string,
     convert_positional_arguments,
     define_function_signature,
-    deprecated_posargs,
     function_digest,
     get_pretty_function_description,
     impersonate,
@@ -1247,7 +1246,6 @@ def given(
     return run_test_as_given
 
 
-@deprecated_posargs
 def find(
     specifier: SearchStrategy[Ex],
     condition: Callable[[Any], bool],

--- a/hypothesis-python/src/hypothesis/extra/codemods.py
+++ b/hypothesis-python/src/hypothesis/extra/codemods.py
@@ -202,14 +202,6 @@ class HypothesisFixPositionalKeywonlyArgs(VisitorBasedCodemodCommand):
             return updated_node
 
         # Create new arg nodes with the newly required keywords
-        params = [
-            p
-            for p in signature(func).parameters.values()
-            if p.kind is not Parameter.VAR_POSITIONAL
-        ]
-        # params comprehension is only useful after @deprecated_posargs applied
-        # once removed we can use paramaters.values(); if never applied why codemod?
-        assert len(params) < len(signature(func).parameters.values())
         assign_nospace = cst.AssignEqual(
             whitespace_before=cst.SimpleWhitespace(""),
             whitespace_after=cst.SimpleWhitespace(""),
@@ -218,6 +210,6 @@ class HypothesisFixPositionalKeywonlyArgs(VisitorBasedCodemodCommand):
             arg
             if arg.keyword or arg.star or p.kind is not Parameter.KEYWORD_ONLY
             else arg.with_changes(keyword=cst.Name(p.name), equal=assign_nospace)
-            for p, arg in zip(params, updated_node.args)
+            for p, arg in zip(signature(func).parameters.values(), updated_node.args)
         ]
         return updated_node.with_changes(args=newargs)

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -24,7 +24,6 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models as dm
 
 from hypothesis import reject
-from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django._fields import from_field
 from hypothesis.strategies._internal import core as st
@@ -88,16 +87,7 @@ def from_model(
     elif len(model) > 1:
         raise TypeError("Too many positional arguments")
     else:
-        try:
-            m_type = field_strategies.pop("model")  # type: ignore
-        except KeyError:
-            raise TypeError("Missing required positional argument `model`") from None
-        else:
-            note_deprecation(
-                "The `model` argument will be positional-only in a future version",
-                since="2020-03-18",
-                has_codemod=False,
-            )
+        raise TypeError("Missing required positional argument `model`")
 
     if not issubclass(m_type, dm.Model):
         raise InvalidArgument("model=%r must be a subtype of Model" % (model,))

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -43,7 +43,6 @@ from lark.grammar import NonTerminal, Terminal
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.utils import calc_label_from_name
-from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal import SearchStrategy, core as st
 
@@ -201,7 +200,6 @@ def check_explicit(name):
 
 @st.cacheable
 @st.defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def from_lark(
     grammar: lark.lark.Lark,
     *,

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -23,7 +23,7 @@ from hypothesis import assume
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.coverage import check_function
-from hypothesis.internal.reflection import deprecated_posargs, proxies
+from hypothesis.internal.reflection import proxies
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal import SearchStrategy, check_strategy, core as st
 from hypothesis.strategies._internal.strategies import T
@@ -346,7 +346,6 @@ def fill_for(elements, unique, fill, name=""):
 
 
 @st.defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def arrays(
     dtype: Any,
     shape: Union[int, Shape, st.SearchStrategy[Shape]],
@@ -464,7 +463,6 @@ def arrays(
 
 
 @st.defines_strategy()
-@deprecated_posargs
 def array_shapes(
     *,
     min_dims: int = 1,
@@ -557,7 +555,6 @@ def dtype_factory(kind, sizes, valid_sizes, endianness):
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def unsigned_integer_dtypes(
     *, endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
 ) -> st.SearchStrategy[np.dtype]:
@@ -574,7 +571,6 @@ def unsigned_integer_dtypes(
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def integer_dtypes(
     *, endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
 ) -> st.SearchStrategy[np.dtype]:
@@ -587,7 +583,6 @@ def integer_dtypes(
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def floating_dtypes(
     *, endianness: str = "?", sizes: Sequence[int] = (16, 32, 64)
 ) -> st.SearchStrategy[np.dtype]:
@@ -604,7 +599,6 @@ def floating_dtypes(
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def complex_number_dtypes(
     *, endianness: str = "?", sizes: Sequence[int] = (64, 128)
 ) -> st.SearchStrategy[np.dtype]:
@@ -644,7 +638,6 @@ def validate_time_slice(max_period, min_period):
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def datetime64_dtypes(
     *, max_period: str = "Y", min_period: str = "ns", endianness: str = "?"
 ) -> st.SearchStrategy[np.dtype]:
@@ -659,7 +652,6 @@ def datetime64_dtypes(
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def timedelta64_dtypes(
     *, max_period: str = "Y", min_period: str = "ns", endianness: str = "?"
 ) -> st.SearchStrategy[np.dtype]:
@@ -674,7 +666,6 @@ def timedelta64_dtypes(
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def byte_string_dtypes(
     *, endianness: str = "?", min_len: int = 1, max_len: int = 16
 ) -> st.SearchStrategy[np.dtype]:
@@ -690,7 +681,6 @@ def byte_string_dtypes(
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def unicode_string_dtypes(
     *, endianness: str = "?", min_len: int = 1, max_len: int = 16
 ) -> st.SearchStrategy[np.dtype]:
@@ -718,7 +708,6 @@ def _no_title_is_name_of_a_titled_field(ls):
 
 
 @defines_dtype_strategy
-@deprecated_posargs
 def array_dtypes(
     subtype_strategy: st.SearchStrategy[np.dtype] = scalar_dtypes(),
     *,
@@ -755,7 +744,6 @@ def array_dtypes(
 
 
 @st.defines_strategy()
-@deprecated_posargs
 def nested_dtypes(
     subtype_strategy: st.SearchStrategy[np.dtype] = scalar_dtypes(),
     *,
@@ -778,7 +766,6 @@ def nested_dtypes(
 
 
 @st.defines_strategy()
-@deprecated_posargs
 def valid_tuple_axes(
     ndim: int,
     *,
@@ -830,7 +817,6 @@ def valid_tuple_axes(
 
 
 @st.defines_strategy()
-@deprecated_posargs
 def broadcastable_shapes(
     shape: Shape,
     *,
@@ -1442,7 +1428,6 @@ def basic_indices(
 
 
 @st.defines_strategy()
-@deprecated_posargs
 def integer_array_indices(
     shape: Shape,
     *,

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -26,7 +26,6 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as npst
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.coverage import check, check_function
-from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.internal.validation import (
     check_type,
     check_valid_interval,
@@ -176,7 +175,6 @@ def range_indexes(
 
 @st.cacheable
 @st.defines_strategy()
-@deprecated_posargs
 def indexes(
     *,
     elements: Optional[st.SearchStrategy[Ex]] = None,
@@ -217,7 +215,6 @@ def indexes(
 
 
 @st.defines_strategy()
-@deprecated_posargs
 def series(
     *,
     elements: Optional[st.SearchStrategy[Ex]] = None,
@@ -333,7 +330,6 @@ class column:
     unique = attr.ib(default=False)
 
 
-@deprecated_posargs
 def columns(
     names_or_number: Union[int, Sequence[str]],
     *,
@@ -361,7 +357,6 @@ def columns(
     ]
 
 
-@deprecated_posargs
 @st.defines_strategy()
 def data_frames(
     columns: Optional[Sequence[column]] = None,

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -18,9 +18,9 @@ from inspect import signature
 import pytest
 
 from hypothesis import HealthCheck, Verbosity, core, settings
-from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.detection import is_hypothesis_test
+from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.statistics import collector, describe_statistics
 
@@ -181,10 +181,10 @@ else:
                         if fx.argname in argnames:
                             active_fx = item._request._get_active_fixturedef(fx.argname)
                             if active_fx.scope == "function":
-                                note_deprecation(
+                                fail_health_check(
+                                    settings,
                                     msg % (item.nodeid, fx.argname),
-                                    since="2020-02-29",
-                                    has_codemod=False,
+                                    HealthCheck.function_scoped_fixture,
                                 )
 
             if item.get_closest_marker("parametrize") is not None:

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -78,15 +78,8 @@ def check_valid_magnitude(value, name):
     check_valid_bound(value, name)
     if value is not None and value < 0:
         raise InvalidArgument("%s=%r must not be negative." % (name, value))
-    if value is None and name == "min_magnitude":
-        from hypothesis._settings import note_deprecation
-
-        note_deprecation(
-            "min_magnitude=None is deprecated; use min_magnitude=0 "
-            "or omit the argument entirely.",
-            since="2020-05-13",
-            has_codemod=True,
-        )
+    elif value is None and name == "min_magnitude":
+        raise InvalidArgument("Use min_magnitude=0 or omit the argument entirely.")
 
 
 @check_function

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -28,7 +28,6 @@ import string
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
-from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.strategies._internal import core as st
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
@@ -133,7 +132,6 @@ class DomainNameStrategy(SearchStrategy):
 
 
 @st.defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def domains(
     *, max_length: int = 255, max_element_length: int = 63
 ) -> SearchStrategy[str]:

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -26,12 +26,10 @@ definitions it links to.  If not, report the bug!
 import os.path
 import string
 
-from hypothesis._settings import note_deprecation
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.reflection import deprecated_posargs
 from hypothesis.strategies._internal import core as st
-from hypothesis.strategies._internal.ipaddress import ip_addresses
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
 URL_SAFE_CHARACTERS = frozenset(string.ascii_letters + string.digits + "$-_.+!*'(),~")
@@ -159,25 +157,3 @@ def urls() -> SearchStrategy[str]:
     return st.builds(
         "{}://{}{}/{}".format, schemes, domains(), st.just("") | ports, paths
     )
-
-
-@st.defines_strategy(force_reusable_values=True)
-def ip4_addr_strings() -> SearchStrategy[str]:
-    note_deprecation(
-        "Use `ip_addresses(v=4).map(str)` instead of `ip4_addr_strings()`; "
-        "the provisional strategy is less flexible and will be removed.",
-        since="2020-01-21",
-        has_codemod=False,
-    )
-    return ip_addresses(v=4).map(str)
-
-
-@st.defines_strategy(force_reusable_values=True)
-def ip6_addr_strings() -> SearchStrategy[str]:
-    note_deprecation(
-        "Use `ip_addresses(v=6).map(str)` instead of `ip6_addr_strings()`; "
-        "the provisional strategy is less flexible and will be removed.",
-        since="2020-01-21",
-        has_codemod=False,
-    )
-    return ip_addresses(v=6).map(str)

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -37,13 +37,7 @@ from hypothesis.control import current_build_context
 from hypothesis.core import given
 from hypothesis.errors import InvalidArgument, InvalidDefinition
 from hypothesis.internal.conjecture import utils as cu
-from hypothesis.internal.reflection import (
-    deprecated_posargs,
-    function_digest,
-    nicerepr,
-    proxies,
-    qualname,
-)
+from hypothesis.internal.reflection import function_digest, nicerepr, proxies, qualname
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import current_verbosity, report
 from hypothesis.strategies._internal.featureflags import FeatureStrategy
@@ -71,7 +65,6 @@ class TestCaseProperty:  # pragma: no cover
         raise AttributeError("Cannot delete TestCase")
 
 
-@deprecated_posargs
 def run_state_machine_as_test(state_machine_factory, *, settings=None):
     """Run a state machine definition as a test, either silently doing nothing
     or printing a minimal breaking program and raising an exception.
@@ -549,7 +542,6 @@ PRECONDITION_MARKER = "hypothesis_stateful_precondition"
 INVARIANT_MARKER = "hypothesis_stateful_invariant"
 
 
-@deprecated_posargs
 def rule(*, targets=(), target=None, **kwargs):
     """Decorator for RuleBasedStateMachine. Any name present in target or
     targets will define where the end result of this function should go. If
@@ -599,7 +591,6 @@ def rule(*, targets=(), target=None, **kwargs):
     return accept
 
 
-@deprecated_posargs
 def initialize(*, targets=(), target=None, **kwargs):
     """Decorator for RuleBasedStateMachine.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -73,7 +73,6 @@ from hypothesis.internal.floats import (
 )
 from hypothesis.internal.reflection import (
     define_function_signature,
-    deprecated_posargs,
     get_pretty_function_description,
     is_typed_named_tuple,
     nicerepr,
@@ -424,7 +423,6 @@ def booleans() -> SearchStrategy[bool]:
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def floats(
     min_value: Optional[Real] = None,
     max_value: Optional[Real] = None,
@@ -703,7 +701,6 @@ def identity(x):
 
 @cacheable
 @defines_strategy()
-@deprecated_posargs
 def lists(
     elements: SearchStrategy[Ex],
     *,
@@ -823,7 +820,6 @@ def lists(
 
 @cacheable
 @defines_strategy()
-@deprecated_posargs
 def sets(
     elements: SearchStrategy[Ex],
     *,
@@ -846,7 +842,6 @@ def sets(
 
 @cacheable
 @defines_strategy()
-@deprecated_posargs
 def frozensets(
     elements: SearchStrategy[Ex],
     *,
@@ -876,7 +871,6 @@ class PrettyIter:
 
 
 @defines_strategy()
-@deprecated_posargs
 def iterables(
     elements: SearchStrategy[Ex],
     *,
@@ -944,7 +938,6 @@ def fixed_dictionaries(
 
 @cacheable
 @defines_strategy()
-@deprecated_posargs
 def dictionaries(
     keys: SearchStrategy[Ex],
     values: SearchStrategy[T],
@@ -980,7 +973,6 @@ def dictionaries(
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def characters(
     *,
     whitelist_categories: Optional[Sequence[str]] = None,
@@ -1087,7 +1079,6 @@ def characters(
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def text(
     alphabet: Union[Sequence[str], SearchStrategy[str]] = characters(
         blacklist_categories=("Cs",)
@@ -1143,7 +1134,6 @@ def text(
 
 @cacheable
 @defines_strategy()
-@deprecated_posargs
 def from_regex(
     regex: Union[AnyStr, Pattern[AnyStr]], *, fullmatch: bool = False
 ) -> SearchStrategy[AnyStr]:
@@ -1184,7 +1174,6 @@ def from_regex(
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def binary(
     *,
     min_size: int = 0,
@@ -1630,7 +1619,6 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def fractions(
     min_value: Optional[Union[Real, str]] = None,
     max_value: Optional[Union[Real, str]] = None,
@@ -1740,7 +1728,6 @@ def _as_finite_decimal(
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def decimals(
     min_value: Optional[Union[Real, str]] = None,
     max_value: Optional[Union[Real, str]] = None,
@@ -1828,7 +1815,6 @@ def decimals(
     return strat | (sampled_from(special) if special else nothing())
 
 
-@deprecated_posargs
 def recursive(
     base: SearchStrategy[Ex],
     extend: Callable[[SearchStrategy[Any]], SearchStrategy[T]],
@@ -1951,7 +1937,6 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
 
 @defines_strategy(force_reusable_values=True)
 @cacheable
-@deprecated_posargs
 def complex_numbers(
     *,
     min_magnitude: Real = 0,
@@ -2035,7 +2020,6 @@ def complex_numbers(
     return constrained_complex()
 
 
-@deprecated_posargs
 def shared(
     base: SearchStrategy[Ex],
     *,
@@ -2062,7 +2046,6 @@ def shared(
 
 @cacheable
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def uuids(*, version: Optional[int] = None) -> SearchStrategy[UUID]:
     """Returns a strategy that generates :class:`UUIDs <uuid.UUID>`.
 
@@ -2107,7 +2090,6 @@ class RunnerStrategy(SearchStrategy):
 
 
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def runner(*, default: Any = not_set) -> SearchStrategy[Any]:
     """A strategy for getting "the current test runner", whatever that may be.
     The exact meaning depends on the entry point, but it will usually be the
@@ -2295,7 +2277,6 @@ def emails() -> SearchStrategy[str]:
 
 
 @defines_strategy()
-@deprecated_posargs
 def functions(
     *,
     like: Callable[..., Any] = lambda: None,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1212,7 +1212,7 @@ def binary(
 def randoms(
     *,
     note_method_calls: bool = False,
-    use_true_random: Optional[bool] = None,
+    use_true_random: bool = False,
 ) -> SearchStrategy[random.Random]:
     """Generates instances of ``random.Random``. The generated Random instances
     are of a special HypothesisRandom subclass.
@@ -1228,16 +1228,8 @@ def randoms(
       flag should only be set to True when your code relies on the distribution
       of values for correctness.
     """
-    if use_true_random is None:
-        note_deprecation(
-            """Defaulting to old behaviour of use_true_random=True. If you want
-            to keep that behaviour, set use_true_random=True explicitly. If you
-            want the new behaviour (which will become the default in future),
-            set use_true_random=False.""",
-            since="2020-06-30",
-            has_codemod=False,
-        )
-        use_true_random = True
+    check_type(bool, note_method_calls, "note_method_calls")
+    check_type(bool, use_true_random, "use_true_random")
 
     from hypothesis.strategies._internal.random import RandomStrategy
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1986,8 +1986,6 @@ def complex_numbers(
     check_valid_magnitude(min_magnitude, "min_magnitude")
     check_valid_magnitude(max_magnitude, "max_magnitude")
     check_valid_interval(min_magnitude, max_magnitude, "min_magnitude", "max_magnitude")
-    if min_magnitude is None:
-        min_magnitude = 0
     if max_magnitude == math.inf:
         max_magnitude = None
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -50,7 +50,6 @@ from uuid import UUID
 
 import attr
 
-from hypothesis._settings import note_deprecation
 from hypothesis.control import cleanup, note, reject
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.cache import LRUReusedCache
@@ -2231,26 +2230,12 @@ def register_type_strategy(
         raise InvalidArgument("strategy=%r must not be empty")
     elif types.has_type_arguments(custom_type):
         origin = getattr(custom_type, "__origin__", None)
-        if callable(strategy):
-            strategy_repr = get_pretty_function_description(strategy)
-        else:
-            strategy_repr = repr(strategy)
-        note_deprecation(
-            "Registering a generic type with arguments (%r) is deprecated, and "
-            "will be an error in future, because the resolution logic is badly "
-            "broken.  Instead, register a function for the origin type (%r) "
-            "which can inspect specific type objects and return a strategy.  "
-            "%s will be registered for any type arguments."
-            % (custom_type, origin, strategy_repr),
-            since="2020-08-17",
-            has_codemod=False,
+        raise InvalidArgument(
+            f"Cannot register generic type {custom_type!r}, because it has type "
+            "arguments which would not be handled.  Instead, register a function "
+            f"for {origin!r} which can inspect specific type objects and return a "
+            "strategy."
         )
-        if origin in types._global_type_lookup:
-            raise InvalidArgument(
-                "Cannot register %r, because the without-arguments form %r already "
-                "has a registered strategy %s" % (custom_type, origin, strategy_repr)
-            )
-        custom_type = origin
 
     types._global_type_lookup[custom_type] = strategy
     from_type.__clear_cache()  # type: ignore

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -24,7 +24,6 @@ from hypothesis.internal.conjecture import utils
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal.core import (
     defines_strategy,
-    deprecated_posargs,
     just,
     none,
     sampled_from,
@@ -176,7 +175,6 @@ class DatetimeStrategy(SearchStrategy):
 
 
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def datetimes(
     min_value: dt.datetime = dt.datetime.min,
     max_value: dt.datetime = dt.datetime.max,
@@ -246,7 +244,6 @@ class TimeStrategy(SearchStrategy):
 
 
 @defines_strategy(force_reusable_values=True)
-@deprecated_posargs
 def times(
     min_value: dt.time = dt.time.min,
     max_value: dt.time = dt.time.max,

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -19,7 +19,6 @@ import sys
 from hypothesis import given, reject, strategies as st
 from hypothesis.strategies import complex_numbers
 from tests.common.debug import minimal
-from tests.common.utils import checks_deprecated_behaviour
 
 
 def test_minimal():
@@ -73,11 +72,6 @@ def test_min_magnitude_respected(data, mag):
 
 def test_minimal_min_magnitude_zero():
     assert minimal(complex_numbers(min_magnitude=0), lambda x: True) == 0
-
-
-@checks_deprecated_behaviour
-def test_minimal_min_magnitude_none():
-    assert minimal(complex_numbers(min_magnitude=None), lambda x: True) == 0
 
 
 def test_minimal_min_magnitude_positive():

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -138,6 +138,7 @@ def fn_ktest(*fnkwargs):
     (ds.floats, {"min_value": 0.0, "max_value": 1.0, "allow_infinity": True}),
     (ds.floats, {"min_value": math.inf, "allow_infinity": False}),
     (ds.floats, {"max_value": -math.inf, "allow_infinity": False}),
+    (ds.complex_numbers, {"min_magnitude": None}),
     (ds.complex_numbers, {"min_magnitude": math.nan}),
     (ds.complex_numbers, {"max_magnitude": math.nan}),
     (ds.complex_numbers, {"max_magnitude": complex(1, 2)}),

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -183,6 +183,8 @@ def fn_ktest(*fnkwargs):
     (ds.ip_addresses, {"v": 6, "network": "127.0.0.0/8"}),
     (ds.ip_addresses, {"network": b"127.0.0.0/8"}),  # only unicode strings are valid
     (ds.ip_addresses, {"network": b"::/64"}),
+    (ds.randoms, {"use_true_random": "False"}),
+    (ds.randoms, {"note_method_calls": "True"}),
 )
 def test_validates_keyword_arguments(fn, kwargs):
     with pytest.raises(InvalidArgument):

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-import ipaddress
 import re
 import string
 
@@ -21,9 +20,8 @@ import pytest
 
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
-from hypothesis.provisional import domains, ip4_addr_strings, ip6_addr_strings, urls
+from hypothesis.provisional import domains, urls
 from tests.common.debug import find_any
-from tests.common.utils import checks_deprecated_behaviour
 
 
 @given(urls())
@@ -35,22 +33,6 @@ def test_is_URL(url):
     assert all(
         re.match("^[0-9A-Fa-f]{2}", after_perc) for after_perc in path.split("%")[1:]
     )
-
-
-@checks_deprecated_behaviour
-@given(ip4_addr_strings())
-def test_is_IP4_addr(address):
-    as_num = [int(n) for n in address.split(".")]
-    assert len(as_num) == 4
-    assert all(0 <= n <= 255 for n in as_num)
-
-
-@checks_deprecated_behaviour
-@given(ip6_addr_strings())
-def test_is_IP6_addr(address):
-    # The IPv6Address constructor does all the validation we could need
-    assert isinstance(address, str)
-    ipaddress.IPv6Address(address)
 
 
 @pytest.mark.parametrize("max_length", [-1, 0, 3, 4.0, 256])

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -29,7 +29,7 @@ from hypothesis.strategies._internal.random import (
     normalize_zero,
 )
 from tests.common.debug import find_any
-from tests.common.utils import capture_out, checks_deprecated_behaviour
+from tests.common.utils import capture_out
 
 
 def test_implements_all_random_methods():
@@ -219,10 +219,9 @@ def test_state_is_consistent(r1, r2):
     assert r1.getstate() == r2.getstate()
 
 
-@checks_deprecated_behaviour
 @given(st.randoms())
 def test_does_not_use_true_random_by_default(rnd):
-    assert isinstance(rnd, TrueRandom)
+    assert not isinstance(rnd, TrueRandom)
 
 
 @given(st.randoms(use_true_random=False))

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -38,7 +38,7 @@ from hypothesis.internal.reflection import (
     source_exec_as_module,
     unbind_method,
 )
-from tests.common.utils import checks_deprecated_behaviour, raises
+from tests.common.utils import raises
 
 
 def do_conversion_test(f, args, kwargs):
@@ -705,19 +705,3 @@ def test_too_many_posargs_fails():
 def test_overlapping_posarg_kwarg_fails():
     with pytest.raises(TypeError):
         st.times(time.min, time.max, st.none(), timezones=st.just(None)).validate()
-
-
-@checks_deprecated_behaviour
-def test_fails_to_detect_kwarg_with_default_value():
-    # Unfortunately we can't detect that this is an error, so you only get
-    # the warning about passing an argument positionally.  At least it warns!
-    st.floats(0, 1, False, allow_nan=None).validate()
-
-
-def test_repr_suggests_kwargs_for_deprecated_posargs():
-    # We don't get a deprecation warning here because we only instantiate the lazy
-    # wrapper, not the underlying strategy.  Note that this omits posargs that carry
-    # their default value from the resulting repr - it's "how to get this strategy",
-    # not "here's exactly what you passed in" (usually but not always the same).
-    strat = st.floats(0, None, False, True)
-    assert repr(strat) == "floats(min_value=0, allow_infinity=True, allow_nan=False)"

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -30,7 +30,11 @@ from hypothesis._settings import (
     settings,
 )
 from hypothesis.database import ExampleDatabase
-from hypothesis.errors import InvalidArgument, InvalidState
+from hypothesis.errors import (
+    HypothesisDeprecationWarning,
+    InvalidArgument,
+    InvalidState,
+)
 from hypothesis.stateful import RuleBasedStateMachine, rule
 from hypothesis.utils.conventions import not_set
 from tests.common.utils import counts_calls, fails_with
@@ -474,3 +478,11 @@ def test_note_deprecation_checks_date():
     assert len(rec) == 1
     with pytest.raises(AssertionError):
         note_deprecation("This is way too old", since="1999-12-31", has_codemod=False)
+
+
+def test_note_deprecation_checks_has_codemod():
+    with pytest.warns(
+        HypothesisDeprecationWarning,
+        match="The `hypothesis codemod` command-line tool",
+    ):
+        note_deprecation("This is bad", since="2021-01-01", has_codemod=True)

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -29,7 +29,7 @@ from hypothesis.strategies._internal import types
 from hypothesis.strategies._internal.core import _strategies
 from hypothesis.strategies._internal.types import _global_type_lookup
 from tests.common.debug import assert_all_examples, find_any
-from tests.common.utils import checks_deprecated_behaviour, fails_with, temp_registered
+from tests.common.utils import fails_with, temp_registered
 
 # Build a set of all types output by core strategies
 blacklist = [
@@ -246,21 +246,10 @@ _skip_callables_mark = pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason=
     ids=repr,
 )
 @pytest.mark.parametrize("strategy", [st.none(), lambda _: st.none()])
-@checks_deprecated_behaviour
 def test_generic_origin_with_type_args(generic, strategy):
-    try:
-        # Registering a generic type with args is deprecated
+    with pytest.raises(InvalidArgument):
         st.register_type_strategy(generic, strategy)
-        assert generic not in types._global_type_lookup
-        assert generic.__origin__ in types._global_type_lookup
-        # But trying to register another strategy does, since that could be
-        # a symptom of trying multiple registrations for different args
-        with pytest.raises(InvalidArgument):
-            st.register_type_strategy(generic, strategy)
-    finally:
-        st.from_type.__clear_cache()
-        for x in (generic, generic.__origin__):
-            types._global_type_lookup.pop(x, None)
+    assert generic not in types._global_type_lookup
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -21,11 +21,7 @@ from django.contrib.auth.models import User
 
 from hypothesis import HealthCheck, assume, given, infer, settings
 from hypothesis.control import reject
-from hypothesis.errors import (
-    HypothesisDeprecationWarning,
-    HypothesisException,
-    InvalidArgument,
-)
+from hypothesis.errors import HypothesisException, InvalidArgument
 from hypothesis.extra.django import (
     TestCase,
     TransactionTestCase,
@@ -202,6 +198,4 @@ class TestPosOnlyArg(TestCase):
     def test_from_model_argspec(self):
         self.assertRaises(TypeError, from_model().example)
         self.assertRaises(TypeError, from_model(Car, None).example)
-        self.assertWarns(
-            HypothesisDeprecationWarning, from_model(model=Customer).example
-        )
+        self.assertRaises(TypeError, from_model(model=Customer).example)

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -112,8 +112,7 @@ def test_autouse_function_scoped_fixture(x):
 
 def test_given_plus_function_scoped_non_autouse_fixtures_are_deprecated(testdir):
     script = testdir.makepyfile(TESTSUITE)
-    testdir.runpytest(script).assert_outcomes(passed=5)
-    testdir.runpytest(script, "-Werror").assert_outcomes(passed=1, failed=4)
+    testdir.runpytest(script).assert_outcomes(passed=1, failed=4)
 
 
 CONFTEST_SUPPRESS = """
@@ -130,10 +129,8 @@ def test_suppress_fixture_health_check_via_profile(testdir):
     script = testdir.makepyfile(TESTSUITE)
     testdir.makeconftest(CONFTEST_SUPPRESS)
 
-    testdir.runpytest(script, "-Werror").assert_outcomes(passed=1, failed=4)
-    testdir.runpytest(
-        script, "-Werror", "--hypothesis-profile=suppress"
-    ).assert_outcomes(passed=5)
+    testdir.runpytest(script).assert_outcomes(passed=1, failed=4)
+    testdir.runpytest(script, "--hypothesis-profile=suppress").assert_outcomes(passed=5)
 
 
 TESTSCRIPT_SUPPRESS_FIXTURE = """
@@ -158,8 +155,7 @@ def test_suppresses_health_check_2(capsys, x):
 
 def test_suppress_health_check_function_scoped_fixture(testdir):
     script = testdir.makepyfile(TESTSCRIPT_SUPPRESS_FIXTURE)
-    testdir.runpytest(script).assert_outcomes(passed=3)
-    testdir.runpytest(script, "-Werror").assert_outcomes(passed=2, failed=1)
+    testdir.runpytest(script).assert_outcomes(passed=2, failed=1)
 
 
 TESTSCRIPT_OVERRIDE_FIXTURE = """


### PR DESCRIPTION
Heya @HypothesisWorks/hypothesis-python-contributors!  I present for your review our smallest major release since 3.0.0:  enforcing keyword-only arguments and finalising six smaller deprecations.

It should also be pretty easy to update - most changes are small, and for the calling convention change we've already shipped a "codemod" which can automatically update user code.  Nonetheless, as per #2709 I think it's worth shipping this now to give users and their tools the nicest interface and learning experience we can.