### PR TITLE
Improve type annotations for `one_of` and `SearchStrategy.__or__`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves the type annotations for :func:`~hypothesis.strategies.one_of`,
+by adding overloads to handle up to five distinct arguments as
+:class:`~python:typing.Union` before falling back to :class:`~python:typing.Any`,
+as well as annotating the ``|`` (``__or__``) operator for strategies (:issue:`2765`).

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -188,6 +188,7 @@ def _strategy_for(param: inspect.Parameter) -> Union[st.SearchStrategy, InferTyp
         return st.text()
     for strategy, names in _GUESS_STRATEGIES_BY_NAME:
         if param.name in names:
+            assert isinstance(strategy, st.SearchStrategy)
             return strategy
     # And if all that failed, we'll return nothing() - the user will have to
     # fill this in by hand, and we'll leave a comment to that effect later.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -296,8 +296,52 @@ def none() -> SearchStrategy[None]:
     return just(None)
 
 
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+
+
 @overload
 def one_of(args: Sequence[SearchStrategy[Any]]) -> SearchStrategy[Any]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def one_of(a1: SearchStrategy[Ex]) -> SearchStrategy[Ex]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def one_of(
+    a1: SearchStrategy[Ex], a2: SearchStrategy[K]
+) -> SearchStrategy[Union[Ex, K]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def one_of(
+    a1: SearchStrategy[Ex], a2: SearchStrategy[K], a3: SearchStrategy[V]
+) -> SearchStrategy[Union[Ex, K, V]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def one_of(
+    a1: SearchStrategy[Ex],
+    a2: SearchStrategy[K],
+    a3: SearchStrategy[V],
+    a4: SearchStrategy[T4],
+) -> SearchStrategy[Union[Ex, K, V, T4]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def one_of(
+    a1: SearchStrategy[Ex],
+    a2: SearchStrategy[K],
+    a3: SearchStrategy[V],
+    a4: SearchStrategy[T4],
+    a5: SearchStrategy[T5],
+) -> SearchStrategy[Union[Ex, K, V, T4, T5]]:
     raise NotImplementedError
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -17,7 +17,7 @@ import sys
 import warnings
 from collections import defaultdict
 from random import choice as random_choice
-from typing import Any, Callable, Generic, List, TypeVar
+from typing import Any, Callable, Generic, List, TypeVar, Union
 
 from hypothesis._settings import HealthCheck, Phase, Verbosity, settings
 from hypothesis.control import _current_build_context, assume
@@ -352,7 +352,7 @@ class SearchStrategy(Generic[Ex]):
     def branches(self) -> List["SearchStrategy[Ex]"]:
         return [self]
 
-    def __or__(self, other):
+    def __or__(self, other: "SearchStrategy[T]") -> "SearchStrategy[Union[Ex, T]]":
         """Return a strategy which produces values by randomly drawing from one
         of this strategy or the other strategy.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -53,14 +53,6 @@ FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
 )
 
 
-def one_of_strategies(xs):
-    """Helper function for unioning multiple strategies."""
-    xs = tuple(xs)
-    if not xs:
-        raise ValueError("Cannot join an empty list of strategies")
-    return OneOfStrategy(xs)
-
-
 def recursive_property(name, default):
     """Handle properties which may be mutually recursive among a set of
     strategies.
@@ -368,7 +360,7 @@ class SearchStrategy(Generic[Ex]):
         """
         if not isinstance(other, SearchStrategy):
             raise ValueError("Cannot | a SearchStrategy with %r" % (other,))
-        return one_of_strategies((self, other))
+        return OneOfStrategy((self, other))
 
     def validate(self) -> None:
         """Throw an exception if the strategy is not valid.

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -20,7 +20,6 @@ import pytest
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import booleans, integers, just, tuples
-from hypothesis.strategies._internal.strategies import one_of_strategies
 from tests.common.debug import assert_no_examples
 
 
@@ -28,11 +27,6 @@ def test_or_errors_when_given_non_strategy():
     bools = tuples(booleans())
     with pytest.raises(ValueError):
         bools | "foo"
-
-
-def test_joining_zero_strategies_fails():
-    with pytest.raises(ValueError):
-        one_of_strategies(())
 
 
 SomeNamedTuple = namedtuple("SomeNamedTuple", ("a", "b"))

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -59,11 +59,20 @@ def get_mypy_analysed_type(fname, val):
         ("lists(none())", "list[None]"),
         ("dictionaries(integers(), datetimes())", "dict[int, datetime.datetime]"),
         ("data()", "hypothesis.strategies._internal.core.DataObject"),
+        ("none() | integers()", "Union[None, int]"),
         # Ex`-1 stands for recursion in the whole type, i.e. Ex`0 == Union[...]
         ("recursive(integers(), lists)", "Union[list[Ex`-1], int]"),
-        # See https://github.com/python/mypy/issues/5269 - fix the hints on
-        # `one_of` and document the minimum Mypy version when the issue is fixed.
-        ("one_of(integers(), text())", "Any"),
+        # We have overloads for up to five types, then fall back to Any.
+        # (why five?  JSON atoms are None|bool|int|float|str and we do that a lot)
+        ("one_of(integers(), text())", "Union[int, str]"),
+        (
+            "one_of(integers(), text(), none(), binary(), builds(list))",
+            "Union[int, str, None, bytes, list[_T`1]]",
+        ),
+        (
+            "one_of(integers(), text(), none(), binary(), builds(list), builds(dict))",
+            "Any",
+        ),
     ],
 )
 def test_revealed_types(tmpdir, val, expect):


### PR DESCRIPTION
Closes #2765.