### PR TITLE
Remove `Clone` trait impl from `Engine`

### DIFF
--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -553,12 +553,6 @@ pub struct Engine {
     sender: SyncSender<TestResult>,
 }
 
-impl Clone for Engine {
-    fn clone(&self) -> Engine {
-        panic!("BUG: The Engine was unexpectedly cloned");
-    }
-}
-
 fn bytes_to_u64s(bytes: &[u8]) -> Vec<u64>{
     let mut reader = io::Cursor::new(bytes);
     let mut result = Vec::new();

--- a/hypothesis-ruby/docs/debt.md
+++ b/hypothesis-ruby/docs/debt.md
@@ -29,17 +29,6 @@ The goals of this documentation are:
 
 ## Awful Hacks
 
-### Panicky Clones
-
-Engine is currently set up to implement Clone but to panic when
-you call it.
-
-This is because [Helix seems to needlessly derive the Clone
-trait](https://github.com/tildeio/helix/issues/143).
-
-Can be removed when: That issue is fixed, or an alternative
-workaround is suggested.
-
 ### Threads as a Control Flow Mechanism
 
 Rather than attempt to encode the generation state machine


### PR DESCRIPTION
As per docs:

> Can be removed when: That issue is fixed, or an alternative workaround is suggested.

Now we don't use `helix` at all, and `rutie` doesn't require `Clone` to be implemented.