### PR TITLE
Finalize CI for Rust code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - check-ruby-tests
           - check-conjecture-rust-format
           - check-rust-tests
+          - audit-conjecture-rust
           - lint-conjecture-rust
         python-version: ["3.8"]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           - lint-ruby
           - check-ruby-tests
           - check-rust-in-ruby-format
+          - lint-rust-in-ruby
           - check-conjecture-rust-format
           - check-rust-tests
           - audit-conjecture-rust

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - check-ruby-tests
           - check-rust-in-ruby-format
           - lint-rust-in-ruby
+          - audit-rust-in-ruby
           - check-conjecture-rust-format
           - check-rust-tests
           - audit-conjecture-rust

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           - check-quality
           - lint-ruby
           - check-ruby-tests
+          - check-rust-in-ruby-format
           - check-conjecture-rust-format
           - check-rust-tests
           - audit-conjecture-rust

--- a/hypothesis-ruby/src/lib.rs
+++ b/hypothesis-ruby/src/lib.rs
@@ -50,6 +50,7 @@ wrappable_struct!(
 
 class!(HypothesisCoreDataSource);
 
+#[rustfmt::skip]
 methods!(
     HypothesisCoreDataSource,
     itself,
@@ -149,6 +150,7 @@ wrappable_struct!(
 
 class!(HypothesisCoreEngine);
 
+#[rustfmt::skip]
 methods!(
     HypothesisCoreEngine,
     itself,
@@ -277,6 +279,7 @@ wrappable_struct!(
 
 class!(HypothesisCoreIntegers);
 
+#[rustfmt::skip]
 methods!(
     HypothesisCoreIntegers,
     itself,
@@ -333,6 +336,7 @@ wrappable_struct!(
 
 class!(HypothesisCoreRepeatValues);
 
+#[rustfmt::skip]
 methods!(
     HypothesisCoreRepeatValues,
     itself,
@@ -394,6 +398,7 @@ wrappable_struct!(
 
 class!(HypothesisCoreBoundedIntegers);
 
+#[rustfmt::skip]
 methods!(
     HypothesisCoreBoundedIntegers,
     itself,

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -490,6 +490,12 @@ def lint_rust_in_ruby():
     hr.cargo("clippy")
 
 
+@ruby_task
+def audit_rust_in_ruby():
+    hr.cargo("install", "cargo-audit")
+    hr.cargo("audit")
+
+
 @task()
 def python(*args):
     os.execv(sys.executable, (sys.executable,) + args)

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -475,6 +475,16 @@ def check_ruby_tests():
     hr.rake_task("minitest")
 
 
+@ruby_task
+def format_rust_in_ruby():
+    hr.cargo("fmt")
+
+
+@ruby_task
+def check_rust_in_ruby_format():
+    hr.cargo("fmt", "--", "--check")
+
+
 @task()
 def python(*args):
     os.execv(sys.executable, (sys.executable,) + args)

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -508,6 +508,12 @@ def lint_conjecture_rust():
     cr.cargo("clippy")
 
 
+@rust_task
+def audit_conjecture_rust():
+    cr.cargo("install", "cargo-audit")
+    cr.cargo("audit")
+
+
 @task()
 def tasks():
     """Print a list of all task names supported by the build system."""

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -485,6 +485,11 @@ def check_rust_in_ruby_format():
     hr.cargo("fmt", "--", "--check")
 
 
+@ruby_task
+def lint_rust_in_ruby():
+    hr.cargo("clippy")
+
+
 @task()
 def python(*args):
     os.execv(sys.executable, (sys.executable,) + args)

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -140,6 +140,12 @@ def ensure_bundler():
     bundle_command("install")
 
 
+def cargo(*args):
+    install.ensure_rustup()
+    with in_dir(BASE_DIR):
+        subprocess.check_call(("cargo",) + args)
+
+
 RUBY_TO_PRINT_VERSION = """
 require 'rubygems'
 spec = Gem::Specification::load(%r)


### PR DESCRIPTION
Resolves #2746 

This PR adds `cargo audit` and applies all Rust tooling we have to the Rust code inside Hypothesis-Ruby.
Note that running `cargo install cargo-audit` updates `cargo-audit` to the latest installed version if it is installed. If it is already the latest one, it skips the installation.