### PR TITLE
Adhere to the 20-char limit to cargo keywords.

### DIFF
--- a/conjecture-rust/Cargo.toml
+++ b/conjecture-rust/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["David R. MacIver <david@drmaciver.com>"]
 homepage = "https://github.com/HypothesisWorks/hypothesis/tree/master/conjecture-rust"
 repository = "https://github.com/HypothesisWorks/hypothesis/"
 
-keywords = ["testing", "fuzzing", "shrinking", "property-based-testing"]
+keywords = ["testing", "fuzzing", "shrinking", "property-based"]
 categories = ["development-tools::testing"]
 description = "Core engine for Hypothesis implementations"
 

--- a/conjecture-rust/RELEASE.md
+++ b/conjecture-rust/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release is required following an unsuccesful deploy of 0.5.0 due to usage of a cargo keyword that was too long.


### PR DESCRIPTION
Documentation here: https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field