### PR TITLE
Support skipping shrinking

### DIFF
--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -15,6 +15,11 @@ use data::{DataSource, DataStreamSlice, Status, TestResult};
 use database::BoxedDatabase;
 use intminimize::minimize_integer;
 
+#[derive(Debug, PartialEq)]
+pub enum Phase {
+    Shrink,
+}
+
 #[derive(Debug, Clone)]
 enum LoopExitReason {
     Complete,
@@ -36,6 +41,7 @@ struct MainGenerationLoop {
     sender: SyncSender<LoopCommand>,
     max_examples: u64,
     random: ChaChaRng,
+    skip_phases: Vec<Phase>,
 
     best_example: Option<TestResult>,
     minimized_examples: HashMap<u64, TestResult>,
@@ -87,6 +93,9 @@ impl MainGenerationLoop {
             self.generate_examples()?;
         }
 
+        if self.skip_phases.contains(&Phase::Shrink) {
+            return Err(LoopExitReason::Complete);
+        }
         // At the start of this loop we usually only have one example in
         // self.minimized_examples, but as we shrink we may find other ones.
         // Additionally, we may have multiple different failing examples from
@@ -565,7 +574,13 @@ fn u64s_to_bytes(ints: &[u64]) -> Vec<u8> {
 }
 
 impl Engine {
-    pub fn new(name: String, max_examples: u64, seed: &[u32], db: BoxedDatabase) -> Engine {
+    pub fn new(
+        name: String,
+        max_examples: u64,
+        skip_phases: Vec<Phase>,
+        seed: &[u32],
+        db: BoxedDatabase,
+    ) -> Engine {
         let (send_local, recv_remote) = sync_channel(1);
         let (send_remote, recv_local) = sync_channel(1);
 
@@ -573,6 +588,7 @@ impl Engine {
             database: db,
             name,
             max_examples,
+            skip_phases,
             random: ChaChaRng::from_seed(seed),
             sender: send_remote,
             receiver: recv_remote,
@@ -734,6 +750,7 @@ mod tests {
         let mut engine = Engine::new(
             "run_to_results".to_string(),
             1000,
+            vec![],
             &seed,
             Box::new(NoDatabase),
         );

--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -27,7 +27,10 @@ impl TryFrom<&str> for Phase {
     fn try_from(value: &str) -> Result<Self, String> {
         match value {
             "shrink" => Ok(Phase::Shrink),
-            _ => Err(format!("Cannot convert to Phase: {} is not a valid Phase", value))
+            _ => Err(format!(
+                "Cannot convert to Phase: {} is not a valid Phase",
+                value
+            )),
         }
     }
 }

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -5,7 +5,7 @@ Adds support for skipping shrinking. While shrinking is extremely helpful and im
 Usage:
 
 ```
-hypothesis(skip_phases: [:shrink]) do
+hypothesis(phases: Phase.excluding(:shrink)) do
   # Failures here will be displayed directly and shrinking will be avoided
 end
 ```

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+Adds support for skipping shrinking. While shrinking is extremely helpful and important in general, it has the potential to be quite time consuming. It can be useful to observe a raw failure before choosing to allow the engine to try to shrink. [hypothesis-python](https://hypothesis.readthedocs.io/en/latest/settings.html#phases) already provides the ability to skip shrinking, so there is precedent for this being useful. While `hypothesis-ruby` does not have the concept of other "Phases" yet, we can still start off the API by using this concept.
+
+Usage:
+
+```
+hypothesis(skip_phases: [:shrink]) do
+  # Failures here will be displayed directly and shrinking will be avoided
+end
+```

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -201,7 +201,12 @@ module Hypothesis
   #   should store previously failing test cases. If it is nil, Hypothesis
   #   will use a default of .hypothesis/examples in the current directory.
   #   May also be set to false to disable the database functionality.
-  def hypothesis(max_valid_test_cases: 200, database: nil, &block)
+  def hypothesis(
+    max_valid_test_cases: 200,
+    skip_phases: [],
+    database: nil,
+    &block
+  )
     unless World.current_engine.nil?
       raise UsageError, 'Cannot nest hypothesis calls'
     end
@@ -210,6 +215,7 @@ module Hypothesis
       World.current_engine = Engine.new(
         hypothesis_stable_identifier,
         max_examples: max_valid_test_cases,
+        skip_phases: skip_phases,
         database: database
       )
       World.current_engine.run(&block)

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -17,9 +17,14 @@ module Phase
   end
 
   def excluding(*phases)
-    unknown_phases = phases.select { |phase| !Phase.all.include?(phase) }
-    raise ArgumentError.new("Attempting to exclude unknown phases: #{unknown_phases}") unless unknown_phases.empty?
-    
+    unknown_phases = phases.reject { |phase| Phase.all.include?(phase) }
+    unless unknown_phases.empty?
+      raise(
+        ArgumentError,
+        "Attempting to exclude unknown phases: #{unknown_phases}"
+      )
+    end
+
     all - phases
   end
 end

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -16,8 +16,11 @@ module Phase
     [SHRINK]
   end
 
-  def excluding(phase)
-    all - Array(phase)
+  def excluding(*phases)
+    unknown_phases = phases.select { |phase| !Phase.all.include?(phase) }
+    raise ArgumentError.new("Attempting to exclude unknown phases: #{unknown_phases}") unless unknown_phases.empty?
+    
+    all - phases
   end
 end
 

--- a/hypothesis-ruby/lib/hypothesis.rb
+++ b/hypothesis-ruby/lib/hypothesis.rb
@@ -7,6 +7,20 @@ require_relative 'hypothesis/testcase'
 require_relative 'hypothesis/engine'
 require_relative 'hypothesis/world'
 
+module Phase
+  SHRINK = :shrink
+
+  module_function
+
+  def all
+    [SHRINK]
+  end
+
+  def excluding(phase)
+    all - Array(phase)
+  end
+end
+
 # This is the main module for using Hypothesis.
 # It is expected that you will include this in your
 # tests, but its methods are also available on the
@@ -203,7 +217,7 @@ module Hypothesis
   #   May also be set to false to disable the database functionality.
   def hypothesis(
     max_valid_test_cases: 200,
-    skip_phases: [],
+    phases: Phase.all,
     database: nil,
     &block
   )
@@ -215,7 +229,7 @@ module Hypothesis
       World.current_engine = Engine.new(
         hypothesis_stable_identifier,
         max_examples: max_valid_test_cases,
-        skip_phases: skip_phases,
+        phases: phases,
         database: database
       )
       World.current_engine.run(&block)

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -6,7 +6,7 @@ module Hypothesis
   DEFAULT_DATABASE_PATH = File.join(Dir.pwd, '.hypothesis', 'examples')
 
   class Engine
-    attr_reader :current_source, :skip_phases
+    attr_reader :current_source
     attr_accessor :is_find
 
     def initialize(name, options)

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -23,7 +23,7 @@ module Hypothesis
         database,
         seed,
         options.fetch(:max_examples),
-        options.fetch(:skip_phases)
+        options.fetch(:phases)
       )
 
       @exceptions_to_tags = Hash.new { |h, k| h[k] = h.size }

--- a/hypothesis-ruby/lib/hypothesis/engine.rb
+++ b/hypothesis-ruby/lib/hypothesis/engine.rb
@@ -6,7 +6,7 @@ module Hypothesis
   DEFAULT_DATABASE_PATH = File.join(Dir.pwd, '.hypothesis', 'examples')
 
   class Engine
-    attr_reader :current_source
+    attr_reader :current_source, :skip_phases
     attr_accessor :is_find
 
     def initialize(name, options)
@@ -19,7 +19,11 @@ module Hypothesis
       database = nil if database == false
 
       @core_engine = HypothesisCoreEngine.new(
-        name, database, seed, options.fetch(:max_examples)
+        name,
+        database,
+        seed,
+        options.fetch(:max_examples),
+        options.fetch(:skip_phases)
       )
 
       @exceptions_to_tags = Hash.new { |h, k| h[k] = h.size }

--- a/hypothesis-ruby/spec/example_shrinking_spec.rb
+++ b/hypothesis-ruby/spec/example_shrinking_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'shrinking' do
   it 'finds lower bounds on integers' do
     n, = find { any(integers) >= 10 }
     expect(n).to eq(10)
-  end  
-  
+  end
+
   it 'iterates to a fixed point' do
     @original = nil
 

--- a/hypothesis-ruby/spec/example_shrinking_spec.rb
+++ b/hypothesis-ruby/spec/example_shrinking_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe 'shrinking' do
     expect(n).to eq(10)
   end
 
+  it 'does not shrink when shrinking is skipped' do
+    n = 0
+    10.times do
+      n, = find(skip_phases: [:shrink]) { any(integers) >= 10 }
+      break if n != 10
+    end
+
+    expect(n).to_not eq(10)
+  end
+
   it 'iterates to a fixed point' do
     @original = nil
 

--- a/hypothesis-ruby/spec/example_shrinking_spec.rb
+++ b/hypothesis-ruby/spec/example_shrinking_spec.rb
@@ -8,18 +8,8 @@ RSpec.describe 'shrinking' do
   it 'finds lower bounds on integers' do
     n, = find { any(integers) >= 10 }
     expect(n).to eq(10)
-  end
-
-  it 'does not shrink when shrinking is skipped' do
-    n = 0
-    10.times do
-      n, = find(skip_phases: [:shrink]) { any(integers) >= 10 }
-      break if n != 10
-    end
-
-    expect(n).to_not eq(10)
-  end
-
+  end  
+  
   it 'iterates to a fixed point' do
     @original = nil
 

--- a/hypothesis-ruby/spec/phase_specification_spec.rb
+++ b/hypothesis-ruby/spec/phase_specification_spec.rb
@@ -3,8 +3,14 @@ RSpec.describe 'specifying which phases to include' do
 
   it 'alerts of improper phase names' do
     expect do
-      hypothesis(phases: [:sHrInK]) { any(integers) }
+      hypothesis(phases: [:sHrInK])
     end.to raise_exception(ArgumentError, 'Cannot convert to Phase: sHrInK is not a valid Phase')
+  end
+
+  it 'alerts of attempting to exclude an unknown phase' do
+    expect do
+      hypothesis(phases: Phase.excluding(:unknown))
+    end.to raise_exception(ArgumentError, "Attempting to exclude unknown phases: [:unknown]")
   end
 
   it 'does not shrink when shrinking is skipped' do

--- a/hypothesis-ruby/spec/phase_specification_spec.rb
+++ b/hypothesis-ruby/spec/phase_specification_spec.rb
@@ -1,16 +1,24 @@
+# frozen_string_literal: true
+
 RSpec.describe 'specifying which phases to include' do
   include Hypothesis::Debug
 
   it 'alerts of improper phase names' do
     expect do
       hypothesis(phases: [:sHrInK])
-    end.to raise_exception(ArgumentError, 'Cannot convert to Phase: sHrInK is not a valid Phase')
+    end.to raise_exception(
+      ArgumentError,
+      'Cannot convert to Phase: sHrInK is not a valid Phase'
+    )
   end
 
   it 'alerts of attempting to exclude an unknown phase' do
     expect do
       hypothesis(phases: Phase.excluding(:unknown))
-    end.to raise_exception(ArgumentError, "Attempting to exclude unknown phases: [:unknown]")
+    end.to raise_exception(
+      ArgumentError,
+      'Attempting to exclude unknown phases: [:unknown]'
+    )
   end
 
   it 'does not shrink when shrinking is skipped' do

--- a/hypothesis-ruby/spec/phase_specification_spec.rb
+++ b/hypothesis-ruby/spec/phase_specification_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'specifying which phases to include' do
+  include Hypothesis::Debug
+
+  it 'alerts of improper phase names' do
+    expect do
+      hypothesis(phases: [:sHrInK]) { any(integers) }
+    end.to raise_exception(ArgumentError, 'Cannot convert to Phase: sHrInK is not a valid Phase')
+  end
+
+  it 'does not shrink when shrinking is skipped' do
+    n = 0
+    10.times do
+      n, = find(phases: Phase.excluding(:shrink)) { any(integers) >= 10 }
+      break if n != 10
+    end
+
+    expect(n).to_not eq(10)
+  end
+end

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -63,7 +63,9 @@ module Hypothesis
       end
       begin
         Hypothesis::World.current_engine = Hypothesis::Engine.new(
-          'find', max_examples: options.fetch(:max_examples, 1000)
+          'find',
+          max_examples: options.fetch(:max_examples, 1000),
+          skip_phases: options.fetch(:skip_phases, [])
         )
         Hypothesis::World.current_engine.is_find = true
         Hypothesis::World.current_engine.run(&block)

--- a/hypothesis-ruby/spec/spec_helper.rb
+++ b/hypothesis-ruby/spec/spec_helper.rb
@@ -65,7 +65,7 @@ module Hypothesis
         Hypothesis::World.current_engine = Hypothesis::Engine.new(
           'find',
           max_examples: options.fetch(:max_examples, 1000),
-          skip_phases: options.fetch(:skip_phases, [])
+          phases: options.fetch(:phases, Phase.all)
         )
         Hypothesis::World.current_engine.is_find = true
         Hypothesis::World.current_engine.run(&block)

--- a/hypothesis-ruby/src/lib.rs
+++ b/hypothesis-ruby/src/lib.rs
@@ -7,7 +7,10 @@ extern crate conjecture;
 use std::convert::TryFrom;
 use std::mem;
 
-use rutie::{AnyException, AnyObject, Array, Boolean, Class, Exception, Float, Integer, NilClass, Object, RString, Symbol, VM};
+use rutie::{
+    AnyException, AnyObject, Array, Boolean, Class, Exception, Float, Integer, NilClass, Object,
+    RString, Symbol, VM,
+};
 
 use conjecture::data::{DataSource, Status, TestResult};
 use conjecture::database::{BoxedDatabase, DirectoryDatabase, NoDatabase};
@@ -156,14 +159,16 @@ methods!(
         max_example: Integer,
         phases: Array
     ) -> AnyObject {
-        let rust_phases = safe_access(phases).into_iter().map(|ruby_phase| {
-            let phase_sym = safe_access(ruby_phase.try_convert_to::<Symbol>());
-            let phase = Phase::try_from(phase_sym.to_str()).map_err(|e|
-                AnyException::new("ArgumentError", Some(&e))
-            );
+        let rust_phases = safe_access(phases)
+            .into_iter()
+            .map(|ruby_phase| {
+                let phase_sym = safe_access(ruby_phase.try_convert_to::<Symbol>());
+                let phase = Phase::try_from(phase_sym.to_str())
+                    .map_err(|e| AnyException::new("ArgumentError", Some(&e)));
 
-            safe_access(phase)
-        }).collect();
+                safe_access(phase)
+            })
+            .collect();
 
         let core_engine = HypothesisCoreEngineStruct::new(
             safe_access(name).to_string(),
@@ -478,5 +483,5 @@ fn mark_child_status(
 }
 
 fn safe_access<T>(value: Result<T, AnyException>) -> T {
-  value.map_err(VM::raise_ex).unwrap()
+    value.map_err(VM::raise_ex).unwrap()
 }


### PR DESCRIPTION
From the `RELEASE.rst`:

Adds support for skipping shrinking. While shrinking is extremely helpful and important in general, it has the potential to be quite time consuming. It can be useful to observe a raw failure before choosing to allow the engine to try to shrink. [hypothesis-python](https://hypothesis.readthedocs.io/en/latest/settings.html#phases) already provides the ability to skip shrinking, so there is precedent for this being useful. While `hypothesis-ruby` does not have the concept of other "Phases" yet, we can still start off the API by using this concept.

Usage:

```
hypothesis(phases: Phase.excluding(:shrink)) do
  # Failures here will be displayed directly and shrinking will be avoided
end
```