### PR TITLE
Fix race condition inside recursive strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release prevents a race condition inside :func:`~hypothesis.strategies.recursive` strategies.
+The race condition occurs when the same :func:`~hypothesis.strategies.recursive` strategy is shared among tests
+that are running in multiple threads (:issue:`2717`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
@@ -13,6 +13,7 @@
 #
 # END HEADER
 
+import threading
 from contextlib import contextmanager
 
 from hypothesis.errors import InvalidArgument
@@ -29,8 +30,23 @@ class LimitedStrategy(SearchStrategy):
     def __init__(self, strategy):
         super().__init__()
         self.base_strategy = strategy
-        self.marker = 0
-        self.currently_capped = False
+        self._threadlocal = threading.local()
+
+    @property
+    def marker(self):
+        return getattr(self._threadlocal, "marker", 0)
+
+    @marker.setter
+    def marker(self, value):
+        self._threadlocal.marker = value
+
+    @property
+    def currently_capped(self):
+        return getattr(self._threadlocal, "currently_capped", False)
+
+    @currently_capped.setter
+    def currently_capped(self, value):
+        self._threadlocal.currently_capped = value
 
     def __repr__(self):
         return "LimitedStrategy(%r)" % (self.base_strategy,)


### PR DESCRIPTION
Fixes #2717.

In the end, I chose thread-local storage for solving the issue as proposed in the linked issue. Here are my thoughts on why I implemented it this way & comparing how it changes the status quo.

**Single thread**

At the moment, a recursive strategy may fail on this assertion if it calls itself in `do_draw` [here](https://github.com/HypothesisWorks/hypothesis/blob/master/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py#L99):

```python
                with self.limited_base.capped(self.max_leaves):
                    return data.draw(self.strategy)
```

The strategy may look like this:

```python
from hypothesis import strategies as st

SELF_REF = st.recursive(
    st.deferred(lambda: SELF_REF | st.booleans()),
    lambda s: st.lists(s, min_size=1)
)
```

I am not sure how meaningful such a strategy is, but it is not explicitly prohibited, as far as I can tell. From the one above, I'd expect lists like this - `[True, [False, True, [True]], False]`, or just a boolean. However, a simpler one seems to be producing the same data:

```python
SELF_REF = st.recursive(
    st.booleans(),
    lambda s: st.lists(s, min_size=1)
)
```

I am not sure if there are cases that can only be expressed by using `deferred` inside `recursive`. If there are legitimate use cases, then we might want to rethink capping. Let me know what you think - it might be worth a separate issue, but I'll share my current thoughts on this here.

(Please, correct me if I miss something in my reasoning)
As far as I see, the cap is needed to prevent the drawing from this strategy & generating a certain maximum amount of leaves. However, assuming a single thread (more on the multi-threaded behavior in the next section) and such a self-referential strategy, I am not sure if capping is needed as it is - we can just apply it once on the first `capped` usage and make all subsequent calls no-op (e.g., just `yield` without modifying `marked`). Then we still have the `marker` set only once on the very first `RecursiveStrategy.do_draw` call, and it will be monotonically decreasing. Therefore, we'll have the max size properly maintained, and there will be no oversized subtrees because at some point, `LimitReached` will occur.

Anyway, the current behavior for such a case leads to `AssertionError`. With a not-reentrant lock, as I initially mentioned in the linked issue, such a strategy will cause a deadlock. A reentrant one will keep the current behavior for a single-threaded case. Thread-local storage will also keep it.

**Multiple threads**

This use case is about multiple threads that run tests that share the same strategy. `RLock` solves the race condition more conservatively by preventing other threads from calling `capped`, but having such a lengthy synchronization point decreases the potential gain of running tests concurrently. I don't have precise numbers on the impact. Still, with thread-local storage, the synchronization point is much smaller (there is a reentrant lock on `data.__getattribute__`), and it goes in line with other cases (like the mentioned `DynamicVariable` class).

Let me know what do you think :)

cc @Zac-HD @Zalathar 