### PR TITLE
Fix the failing `minimizes_all_examples` test in conjecture rust

### DIFF
--- a/conjecture-rust/src/engine.rs
+++ b/conjecture-rust/src/engine.rs
@@ -21,6 +21,12 @@ pub enum Phase {
     Shrink,
 }
 
+impl Phase {
+    pub fn all() -> Vec<Self> {
+        vec![Phase::Shrink]
+    }
+}
+
 impl TryFrom<&str> for Phase {
     type Error = String;
 
@@ -765,7 +771,7 @@ mod tests {
         let mut engine = Engine::new(
             "run_to_results".to_string(),
             1000,
-            vec![],
+            Phase::all(),
             &seed,
             Box::new(NoDatabase),
         );


### PR DESCRIPTION
An easy fix for the failing test. I am not entirely happy with that since the variants in `Phase` and inside `all` should be synced manually :(