### PR TITLE
Add linting for conjecture rust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           - lint-ruby
           - check-ruby-tests
           - check-conjecture-rust-format
+          - lint-conjecture-rust
         python-version: ["3.8"]
         include:
           - task: check-py36

--- a/conjecture-rust/src/data.rs
+++ b/conjecture-rust/src/data.rs
@@ -6,6 +6,7 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 
 pub type DataStream = Vec<u64>;
+pub type DataStreamSlice = [u64];
 
 #[derive(Debug, Clone)]
 pub struct FailedDraw;
@@ -121,7 +122,7 @@ impl DataSource {
         Ok(result)
     }
 
-    pub fn to_result(mut self, status: Status) -> TestResult {
+    pub fn into_result(self, status: Status) -> TestResult {
         TestResult {
             record: self.record,
             status,
@@ -129,7 +130,7 @@ impl DataSource {
             sizes: self.sizes,
             draws: self
                 .draws
-                .drain(..)
+                .into_iter()
                 .filter_map(|d| match d {
                     DrawInProgress {
                         depth,

--- a/conjecture-rust/src/distributions.rs
+++ b/conjecture-rust/src/distributions.rs
@@ -151,7 +151,7 @@ impl Sampler {
         for (i, w) in weights.iter().enumerate() {
             let scaled = n * w / total;
             scaled_probabilities.push(scaled);
-            if scaled == 1.0 {
+            if (scaled - 1.0).abs() < f32::EPSILON {
                 table.push(SamplerEntry::single(i))
             } else if scaled > 1.0 {
                 large.push(Reverse(i));

--- a/conjecture-rust/src/lib.rs
+++ b/conjecture-rust/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::many_single_char_names)]
 extern crate byteorder;
 extern crate core;
 extern crate crypto_hash;

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -503,6 +503,11 @@ def check_conjecture_rust_format():
     cr.cargo("fmt", "--", "--check")
 
 
+@rust_task
+def lint_conjecture_rust():
+    cr.cargo("clippy")
+
+
 @task()
 def tasks():
     """Print a list of all task names supported by the build system."""


### PR DESCRIPTION
This PR implements a CI job for running `cargo clippy` on `conjecture-rust` source code and fixes some reported issues.

Details:
 - Disabled the `many_single_char_names` lint globally because I am not sure if it is needed for cases when multiple indices are involved. Let me know if you think it is better to disable it locally for specific code blocks
 - `to_result` -> `into_result`. In this part, I also changed `mut self` to `self` because there is no need to call `drain` that mutates the `draws` vector - it is dropped anyway at the end of this function (as we have `self` by value)
 - Added `DataStreamSlice` type alias that is used in `Shrinker.execute` and `Shrinker.incorporate`. 

Let me know what do you think! :) 

At this stage, the build should be green. For the next steps, we can incrementally apply other lints & go towards the `pedantic` set. Additionally, we can take some from `clippy::nursery` and the compiler [itself](https://doc.rust-lang.org/rustc/lints/groups.html).

There are many pretty useful things in there - @sobolevn, as you mention that you'd like to have more Rust practice, feel free to take any of those (and let me know if you're ok with working on lints at all) :)