### PR TITLE
Add release description for shrinking skipping feature.

### DIFF
--- a/conjecture-rust/RELEASE.md
+++ b/conjecture-rust/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adds support for skipping shrinking. While shrinking is extremely helpful and important in general, it has the potential to be quite time consuming. It can be useful to observe a raw failure before choosing to allow the engine to try to shrink. [hypothesis-python](https://hypothesis.readthedocs.io/en/latest/settings.html#phases) already provides the ability to skip shrinking, so there is precedent for this being useful.


### PR DESCRIPTION
Since https://github.com/HypothesisWorks/hypothesis/pull/2772 made changes to conjecture-rust, the new version of it needs to be published to crates.io in order for the hypothesis-ruby gem to be able to use the new code. 

I noticed that the API key and everything is still in the hypothesistooling for conjecture-rust, so is this all that's needed to publish a new version?