### PR TITLE
Use a slice in `Sampler::new` instead of a vector

### DIFF
--- a/conjecture-rust/RELEASE.md
+++ b/conjecture-rust/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release improves flexibility and performance of `distributions::Sampler::new` by allowing it to accept `&[f32]` instead of a `Vec`.
+It also positively affects `distributions::good_bitlengths` as it does not have to allocate a vector anymore.

--- a/conjecture-rust/src/distributions.rs
+++ b/conjecture-rust/src/distributions.rs
@@ -131,7 +131,7 @@ pub struct Sampler {
 }
 
 impl Sampler {
-    pub fn new(weights: Vec<f32>) -> Sampler {
+    pub fn new(weights: &[f32]) -> Sampler {
         // FIXME: The correct thing to do here is to allow this,
         // return early, and make this reject the data, but we don't
         // currently have the status built into our data properly...
@@ -216,7 +216,7 @@ impl Sampler {
 }
 
 pub fn good_bitlengths() -> Sampler {
-    let weights = vec![
+    let weights = [
         4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, // 1 byte
         2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, // 2 bytes
         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, // 3 bytes
@@ -227,7 +227,7 @@ pub fn good_bitlengths() -> Sampler {
         0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, // 8 bytes (last bit spare for sign)
     ];
     assert!(weights.len() == 63);
-    Sampler::new(weights)
+    Sampler::new(&weights)
 }
 
 pub fn integer_from_bitlengths(source: &mut DataSource, bitlengths: &Sampler) -> Draw<i64> {

--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch contains minor performance improvements for `HypothesisCoreIntegers` class instantiation.


### PR DESCRIPTION
It is a minor change that slightly improves the flexibility of `Sampler::new`.
The `weights` value is not moved, so the callee can use it again after `Sampler::new` is called without cloning. It also positively affects the performance side (very minor though) - `weights` inside `good_bitlengths` becomes stack-allocated + the size of `&[f32]` is less than `Vec<f32>`, so the call is cheaper. There is only one usage, though, but it doesn't bring any restrictions (except if moving `weights` is intentional from the API point of view, which I doubt is the case).