### PR TITLE
Actually mark filter iterations as discarded

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes some small improvements to how filtered strategies work. It should improve the performance of shrinking filtered strategies,
+and may under some (probably rare) circumstances improve the diversity of generated examples.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -48,6 +48,10 @@ MAPPED_SEARCH_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
     "another attempted draw in MappedSearchStrategy"
 )
 
+FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
+    "single loop iteration in FilteredStrategy"
+)
+
 
 def one_of_strategies(xs):
     """Helper function for unioning multiple strategies."""
@@ -773,10 +777,13 @@ class FilteredStrategy(SearchStrategy):
     def default_do_filtered_draw(self, data):
         for i in range(3):
             start_index = data.index
+            data.start_example(FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL)
             value = data.draw(self.filtered_strategy)
             if self.condition(value):
+                data.stop_example()
                 return value
             else:
+                data.stop_example(discard=True)
                 if i == 0:
                     self.note_retried(data)
                 # This is to guard against the case where we consume no data.

--- a/hypothesis-python/tests/cover/test_filtered_strategy.py
+++ b/hypothesis-python/tests/cover/test_filtered_strategy.py
@@ -1,0 +1,27 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import hypothesis.strategies as st
+from hypothesis.internal.conjecture.data import ConjectureData
+
+
+def test_filter_iterations_are_marked_as_discarded():
+    x = st.integers(0, 255).filter(lambda x: x == 0)
+
+    data = ConjectureData.for_buffer([2, 1, 0])
+
+    assert data.draw(x) == 0
+
+    assert data.has_discards


### PR DESCRIPTION
Hey, you know how we have the `remove_discarded` shrink pass specifically designed for e.g. improving the shrinking performance of filtered strategies by removing early iterations in the rejection sampling loop? Neat feature, right?

I was writing a short blog post explaining it and then thought I'd double check the code and discovered we weren't actually marking discarded iterations in filtered strategies as discarded, so they were never actually triggering this shrink pass. Whoops. 😳 

Anyway, this PR fixes that.