### PR TITLE
Remove references to RSpec.

### DIFF
--- a/hypothesis-ruby/Gemfile
+++ b/hypothesis-ruby/Gemfile
@@ -4,10 +4,13 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'minitest', '~> 5.8.4'
-gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 0.51.0'
 gem 'simplecov', '~> 0.15.1'
 gem 'yard', '~> 0.9.12'
 gem 'redcarpet', '~> 3.4.0'
 gem 'rutie', '~> 0.0.3'
+gem 'minitest', '~> 5.8.4'
+
+group(:rspec) do
+  gem 'rspec', '~> 3.0'
+end

--- a/hypothesis-ruby/Gemfile.lock
+++ b/hypothesis-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hypothesis-specs (0.2.0)
+    hypothesis-specs (0.3.0)
       rake (>= 10.0, < 13.0)
       rutie (~> 0.0.3)
 

--- a/hypothesis-ruby/README.markdown
+++ b/hypothesis-ruby/README.markdown
@@ -71,7 +71,7 @@ Right now this is really more to allow you to try it out and provide feedback th
 The more feedback we get, the sooner it will get there!
 
 Note that in order to use Hypothesis for Ruby, you will need a rust toolchain installed.
-Please go to [https://www.rustup.rs](https://www.rustup.rs) and follow the instructions if you do not already have one.
+Please go to [https://www.rustup.rs](https://www.rustup.rs) and follow the instructions if you do not already have one. You will most likely need to compile your Ruby executable with the `--enable-shared` option. See [here](https://github.com/danielpclark/rutie#dynamic-vs-static-builds).
 
 ## Project Status
 

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This removes hypothesis-ruby's dependence on RSpec. Now, it can be used with any Ruby test runner.

--- a/hypothesis-ruby/Rakefile
+++ b/hypothesis-ruby/Rakefile
@@ -5,7 +5,7 @@ require 'date'
 require 'open3'
 
 task :build do
-  system('cargo build --release')
+  sh('cargo build --release')
 end
 
 begin
@@ -20,7 +20,23 @@ begin
   end
 
   task test: %i[build spec minitests]
+  task rspec: %i[build spec]
+  task minitest: %i[build without_rspec] do
+    begin
+      Rake::Task['minitests'].execute
+    ensure
+      Rake::Task['with_rspec'].execute
+    end
+  end
 rescue LoadError
+end
+
+task :without_rspec do
+  sh('bundle config set without rspec')
+end
+
+task :with_rspec do
+  sh('bundle config unset without')
 end
 
 def rubocop(fix:)

--- a/hypothesis-ruby/docs/debt.md
+++ b/hypothesis-ruby/docs/debt.md
@@ -84,17 +84,6 @@ Can be removed when one of:
   threading bugs (but fearless concurrency, David!) outweighs
   my desire to not use nightly.
 
-
-### Monkey-patching Helix for our Build
-
-I was very very bored of Helix's build support [not actually failing
-the rake task when the build fails](https://github.com/tildeio/helix/issues/133),
-so I've monkey-patched their build system in our Rakefile in order
-to make it error properly in this case.
-
-Can be removed when: The linked issue is fixed.
-
-
 ### Stable identifiers from RSpec
 
 Another "I did terrible things to RSpec" entry, sorry. RSpec's

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -2,14 +2,10 @@
 
 require 'rutie'
 
-require 'rspec/expectations'
-
 module Hypothesis
   DEFAULT_DATABASE_PATH = File.join(Dir.pwd, '.hypothesis', 'examples')
 
   class Engine
-    include RSpec::Matchers
-
     attr_reader :current_source
     attr_accessor :is_find
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -471,7 +471,8 @@ def lint_ruby():
 
 @ruby_task
 def check_ruby_tests():
-    hr.rake_task("test")
+    hr.rake_task("rspec")
+    hr.rake_task("minitest")
 
 
 @task()


### PR DESCRIPTION
It doesn't look like any RSpec code is actually invoked in the codebase, and requiring these files prevents using hypothesis-ruby with different test runners (i.e. Minitest).

Minitest is the default test runner with Rails, and supporting it would be great. I don't see a compelling reason to limit hypothesis-ruby to RSpec alone.