### PR TITLE
Remove dependency on DRMacIver for Rust reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,5 @@
 # Engine changes need to be approved by DRMacIver, as per
 # https://github.com/HypothesisWorks/hypothesis/blob/master/guides/review.rst#engine-changes
-/conjecture-rust/ @DRMacIver
 /hypothesis-python/src/hypothesis/internal/conjecture/ @DRMacIver
 
 # Changes to the paper also need to be approved by DRMacIver

--- a/guides/review.rst
+++ b/guides/review.rst
@@ -244,8 +244,7 @@ Engine Changes
 
 Engine changes are anything that change a "fundamental" of how Hypothesis
 works. A good rule of thumb is that an engine change is anything that touches
-a file in hypothesis.internal.conjecture (Python version) or Rust code (Ruby
-version).
+a file in hypothesis.internal.conjecture (Python version).
 
 All such changes should:
 


### PR DESCRIPTION
As discussed in https://github.com/HypothesisWorks/hypothesis/pull/2761, it sounds like we're ok with removing the blocking codeowner for Rust code. 