### PR TITLE
Update our autoformatter stack to use `shed`; move from %-formatting to f-strings

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,5 @@
 [settings]
-known_first_party = hypothesis, hypothesistooling, tests
+known_first_party = hypothesis, hypothesistooling
+known_local_folder = tests
 profile = black
 combine_as_imports = True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,0 @@
-[settings]
-known_first_party = hypothesis, hypothesistooling
-known_local_folder = tests
-profile = black
-combine_as_imports = True

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch updates our automatic code formatting to use :pypi:`shed`,
+which includes :pypi:`autoflake`, :pypi:`black`, :pypi:`isort`, and
+:pypi:`pyupgrade` (:issue:`2780`).

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -43,8 +43,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "Hypothesis"
-copyright = "2013-%s, David R. MacIver" % datetime.datetime.utcnow().year
 author = "David R. MacIver"
+copyright = f"2013-{datetime.datetime.utcnow().year}, {author}"
 
 _d = {}
 with open(

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -114,7 +114,7 @@ You can also mark custom events in a test using the ``event`` function:
 
 .. code:: python
 
-  from hypothesis import given, event, strategies as st
+  from hypothesis import event, given, strategies as st
 
 
   @given(st.integers().filter(lambda x: x % 2 == 0))

--- a/hypothesis-python/docs/django.rst
+++ b/hypothesis-python/docs/django.rst
@@ -123,7 +123,7 @@ the *flatmap* function as follows:
 
 .. code:: python
 
-  from hypothesis.strategies import lists, just
+  from hypothesis.strategies import just, lists
 
 
   def generate_with_shops(company):

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -94,10 +94,9 @@ First we need to define a strategy for Node:
 
 .. code:: python
 
-  from hypothesis import settings, strategies
-  import hypothesis.strategies as s
+  import hypothesis.strategies as st
 
-  NodeStrategy = s.builds(Node, s.integers(), s.lists(s.booleans(), max_size=10))
+  NodeStrategy = st.builds(Node, st.integers(), st.lists(st.booleans(), max_size=10))
 
 We want to generate *short* lists of values so that there's a decent chance of
 one being a prefix of the other (this is also why the choice of bool as the
@@ -111,7 +110,7 @@ We can now write a test:
   from hypothesis import given
 
 
-  @given(s.lists(NodeStrategy))
+  @given(st.lists(NodeStrategy))
   def test_sorting_nodes_is_prefix_sorted(xs):
       sort_nodes(xs)
       assert is_prefix_sorted(xs)
@@ -141,7 +140,7 @@ for lists of nodes to give us a strategy for lists of nodes with unique labels:
 
 .. code:: python
 
-    @given(s.lists(NodeStrategy).map(deduplicate_nodes_by_label))
+    @given(st.lists(NodeStrategy).map(deduplicate_nodes_by_label))
     def test_sorting_nodes_is_prefix_sorted(xs):
         sort_nodes(xs)
         assert is_prefix_sorted(xs)
@@ -189,51 +188,47 @@ conversions behave as you would expect them to. These tests should all pass,
 and are mostly a demonstration of some useful sorts of thing to test with
 Hypothesis, and how the :func:`~hypothesis.strategies.datetimes` strategy works.
 
-.. code-block:: pycon
+.. code-block:: python
 
-    >>> from datetime import timedelta
-    >>> from hypothesis.extra.pytz import timezones
-    >>> from hypothesis.strategies import datetimes
+    from datetime import timedelta
 
-    >>> # The datetimes strategy is naive by default, so tell it to use timezones
-    >>> aware_datetimes = datetimes(timezones=timezones())
+    # The datetimes strategy is naive by default, so tell it to use timezones
+    aware_datetimes = st.datetimes(timezones=st.timezones())
 
-    >>> @given(aware_datetimes, timezones(), timezones())
-    ... def test_convert_via_intermediary(dt, tz1, tz2):
-    ...     """Test that converting between timezones is not affected
-    ...     by a detour via another timezone.
-    ...     """
-    ...     assert dt.astimezone(tz1).astimezone(tz2) == dt.astimezone(tz2)
 
-    >>> @given(aware_datetimes, timezones())
-    ... def test_convert_to_and_fro(dt, tz2):
-    ...     """If we convert to a new timezone and back to the old one
-    ...     this should leave the result unchanged.
-    ...     """
-    ...     tz1 = dt.tzinfo
-    ...     assert dt == dt.astimezone(tz2).astimezone(tz1)
+    @given(aware_datetimes, st.timezones(), st.timezones())
+    def test_convert_via_intermediary(dt, tz1, tz2):
+        """Test that converting between timezones is not affected
+        by a detour via another timezone.
+        """
+        assert dt.astimezone(tz1).astimezone(tz2) == dt.astimezone(tz2)
 
-    >>> @given(aware_datetimes, timezones())
-    ... def test_adding_an_hour_commutes(dt, tz):
-    ...     """When converting between timezones it shouldn't matter
-    ...     if we add an hour here or add an hour there.
-    ...     """
-    ...     an_hour = timedelta(hours=1)
-    ...     assert (dt + an_hour).astimezone(tz) == dt.astimezone(tz) + an_hour
 
-    >>> @given(aware_datetimes, timezones())
-    ... def test_adding_a_day_commutes(dt, tz):
-    ...     """When converting between timezones it shouldn't matter
-    ...     if we add a day here or add a day there.
-    ...     """
-    ...     a_day = timedelta(days=1)
-    ...     assert (dt + a_day).astimezone(tz) == dt.astimezone(tz) + a_day
+    @given(aware_datetimes, st.timezones())
+    def test_convert_to_and_fro(dt, tz2):
+        """If we convert to a new timezone and back to the old one
+        this should leave the result unchanged.
+        """
+        tz1 = dt.tzinfo
+        assert dt == dt.astimezone(tz2).astimezone(tz1)
 
-    >>> # And we can check that our tests pass
-    >>> test_convert_via_intermediary()
-    >>> test_convert_to_and_fro()
-    >>> test_adding_an_hour_commutes()
-    >>> test_adding_a_day_commutes()
+
+    @given(aware_datetimes, st.timezones())
+    def test_adding_an_hour_commutes(dt, tz):
+        """When converting between timezones it shouldn't matter
+        if we add an hour here or add an hour there.
+        """
+        an_hour = timedelta(hours=1)
+        assert (dt + an_hour).astimezone(tz) == dt.astimezone(tz) + an_hour
+
+
+    @given(aware_datetimes, st.timezones())
+    def test_adding_a_day_commutes(dt, tz):
+        """When converting between timezones it shouldn't matter
+        if we add a day here or add a day there.
+        """
+        a_day = timedelta(days=1)
+        assert (dt + a_day).astimezone(tz) == dt.astimezone(tz) + a_day
 
 -------------------
 Condorcet's paradox
@@ -314,7 +309,7 @@ hammer their API without their permission).
 All this does is use Hypothesis to generate arbitrary JSON data matching the
 format their API asks for and check for 500 errors. More advanced tests which
 then use the result and go on to do other things are definitely also possible.
-The :pypi:`swagger-conformance` package provides an excellent example of this!
+The :pypi:`schemathesis` package provides an excellent example of this!
 
 .. code:: python
 

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -20,13 +20,13 @@ Suppose we've got the following type:
 
 .. code:: python
 
-    class Node(object):
+    class Node:
         def __init__(self, label, value):
             self.label = label
             self.value = tuple(value)
 
         def __repr__(self):
-            return "Node(%r, %r)" % (self.label, self.value)
+            return f"Node({self.label!r}, {self.value!r})"
 
         def sorts_before(self, other):
             if len(self.value) >= len(other.value):
@@ -52,7 +52,7 @@ define the following code:
 
 
     @total_ordering
-    class TopoKey(object):
+    class TopoKey:
         def __init__(self, node):
             self.value = node
 
@@ -249,9 +249,11 @@ Without further ado, here is the code:
 
 .. code:: python
 
-    from hypothesis import given, assume
-    from hypothesis.strategies import lists, permutations
     from collections import Counter
+
+    from hypothesis import given
+    from hypothesis.strategies import lists, permutations
+
 
     # We need at least three candidates and at least three voters to have a
     # paradox; anything less can only lead to victories or at worst ties.
@@ -313,15 +315,16 @@ The :pypi:`schemathesis` package provides an excellent example of this!
 
 .. code:: python
 
-    import unittest
-    from hypothesis import given, assume, settings, strategies as st
-    from collections import namedtuple
-    import requests
+    import math
     import os
     import random
     import time
-    import math
+    import unittest
+    from collections import namedtuple
 
+    import requests
+
+    from hypothesis import assume, given, strategies as st
 
     Goal = namedtuple("Goal", ("slug",))
 

--- a/hypothesis-python/docs/quickstart.rst
+++ b/hypothesis-python/docs/quickstart.rst
@@ -102,11 +102,10 @@ explicitly by using the :func:`@example <hypothesis.example>` decorator:
 
 .. code:: python
 
-  from hypothesis import example, given
-  from hypothesis.strategies import text
+  from hypothesis import example, given, strategies as st
 
 
-  @given(text())
+  @given(st.text())
   @example("")
   def test_decode_inverts_encode(s):
       assert decode(encode(s)) == s
@@ -122,7 +121,7 @@ well as positional. The following would have worked just as well:
 
 .. code:: python
 
-  @given(s=text())
+  @given(s=st.text())
   @example(s="")
   def test_decode_inverts_encode(s):
       assert decode(encode(s)) == s
@@ -234,8 +233,7 @@ Here are some other examples of how you could use that:
 
 .. code:: python
 
-    import hypothesis.strategies as st
-    from hypothesis import given
+    from hypothesis import given, strategies as st
 
 
     @given(st.integers(), st.integers())

--- a/hypothesis-python/docs/quickstart.rst
+++ b/hypothesis-python/docs/quickstart.rst
@@ -102,7 +102,7 @@ explicitly by using the :func:`@example <hypothesis.example>` decorator:
 
 .. code:: python
 
-  from hypothesis import given, example
+  from hypothesis import example, given
   from hypothesis.strategies import text
 
 
@@ -234,8 +234,8 @@ Here are some other examples of how you could use that:
 
 .. code:: python
 
-    from hypothesis import given
     import hypothesis.strategies as st
+    from hypothesis import given
 
 
     @given(st.integers(), st.integers())

--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -82,8 +82,8 @@ in their behaviour.
 
   import shutil
   import tempfile
-
   from collections import defaultdict
+
   import hypothesis.strategies as st
   from hypothesis.database import DirectoryBasedExampleDatabase
   from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
@@ -91,7 +91,7 @@ in their behaviour.
 
   class DatabaseComparison(RuleBasedStateMachine):
       def __init__(self):
-          super(DatabaseComparison, self).__init__()
+          super().__init__()
           self.tempd = tempfile.mkdtemp()
           self.database = DirectoryBasedExampleDatabase(self.tempd)
           self.model = defaultdict(set)
@@ -220,7 +220,7 @@ Initializes are typically useful to populate bundles:
 .. code:: python
 
     import hypothesis.strategies as st
-    from hypothesis.stateful import RuleBasedStateMachine, Bundle, rule, initialize
+    from hypothesis.stateful import Bundle, RuleBasedStateMachine, initialize, rule
 
     name_strategy = st.text(min_size=1).filter(lambda x: "/" not in x)
 
@@ -236,11 +236,11 @@ Initializes are typically useful to populate bundles:
 
         @rule(target=folders, name=name_strategy)
         def create_folder(self, parent, name):
-            return "%s/%s" % (parent, name)
+            return f"{parent}/{name}"
 
         @rule(target=files, name=name_strategy)
         def create_file(self, parent, name):
-            return "%s/%s" % (parent, name)
+            return f"{parent}/{name}"
 
 
 -------------
@@ -258,7 +258,7 @@ that returns True or False based on the RuleBasedStateMachine instance.
 
 .. code:: python
 
-    from hypothesis.stateful import RuleBasedStateMachine, rule, precondition
+    from hypothesis.stateful import RuleBasedStateMachine, precondition, rule
 
 
     class NumberModifier(RuleBasedStateMachine):
@@ -295,7 +295,7 @@ decorator that marks a function to be run after every step.
 
 .. code:: python
 
-    from hypothesis.stateful import RuleBasedStateMachine, rule, invariant
+    from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
 
     class NumberModifier(RuleBasedStateMachine):

--- a/hypothesis-python/scripts/validate_branch_check.py
+++ b/hypothesis-python/scripts/validate_branch_check.py
@@ -48,11 +48,11 @@ if __name__ == "__main__":
         print("The following were always True:")
         print()
         for c in always_true:
-            print("  * %s" % (c,))
+            print(f"  * {c}")
     if always_false:
         print("The following were always False:")
         print()
         for c in always_false:
-            print("  * %s" % (c,))
+            print(f"  * {c}")
     if failure:
         sys.exit(1)

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -114,10 +114,10 @@ class settingsMeta(type):
             )
         elif not (isinstance(value, settingsProperty) or name.startswith("_")):
             raise AttributeError(
-                "Cannot assign hypothesis.settings.%s=%r - the settings "
+                f"Cannot assign hypothesis.settings.{name}={value!r} - the settings "
                 "class is immutable.  You can change the global default "
                 "settings with settings.load_profile, or use @settings(...) "
-                "to decorate your test instead." % (name, value)
+                "to decorate your test instead."
             )
         return type.__setattr__(self, name, value)
 
@@ -189,7 +189,7 @@ class settings(metaclass=settingsMeta):
         if not callable(test):
             raise InvalidArgument(
                 "settings objects can be called as a decorator with @given, "
-                "but decorated test=%r is not callable." % (test,)
+                f"but decorated test={test!r} is not callable."
             )
         if inspect.isclass(test):
             from hypothesis.stateful import RuleBasedStateMachine
@@ -213,14 +213,11 @@ class settings(metaclass=settingsMeta):
         if hasattr(test, "_hypothesis_internal_settings_applied"):
             # Can't use _hypothesis_internal_use_settings as an indicator that
             # @settings was applied, because @given also assigns that attribute.
+            descr = get_pretty_function_description(test)
             raise InvalidArgument(
-                "%s has already been decorated with a settings object."
-                "\n    Previous:  %r\n    This:  %r"
-                % (
-                    get_pretty_function_description(test),
-                    test._hypothesis_internal_use_settings,
-                    self,
-                )
+                f"{descr} has already been decorated with a settings object.\n"
+                f"    Previous:  {test._hypothesis_internal_use_settings!r}\n"
+                f"    This:  {self!r}"
             )
 
         test._hypothesis_internal_use_settings = self
@@ -279,8 +276,8 @@ class settings(metaclass=settingsMeta):
         raise AttributeError("settings objects are immutable")
 
     def __repr__(self):
-        bits = ("{}={!r}".format(name, getattr(self, name)) for name in all_settings)
-        return "settings(%s)" % ", ".join(sorted(bits))
+        bits = sorted(f"{name}={getattr(self, name)!r}" for name in all_settings)
+        return "settings({})".format(", ".join(bits))
 
     def show_changed(self):
         bits = []
@@ -352,8 +349,8 @@ def _max_examples_validator(x):
     check_type(int, x, name="max_examples")
     if x < 1:
         raise InvalidArgument(
-            "max_examples=%r should be at least one. You can disable example "
-            "generation with the `phases` setting instead." % (x,)
+            f"max_examples={x!r} should be at least one. You can disable "
+            "example generation with the `phases` setting instead."
         )
     return x
 
@@ -406,9 +403,9 @@ def _validate_database(db):
         return db
     raise InvalidArgument(
         "Arguments to the database setting must be None or an instance of "
-        "ExampleDatabase.  Try passing database=ExampleDatabase(%r), or "
+        f"ExampleDatabase.  Try passing database=ExampleDatabase({db!r}), or "
         "construct and use one of the specific subclasses in "
-        "hypothesis.database" % (db,)
+        "hypothesis.database"
     )
 
 
@@ -569,8 +566,8 @@ def validate_health_check_suppressions(suppressions):
     for s in suppressions:
         if not isinstance(s, HealthCheck):
             raise InvalidArgument(
-                "Non-HealthCheck value %r of type %s is invalid in suppress_health_check."
-                % (s, type(s).__name__)
+                f"Non-HealthCheck value {s!r} of type {type(s).__name__} "
+                "is invalid in suppress_health_check."
             )
     return suppressions
 
@@ -595,9 +592,9 @@ def _validate_deadline(x):
     if x is None:
         return x
     invalid_deadline_error = InvalidArgument(
-        "deadline=%r (type %s) must be a timedelta object, an integer or float "
-        "number of milliseconds, or None to disable the per-test-case deadline."
-        % (x, type(x).__name__)
+        f"deadline={x!r} (type {type(x).__name__}) must be a timedelta object, "
+        "an integer or float number of milliseconds, or None to disable the "
+        "per-test-case deadline."
     )
     if isinstance(x, (int, float)):
         if isinstance(x, bool):
@@ -606,14 +603,14 @@ def _validate_deadline(x):
             x = duration(milliseconds=x)
         except OverflowError:
             raise InvalidArgument(
-                "deadline=%r is invalid, because it is too large to represent "
-                "as a timedelta. Use deadline=None to disable deadlines." % (x,)
+                f"deadline={x!r} is invalid, because it is too large to represent "
+                "as a timedelta. Use deadline=None to disable deadlines."
             ) from None
     if isinstance(x, datetime.timedelta):
         if x <= datetime.timedelta(0):
             raise InvalidArgument(
-                "deadline=%r is invalid, because it is impossible to meet a "
-                "deadline <= 0. Use deadline=None to disable deadlines." % (x,)
+                f"deadline={x!r} is invalid, because it is impossible to meet a "
+                "deadline <= 0. Use deadline=None to disable deadlines."
             )
         return duration(seconds=x.total_seconds())
     raise invalid_deadline_error

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -73,7 +73,7 @@ class settingsProperty:
         obj.__dict__[self.name] = value
 
     def __delete__(self, obj):
-        raise AttributeError("Cannot delete attribute %s" % (self.name,))
+        raise AttributeError(f"Cannot delete attribute {self.name}")
 
     @property
     def __doc__(self):
@@ -83,7 +83,7 @@ class settingsProperty:
             if self.show_default
             else "(dynamically calculated)"
         )
-        return "%s\n\ndefault value: ``%s``" % (description, default)
+        return f"{description}\n\ndefault value: ``{default}``"
 
 
 default_variable = DynamicVariable(None)
@@ -139,7 +139,7 @@ class settings(metaclass=settingsMeta):
         if name in all_settings:
             return all_settings[name].default
         else:
-            raise AttributeError("settings has no attribute %s" % (name,))
+            raise AttributeError(f"settings has no attribute {name}")
 
     def __init__(
         self,
@@ -279,7 +279,7 @@ class settings(metaclass=settingsMeta):
         raise AttributeError("settings objects are immutable")
 
     def __repr__(self):
-        bits = ("%s=%r" % (name, getattr(self, name)) for name in all_settings)
+        bits = ("{}={!r}".format(name, getattr(self, name)) for name in all_settings)
         return "settings(%s)" % ", ".join(sorted(bits))
 
     def show_changed(self):
@@ -287,7 +287,7 @@ class settings(metaclass=settingsMeta):
         for name, setting in all_settings.items():
             value = getattr(self, name)
             if value != setting.default:
-                bits.append("%s=%r" % (name, value))
+                bits.append(f"{name}={value!r}")
         return ", ".join(sorted(bits, key=len))
 
     @staticmethod
@@ -437,7 +437,7 @@ class Phase(IntEnum):
     shrink = 4
 
     def __repr__(self):
-        return "Phase.%s" % (self.name,)
+        return f"Phase.{self.name}"
 
 
 @unique
@@ -448,7 +448,7 @@ class HealthCheck(Enum):
     """
 
     def __repr__(self):
-        return "%s.%s" % (self.__class__.__name__, self.name)
+        return f"{self.__class__.__name__}.{self.name}"
 
     @classmethod
     def all(cls) -> List["HealthCheck"]:
@@ -505,7 +505,7 @@ class Verbosity(IntEnum):
     debug = 3
 
     def __repr__(self):
-        return "Verbosity.%s" % (self.name,)
+        return f"Verbosity.{self.name}"
 
 
 settings._define_setting(
@@ -520,7 +520,7 @@ def _validate_phases(phases):
     phases = tuple(phases)
     for a in phases:
         if not isinstance(a, Phase):
-            raise InvalidArgument("%r is not a valid phase" % (a,))
+            raise InvalidArgument(f"{a!r} is not a valid phase")
     return tuple(p for p in list(Phase) if p in phases)
 
 
@@ -538,7 +538,7 @@ settings._define_setting(
 def _validate_stateful_step_count(x):
     check_type(int, x, name="stateful_step_count")
     if x < 1:
-        raise InvalidArgument("stateful_step_count=%r must be at least one." % (x,))
+        raise InvalidArgument(f"stateful_step_count={x!r} must be at least one.")
     return x
 
 
@@ -588,7 +588,7 @@ class duration(datetime.timedelta):
 
     def __repr__(self):
         ms = self.total_seconds() * 1000
-        return "timedelta(milliseconds=%r)" % (int(ms) if ms == int(ms) else ms,)
+        return "timedelta(milliseconds={!r})".format(int(ms) if ms == int(ms) else ms)
 
 
 def _validate_deadline(x):

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -177,7 +177,7 @@ def target(observation: Union[int, float], *, label: str = "") -> None:
     """
     check_type((int, float), observation, "observation")
     if not math.isfinite(observation):
-        raise InvalidArgument("observation=%r must be a finite float." % observation)
+        raise InvalidArgument(f"observation={observation!r} must be a finite float.")
     check_type(str, label, "label")
 
     context = _current_build_context.value

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -183,7 +183,7 @@ def target(observation: Union[int, float], *, label: str = "") -> None:
     context = _current_build_context.value
     if context is None:
         raise InvalidArgument("Calling target() outside of a test is invalid.")
-    verbose_report("Saw target(observation=%r, label=%r)" % (observation, label))
+    verbose_report(f"Saw target(observation={observation!r}, label={label!r})")
 
     if label in context.data.target_observations:
         raise InvalidArgument(

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -192,7 +192,7 @@ def decode_failure(blob):
     try:
         buffer = base64.b64decode(blob)
     except Exception:
-        raise InvalidArgument("Invalid base64 encoded string: %r" % (blob,))
+        raise InvalidArgument(f"Invalid base64 encoded string: {blob!r}")
     prefix = buffer[:1]
     if prefix == b"\0":
         return buffer[1:]
@@ -200,10 +200,10 @@ def decode_failure(blob):
         try:
             return zlib.decompress(buffer[1:])
         except zlib.error:
-            raise InvalidArgument("Invalid zlib compression for blob %r" % (blob,))
+            raise InvalidArgument(f"Invalid zlib compression for blob {blob!r}")
     else:
         raise InvalidArgument(
-            "Could not decode blob %r: Invalid start byte %r" % (blob, prefix)
+            f"Could not decode blob {blob!r}: Invalid start byte {prefix!r}"
         )
 
 
@@ -218,7 +218,7 @@ class WithRunner(MappedSearchStrategy):
         return self.mapped_strategy.do_draw(data)
 
     def __repr__(self):
-        return "WithRunner(%r, runner=%r)" % (self.mapped_strategy, self.runner)
+        return f"WithRunner({self.mapped_strategy!r}, runner={self.runner!r})"
 
 
 def is_invalid_test(name, original_argspec, given_arguments, given_kwargs):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1135,9 +1135,9 @@ def given(
                     if not (state.failed_normally or generated_seed is None):
                         if running_under_pytest:
                             report(
-                                "You can add @seed(%(seed)d) to this test or "
-                                "run pytest with --hypothesis-seed=%(seed)d "
-                                "to reproduce this failure." % {"seed": generated_seed}
+                                f"You can add @seed({generated_seed}) to this test or "
+                                f"run pytest with --hypothesis-seed={generated_seed} "
+                                "to reproduce this failure."
                             )
                         else:
                             report(

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -848,16 +848,12 @@ class StateForActualGivenExecution:
 
         if flaky > 0:
             raise Flaky(
-                (
-                    "Hypothesis found %d distinct failures, but %d of them "
-                    "exhibited some sort of flaky behaviour."
-                )
-                % (len(self.falsifying_examples), flaky)
+                f"Hypothesis found {len(self.falsifying_examples)} distinct failures, "
+                f"but {flaky} of them exhibited some sort of flaky behaviour."
             )
         else:
             raise MultipleFailures(
-                ("Hypothesis found %d distinct failures.")
-                % (len(self.falsifying_examples))
+                f"Hypothesis found {len(self.falsifying_examples)} distinct failures."
             )
 
     def __flaky(self, message):
@@ -1101,8 +1097,9 @@ def given(
                             type(err), err, err.__traceback__
                         )
                         report("".join(tb_lines))
-                    msg = "Hypothesis found %d failures in explicit examples."
-                    raise MultipleFailures(msg % (len(errors)))
+                    raise MultipleFailures(
+                        f"Hypothesis found {len(errors)} failures in explicit examples."
+                    )
                 elif errors:
                     fragments, the_error_hypothesis_found = errors[0]
                     for f in fragments:
@@ -1144,8 +1141,8 @@ def given(
                             )
                         else:
                             report(
-                                "You can add @seed(%d) to this test to "
-                                "reproduce this failure." % (generated_seed,)
+                                f"You can add @seed({generated_seed}) to this test to "
+                                "reproduce this failure."
                             )
                     # The dance here is to avoid showing users long tracebacks
                     # full of Hypothesis internals they don't care about.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -61,7 +61,7 @@ def _db_for_path(path=None):
                 HypothesisWarning(
                     "The database setting is not configured, and the default "
                     "location is unusable - falling back to an in-memory "
-                    "database for this session.  path=%r" % (path,)
+                    f"database for this session.  path={path!r}"
                 )
             )
             return InMemoryExampleDatabase()
@@ -108,12 +108,12 @@ class ExampleDatabase(metaclass=_EDMeta):
 
         If this value is already present for this key, silently do nothing.
         """
-        raise NotImplementedError("%s.save" % (type(self).__name__))
+        raise NotImplementedError(f"{type(self).__name__}.save")
 
     @abc.abstractmethod
     def fetch(self, key: bytes) -> Iterable[bytes]:
         """Return an iterable over all values matching this key."""
-        raise NotImplementedError("%s.fetch" % (type(self).__name__))
+        raise NotImplementedError(f"{type(self).__name__}.fetch")
 
     @abc.abstractmethod
     def delete(self, key: bytes, value: bytes) -> None:
@@ -121,7 +121,7 @@ class ExampleDatabase(metaclass=_EDMeta):
 
         If this value is not present, silently do nothing.
         """
-        raise NotImplementedError("%s.delete" % (type(self).__name__))
+        raise NotImplementedError(f"{type(self).__name__}.delete")
 
     def move(self, src: bytes, dest: bytes, value: bytes) -> None:
         """Move ``value`` from key ``src`` to key ``dest``. Equivalent to

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -150,7 +150,7 @@ class InMemoryExampleDatabase(ExampleDatabase):
         self.data = {}
 
     def __repr__(self) -> str:
-        return "InMemoryExampleDatabase(%r)" % (self.data,)
+        return f"InMemoryExampleDatabase({self.data!r})"
 
     def fetch(self, key: bytes) -> Iterable[bytes]:
         yield from self.data.get(key, ())
@@ -190,7 +190,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         self.keypaths = {}  # type: dict
 
     def __repr__(self) -> str:
-        return "DirectoryBasedExampleDatabase(%r)" % (self.path,)
+        return f"DirectoryBasedExampleDatabase({self.path!r})"
 
     def _key_path(self, key):
         try:

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -37,9 +37,7 @@ class NoSuchExample(HypothesisException):
     """
 
     def __init__(self, condition_string, extra=""):
-        super().__init__(
-            "No examples found of condition %s%s" % (condition_string, extra)
-        )
+        super().__init__(f"No examples found of condition {condition_string}{extra}")
 
 
 class Unsatisfiable(HypothesisException):

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -262,9 +262,7 @@ def register_field_strategy(
     ``strategy`` must be a :class:`~hypothesis.strategies.SearchStrategy`.
     """
     if not issubclass(field_type, (dm.Field, df.Field)):
-        raise InvalidArgument(
-            "field_type=%r must be a subtype of Field" % (field_type,)
-        )
+        raise InvalidArgument(f"field_type={field_type!r} must be a subtype of Field")
     check_type(st.SearchStrategy, strategy, "strategy")
     if field_type in _global_field_lookup:
         raise InvalidArgument(

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -174,7 +174,7 @@ def _for_form_ip(field):
         return st.ip_addresses(v=4).map(str)
     if validate_ipv6_address in field.default_validators:
         return _ipv6_strings
-    raise ResolutionFailed("No IP version validator on field=%r" % field)
+    raise ResolutionFailed(f"No IP version validator on field={field!r}")
 
 
 @register_for(dm.DecimalField)
@@ -266,8 +266,8 @@ def register_field_strategy(
     check_type(st.SearchStrategy, strategy, "strategy")
     if field_type in _global_field_lookup:
         raise InvalidArgument(
-            "field_type=%r already has a registered strategy (%r)"
-            % (field_type, _global_field_lookup[field_type])
+            f"field_type={field_type!r} already has a registered "
+            f"strategy ({_global_field_lookup[field_type]!r})"
         )
     if issubclass(field_type, dm.AutoField):
         raise InvalidArgument("Cannot register a strategy for an AutoField")
@@ -310,7 +310,7 @@ def from_field(field: F) -> st.SearchStrategy[Union[F, None]]:
         if type(field) not in _global_field_lookup:
             if getattr(field, "null", False):
                 return st.none()
-            raise ResolutionFailed("Could not infer a strategy for %r", (field,))
+            raise ResolutionFailed(f"Could not infer a strategy for {field!r}")
         strategy = _global_field_lookup[type(field)]  # type: ignore
         if not isinstance(strategy, st.SearchStrategy):
             strategy = strategy(field)

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -194,7 +194,7 @@ def from_form(
             # decomposing the individual sub-fields into the names that
             # the form validation process expects
             for i, _field in enumerate(field.fields):
-                fields_by_name["%s_%d" % (name, i)] = _field
+                fields_by_name[f"{name}_{i}"] = _field
         else:
             fields_by_name[name] = field
     for name, value in sorted(field_strategies.items()):

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -90,7 +90,7 @@ def from_model(
         raise TypeError("Missing required positional argument `model`")
 
     if not issubclass(m_type, dm.Model):
-        raise InvalidArgument("model=%r must be a subtype of Model" % (model,))
+        raise InvalidArgument(f"model={model!r} must be a subtype of Model")
 
     fields_by_name = {f.name: f for f in m_type._meta.concrete_fields}
     for name, value in sorted(field_strategies.items()):
@@ -172,7 +172,7 @@ def from_form(
     # ImageField
     form_kwargs = form_kwargs or {}
     if not issubclass(form, df.BaseForm):
-        raise InvalidArgument("form=%r must be a subtype of Form" % (form,))
+        raise InvalidArgument(f"form={form!r} must be a subtype of Form")
 
     # Forms are a little bit different from models. Model classes have
     # all their fields defined, whereas forms may have different fields

--- a/hypothesis-python/src/hypothesis/extra/dpcontracts.py
+++ b/hypothesis-python/src/hypothesis/extra/dpcontracts.py
@@ -45,8 +45,7 @@ def fulfill(contract_func):
     """
     if not hasattr(contract_func, "__contract_wrapped_func__"):
         raise InvalidArgument(
-            "There are no dpcontracts preconditions associated with %s"
-            % (contract_func.__name__,)
+            f"{contract_func.__name__} has no dpcontracts preconditions"
         )
 
     @proxies(contract_func)

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -706,6 +706,7 @@ def fuzz(func: Callable, *, except_: Except = (), style: str = "pytest") -> str:
     .. code-block:: python
 
         from re import compile, error
+
         from hypothesis.extra import ghostwriter
 
         ghostwriter.fuzz(compile, except_=error)
@@ -717,9 +718,11 @@ def fuzz(func: Callable, *, except_: Except = (), style: str = "pytest") -> str:
         # This test code was written by the `hypothesis.extra.ghostwriter` module
         # and is provided under the Creative Commons Zero public domain dedication.
         import re
+
         from hypothesis import given, reject, strategies as st
 
         # TODO: replace st.nothing() with an appropriate strategy
+
 
         @given(pattern=st.nothing(), flags=st.just(0))
         def test_fuzz_compile(pattern, flags):
@@ -753,10 +756,13 @@ def idempotent(func: Callable, *, except_: Except = (), style: str = "pytest") -
     .. code-block:: python
 
         from typing import Sequence
+
         from hypothesis.extra import ghostwriter
+
 
         def timsort(seq: Sequence[int]) -> Sequence[int]:
             return sorted(seq)
+
 
         ghostwriter.idempotent(timsort)
 
@@ -768,6 +774,7 @@ def idempotent(func: Callable, *, except_: Except = (), style: str = "pytest") -
         # and is provided under the Creative Commons Zero public domain dedication.
 
         from hypothesis import given, strategies as st
+
 
         @given(seq=st.one_of(st.binary(), st.binary().map(bytearray), st.lists(st.integers())))
         def test_idempotent_timsort(seq):

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -127,8 +127,8 @@ class LarkStrategy(SearchStrategy):
         if unknown_explicit:
             raise InvalidArgument(
                 "The following arguments were passed as explicit_strategies, "
-                "but there is no such terminal production in this grammar: %r"
-                % (sorted(unknown_explicit),)
+                "but there is no such terminal production in this grammar: "
+                + repr(sorted(unknown_explicit))
             )
         self.terminal_strategies.update(explicit)
 

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -157,7 +157,7 @@ class LarkStrategy(SearchStrategy):
             return self.__rule_labels[name]
         except KeyError:
             return self.__rule_labels.setdefault(
-                name, calc_label_from_name("LARK:%s" % (name,))
+                name, calc_label_from_name(f"LARK:{name}")
             )
 
     def draw_symbol(self, data, symbol, draw_state):
@@ -235,7 +235,7 @@ def from_lark(
     else:
         check_type(dict, explicit, "explicit")
         explicit = {
-            k: v.map(check_explicit("explicit[%r]=%r" % (k, v)))
+            k: v.map(check_explicit(f"explicit[{k!r}]={v!r}"))
             for k, v in explicit.items()
         }
     return LarkStrategy(grammar, start, explicit)

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -189,8 +189,8 @@ class ArrayStrategy(SearchStrategy):
             result[idx] = val
         except TypeError as err:
             raise InvalidArgument(
-                "Could not add element=%r of %r to array of %r - possible mismatch "
-                "of time units in dtypes?" % (val, val.dtype, result.dtype)
+                f"Could not add element={val!r} of {val.dtype!r} to array of "
+                f"{result.dtype!r} - possible mismatch of time units in dtypes?"
             ) from err
         if self._check_elements and val != result[idx] and val == val:
             raise InvalidArgument(
@@ -308,8 +308,7 @@ class ArrayStrategy(SearchStrategy):
 
                     if not is_nan:
                         raise InvalidArgument(
-                            "Cannot fill unique array with non-NaN "
-                            "value %r" % (fill_value,)
+                            f"Cannot fill unique array with non-NaN value {fill_value!r}"
                         )
 
                 np.putmask(result, needs_fill, one_element)
@@ -1090,13 +1089,12 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
                 "Hypothesis does not yet support generalised ufunc signatures "
                 "with multiple output arrays - mostly because we don't know of "
                 "anyone who uses them!  Please get in touch with us to fix that."
-                "\n (signature=%r)" % (signature,)
+                f"\n (signature={signature!r})"
             )
         if re.match(np.lib.function_base._SIGNATURE, signature):
             raise InvalidArgument(
-                "signature=%r matches Numpy's regex for gufunc signatures, but "
-                "contains shapes with more than 32 dimensions and is thus invalid."
-                % (signature,)
+                f"signature={signature!r} matches Numpy's regex for gufunc signatures, "
+                "but contains shapes with more than 32 dimensions and is thus invalid."
             )
         raise InvalidArgument(f"{signature!r} is not a valid gufunc signature")
     input_shapes, output_shapes = (
@@ -1265,8 +1263,8 @@ def mutually_broadcastable_shapes(
         if sig_dims == 0:
             raise InvalidArgument("max_dims cannot exceed 32")
         raise InvalidArgument(
-            "max_dims=%r would exceed the 32-dimension limit given signature=%r"
-            % (signature, parsed_signature)
+            f"max_dims={signature!r} would exceed the 32-dimension limit given "
+            f"signature={parsed_signature!r}"
         )
 
     dims, bnd_name = (max_dims, "max_dims") if strict_check else (min_dims, "min_dims")

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -341,7 +341,7 @@ def fill_for(elements, unique, fill, name=""):
         else:
             fill = elements
     else:
-        st.check_strategy(fill, "%s.fill" % (name,) if name else "fill")
+        st.check_strategy(fill, f"{name}.fill" if name else "fill")
     return fill
 
 
@@ -1098,7 +1098,7 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
                 "contains shapes with more than 32 dimensions and is thus invalid."
                 % (signature,)
             )
-        raise InvalidArgument("%r is not a valid gufunc signature" % (signature,))
+        raise InvalidArgument(f"{signature!r} is not a valid gufunc signature")
     input_shapes, output_shapes = (
         tuple(tuple(re.findall(_DIMENSION, a)) for a in re.findall(_SHAPE, arg_list))
         for arg_list in signature.split("->")
@@ -1412,11 +1412,11 @@ def basic_indices(
     order_check("dims", 0, min_dims, max_dims)
     check_argument(
         max_dims <= 32,
-        "max_dims=%r, but numpy arrays have at most 32 dimensions" % (max_dims,),
+        f"max_dims={max_dims!r}, but numpy arrays have at most 32 dimensions",
     )
     check_argument(
         all(isinstance(x, int) and x >= 0 for x in shape),
-        "shape=%r, but all dimensions must be of integer size >= 0" % (shape,),
+        f"shape={shape!r}, but all dimensions must be of integer size >= 0",
     )
     return BasicIndexStrategy(
         shape,
@@ -1476,11 +1476,11 @@ def integer_array_indices(
     check_type(tuple, shape, "shape")
     check_argument(
         shape and all(isinstance(x, int) and x > 0 for x in shape),
-        "shape=%r must be a non-empty tuple of integers > 0" % (shape,),
+        f"shape={shape!r} must be a non-empty tuple of integers > 0",
     )
     check_strategy(result_shape, "result_shape")
     check_argument(
-        np.issubdtype(dtype, np.integer), "dtype=%r must be an integer dtype" % (dtype,)
+        np.issubdtype(dtype, np.integer), f"dtype={dtype!r} must be an integer dtype"
     )
     signed = np.issubdtype(dtype, np.signedinteger)
 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -72,11 +72,7 @@ def elements_and_dtype(elements, dtype, source=None):
         with check("dtype is not None"):
             if dtype is None:
                 raise InvalidArgument(
-                    (
-                        "At least one of %(prefix)selements or %(prefix)sdtype "
-                        "must be provided."
-                    )
-                    % {"prefix": prefix}
+                    f"At least one of {prefix}elements or {prefix}dtype must be provided."
                 )
 
     with check("is_categorical_dtype"):
@@ -506,11 +502,11 @@ def data_frames(
     column_names = set()  # type: Set[str]
 
     for i, c in enumerate(cols):
-        check_type(column, c, "columns[%d]" % (i,))
+        check_type(column, c, f"columns[{i}]")
 
         c = copy(c)
         if c.name is None:
-            label = "columns[%d]" % (i,)
+            label = f"columns[{i}]"
             c.name = i
         else:
             label = c.name

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -64,10 +64,10 @@ def elements_and_dtype(elements, dtype, source=None):
     if source is None:
         prefix = ""
     else:
-        prefix = "%s." % (source,)
+        prefix = f"{source}."
 
     if elements is not None:
-        st.check_strategy(elements, "%selements" % (prefix,))
+        st.check_strategy(elements, f"{prefix}elements")
     else:
         with check("dtype is not None"):
             if dtype is None:
@@ -82,7 +82,7 @@ def elements_and_dtype(elements, dtype, source=None):
     with check("is_categorical_dtype"):
         if is_categorical_dtype(dtype):
             raise InvalidArgument(
-                "%sdtype is categorical, which is currently unsupported" % (prefix,)
+                f"{prefix}dtype is categorical, which is currently unsupported"
             )
 
     dtype = try_convert(np.dtype, dtype, "dtype")
@@ -92,7 +92,7 @@ def elements_and_dtype(elements, dtype, source=None):
     elif dtype is not None:
 
         def convert_element(value):
-            name = "draw(%selements)" % (prefix,)
+            name = f"draw({prefix}elements)"
             try:
                 return np.array([value], dtype=dtype)[0]
             except TypeError:
@@ -102,7 +102,7 @@ def elements_and_dtype(elements, dtype, source=None):
                 )
             except ValueError:
                 raise InvalidArgument(
-                    "Cannot convert %s=%r to type %s" % (name, value, dtype.str)
+                    f"Cannot convert {name}={value!r} to type {dtype.str}"
                 )
 
         elements = elements.map(convert_element)
@@ -524,7 +524,7 @@ def data_frames(
                 )
 
         if c.name in column_names:
-            raise InvalidArgument("duplicate definition of column name %r" % (c.name,))
+            raise InvalidArgument(f"duplicate definition of column name {c.name!r}")
 
         column_names.add(c.name)
 

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -95,7 +95,7 @@ else:
         settings_str = settings.get_profile(profile).show_changed()
         if settings_str != "":
             settings_str = " -> %s" % (settings_str)
-        return "hypothesis profile %r%s" % (profile, settings_str)
+        return f"hypothesis profile {profile!r}{settings_str}"
 
     def pytest_configure(config):
         core.running_under_pytest = True
@@ -105,7 +105,7 @@ else:
         verbosity_name = config.getoption(VERBOSITY_OPTION)
         if verbosity_name:
             verbosity_value = Verbosity[verbosity_name]
-            profile_name = "%s-with-%s-verbosity" % (
+            profile_name = "{}-with-{}-verbosity".format(
                 settings._current_profile,
                 verbosity_name,
             )

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -94,7 +94,7 @@ else:
             profile = settings._current_profile
         settings_str = settings.get_profile(profile).show_changed()
         if settings_str != "":
-            settings_str = " -> %s" % (settings_str)
+            settings_str = f" -> {settings_str}"
         return f"hypothesis profile {profile!r}{settings_str}"
 
     def pytest_configure(config):
@@ -105,14 +105,11 @@ else:
         verbosity_name = config.getoption(VERBOSITY_OPTION)
         if verbosity_name:
             verbosity_value = Verbosity[verbosity_name]
-            profile_name = "{}-with-{}-verbosity".format(
-                settings._current_profile,
-                verbosity_name,
-            )
+            name = f"{settings._current_profile}-with-{verbosity_name}-verbosity"
             # register_profile creates a new profile, exactly like the current one,
             # with the extra values given (in this case 'verbosity')
-            settings.register_profile(profile_name, verbosity=verbosity_value)
-            settings.load_profile(profile_name)
+            settings.register_profile(name, verbosity=verbosity_value)
+            settings.load_profile(name)
         seed = config.getoption(SEED_OPTION)
         if seed is not None:
             try:

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -141,7 +141,7 @@ class GenericCache:
         i = self.keys_to_indices[key]
         entry = self.data[i]
         if entry.pins == 0:
-            raise ValueError("Key %r has not been pinned" % (key,))
+            raise ValueError(f"Key {key!r} has not been pinned")
         entry.pins -= 1
         if entry.pins == 0:
             self.__pinned_entry_count -= 1
@@ -159,7 +159,7 @@ class GenericCache:
         self.__pinned_entry_count = 0
 
     def __repr__(self):
-        return "{%s}" % (", ".join("%r: %r" % (e.key, e.value) for e in self.data),)
+        return "{{{}}}".format(", ".join(f"{e.key!r}: {e.value!r}" for e in self.data))
 
     def new_entry(self, key, value):
         """Called when a key is written that does not currently appear in the

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -159,7 +159,7 @@ class GenericCache:
         self.__pinned_entry_count = 0
 
     def __repr__(self):
-        return "{{{}}}".format(", ".join(f"{e.key!r}: {e.value!r}" for e in self.data))
+        return "{" + ", ".join(f"{e.key!r}: {e.value!r}" for e in self.data) + "}"
 
     def new_entry(self, key, value):
         """Called when a key is written that does not currently appear in the

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -146,7 +146,7 @@ def as_general_categories(cats, name="cats"):
             out.update(x for x in cs if x.startswith(c))
         elif c not in cs:
             raise InvalidArgument(
-                "In %s=%r, %r is not a valid Unicode category." % (name, cats, c)
+                f"In {name}={cats!r}, {c!r} is not a valid Unicode category."
             )
     return tuple(c for c in cs if c in out)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -117,7 +117,7 @@ class Example:
         return (self.owner is not other.owner) or (self.index != other.index)
 
     def __repr__(self):
-        return "examples[%d]" % (self.index,)
+        return f"examples[{self.index}]"
 
     @property
     def label(self):
@@ -450,7 +450,7 @@ class Examples:
         assert isinstance(i, int)
         n = len(self)
         if i < -n or i >= n:
-            raise IndexError("Index %d out of range [-%d, %d)" % (i, n, n))
+            raise IndexError(f"Index {i} out of range [-{n}, {n})")
         if i < 0:
             i += n
         return Example(self, i)
@@ -582,7 +582,7 @@ class Blocks:
     def _check_index(self, i):
         n = len(self)
         if i < -n or i >= n:
-            raise IndexError("Index %d out of range [-%d, %d)" % (i, n, n))
+            raise IndexError(f"Index {i} out of range [-{n}, {n})")
         if i < 0:
             i += n
         return i

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -33,8 +33,8 @@ class ExtraInformation:
     be added to the final ``ConjectureResult``."""
 
     def __repr__(self):
-        return "ExtraInformation(%s)" % (
-            ", ".join(["%s=%r" % (k, v) for k, v in self.__dict__.items()]),
+        return "ExtraInformation({})".format(
+            ", ".join([f"{k}={v!r}" for k, v in self.__dict__.items()]),
         )
 
     def has_information(self):
@@ -48,7 +48,7 @@ class Status(IntEnum):
     INTERESTING = 3
 
     def __repr__(self):
-        return "Status.%s" % (self.name,)
+        return f"Status.{self.name}"
 
 
 @attr.s(frozen=True, slots=True)
@@ -661,7 +661,7 @@ class Blocks:
                 parts.append("...")
             else:
                 parts.append(repr(b))
-        return "Block([%s])" % (", ".join(parts),)
+        return "Block([{}])".format(", ".join(parts))
 
 
 class _Overrun:
@@ -841,7 +841,7 @@ class ConjectureData:
 
     def __assert_not_frozen(self, name):
         if self.frozen:
-            raise Frozen("Cannot call %s on frozen ConjectureData" % (name,))
+            raise Frozen(f"Cannot call {name} on frozen ConjectureData")
 
     def note(self, value):
         self.__assert_not_frozen("note")

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/__init__.py
@@ -615,14 +615,8 @@ class ConcreteDFA(DFA):
                     table[-1][1] = c
             transitions.append([(u, j) if u == v else (u, v, j) for u, v, j in table])
 
-        if self.__start != 0:
-            return "ConcreteDFA(%r, %r, start=%r)" % (
-                transitions,
-                self.__accepting,
-                self.__start,
-            )
-        else:
-            return "ConcreteDFA(%r, %r)" % (transitions, self.__accepting)
+        start = "" if self.__start == 0 else f", start={self.__start!r}"
+        return f"ConcreteDFA({transitions!r}, {self.__accepting!r}{start})"
 
     @property
     def start(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -447,7 +447,7 @@ class IntegerNormalizer:
         self.__cache = {}
 
     def __repr__(self):
-        return "IntegerNormalizer(%r)" % (list(self.__values),)
+        return "IntegerNormalizer({!r})".format(list(self.__values))
 
     def __copy__(self):
         result = IntegerNormalizer()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -447,7 +447,7 @@ class IntegerNormalizer:
         self.__cache = {}
 
     def __repr__(self):
-        return "IntegerNormalizer({!r})".format(list(self.__values))
+        return f"IntegerNormalizer({list(self.__values)!r})"
 
     def __copy__(self):
         result = IntegerNormalizer()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -487,9 +487,7 @@ class ConjectureRunner:
         if data.status == Status.INTERESTING:
             status = f"{status} ({data.interesting_origin!r})"
 
-        self.debug(
-            "%d bytes %r -> %s, %s" % (data.index, stack[0], status, data.output)
-        )
+        self.debug(f"{data.index} bytes {stack[0]!r} -> {status}, {data.output}")
 
     def run(self):
         with local_settings(self.settings):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -73,7 +73,7 @@ class ExitReason(Enum):
         "settings.max_examples={s.max_examples}, "
         "but < 10% of examples satisfied assumptions"
     )
-    max_shrinks = "shrunk example %s times" % (MAX_SHRINKS,)
+    max_shrinks = f"shrunk example {MAX_SHRINKS} times"
     finished = "nothing left to do"
     flaky = "test was flaky"
     very_slow_shrinking = "shrinking was very slow"
@@ -485,7 +485,7 @@ class ConjectureRunner:
         status = repr(data.status)
 
         if data.status == Status.INTERESTING:
-            status = "%s (%r)" % (status, data.interesting_origin)
+            status = f"{status} ({data.interesting_origin!r})"
 
         self.debug(
             "%d bytes %r -> %s, %s" % (data.index, stack[0], status, data.output)
@@ -584,7 +584,7 @@ class ConjectureRunner:
         self.statistics["stopped-because"] = reason.describe(self.settings)
         if self.best_observed_targets:
             self.statistics["targets"] = dict(self.best_observed_targets)
-        self.debug("exit_with(%s)" % (reason.name,))
+        self.debug(f"exit_with({reason.name})")
         self.exit_reason = reason
         raise RunIsComplete()
 
@@ -955,7 +955,7 @@ class ConjectureRunner:
                 ),
                 key=lambda kv: (sort_key(kv[1].buffer), sort_key(repr(kv[0]))),
             )
-            self.debug("Shrinking %r" % (target,))
+            self.debug(f"Shrinking {target!r}")
 
             if not self.settings.report_multiple_bugs:
                 # If multi-bug reporting is disabled, we shrink our currently-minimal

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -82,7 +82,7 @@ class IntList:
         return self.__underlying.count(n)
 
     def __repr__(self):
-        return "IntList({!r})".format(list(self))
+        return f"IntList({list(self)!r})"
 
     def __len__(self):
         return len(self.__underlying)
@@ -202,7 +202,7 @@ class LazySequenceCopy:
     def __check_index(self, i):
         n = len(self)
         if i < -n or i >= n:
-            raise IndexError("Index %d out of range [0, %d)" % (i, n))
+            raise IndexError(f"Index {i} out of range [0, {n})")
         if i < 0:
             i += n
         assert 0 <= i < n

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -68,11 +68,11 @@ class IntList:
             except OverflowError:
                 pass
         else:  # pragma: no cover
-            raise AssertionError("Could not create storage for %r" % (values,))
+            raise AssertionError(f"Could not create storage for {values!r}")
         if isinstance(self.__underlying, list):
             for v in self.__underlying:
                 if v < 0 or not isinstance(v, int):
-                    raise ValueError("Could not create IntList for %r" % (values,))
+                    raise ValueError(f"Could not create IntList for {values!r}")
 
     @classmethod
     def of_length(self, n):
@@ -82,7 +82,7 @@ class IntList:
         return self.__underlying.count(n)
 
     def __repr__(self):
-        return "IntList(%r)" % (list(self),)
+        return "IntList({!r})".format(list(self))
 
     def __len__(self):
         return len(self.__underlying)
@@ -309,7 +309,7 @@ class SelfOrganisingList:
         self.__values = list(values)
 
     def __repr__(self):
-        return "SelfOrganisingList(%r)" % (self.__values,)
+        return f"SelfOrganisingList({self.__values!r})"
 
     def add(self, value):
         """Add a value to this list."""

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1330,13 +1330,13 @@ class Shrinker:
                 elif d == "X":
                     del attempt[u:v]
                 else:  # pragma: no cover
-                    raise AssertionError("Unrecognised command %r" % (d,))
+                    raise AssertionError(f"Unrecognised command {d!r}")
         return self.incorporate_new_buffer(attempt)
 
 
 def shrink_pass_family(f):
     def accept(*args):
-        name = "%s(%s)" % (f.__name__, ", ".join(map(repr, args)))
+        name = "{}({})".format(f.__name__, ", ".join(map(repr, args)))
         if name not in SHRINK_PASS_DEFINITIONS:
 
             def run(self, chooser):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -193,8 +193,7 @@ class Shrinker:
         i = 0
         while i < len(self.shrink_target.buffer):
             if not self.incorporate_new_buffer(
-                self.shrink_target.buffer[: i] +
-                self.shrink_target.buffer[i + 1 :]
+                self.shrink_target.buffer[:i] + self.shrink_target.buffer[i + 1 :]
             ):
                 i += 1
 
@@ -1265,6 +1264,7 @@ class Shrinker:
 
             import hypothesis.strategies as st
             from hypothesis import given
+
 
             @given(st.text(), st.text())
             def test_not_equal(x, y):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -41,9 +41,9 @@ class Shrinker:
         return len(self.__seen)
 
     def __repr__(self):
-        return "%s(%sinitial=%r, current=%r)" % (
+        return "{}({}initial={!r}, current={!r})".format(
             type(self).__name__,
-            "" if self.name is None else "%r, " % (self.name,),
+            "" if self.name is None else f"{self.name!r}, ",
             self.initial,
             self.current,
         )
@@ -116,14 +116,14 @@ class Shrinker:
         if not self.left_is_better(value, self.current):
             if value != self.current and (value == value):
                 self.debug(
-                    "Rejected %r as worse than self.current=%r" % (value, self.current)
+                    f"Rejected {value!r} as worse than self.current={self.current!r}"
                 )
             return False
         if value in self.__seen:
             return False
         self.__seen.add(value)
         if self.__predicate(value):
-            self.debug("shrinking to %r" % (value,))
+            self.debug(f"shrinking to {value!r}")
             self.changes += 1
             self.current = value
             return True

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
@@ -57,7 +57,7 @@ def update_learned_dfas():
     lines.append("")
 
     for k, v in sorted(SHRINKING_DFAS.items()):
-        lines.append("SHRINKING_DFAS[%r] = %r  # noqa: E501" % (k, v))
+        lines.append(f"SHRINKING_DFAS[{k!r}] = {v!r}  # noqa: E501")
 
     lines.append("")
     lines.append("# fmt: on")

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -48,7 +48,7 @@ def register_random(r: random.Random) -> None:
     choose to use the :func:`~hypothesis.strategies.random_module` strategy.
     """
     if not (hasattr(r, "seed") and hasattr(r, "getstate") and hasattr(r, "setstate")):
-        raise InvalidArgument("r=%r does not have all the required methods" % (r,))
+        raise InvalidArgument(f"r={r!r} does not have all the required methods")
     if r not in RANDOMS_TO_MANAGE:
         RANDOMS_TO_MANAGE.append(r)
 

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -51,7 +51,7 @@ def belongs_to(package):
         cache[ftype][filepath] = result
         return result
 
-    accept.__name__ = "is_%s_file" % (package.__name__,)
+    accept.__name__ = f"is_{package.__name__}_file"
     return accept
 
 

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -44,7 +44,7 @@ def sign(x):
         return math.copysign(1.0, x)
     except TypeError:
         raise TypeError(
-            "Expected float but got {!r} of type {}".format(x, type(x).__name__)
+            f"Expected float but got {x!r} of type {type(x).__name__}"
         ) from None
 
 

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -44,7 +44,7 @@ def sign(x):
         return math.copysign(1.0, x)
     except TypeError:
         raise TypeError(
-            "Expected float but got %r of type %s" % (x, type(x).__name__)
+            "Expected float but got {!r} of type {}".format(x, type(x).__name__)
         ) from None
 
 

--- a/hypothesis-python/src/hypothesis/internal/intervalsets.py
+++ b/hypothesis-python/src/hypothesis/internal/intervalsets.py
@@ -55,7 +55,7 @@ class IntervalSet:
         return r
 
     def __repr__(self):
-        return "IntervalSet(%r)" % (self.intervals,)
+        return f"IntervalSet({self.intervals!r})"
 
     def index(self, value):
         for offset, (u, v) in zip(self.offsets, self.intervals):

--- a/hypothesis-python/src/hypothesis/internal/intervalsets.py
+++ b/hypothesis-python/src/hypothesis/internal/intervalsets.py
@@ -33,7 +33,7 @@ class IntervalSet:
         if i < 0:
             i = self.size + i
         if i < 0 or i >= self.size:
-            raise IndexError("Invalid index %d for [0, %d)" % (i, self.size))
+            raise IndexError(f"Invalid index {i} for [0, {self.size})")
         # Want j = maximal such that offsets[j] <= i
 
         j = len(self.intervals) - 1
@@ -62,10 +62,10 @@ class IntervalSet:
             if u == value:
                 return offset
             elif u > value:
-                raise ValueError("%d is not in list" % (value,))
+                raise ValueError(f"{value} is not in list")
             if value <= v:
                 return offset + (value - u)
-        raise ValueError("%d is not in list" % (value,))
+        raise ValueError(f"{value} is not in list")
 
     def index_above(self, value):
         for offset, (u, v) in zip(self.offsets, self.intervals):

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -507,10 +507,10 @@ def define_function_signature(name, docstring, argspec):
         elif argspec.kwonlyargs:
             parts.append("*")
         for k in must_pass_as_kwargs:
-            invocation_parts.append("{k}={k}".format(k=k))
+            invocation_parts.append(f"{k}={k}")
 
         for k in argspec.kwonlyargs:
-            invocation_parts.append("{k}={k}".format(k=k))
+            invocation_parts.append(f"{k}={k}")
             if k in (argspec.kwonlydefaults or []):
                 parts.append(f"{k}=not_set")
             else:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -197,7 +197,7 @@ def convert_positional_arguments(function, args, kwargs):
         for i in range(len(args), len(argspec.args) - len(argspec.defaults or ())):
             if argspec.args[i] not in kwargs:
                 raise TypeError(
-                    "No value provided for argument %s" % (argspec.args[i],)
+                    "No value provided for argument {}".format(argspec.args[i])
                 )
     for kw in argspec.kwonlyargs:
         if kw not in new_kwargs:
@@ -268,7 +268,7 @@ def extract_lambda_source(f):
             arg_strings.append(a)
 
     if arg_strings:
-        if_confused = "lambda %s: <unknown>" % (", ".join(arg_strings),)
+        if_confused = "lambda {}: <unknown>".format(", ".join(arg_strings))
     else:
         if_confused = "lambda: <unknown>"
     try:
@@ -397,7 +397,7 @@ def get_pretty_function_description(f):
         # Some objects, like `builtins.abs` are of BuiltinMethodType but have
         # their module as __self__.  This might include c-extensions generally?
         if not (self is None or inspect.isclass(self) or inspect.ismodule(self)):
-            return "%r.%s" % (self, name)
+            return f"{self!r}.{name}"
     return name
 
 
@@ -420,10 +420,10 @@ def arg_string(f, args, kwargs, reorder=True):
 
     for a in argspec.args:
         if a in kwargs:
-            bits.append("%s=%s" % (a, nicerepr(kwargs.pop(a))))
+            bits.append("{}={}".format(a, nicerepr(kwargs.pop(a))))
     if kwargs:
         for a in sorted(kwargs):
-            bits.append("%s=%s" % (a, nicerepr(kwargs[a])))
+            bits.append("{}={}".format(a, nicerepr(kwargs[a])))
 
     return ", ".join([nicerepr(x) for x in args] + bits)
 
@@ -436,7 +436,7 @@ def unbind_method(f):
 
 def check_valid_identifier(identifier):
     if not identifier.isidentifier():
-        raise ValueError("%r is not a valid python identifier" % (identifier,))
+        raise ValueError(f"{identifier!r} is not a valid python identifier")
 
 
 eval_cache = {}  # type: dict
@@ -484,7 +484,7 @@ def define_function_signature(name, docstring, argspec):
         for a in argspec.args[:-n_defaults]:
             parts.append(a)
         for a in argspec.args[-n_defaults:]:
-            parts.append("%s=not_set" % (a,))
+            parts.append(f"{a}=not_set")
     else:
         parts = list(argspec.args)
     used_names = list(argspec.args) + list(argspec.kwonlyargs)
@@ -509,12 +509,12 @@ def define_function_signature(name, docstring, argspec):
         elif argspec.kwonlyargs:
             parts.append("*")
         for k in must_pass_as_kwargs:
-            invocation_parts.append("%(k)s=%(k)s" % {"k": k})
+            invocation_parts.append("{k}={k}".format(k=k))
 
         for k in argspec.kwonlyargs:
-            invocation_parts.append("%(k)s=%(k)s" % {"k": k})
+            invocation_parts.append("{k}={k}".format(k=k))
             if k in (argspec.kwonlydefaults or []):
-                parts.append("%(k)s=not_set" % {"k": k})
+                parts.append(f"{k}=not_set")
             else:
                 parts.append(k)
         if argspec.varkw:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -196,24 +196,22 @@ def convert_positional_arguments(function, args, kwargs):
     if len(args) < len(argspec.args):
         for i in range(len(args), len(argspec.args) - len(argspec.defaults or ())):
             if argspec.args[i] not in kwargs:
-                raise TypeError(
-                    "No value provided for argument {}".format(argspec.args[i])
-                )
+                raise TypeError(f"No value provided for argument {argspec.args[i]}")
     for kw in argspec.kwonlyargs:
         if kw not in new_kwargs:
-            raise TypeError("No value provided for argument %s" % kw)
+            raise TypeError(f"No value provided for argument {kw}")
 
     if len(args) > len(argspec.args) and not argspec.varargs:
         raise TypeError(
-            "%s() takes at most %d positional arguments (%d given)"
-            % (function.__name__, len(argspec.args), len(args))
+            "{}() takes at most {} positional arguments ({} given)".format(
+                function.__name__, len(argspec.args), len(args)
+            )
         )
 
     for arg, name in zip(args, argspec.args):
         if name in new_kwargs:
             raise TypeError(
-                "%s() got multiple values for keyword argument %r"
-                % (function.__name__, name)
+                f"{function.__name__}() got multiple values for keyword argument {name!r}"
             )
         else:
             new_kwargs[name] = arg
@@ -522,7 +520,7 @@ def define_function_signature(name, docstring, argspec):
             parts.append("**" + argspec.varkw)
             invocation_parts.append("**" + argspec.varkw)
 
-        candidate_names = ["f"] + ["f_%d" % (i,) for i in range(1, len(used_names) + 2)]
+        candidate_names = ["f"] + [f"f_{i}" for i in range(1, len(used_names) + 2)]
 
         for funcname in candidate_names:  # pragma: no branch
             if funcname not in used_names:

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -63,9 +63,9 @@ def check_valid_bound(value, name):
     if value is None or isinstance(value, (int, Rational)):
         return
     if not isinstance(value, (Real, decimal.Decimal)):
-        raise InvalidArgument("%s=%r must be a real number." % (name, value))
+        raise InvalidArgument(f"{name}={value!r} must be a real number.")
     if math.isnan(value):
-        raise InvalidArgument("Invalid end point %s=%r" % (name, value))
+        raise InvalidArgument(f"Invalid end point {name}={value!r}")
 
 
 @check_function
@@ -77,7 +77,7 @@ def check_valid_magnitude(value, name):
     """
     check_valid_bound(value, name)
     if value is not None and value < 0:
-        raise InvalidArgument("%s=%r must not be negative." % (name, value))
+        raise InvalidArgument(f"{name}={value!r} must not be negative.")
     elif value is None and name == "min_magnitude":
         raise InvalidArgument("Use min_magnitude=0 or omit the argument entirely.")
 
@@ -108,7 +108,7 @@ def check_valid_size(value, name):
         return
     check_type(int, value, name)
     if value < 0:
-        raise InvalidArgument("Invalid size %s=%r < 0" % (name, value))
+        raise InvalidArgument(f"Invalid size {name}={value!r} < 0")
 
 
 @check_function

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -338,11 +338,10 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
             n_output_vars = len(result.values)
         else:
             n_output_vars = 1
-        output_assignment = (
-            "%s = " % (", ".join(self._last_names(n_output_vars)),)
-            if rule.targets and n_output_vars >= 1
-            else ""
-        )
+        if rule.targets and n_output_vars >= 1:
+            output_assignment = ", ".join(self._last_names(n_output_vars)) + " = "
+        else:
+            output_assignment = ""
         report(
             "%sstate.%s(%s)"
             % (

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -224,9 +224,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
 
     def __init__(self):
         if not self.rules():
-            raise InvalidDefinition(
-                "Type {} defines no rules".format(type(self).__name__)
-            )
+            raise InvalidDefinition(f"Type {type(self).__name__} defines no rules")
         self.bundles = {}  # type: Dict[str, list]
         self.name_counter = 1
         self.names_to_values = {}  # type: Dict[str, Any]
@@ -251,14 +249,14 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
         return "{}({})".format(type(self).__name__, nicerepr(self.bundles))
 
     def _new_name(self):
-        result = "v%d" % (self.name_counter,)
+        result = f"v{self.name_counter}"
         self.name_counter += 1
         return result
 
     def _last_names(self, n):
         assert self.name_counter > n
         count = self.name_counter
-        return ["v%d" % (i,) for i in range(count - n, count)]
+        return [f"v{i}" for i in range(count - n, count)]
 
     def bundle(self, name):
         return self.bundles.setdefault(name, [])
@@ -345,8 +343,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
         else:
             output_assignment = ""
         report(
-            "%sstate.%s(%s)"
-            % (
+            "{}state.{}({})".format(
                 output_assignment,
                 rule.function.__name__,
                 ", ".join("%s=%s" % kv for kv in data.items()),

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -94,7 +94,7 @@ def run_state_machine_as_test(state_machine_factory, *, settings=None):
         )
         try:
             if print_steps:
-                report("state = %s()" % (machine.__class__.__name__,))
+                report(f"state = {machine.__class__.__name__}()")
             machine.check_invariants()
             max_steps = settings.stateful_step_count
             steps_run = 0
@@ -224,7 +224,9 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
 
     def __init__(self):
         if not self.rules():
-            raise InvalidDefinition("Type %s defines no rules" % (type(self).__name__,))
+            raise InvalidDefinition(
+                "Type {} defines no rules".format(type(self).__name__)
+            )
         self.bundles = {}  # type: Dict[str, list]
         self.name_counter = 1
         self.names_to_values = {}  # type: Dict[str, Any]
@@ -246,7 +248,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
         return self.__stream.getvalue()
 
     def __repr__(self):
-        return "%s(%s)" % (type(self).__name__, nicerepr(self.bundles))
+        return "{}({})".format(type(self).__name__, nicerepr(self.bundles))
 
     def _new_name(self):
         result = "v%d" % (self.name_counter,)
@@ -450,8 +452,8 @@ class Bundle(SearchStrategy):
     def __repr__(self):
         consume = self.__reference_strategy.consume
         if consume is False:
-            return "Bundle(name=%r)" % (self.name,)
-        return "Bundle(name=%r, consume=%r)" % (self.name, consume)
+            return f"Bundle(name={self.name!r})"
+        return f"Bundle(name={self.name!r}, consume={consume!r})"
 
     def calc_is_empty(self, recur):
         # We assume that a bundle will grow over time
@@ -760,14 +762,14 @@ class RuleStrategy(SearchStrategy):
         )
 
     def __repr__(self):
-        return "%s(machine=%s({...}))" % (
+        return "{}(machine={}({{...}}))".format(
             self.__class__.__name__,
             self.machine.__class__.__name__,
         )
 
     def do_draw(self, data):
         if not any(self.is_valid(rule) for rule in self.rules):
-            msg = "No progress can be made from state %r" % (self.machine,)
+            msg = f"No progress can be made from state {self.machine!r}"
             raise InvalidDefinition(msg) from None
 
         feature_flags = data.draw(self.enabled_rules_strategy)

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -75,9 +75,9 @@ def describe_statistics(stats_dict):
         if upper == 0:
             ms = "< 1ms"
         elif lower == upper:
-            ms = "~ %dms" % (lower,)
+            ms = f"~ {lower}ms"
         else:
-            ms = "%d-%d ms" % (lower, upper)
+            ms = f"{lower}-{upper} ms"
         drawtime_percent = 100 * statistics.mean(
             t["drawtime"] / t["runtime"] if t["runtime"] > 0 else 0 for t in cases
         )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -45,10 +45,10 @@ class TupleStrategy(SearchStrategy):
 
     def __repr__(self):
         if len(self.element_strategies) == 1:
-            tuple_string = "%s," % (repr(self.element_strategies[0]),)
+            tuple_string = "{},".format(repr(self.element_strategies[0]))
         else:
             tuple_string = ", ".join(map(repr, self.element_strategies))
-        return "TupleStrategy((%s))" % (tuple_string,)
+        return f"TupleStrategy(({tuple_string}))"
 
     def calc_has_reusable_values(self, recur):
         return all(recur(e) for e in self.element_strategies)
@@ -118,7 +118,7 @@ class ListStrategy(SearchStrategy):
         return result
 
     def __repr__(self):
-        return "%s(%r, min_size=%r, max_size=%r)" % (
+        return "{}({!r}, min_size={!r}, max_size={!r})".format(
             self.__class__.__name__,
             self.element_strategy,
             self.min_size,
@@ -227,7 +227,7 @@ class FixedKeysDictStrategy(MappedSearchStrategy):
         return recur(self.mapped_strategy)
 
     def __repr__(self):
-        return "FixedKeysDictStrategy(%r, %r)" % (self.keys, self.mapped_strategy)
+        return f"FixedKeysDictStrategy({self.keys!r}, {self.mapped_strategy!r})"
 
     def pack(self, value):
         return self.dict_type(zip(self.keys, value))
@@ -258,7 +258,7 @@ class FixedAndOptionalKeysDictStrategy(SearchStrategy):
         return recur(self.fixed)
 
     def __repr__(self):
-        return "FixedAndOptionalKeysDictStrategy(%r, %r)" % (
+        return "FixedAndOptionalKeysDictStrategy({!r}, {!r})".format(
             self.required,
             self.optional,
         )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -45,7 +45,7 @@ class TupleStrategy(SearchStrategy):
 
     def __repr__(self):
         if len(self.element_strategies) == 1:
-            tuple_string = "{},".format(repr(self.element_strategies[0]))
+            tuple_string = f"{self.element_strategies[0]!r},"
         else:
             tuple_string = ", ".join(map(repr, self.element_strategies))
         return f"TupleStrategy(({tuple_string}))"
@@ -119,10 +119,7 @@ class ListStrategy(SearchStrategy):
 
     def __repr__(self):
         return "{}({!r}, min_size={!r}, max_size={!r})".format(
-            self.__class__.__name__,
-            self.element_strategy,
-            self.min_size,
-            self.max_size,
+            self.__class__.__name__, self.element_strategy, self.min_size, self.max_size
         )
 
 
@@ -258,10 +255,7 @@ class FixedAndOptionalKeysDictStrategy(SearchStrategy):
         return recur(self.fixed)
 
     def __repr__(self):
-        return "FixedAndOptionalKeysDictStrategy({!r}, {!r})".format(
-            self.required,
-            self.optional,
-        )
+        return f"FixedAndOptionalKeysDictStrategy({self.required!r}, {self.optional!r})"
 
     def do_draw(self, data):
         result = data.draw(self.fixed)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1466,7 +1466,8 @@ def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
 
         def everything_except(excluded_types):
             return (
-                from_type(type).flatmap(from_type)
+                from_type(type)
+                .flatmap(from_type)
                 .filter(lambda x: not isinstance(x, excluded_types))
             )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -548,9 +548,9 @@ def floats(
         )
 
     if exclude_min and (min_value is None or min_value == math.inf):
-        raise InvalidArgument("Cannot exclude min_value=%r" % (min_value,))
+        raise InvalidArgument(f"Cannot exclude min_value={min_value!r}")
     if exclude_max and (max_value is None or max_value == -math.inf):
-        raise InvalidArgument("Cannot exclude max_value=%r" % (max_value,))
+        raise InvalidArgument(f"Cannot exclude max_value={max_value!r}")
 
     if min_value is not None and (
         exclude_min or (min_arg is not None and min_value < min_arg)
@@ -593,7 +593,7 @@ def floats(
             "and max_value=%r" % (width, min_arg, max_arg)
         )
         if exclude_min or exclude_max:
-            msg += ", exclude_min=%r and exclude_max=%r" % (exclude_min, exclude_max)
+            msg += f", exclude_min={exclude_min!r} and exclude_max={exclude_max!r}"
         raise InvalidArgument(msg)
 
     if allow_infinity is None:
@@ -725,9 +725,9 @@ def sampled_from(elements):
     if len(values) == 1:
         return just(values[0])
     if isinstance(elements, type) and issubclass(elements, enum.Enum):
-        repr_ = "sampled_from(%s.%s)" % (elements.__module__, elements.__name__)
+        repr_ = f"sampled_from({elements.__module__}.{elements.__name__})"
     else:
-        repr_ = "sampled_from(%r)" % (elements,)
+        repr_ = f"sampled_from({elements!r})"
     if isclass(elements) and issubclass(elements, enum.Flag):
         # Combinations of enum.Flag members are also members.  We generate
         # these dynamically, because static allocation takes O(2^n) memory.
@@ -961,11 +961,11 @@ def fixed_dictionaries(
     """
     check_type(dict, mapping, "mapping")
     for k, v in mapping.items():
-        check_strategy(v, "mapping[%r]" % (k,))
+        check_strategy(v, f"mapping[{k!r}]")
     if optional is not None:
         check_type(dict, optional, "optional")
         for k, v in optional.items():
-            check_strategy(v, "optional[%r]" % (k,))
+            check_strategy(v, f"optional[{k!r}]")
         if type(mapping) != type(optional):
             raise InvalidArgument(
                 "Got arguments of different types: mapping=%s, optional=%s"
@@ -1275,7 +1275,7 @@ class RandomSeeder:
         self.seed = seed
 
     def __repr__(self):
-        return "RandomSeeder(%r)" % (self.seed,)
+        return f"RandomSeeder({self.seed!r})"
 
 
 class RandomModule(SearchStrategy):
@@ -1489,7 +1489,7 @@ def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
             lambda thing: deferred(lambda: _from_type(thing)),
             (thing,),
             {},
-            force_repr="from_type(%r)" % (thing,),
+            force_repr=f"from_type({thing!r})",
         )
 
 
@@ -1537,7 +1537,7 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
                 % (thing, nicerepr(strat_or_callable), strategy)
             )
         if strategy.is_empty:
-            raise ResolutionFailed("Error: %r resolved to an empty strategy" % (thing,))
+            raise ResolutionFailed(f"Error: {thing!r} resolved to an empty strategy")
         return strategy
 
     if not isinstance(thing, type):
@@ -1568,7 +1568,7 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
                 else:
                     literals.append(arg)
             return sampled_from(literals)
-        raise InvalidArgument("thing=%s must be a type" % (thing,))
+        raise InvalidArgument(f"thing={thing} must be a type")
     # Now that we know `thing` is a type, the first step is to check for an
     # explicitly registered strategy.  This is the best (and hopefully most
     # common) way to resolve a type to a strategy.  Note that the value in the
@@ -1764,10 +1764,10 @@ def _as_finite_decimal(
         if allow_infinity or allow_infinity is None:
             return None
         raise InvalidArgument(
-            "allow_infinity=%r, but %s=%r" % (allow_infinity, name, value)
+            f"allow_infinity={allow_infinity!r}, but {name}={value!r}"
         )
     # This could be infinity, quiet NaN, or signalling NaN
-    raise InvalidArgument("Invalid %s=%r" % (name, value))
+    raise InvalidArgument(f"Invalid {name}={value!r}")
 
 
 @cacheable

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -538,13 +538,13 @@ def floats(
 
     if min_value != min_arg:
         raise InvalidArgument(
-            "min_value=%r cannot be exactly represented as a float of width "
-            "%d - use min_value=%r instead." % (min_arg, width, min_value)
+            f"min_value={min_arg!r} cannot be exactly represented as a float "
+            f"of width {width} - use min_value={min_value!r} instead."
         )
     if max_value != max_arg:
         raise InvalidArgument(
-            "max_value=%r cannot be exactly represented as a float of width "
-            "%d - use max_value=%r instead" % (max_arg, width, max_value)
+            f"max_value={max_arg!r} cannot be exactly represented as a float "
+            f"of width {width} - use max_value={max_value!r} instead."
         )
 
     if exclude_min and (min_value is None or min_value == math.inf):
@@ -834,9 +834,9 @@ def lists(
             element_count = len(elements.elements)
             if min_size > element_count:
                 raise InvalidArgument(
-                    "Cannot create a collection of min_size=%r unique elements with "
-                    "values drawn from only %d distinct elements"
-                    % (min_size, element_count)
+                    f"Cannot create a collection of min_size={min_size!r} unique "
+                    f"elements with values drawn from only {element_count} distinct "
+                    "elements"
                 )
 
             if max_size is not None:
@@ -1833,8 +1833,8 @@ def decimals(
             max_num = floor(ctx(max_value).divide(max_value, factor))
         if min_num is not None and max_num is not None and min_num > max_num:
             raise InvalidArgument(
-                "There are no decimals with %d places between min_value=%r "
-                "and max_value=%r " % (places, min_value, max_value)
+                f"There are no decimals with {places} places between "
+                f"min_value={min_value!r} and max_value={max_value!r}"
             )
         strat = integers(min_num, max_num).map(int_to_decimal)
     else:
@@ -2168,9 +2168,9 @@ class DataObject:
         result = self.conjecture_data.draw(strategy)
         self.count += 1
         if label is not None:
-            note("Draw %d (%s): %r" % (self.count, label, result))
+            note(f"Draw {self.count} ({label}): {result!r}")
         else:
-            note("Draw %d: %r" % (self.count, result))
+            note(f"Draw {self.count}: {result!r}")
         return result
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1074,9 +1074,9 @@ def characters(
     ):
         raise InvalidArgument(
             "Nothing is excluded by other arguments, so passing only "
-            "whitelist_characters=%(chars)r would have no effect.  Also pass "
-            "whitelist_categories=(), or use sampled_from(%(chars)r) instead."
-            % {"chars": whitelist_characters}
+            f"whitelist_characters={whitelist_characters!r} would have no effect.  "
+            "Also pass whitelist_categories=(), or use "
+            f"sampled_from({whitelist_characters!r}) instead."
         )
     blacklist_characters = blacklist_characters or ""
     whitelist_characters = whitelist_characters or ""

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -219,9 +219,9 @@ def datetimes(
     check_type(dt.datetime, min_value, "min_value")
     check_type(dt.datetime, max_value, "max_value")
     if min_value.tzinfo is not None:
-        raise InvalidArgument("min_value=%r must not have tzinfo" % (min_value,))
+        raise InvalidArgument(f"min_value={min_value!r} must not have tzinfo")
     if max_value.tzinfo is not None:
-        raise InvalidArgument("max_value=%r must not have tzinfo" % (max_value,))
+        raise InvalidArgument(f"max_value={max_value!r} must not have tzinfo")
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     if not isinstance(timezones, SearchStrategy):
         raise InvalidArgument(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
@@ -43,14 +43,7 @@ class DeferredStrategy(SearchStrategy):
             result = self.__definition()
             if result is self:
                 raise InvalidArgument("Cannot define a deferred strategy to be itself")
-            if not isinstance(result, SearchStrategy):
-                raise InvalidArgument(
-                    (
-                        "Expected definition to return a SearchStrategy but "
-                        "returned %r of type %s"
-                    )
-                    % (result, type(result).__name__)
-                )
+            check_strategy(result, "definition()")
             self.__wrapped_strategy = result
             self.__definition = None
         return self.__wrapped_strategy

--- a/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
@@ -78,7 +78,7 @@ class DeferredStrategy(SearchStrategy):
     def __repr__(self):
         if self.__wrapped_strategy is not None:
             if self.__in_repr:
-                return "(deferred@%r)" % (id(self),)
+                return "(deferred@{!r})".format(id(self))
             try:
                 self.__in_repr = True
                 return repr(self.__wrapped_strategy)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
@@ -17,7 +17,7 @@ import inspect
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.reflection import get_pretty_function_description
-from hypothesis.strategies._internal.strategies import SearchStrategy
+from hypothesis.strategies._internal.strategies import SearchStrategy, check_strategy
 
 
 class DeferredStrategy(SearchStrategy):
@@ -34,11 +34,8 @@ class DeferredStrategy(SearchStrategy):
         if self.__wrapped_strategy is None:
             if not inspect.isfunction(self.__definition):
                 raise InvalidArgument(
-                    (
-                        "Excepted a definition to be a function but got %r of type"
-                        " %s instead."
-                    )
-                    % (self.__definition, type(self.__definition).__name__)
+                    f"Expected definition to be a function but got {self.__definition!r} "
+                    f"of type {type(self.__definition).__name__} instead."
                 )
             result = self.__definition()
             if result is self:
@@ -78,14 +75,15 @@ class DeferredStrategy(SearchStrategy):
     def __repr__(self):
         if self.__wrapped_strategy is not None:
             if self.__in_repr:
-                return "(deferred@{!r})".format(id(self))
+                return f"(deferred@{id(self)!r})"
             try:
                 self.__in_repr = True
                 return repr(self.__wrapped_strategy)
             finally:
                 self.__in_repr = False
         else:
-            return "deferred(%s)" % (get_pretty_function_description(self.__definition))
+            description = get_pretty_function_description(self.__definition)
+            return f"deferred({description})"
 
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
@@ -101,7 +101,7 @@ class FeatureFlags:
                 disabled.append(name)
             else:
                 enabled.append(name)
-        return "FeatureFlags(enabled=%r, disabled=%r)" % (enabled, disabled)
+        return f"FeatureFlags(enabled={enabled!r}, disabled={disabled!r})"
 
 
 class FeatureStrategy(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
@@ -28,7 +28,7 @@ class FlatMapStrategy(SearchStrategy):
 
     def __repr__(self):
         if not hasattr(self, "_cached_repr"):
-            self._cached_repr = "%r.flatmap(%s)" % (
+            self._cached_repr = "{!r}.flatmap({})".format(
                 self.flatmapped_strategy,
                 get_pretty_function_description(self.expand),
             )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -101,7 +101,7 @@ def ip_addresses(
     if v is not None:
         check_type(int, v, "v")
         if v != 4 and v != 6:
-            raise InvalidArgument("v=%r, but only v=4 or v=6 are valid" % (v,))
+            raise InvalidArgument(f"v={v!r}, but only v=4 or v=6 are valid")
     if network is None:
         # We use the reserved-address registries to boost the chance
         # of generating one of the various special types of address.
@@ -121,6 +121,6 @@ def ip_addresses(
     check_type((IPv4Network, IPv6Network), network, "network")
     assert isinstance(network, (IPv4Network, IPv6Network))  # for Mypy
     if v not in (None, network.version):
-        raise InvalidArgument("v=%r is incompatible with network=%r" % (v, network))
+        raise InvalidArgument(f"v={v!r} is incompatible with network={network!r}")
     addr_type = IPv4Address if network.version == 4 else IPv6Address
     return integers(int(network[0]), int(network[-1])).map(addr_type)  # type: ignore

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -114,7 +114,7 @@ class LazyStrategy(SearchStrategy):
 
     def do_validate(self):
         w = self.wrapped_strategy
-        assert isinstance(w, SearchStrategy), "%r returned non-strategy %r" % (self, w)
+        assert isinstance(w, SearchStrategy), f"{self!r} returned non-strategy {w!r}"
         w.validate()
 
     def __repr__(self):
@@ -140,7 +140,7 @@ class LazyStrategy(SearchStrategy):
             for k, v in defaults.items():
                 if k in kwargs_for_repr and kwargs_for_repr[k] is v:
                     del kwargs_for_repr[k]
-            self.__representation = "%s(%s)" % (
+            self.__representation = "{}({})".format(
                 self.function.__name__,
                 arg_string(self.function, _args, kwargs_for_repr, reorder=False),
             )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
@@ -41,7 +41,7 @@ class JustStrategy(SampledFromStrategy):
     def __repr__(self):
         if self.value is None:
             return "none()"
-        return "just(%r)" % (self.value,)
+        return f"just({self.value!r})"
 
     def calc_has_reusable_values(self, recur):
         return True
@@ -52,7 +52,7 @@ class JustStrategy(SampledFromStrategy):
     def do_draw(self, data):
         result = self._transform(self.value)
         if result is filter_not_satisfied:
-            data.note_event("Aborted test because unable to satisfy %r" % (self,))
+            data.note_event(f"Aborted test because unable to satisfy {self!r}")
             data.mark_invalid()
         return result
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -161,7 +161,7 @@ class FixedBoundedFloatStrategy(SearchStrategy):
         self.width = width
 
     def __repr__(self):
-        return "FixedBoundedFloatStrategy(%s, %s, %s)" % (
+        return "FixedBoundedFloatStrategy({}, {}, {})".format(
             self.lower_bound,
             self.upper_bound,
             self.width,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -51,7 +51,7 @@ class BoundedIntStrategy(SearchStrategy):
         self.end = end
 
     def __repr__(self):
-        return "BoundedIntStrategy(%d, %d)" % (self.start, self.end)
+        return f"BoundedIntStrategy({self.start}, {self.end})"
 
     def do_draw(self, data):
         return d.integer_range(data, self.start, self.end)
@@ -162,9 +162,7 @@ class FixedBoundedFloatStrategy(SearchStrategy):
 
     def __repr__(self):
         return "FixedBoundedFloatStrategy({}, {}, {})".format(
-            self.lower_bound,
-            self.upper_bound,
-            self.width,
+            self.lower_bound, self.upper_bound, self.width
         )
 
     def do_draw(self, data):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -410,7 +410,7 @@ class TrueRandom(HypothesisRandom):
         return result
 
     def __repr__(self):
-        return "Random(%r)" % (self.__seed,)
+        return f"Random({self.__seed!r})"
 
     def seed(self, seed):
         self.__random.seed(seed)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -54,19 +54,10 @@ class HypothesisRandom(Random):
             return
 
         args, kwargs = convert_kwargs(method, kwargs)
-
-        report(
-            "%r.%s(%s) -> %r"
-            % (
-                self,
-                method,
-                ", ".join(
-                    list(map(repr, args))
-                    + ["%s=%r" % (k, v) for k, v in kwargs.items()]
-                ),
-                result,
-            )
+        argstr = ", ".join(
+            list(map(repr, args)) + [f"{k}={v!r}" for k, v in kwargs.items()]
         )
+        report(f"{self!r}.{method}({argstr}) -> {result!r}")
 
     def _hypothesis_do_random(self, method, kwargs):
         raise NotImplementedError()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -256,9 +256,7 @@ class ArtificialRandom(HypothesisRandom):
 
             step = kwargs["step"]
             if start == stop:
-                raise ValueError(
-                    "empty range for randrange(%d, %d, %d)" % (start, stop, step)
-                )
+                raise ValueError(f"empty range for randrange({start}, {stop}, {step})")
 
             if step != 1:
                 endpoint = (stop - start) // step
@@ -289,7 +287,7 @@ class ArtificialRandom(HypothesisRandom):
 
             if k > len(seq) or k < 0:
                 raise ValueError(
-                    "Sample size %d not in expected range 0 <= k <= %d" % (k, len(seq))
+                    f"Sample size {k} not in expected range 0 <= k <= {len(seq)}"
                 )
 
             result = self.__data.draw(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
@@ -16,10 +16,13 @@
 import threading
 from contextlib import contextmanager
 
-from hypothesis.errors import InvalidArgument
 from hypothesis.internal.lazyformat import lazyformat
 from hypothesis.internal.reflection import get_pretty_function_description
-from hypothesis.strategies._internal.strategies import OneOfStrategy, SearchStrategy
+from hypothesis.strategies._internal.strategies import (
+    OneOfStrategy,
+    SearchStrategy,
+    check_strategy,
+)
 
 
 class LimitReached(BaseException):
@@ -94,18 +97,11 @@ class RecursiveStrategy(SearchStrategy):
         return self._cached_repr
 
     def do_validate(self):
-        if not isinstance(self.base, SearchStrategy):
-            raise InvalidArgument(
-                "Expected base to be SearchStrategy but got %r" % (self.base,)
-            )
+        check_strategy(self.base, "base")
         extended = self.extend(self.limited_base)
-        if not isinstance(extended, SearchStrategy):
-            raise InvalidArgument(
-                "Expected extend(%r) to be a SearchStrategy but got %r"
-                % (self.limited_base, extended)
-            )
+        check_strategy(extended, f"extend({self.limited_base!r})")
         self.limited_base.validate()
-        self.extend(self.limited_base).validate()
+        extended.validate()
 
     def do_draw(self, data):
         count = 0

--- a/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
@@ -52,7 +52,7 @@ class LimitedStrategy(SearchStrategy):
         self._threadlocal.currently_capped = value
 
     def __repr__(self):
-        return "LimitedStrategy(%r)" % (self.base_strategy,)
+        return f"LimitedStrategy({self.base_strategy!r})"
 
     def do_validate(self):
         self.base_strategy.validate()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
@@ -29,9 +29,9 @@ class SharedStrategy(SearchStrategy):
 
     def __repr__(self):
         if self.key is not None:
-            return "shared(%r, key=%r)" % (self.base, self.key)
+            return f"shared({self.base!r}, key={self.key!r})"
         else:
-            return "shared(%r)" % (self.base,)
+            return f"shared({self.base!r})"
 
     def do_draw(self, data):
         if not hasattr(data, SHARED_STRATEGY_ATTRIBUTE):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -359,7 +359,7 @@ class SearchStrategy(Generic[Ex]):
         This method is part of the public API.
         """
         if not isinstance(other, SearchStrategy):
-            raise ValueError("Cannot | a SearchStrategy with %r" % (other,))
+            raise ValueError(f"Cannot | a SearchStrategy with {other!r}")
         return OneOfStrategy((self, other))
 
     def validate(self) -> None:
@@ -407,7 +407,7 @@ class SearchStrategy(Generic[Ex]):
         pass
 
     def do_draw(self, data: ConjectureData) -> Ex:
-        raise NotImplementedError("%s.do_draw" % (type(self).__name__,))
+        raise NotImplementedError("{}.do_draw".format(type(self).__name__))
 
     def __init__(self):
         pass
@@ -477,7 +477,7 @@ class SampledFromStrategy(SearchStrategy):
     def do_draw(self, data):
         result = self.do_filtered_draw(data, self)
         if result is filter_not_satisfied:
-            data.note_event("Aborted test because unable to satisfy %r" % (self,))
+            data.note_event(f"Aborted test because unable to satisfy {self!r}")
             data.mark_invalid()
         return result
 
@@ -661,7 +661,7 @@ class MappedSearchStrategy(SearchStrategy):
 
     def __repr__(self):
         if not hasattr(self, "_cached_repr"):
-            self._cached_repr = "%r.map(%s)" % (
+            self._cached_repr = "{!r}.map({})".format(
                 self.mapped_strategy,
                 get_pretty_function_description(self.pack),
             )
@@ -726,7 +726,7 @@ class FilteredStrategy(SearchStrategy):
 
     def __repr__(self):
         if not hasattr(self, "_cached_repr"):
-            self._cached_repr = "%r%s" % (
+            self._cached_repr = "{!r}{}".format(
                 self.filtered_strategy,
                 "".join(
                     ".filter(%s)" % get_pretty_function_description(cond)
@@ -759,7 +759,7 @@ class FilteredStrategy(SearchStrategy):
         if result is not filter_not_satisfied:
             return result
 
-        data.note_event("Aborted test because unable to satisfy %r" % (self,))
+        data.note_event(f"Aborted test because unable to satisfy {self!r}")
         data.mark_invalid()
         raise NotImplementedError("Unreachable, for Mypy")
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -407,7 +407,7 @@ class SearchStrategy(Generic[Ex]):
         pass
 
     def do_draw(self, data: ConjectureData) -> Ex:
-        raise NotImplementedError("{}.do_draw".format(type(self).__name__))
+        raise NotImplementedError(f"{type(self).__name__}.do_draw")
 
     def __init__(self):
         pass

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -62,7 +62,7 @@ except ImportError:
 def type_sorting_key(t):
     """Minimise to None, then non-container types, then container types."""
     if not is_a_type(t):  # This branch is for Python < 3.8
-        raise InvalidArgument("thing=%s must be a type" % (t,))  # pragma: no cover
+        raise InvalidArgument(f"thing={t} must be a type")  # pragma: no cover
     if t is None or t is type(None):  # noqa: E721
         return (-1, repr(t))
     if not isinstance(t, type):  # pragma: no cover
@@ -201,7 +201,7 @@ def from_typing_type(thing):
     if sys.version_info[:2] < (3, 9) and not isinstance(
         thing, typing_root_type
     ):  # pragma: no cover
-        raise ResolutionFailed("Cannot resolve %s to a strategy" % (thing,))
+        raise ResolutionFailed(f"Cannot resolve {thing} to a strategy")
 
     # Some "generic" classes are not generic *in* anything - for example both
     # Hashable and Sized have `__args__ == ()` on Python 3.7 or later.
@@ -655,7 +655,7 @@ def resolve_Callable(thing):
 
 @register(typing.TypeVar)
 def resolve_TypeVar(thing):
-    type_var_key = "typevar=%r" % (thing,)
+    type_var_key = f"typevar={thing!r}"
 
     if getattr(thing, "__bound__", None) is not None:
         bound = thing.__bound__

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -636,7 +636,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
             p.pretty(obj[key])
         p.end_group(1, end)
 
-    inner.__name__ = "_dict_pprinter_factory(%r, %r, %r)" % (start, end, basetype)
+    inner.__name__ = f"_dict_pprinter_factory({start!r}, {end!r}, {basetype!r})"
     return inner
 
 
@@ -744,7 +744,7 @@ def _exception_pprint(obj, p, cycle):
     """Base pprint for all exceptions."""
     name = getattr(obj.__class__, "__qualname__", obj.__class__.__name__)
     if obj.__class__.__module__ not in ("exceptions", "builtins"):
-        name = "%s.%s" % (obj.__class__.__module__, name)
+        name = f"{obj.__class__.__module__}.{name}"
     step = len(name) + 1
     p.begin_group(step, name + "(")
     for idx, arg in enumerate(getattr(obj, "args", ())):

--- a/hypothesis-python/tests/common/__init__.py
+++ b/hypothesis-python/tests/common/__init__.py
@@ -39,6 +39,7 @@ from hypothesis.strategies import (
     text,
     tuples,
 )
+
 from tests.common.debug import TIME_INCREMENT
 
 __all__ = ["standard_types", "OrderedPair", "TIME_INCREMENT"]

--- a/hypothesis-python/tests/common/arguments.py
+++ b/hypothesis-python/tests/common/arguments.py
@@ -26,8 +26,8 @@ def e(a, *args, **kwargs):
 def e_to_str(elt):
     f, args, kwargs = elt
     bits = list(map(repr, args))
-    bits.extend(sorted("%s=%r" % (k, v) for k, v in kwargs.items()))
-    return "%s(%s)" % (f.__name__, ", ".join(bits))
+    bits.extend(sorted(f"{k}={v!r}" for k, v in kwargs.items()))
+    return "{}({})".format(f.__name__, ", ".join(bits))
 
 
 def argument_validation_test(bad_args):

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -23,6 +23,7 @@ from hypothesis import (
 from hypothesis.errors import Found, NoSuchExample, Unsatisfiable
 from hypothesis.internal.conjecture.data import ConjectureData, StopTest
 from hypothesis.internal.reflection import get_pretty_function_description
+
 from tests.common.utils import no_shrink
 
 TIME_INCREMENT = 0.01

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -93,7 +93,7 @@ def find_any(definition, condition=lambda _: True, settings=None):
 def assert_no_examples(strategy, condition=lambda _: True):
     try:
         result = find_any(strategy, condition)
-        assert False, "Expected no results but found %r" % (result,)
+        assert False, f"Expected no results but found {result!r}"
     except (Unsatisfiable, NoSuchExample):
         pass
 
@@ -107,7 +107,7 @@ def assert_all_examples(strategy, predicate):
 
     @given(strategy)
     def assert_examples(s):
-        msg = "Found %r using strategy %s which does not match" % (s, strategy)
+        msg = f"Found {s!r} using strategy {strategy} which does not match"
         assert predicate(s), msg
 
     assert_examples()

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -73,14 +73,10 @@ def run():
 
     for s in settings_module.all_settings.values():
         v = getattr(x, s.name)
-        # Check if it has a dynamically defined default and if so skip
-        # comparison.
+        # Check if it has a dynamically defined default and if so skip comparison.
         if getattr(settings, s.name).show_default:
-            assert v == s.default, "%r == x.%s != s.%s == %r" % (
-                v,
-                s.name,
-                s.name,
-                s.default,
+            assert v == s.default, "({!r} == x.{}) != (s.{} == {!r})".format(
+                v, s.name, s.name, s.default
             )
 
     settings.register_profile(

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -110,8 +110,7 @@ def validate_deprecation():
         warnings.simplefilter("error", HypothesisDeprecationWarning)
         if not any(e.category == HypothesisDeprecationWarning for e in w):
             raise NotDeprecated(
-                "Expected to get a deprecation warning but got %r"
-                % ([e.category for e in w],)
+                f"Expected a deprecation warning but got {[e.category for e in w]!r}"
             )
 
 

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -154,7 +154,7 @@ def counts_calls(func):
 def assert_output_contains_failure(output, test, **kwargs):
     assert test.__name__ + "(" in output
     for k, v in kwargs.items():
-        assert ("%s=%r" % (k, v)) in output
+        assert (f"{k}={v!r}") in output
 
 
 def assert_falsifying_output(

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -164,8 +164,9 @@ def assert_falsifying_output(
         with raises(expected_exception):
             test()
 
-    assert "%s example:" % (example_type,)
-    assert_output_contains_failure(out.getvalue(), test, **kwargs)
+    output = out.getvalue()
+    assert f"{example_type} example:" in output
+    assert_output_contains_failure(output, test, **kwargs)
 
 
 @contextlib.contextmanager

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -21,6 +21,7 @@ import time as time_module
 import pytest
 
 from hypothesis.internal.detection import is_hypothesis_test
+
 from tests.common import TIME_INCREMENT
 from tests.common.setup import run
 

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -105,8 +105,8 @@ def pytest_runtest_call(item):
         if before != after:
             if after in random_states_after_tests:
                 raise Exception(
-                    "%r and %r both used the `random` module, and finished with the "
+                    f"{item.nodeid!r} and {random_states_after_tests[after]!r} "
+                    "both used the `random` module, and finished with the "
                     "same global `random.getstate()`; this is probably a nasty bug!"
-                    % (item.nodeid, random_states_after_tests[after])
                 )
             random_states_after_tests[after] = item.nodeid

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -36,6 +36,7 @@ from hypothesis.internal.conjecture.pareto import DominanceRelation, dominance
 from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.internal.entropy import deterministic_PRNG
+
 from tests.common.strategies import SLOW, HardToShrink
 from tests.common.utils import no_shrink
 from tests.conjecture.common import (

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -20,6 +20,7 @@ from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
+
 from tests.conjecture.common import TEST_SETTINGS, buffer_size_limit
 
 

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -28,6 +28,7 @@ from hypothesis.internal.conjecture.shrinker import (
 )
 from hypothesis.internal.conjecture.shrinking import Float
 from hypothesis.internal.conjecture.utils import Sampler
+
 from tests.conjecture.common import SOME_LABEL, run_to_buffer, shrinking_from
 
 

--- a/hypothesis-python/tests/conjecture/test_shrinking_interface.py
+++ b/hypothesis-python/tests/conjecture/test_shrinking_interface.py
@@ -16,6 +16,7 @@
 from random import Random
 
 from hypothesis.internal.conjecture.shrinking import Integer
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_arbitrary_data.py
+++ b/hypothesis-python/tests/cover/test_arbitrary_data.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import find, given, reporting, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.utils import capture_out, raises
 
 

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -127,7 +127,7 @@ def test_always_evicts_the_lowest_scoring_value(writes, data):
     evicted = set()
 
     def new_score(key):
-        scores[key] = data.draw(st.integers(0, 1000), label="scores[%r]" % (key,))
+        scores[key] = data.draw(st.integers(0, 1000), label=f"scores[{key!r}]")
         return scores[key]
 
     last_entry = [None]
@@ -144,7 +144,7 @@ def test_always_evicts_the_lowest_scoring_value(writes, data):
             return new_score(key)
 
         def on_evict(self, key, value, score):
-            note("Evicted %r" % (key,))
+            note(f"Evicted {key!r}")
             assert score == scores[key]
             del scores[key]
             if len(scores) > 1:

--- a/hypothesis-python/tests/cover/test_cathetus.py
+++ b/hypothesis-python/tests/cover/test_cathetus.py
@@ -35,21 +35,21 @@ def test_cathetus_simple_underflow():
     a = sys.float_info.min
     h = a * math.sqrt(2)
     b = cathetus(h, a)
-    assert b > 0, "expecting positive cathetus(%g, %g), got %g" % (h, a, b)
+    assert b > 0, f"expecting positive cathetus({h:g}, {a:g}), got {b:g}"
 
 
 def test_cathetus_huge_no_overflow():
     h = sys.float_info.max
     a = h / math.sqrt(2)
     b = cathetus(h, a)
-    assert math.isfinite(b), "expecting finite cathetus(%g, %g), got %g" % (h, a, b)
+    assert math.isfinite(b), f"expecting finite cathetus({h:g}, {a:g}), got {b:g}"
 
 
 def test_cathetus_large_no_overflow():
     h = sys.float_info.max / 3
     a = h / math.sqrt(2)
     b = cathetus(h, a)
-    assert math.isfinite(b), "expecting finite cathetus(%g, %g), got %g" % (h, a, b)
+    assert math.isfinite(b), f"expecting finite cathetus({h:g}, {a:g}), got {b:g}"
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -36,7 +36,7 @@ def test_charmap_has_right_categories():
         for u, v in intervals:
             for i in range(u, v + 1):
                 real = unicodedata.category(chr(i))
-                assert real == cat, "%d is %s but reported in %s" % (i, real, cat)
+                assert real == cat, f"{i} is {real} but reported in {cat}"
 
 
 def assert_valid_range_list(ls):

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -18,6 +18,7 @@ import sys
 
 from hypothesis import given, reject, strategies as st
 from hypothesis.strategies import complex_numbers
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import assume, given, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.debug import minimal
 from tests.common.utils import flaky
 

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -29,6 +29,7 @@ from hypothesis.errors import CleanupFailed, InvalidArgument
 from hypothesis.internal.conjecture.data import ConjectureData as TD
 from hypothesis.stateful import RuleBasedStateMachine, rule
 from hypothesis.strategies import integers
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -147,7 +147,7 @@ def test_prints_all_notes_in_verbose_mode():
     @settings(verbosity=Verbosity.debug, database=None)
     @given(integers(1, 10))
     def test(x):
-        msg = "x -> %d" % (x,)
+        msg = f"x -> {x}"
         note(msg)
         messages.add(msg)
         assert x < 5

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -74,7 +74,7 @@ def test_given_shrinks_pytest_helper_errors():
     def inner(x):
         final_value[0] = x
         if x > 100:
-            pytest.fail("x=%r is too big!" % x)
+            pytest.fail(f"x={x!r} is too big!")
 
     with pytest.raises(Failed):
         inner()
@@ -89,7 +89,7 @@ def test_pytest_skip_skips_shrinking():
     def inner(x):
         values.append(x)
         if x > 100:
-            pytest.skip("x=%r is too big!" % x)
+            pytest.skip(f"x={x!r} is too big!")
 
     with pytest.raises(Skipped):
         inner()

--- a/hypothesis-python/tests/cover/test_custom_reprs.py
+++ b/hypothesis-python/tests/cover/test_custom_reprs.py
@@ -25,7 +25,7 @@ def test_includes_non_default_args_in_repr():
 
 def test_sampled_repr_leaves_range_as_range():
     huge = 10 ** 100
-    assert repr(st.sampled_from(range(huge))) == "sampled_from(range(0, %s))" % (huge,)
+    assert repr(st.sampled_from(range(huge))) == f"sampled_from(range(0, {huge}))"
 
 
 def hi(there, stuff):

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.internal.compat import PYPY
 from hypothesis.strategies import dates, datetimes, timedeltas, times
+
 from tests.common.debug import find_any, minimal
 
 

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis import given, settings, strategies as st
 from hypothesis.errors import DeadlineExceeded, Flaky, InvalidArgument
+
 from tests.common.utils import assert_falsifying_output, capture_out, fails_with
 
 

--- a/hypothesis-python/tests/cover/test_debug_information.py
+++ b/hypothesis-python/tests/cover/test_debug_information.py
@@ -18,6 +18,7 @@ import re
 import pytest
 
 from hypothesis import Verbosity, given, settings, strategies as st
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_deferred_strategies.py
+++ b/hypothesis-python/tests/cover/test_deferred_strategies.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.debug import assert_no_examples, minimal
 
 

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -26,6 +26,7 @@ import pytest
 from hypothesis import given, settings, strategies as ds
 from hypothesis.errors import InvalidArgument
 from hypothesis.vendor.pretty import pretty
+
 from tests.common.debug import minimal
 
 # Use `pretty` instead of `repr` for building test names, so that set and dict

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -40,7 +40,7 @@ def fn_test(*fnkwargs):
         ("fn", "args"),
         fnkwargs,
         ids=[
-            "%s(%s)" % (fn.__name__, ", ".join(map(pretty, args)))
+            "{}({})".format(fn.__name__, ", ".join(map(pretty, args)))
             for fn, args in fnkwargs
         ],
     )
@@ -51,7 +51,7 @@ def fn_ktest(*fnkwargs):
     return pytest.mark.parametrize(
         ("fn", "kwargs"),
         fnkwargs,
-        ids=["%s(**%s)" % (fn.__name__, pretty(kwargs)) for fn, kwargs in fnkwargs],
+        ids=["{}(**{})".format(fn.__name__, pretty(kwargs)) for fn, kwargs in fnkwargs],
     )
 
 

--- a/hypothesis-python/tests/cover/test_draw_example.py
+++ b/hypothesis-python/tests/cover/test_draw_example.py
@@ -16,6 +16,7 @@
 import pytest
 
 from hypothesis.strategies import lists
+
 from tests.common import standard_types
 
 

--- a/hypothesis-python/tests/cover/test_error_in_draw.py
+++ b/hypothesis-python/tests/cover/test_error_in_draw.py
@@ -16,6 +16,7 @@
 import pytest
 
 from hypothesis import given, strategies as st
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -27,6 +27,7 @@ from hypothesis.errors import (
     Unsatisfiable,
 )
 from hypothesis.internal.compat import WINDOWS
+
 from tests.common.utils import fails_with
 
 

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -78,7 +78,7 @@ def test_non_interactive_example_emits_warning():
 @pytest.mark.skipif(WINDOWS, reason="pexpect.spawn not supported on Windows")
 def test_interactive_example_does_not_emit_warning():
     try:
-        child = pexpect.spawn("%s -Werror" % (sys.executable,))
+        child = pexpect.spawn(f"{sys.executable} -Werror")
         child.expect(">>> ", timeout=1)
     except pexpect.exceptions.EOF:
         pytest.skip(

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -35,6 +35,7 @@ from hypothesis.errors import (
     MultipleFailures,
 )
 from hypothesis.strategies import floats, integers, nothing, text
+
 from tests.common.utils import assert_falsifying_output, capture_out
 
 

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -193,7 +193,7 @@ def test_examples_are_tried_in_order():
     @settings(phases=[Phase.explicit])
     @example(x=3)
     def test(x):
-        print("x -> %d" % (x,))
+        print(f"x -> {x}")
 
     with capture_out() as out:
         with reporting.with_reporter(reporting.default):
@@ -207,7 +207,7 @@ def test_prints_note_in_failing_example():
     @example(x=43)
     @given(integers())
     def test(x):
-        note("x -> %d" % (x,))
+        note(f"x -> {x}")
         assert x == 42
 
     with capture_out() as out:

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -162,7 +162,7 @@ def test_prints_output_for_explicit_examples():
     def test_positive(x):
         assert x > 0
 
-    assert_falsifying_output(test_positive, x=-1)
+    assert_falsifying_output(test_positive, "Falsifying explicit", x=-1)
 
 
 def test_prints_verbose_output_for_explicit_examples():
@@ -172,9 +172,7 @@ def test_prints_verbose_output_for_explicit_examples():
     def test_always_passes(x):
         pass
 
-    assert_falsifying_output(
-        test_always_passes, x="NOT AN INTEGER", example_type="Trying"
-    )
+    assert_falsifying_output(test_always_passes, "Trying explicit", x="NOT AN INTEGER")
 
 
 def test_captures_original_repr_of_example():
@@ -184,7 +182,7 @@ def test_captures_original_repr_of_example():
         x.append(1)
         assert not x
 
-    assert_falsifying_output(test_mutation, x=[])
+    assert_falsifying_output(test_mutation, "Falsifying explicit", x=[])
 
 
 def test_examples_are_tried_in_order():

--- a/hypothesis-python/tests/cover/test_falsifying_example_output.py
+++ b/hypothesis-python/tests/cover/test_falsifying_example_output.py
@@ -16,6 +16,7 @@
 import pytest
 
 from hypothesis import example, given, strategies as st
+
 from tests.common.utils import capture_out
 
 OUTPUT_NO_LINE_BREAK = """

--- a/hypothesis-python/tests/cover/test_feature_flags.py
+++ b/hypothesis-python/tests/cover/test_feature_flags.py
@@ -15,6 +15,7 @@
 
 from hypothesis import given, strategies as st
 from hypothesis.strategies._internal.featureflags import FeatureFlags, FeatureStrategy
+
 from tests.common.debug import find_any, minimal
 
 STRAT = FeatureStrategy()

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -19,6 +19,7 @@ from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, s
 from hypothesis.errors import Flaky, Unsatisfiable, UnsatisfiedAssumption
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.strategies import booleans, composite, integers, lists, random_module
+
 from tests.common.utils import no_shrink
 
 

--- a/hypothesis-python/tests/cover/test_float_nastiness.py
+++ b/hypothesis-python/tests/cover/test_float_nastiness.py
@@ -30,6 +30,7 @@ from hypothesis.internal.floats import (
     next_down,
     next_up,
 )
+
 from tests.common.debug import find_any, minimal
 
 try:

--- a/hypothesis-python/tests/cover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/cover/test_given_error_conditions.py
@@ -18,6 +18,7 @@ import pytest
 from hypothesis import assume, given, infer, reject, settings
 from hypothesis.errors import InvalidArgument, Unsatisfiable
 from hypothesis.strategies import booleans, integers
+
 from tests.common.utils import fails_with
 
 

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -26,6 +26,7 @@ from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.strategies._internal.lazy import LazyStrategy
 from hypothesis.strategies._internal.strategies import SearchStrategy
+
 from tests.common.utils import no_shrink
 
 HEALTH_CHECK_SETTINGS = settings(max_examples=11, database=None)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -33,6 +33,7 @@ from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.compat import PYPY, get_type_hints, typing_root_type
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types
+
 from tests.common.debug import assert_all_examples, find_any, minimal
 from tests.common.utils import fails_with, temp_registered
 

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -20,6 +20,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.strategies import from_type
+
 from tests.common.debug import find_any
 
 

--- a/hypothesis-python/tests/cover/test_map.py
+++ b/hypothesis-python/tests/cover/test_map.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 from hypothesis import assume, given, strategies as st
+
 from tests.common.debug import assert_no_examples
 
 

--- a/hypothesis-python/tests/cover/test_nothing.py
+++ b/hypothesis-python/tests/cover/test_nothing.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.debug import assert_no_examples, minimal
 
 

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -31,6 +31,7 @@ from hypothesis.strategies import (
     none,
     tuples,
 )
+
 from tests.common.debug import find_any
 
 

--- a/hypothesis-python/tests/cover/test_one_of.py
+++ b/hypothesis-python/tests/cover/test_one_of.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.debug import assert_no_examples
 
 

--- a/hypothesis-python/tests/cover/test_permutations.py
+++ b/hypothesis-python/tests/cover/test_permutations.py
@@ -16,6 +16,7 @@
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import permutations
+
 from tests.common.debug import minimal
 from tests.common.utils import fails_with
 

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -60,6 +60,7 @@ import pytest
 
 from hypothesis.internal.compat import PYPY
 from hypothesis.vendor import pretty
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -85,7 +85,7 @@ def skip_without(mod):
         __import__(mod)
         return lambda f: f
     except ImportError:
-        return pytest.mark.skipif(True, reason="Missing %s" % (mod,))
+        return pytest.mark.skipif(True, reason=f"Missing {mod}")
 
 
 assert_raises = pytest.raises

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -206,7 +206,7 @@ def test_indentation():
     """Test correct indentation in groups."""
     count = 40
     gotoutput = pretty.pretty(MyList(range(count)))
-    expectedoutput = "MyList(\n" + ",\n".join("   %d" % i for i in range(count)) + ")"
+    expectedoutput = "MyList(\n" + ",\n".join(f"   {i}" for i in range(count)) + ")"
 
     assert_equal(gotoutput, expectedoutput)
 
@@ -390,7 +390,7 @@ class MetaClass(type):
         return type.__new__(cls, name, (object,), {"name": name})
 
     def __repr__(self):
-        return "[CUSTOM REPR FOR CLASS %s]" % self.name
+        return f"[CUSTOM REPR FOR CLASS {self.name}]"
 
 
 ClassWithMeta = MetaClass("ClassWithMeta")
@@ -413,7 +413,7 @@ def test_unicode_repr():
     p = pretty.pretty(c)
     assert_equal(p, u)
     p = pretty.pretty([c])
-    assert_equal(p, "[%s]" % u)
+    assert_equal(p, f"[{u}]")
 
 
 def test_basic_class():
@@ -431,7 +431,7 @@ def test_basic_class():
     printer.flush()
     output = stream.getvalue()
 
-    assert_equal(output, "%s.MyObj" % __name__)
+    assert_equal(output, f"{__name__}.MyObj")
     assert_true(type_pprint_wrapper.called)
 
 

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -21,6 +21,7 @@ import pytest
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.provisional import domains, urls
+
 from tests.common.debug import find_any
 
 

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -21,6 +21,7 @@ from hypothesis import find, given, register_random, reporting, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import entropy
 from hypothesis.internal.entropy import deterministic_PRNG
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -28,6 +28,7 @@ from hypothesis.strategies._internal.random import (
     convert_kwargs,
     normalize_zero,
 )
+
 from tests.common.debug import find_any
 from tests.common.utils import capture_out
 

--- a/hypothesis-python/tests/cover/test_recursive.py
+++ b/hypothesis-python/tests/cover/test_recursive.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.debug import find_any, minimal
 
 

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -38,6 +38,7 @@ from hypothesis.internal.reflection import (
     source_exec_as_module,
     unbind_method,
 )
+
 from tests.common.utils import raises
 
 

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -31,6 +31,7 @@ from hypothesis.strategies._internal.regex import (
     UNICODE_WORD_CATEGORIES,
     base_regex_strategy,
 )
+
 from tests.common.debug import assert_all_examples, assert_no_examples, find_any
 
 

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -212,7 +212,7 @@ def test_groups(pattern, is_unicode, invert):
         def group_pred(s):
             return not _p(s)
 
-    pattern = "^%s\\Z" % (pattern,)
+    pattern = f"^{pattern}\\Z"
 
     compiler = unicode_regex if is_unicode else ascii_regex
     strategy = st.from_regex(compiler(pattern))

--- a/hypothesis-python/tests/cover/test_reporting.py
+++ b/hypothesis-python/tests/cover/test_reporting.py
@@ -22,6 +22,7 @@ from hypothesis import given, reporting
 from hypothesis._settings import Verbosity, settings
 from hypothesis.reporting import debug_report, report, verbose_report
 from hypothesis.strategies import integers
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -31,6 +31,7 @@ from hypothesis import (
 )
 from hypothesis.core import decode_failure, encode_failure
 from hypothesis.errors import DidNotReproduce, InvalidArgument, UnsatisfiedAssumption
+
 from tests.common.utils import capture_out, no_shrink
 
 

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -54,7 +54,7 @@ def test_decoding_may_fail(t):
     except InvalidArgument:
         pass
     except Exception as e:
-        assert False, "decoding failed with %r, not InvalidArgument" % (e,)
+        raise AssertionError("Expected an InvalidArgument exception") from e
 
 
 def test_invalid_base_64_gives_invalid_argument():

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -32,6 +32,7 @@ from hypothesis.strategies._internal.strategies import (
     FilteredStrategy,
     filter_not_satisfied,
 )
+
 from tests.common.utils import fails_with
 
 an_enum = enum.Enum("A", "a b c")

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -20,6 +20,7 @@ import pytest
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import booleans, integers, just, tuples
+
 from tests.common.debug import assert_no_examples
 
 

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -45,7 +45,7 @@ def test_just_strategy_uses_repr():
         def __repr__(self):
             return "ABCDEFG"
 
-    assert repr(just(WeirdRepr())) == "just(%r)" % (WeirdRepr(),)
+    assert repr(just(WeirdRepr())) == f"just({WeirdRepr()!r})"
 
 
 def test_can_map():

--- a/hypothesis-python/tests/cover/test_seed_printing.py
+++ b/hypothesis-python/tests/cover/test_seed_printing.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import Verbosity, assume, core, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck
+
 from tests.common.utils import all_values, capture_out
 
 

--- a/hypothesis-python/tests/cover/test_seed_printing.py
+++ b/hypothesis-python/tests/cover/test_seed_printing.py
@@ -58,12 +58,12 @@ def test_prints_seed_only_on_healthcheck(
     seed = test._hypothesis_internal_use_generated_seed
     assert seed is not None
     if fail_healthcheck and verbosity != Verbosity.quiet:
-        assert "@seed(%d)" % (seed,) in output
-        contains_pytest_instruction = ("--hypothesis-seed=%d" % (seed,)) in output
+        assert f"@seed({seed})" in output
+        contains_pytest_instruction = (f"--hypothesis-seed={seed}") in output
         assert contains_pytest_instruction == in_pytest
     else:
         assert "@seed" not in output
-        assert "--hypothesis-seed=%d" % (seed,) not in output
+        assert f"--hypothesis-seed={seed}" not in output
 
 
 def test_uses_global_force(monkeypatch):

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -37,6 +37,7 @@ from hypothesis.errors import (
 )
 from hypothesis.stateful import RuleBasedStateMachine, rule
 from hypothesis.utils.conventions import not_set
+
 from tests.common.utils import counts_calls, fails_with
 
 

--- a/hypothesis-python/tests/cover/test_simple_characters.py
+++ b/hypothesis-python/tests/cover/test_simple_characters.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import characters
+
 from tests.common.debug import assert_no_examples, find_any, minimal
 from tests.common.utils import fails_with
 

--- a/hypothesis-python/tests/cover/test_simple_collections.py
+++ b/hypothesis-python/tests/cover/test_simple_collections.py
@@ -32,6 +32,7 @@ from hypothesis.strategies import (
     text,
     tuples,
 )
+
 from tests.common.debug import find_any, minimal
 from tests.common.utils import flaky
 

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -15,6 +15,7 @@
 
 from hypothesis import given
 from hypothesis.strategies import binary, characters, text, tuples
+
 from tests.common.debug import minimal
 from tests.common.utils import fails_with
 

--- a/hypothesis-python/tests/cover/test_slices.py
+++ b/hypothesis-python/tests/cover/test_slices.py
@@ -16,6 +16,7 @@
 import pytest
 
 from hypothesis import given, settings, strategies as st
+
 from tests.common.debug import assert_all_examples, find_any, minimal
 
 use_several_sizes = pytest.mark.parametrize("size", [1, 2, 5, 10, 100, 1000])

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -19,6 +19,7 @@ from hypothesis import Phase, assume, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import Flaky, MultipleFailures
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
+
 from tests.common.utils import (
     assert_output_contains_failure,
     capture_out,

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -35,6 +35,7 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
 )
 from hypothesis.strategies import binary, booleans, data, integers, just, lists
+
 from tests.common.utils import capture_out, raises
 
 NO_BLOB_SETTINGS = Settings(print_blob=False)

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -527,7 +527,7 @@ class RequiresInit(RuleBasedStateMachine):
     @rule(value=integers())
     def action(self, value):
         if value > self.threshold:
-            raise ValueError("%d is too high" % (value,))
+            raise ValueError(f"{value} is too high")
 
 
 def test_can_use_factory_for_tests():
@@ -921,7 +921,7 @@ def test_initialize_rule_populate_bundle():
 
         @initialize(target=a, dep=just("dep"))
         def initialize_a(self, dep):
-            return "a v1 with (%s)" % dep
+            return f"a v1 with ({dep})"
 
         @rule(param=a)
         def fail_fast(self, param):

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -84,7 +84,7 @@ class Foo:
         seen.append(self)
         global counter
         counter += 1
-        return "COUNTER %d" % (counter,)
+        return f"COUNTER {counter}"
 
 
 def test_formats_are_evaluated_only_once():

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -33,6 +33,7 @@ from hypothesis.strategies import (
     sets,
     text,
 )
+
 from tests.common.utils import (
     assert_falsifying_output,
     capture_out,

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -83,7 +83,7 @@ def test_still_minimizes_on_non_assertion_failures():
     @given(integers())
     def is_not_too_large(x):
         if x >= 10:
-            raise ValueError("No, %s is just too large. Sorry" % x)
+            raise ValueError(f"No, {x} is just too large. Sorry")
 
     with raises(ValueError) as exinfo:
         is_not_too_large()

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -28,6 +28,7 @@ from hypothesis.errors import (
 from hypothesis.strategies._internal import types
 from hypothesis.strategies._internal.core import _strategies
 from hypothesis.strategies._internal.types import _global_type_lookup
+
 from tests.common.debug import assert_all_examples, find_any
 from tests.common.utils import fails_with, temp_registered
 

--- a/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
@@ -38,6 +38,7 @@ import pytest
 from hypothesis import given, strategies as st
 from hypothesis.errors import ResolutionFailed
 from hypothesis.internal.compat import ForwardRef
+
 from tests.common import utils
 
 if TYPE_CHECKING:

--- a/hypothesis-python/tests/cover/test_unittest.py
+++ b/hypothesis-python/tests/cover/test_unittest.py
@@ -21,6 +21,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import FailedHealthCheck, HypothesisWarning
+
 from tests.common.utils import fails_with
 
 

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -36,6 +36,7 @@ from hypothesis.strategies import (
     text,
 )
 from hypothesis.strategies._internal.strategies import check_strategy
+
 from tests.common.utils import fails_with
 
 

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -19,6 +19,7 @@ from hypothesis import example, find, given
 from hypothesis._settings import Verbosity, settings
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.strategies import booleans, integers, lists
+
 from tests.common.debug import minimal
 from tests.common.utils import capture_out, fails
 

--- a/hypothesis-python/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis-python/tests/datetime/test_dateutil_timezones.py
@@ -23,6 +23,7 @@ from hypothesis.errors import FailedHealthCheck, InvalidArgument
 from hypothesis.extra.dateutil import timezones
 from hypothesis.strategies import data, datetimes, just, sampled_from, times
 from hypothesis.strategies._internal.datetime import datetime_does_not_exist
+
 from tests.common.debug import assert_all_examples, find_any, minimal
 from tests.common.utils import fails_with
 

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -23,6 +23,7 @@ from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.pytz import timezones
 from hypothesis.strategies import data, datetimes, just, sampled_from, times
+
 from tests.common.debug import (
     assert_all_examples,
     assert_can_trigger_event,

--- a/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies._internal.datetime import zoneinfo
+
 from tests.common.debug import assert_no_examples, find_any, minimal
 
 

--- a/hypothesis-python/tests/django/manage.py
+++ b/hypothesis-python/tests/django/manage.py
@@ -18,6 +18,7 @@ import sys
 import warnings
 
 from hypothesis import HealthCheck, settings
+
 from tests.common.setup import run
 
 if __name__ == "__main__":

--- a/hypothesis-python/tests/django/toystore/forms.py
+++ b/hypothesis-python/tests/django/toystore/forms.py
@@ -34,12 +34,12 @@ from tests.django.toystore.models import (
 class ReprModelForm(forms.ModelForm):
     def __repr__(self):
         """I recommend putting this in your form to show the failed cases."""
-        return "%r\n%r" % (self.data, self.errors)
+        return f"{self.data!r}\n{self.errors!r}"
 
 
 class ReprForm(forms.Form):
     def __repr__(self):
-        return "%r\n%r" % (self.data, self.errors)
+        return f"{self.data!r}\n{self.errors!r}"
 
 
 class CouldBeCharmingForm(ReprModelForm):

--- a/hypothesis-python/tests/django/toystore/forms.py
+++ b/hypothesis-python/tests/django/toystore/forms.py
@@ -76,7 +76,7 @@ class DynamicForm(ReprForm):
     def __init__(self, field_count=5, **kwargs):
         super().__init__(**kwargs)
         for i in range(field_count):
-            field_name = "field-%d" % (i,)
+            field_name = f"field-{i}"
             self.fields[field_name] = forms.CharField(required=False)
 
 

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -24,6 +24,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django import TestCase, TransactionTestCase
 from hypothesis.internal.compat import PYPY
 from hypothesis.strategies import integers
+
 from tests.django.toystore.models import Company
 
 

--- a/hypothesis-python/tests/django/toystore/test_given_forms.py
+++ b/hypothesis-python/tests/django/toystore/test_given_forms.py
@@ -16,6 +16,7 @@
 from hypothesis import given
 from hypothesis.extra.django import TestCase, from_form, register_field_strategy
 from hypothesis.strategies import booleans, sampled_from
+
 from tests.django.toystore.forms import (
     BasicFieldForm,
     BroadBooleanField,

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -30,6 +30,7 @@ from hypothesis.extra.django import (
 )
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies import binary, just, lists
+
 from tests.django.toystore.models import (
     Car,
     Company,

--- a/hypothesis-python/tests/lark/test_grammar.py
+++ b/hypothesis-python/tests/lark/test_grammar.py
@@ -22,6 +22,7 @@ from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.lark import from_lark
 from hypothesis.strategies import data, just
+
 from tests.common.debug import find_any
 
 # Adapted from the official Lark tutorial, with modifications to ensure

--- a/hypothesis-python/tests/nocover/test_argument_validation.py
+++ b/hypothesis-python/tests/nocover/test_argument_validation.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis import strategies as st
 from hypothesis.strategies._internal.core import _strategies
+
 from tests.common.arguments import argument_validation_test, e
 
 BAD_ARGS = []

--- a/hypothesis-python/tests/nocover/test_argument_validation.py
+++ b/hypothesis-python/tests/nocover/test_argument_validation.py
@@ -61,4 +61,4 @@ def test_consistent_with_api_guide_on_kwonly_args(name):
             or arg.kind != Parameter.POSITIONAL_OR_KEYWORD
             or arg.name in ("min_value", "max_value", "subtype_strategy", "columns")
             or name in ("text", "range_indexes", "badly_draw_lists", "write_pattern")
-        ), "need kwonly args in %s" % (name,)
+        ), f"need kwonly args in {name}"

--- a/hypothesis-python/tests/nocover/test_bad_repr.py
+++ b/hypothesis-python/tests/nocover/test_bad_repr.py
@@ -32,9 +32,7 @@ def test_just_frosty():
 
 
 def test_sampling_snowmen():
-    assert repr(st.sampled_from((Frosty, "hi"))) == "sampled_from((☃, %s))" % (
-        repr("hi"),
-    )
+    assert repr(st.sampled_from((Frosty, "hi"))) == "sampled_from((☃, 'hi'))"
 
 
 def varargs(*args, **kwargs):

--- a/hypothesis-python/tests/nocover/test_boundary_exploration.py
+++ b/hypothesis-python/tests/nocover/test_boundary_exploration.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import HealthCheck, Verbosity, given, reject, settings, strategies as st
 from hypothesis.errors import Unsatisfiable
+
 from tests.common.debug import minimal
 from tests.common.utils import no_shrink
 

--- a/hypothesis-python/tests/nocover/test_build_signature.py
+++ b/hypothesis-python/tests/nocover/test_build_signature.py
@@ -17,6 +17,7 @@ from inspect import signature
 from typing import List, get_type_hints
 
 from hypothesis import given, strategies as st
+
 from tests.common.debug import find_any
 
 

--- a/hypothesis-python/tests/nocover/test_collective_minimization.py
+++ b/hypothesis-python/tests/nocover/test_collective_minimization.py
@@ -18,6 +18,7 @@ import pytest
 from hypothesis import settings
 from hypothesis.errors import Unsatisfiable
 from hypothesis.strategies import lists
+
 from tests.common import standard_types
 from tests.common.debug import minimal
 from tests.common.utils import flaky

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -19,6 +19,7 @@ from hypothesis.internal.compat import int_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
+
 from tests.common.utils import counts_calls, non_covering_examples
 from tests.conjecture.common import run_to_buffer, shrinking_from
 

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -19,6 +19,7 @@ from hypothesis import assume, core, find, given, settings, strategies as st
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from hypothesis.internal.entropy import deterministic_PRNG
+
 from tests.common.utils import all_values, non_covering_examples
 
 

--- a/hypothesis-python/tests/nocover/test_filtering.py
+++ b/hypothesis-python/tests/nocover/test_filtering.py
@@ -70,5 +70,5 @@ def test_chained_filters_repr(base):
 
     filtered = base.filter(foo)
     chained = filtered.filter(bar)
-    assert repr(chained) == "%r.filter(foo).filter(bar)" % (base,)
-    assert repr(filtered) == "%r.filter(foo)" % (base,)
+    assert repr(chained) == f"{base!r}.filter(foo).filter(bar)"
+    assert repr(filtered) == f"{base!r}.filter(foo)"

--- a/hypothesis-python/tests/nocover/test_find.py
+++ b/hypothesis-python/tests/nocover/test_find.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import find, settings as Settings
 from hypothesis.errors import NoSuchExample
 from hypothesis.strategies import booleans, dictionaries, floats, integers, lists
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -29,6 +29,7 @@ from hypothesis.strategies import (
     text,
     tuples,
 )
+
 from tests.common.debug import minimal
 
 ConstantLists = integers().flatmap(lambda i: lists(just(i)))

--- a/hypothesis-python/tests/nocover/test_floating.py
+++ b/hypothesis-python/tests/nocover/test_floating.py
@@ -20,6 +20,7 @@ import sys
 
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.strategies import data, floats, lists
+
 from tests.common.utils import fails
 
 TRY_HARDER = settings(

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -19,6 +19,7 @@ from hypothesis import given
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.strategies import integers
 from hypothesis.strategies._internal.strategies import SearchStrategy
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/nocover/test_large_examples.py
+++ b/hypothesis-python/tests/nocover/test_large_examples.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 from hypothesis import strategies as st
+
 from tests.common.debug import find_any
 
 

--- a/hypothesis-python/tests/nocover/test_nesting.py
+++ b/hypothesis-python/tests/nocover/test_nesting.py
@@ -16,6 +16,7 @@
 from pytest import raises
 
 from hypothesis import Verbosity, given, settings, strategies as st
+
 from tests.common.utils import no_shrink
 
 

--- a/hypothesis-python/tests/nocover/test_randomization.py
+++ b/hypothesis-python/tests/nocover/test_randomization.py
@@ -18,6 +18,7 @@ import random
 from pytest import raises
 
 from hypothesis import Verbosity, find, given, settings, strategies as st
+
 from tests.common.utils import no_shrink
 
 

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -16,6 +16,7 @@
 import threading
 
 from hypothesis import given, settings, strategies as st
+
 from tests.common.debug import find_any, minimal
 from tests.common.utils import flaky
 

--- a/hypothesis-python/tests/nocover/test_regex.py
+++ b/hypothesis-python/tests/nocover/test_regex.py
@@ -26,9 +26,9 @@ def charset(draw):
     negated = draw(st.booleans())
     chars = draw(st.text(string.ascii_letters + string.digits, min_size=1))
     if negated:
-        return "[^%s]" % (chars,)
+        return f"[^{chars}]"
     else:
-        return "[%s]" % (chars,)
+        return f"[{chars}]"
 
 
 COMBINED_MATCHER = re.compile("[?+*]{2}")
@@ -41,7 +41,7 @@ def conservative_regex(draw):
             st.just("."),
             st.sampled_from([re.escape(c) for c in string.printable]),
             charset(),
-            CONSERVATIVE_REGEX.map(lambda s: "(%s)" % (s,)),
+            CONSERVATIVE_REGEX.map(lambda s: f"({s})"),
             CONSERVATIVE_REGEX.map(lambda s: s + "+"),
             CONSERVATIVE_REGEX.map(lambda s: s + "?"),
             CONSERVATIVE_REGEX.map(lambda s: s + "*"),

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
+
 from tests.common.utils import counts_calls, fails_with
 
 

--- a/hypothesis-python/tests/nocover/test_sets.py
+++ b/hypothesis-python/tests/nocover/test_sets.py
@@ -15,6 +15,7 @@
 
 from hypothesis import given, settings
 from hypothesis.strategies import floats, integers, sets
+
 from tests.common.debug import find_any
 
 

--- a/hypothesis-python/tests/nocover/test_sharing.py
+++ b/hypothesis-python/tests/nocover/test_sharing.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 from hypothesis import given, strategies as st
+
 from tests.common.debug import find_any, minimal
 
 x = st.shared(st.integers())

--- a/hypothesis-python/tests/nocover/test_simple_numbers.py
+++ b/hypothesis-python/tests/nocover/test_simple_numbers.py
@@ -20,6 +20,7 @@ import pytest
 
 from hypothesis import given
 from hypothesis.strategies import floats, integers, lists
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/nocover/test_skipping.py
+++ b/hypothesis-python/tests/nocover/test_skipping.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import given
 from hypothesis.core import skip_exceptions_to_reraise
 from hypothesis.strategies import integers
+
 from tests.common.utils import capture_out
 
 

--- a/hypothesis-python/tests/nocover/test_strategy_state.py
+++ b/hypothesis-python/tests/nocover/test_strategy_state.py
@@ -46,7 +46,7 @@ def clamp(lower, value, upper):
     """Given a value and optional lower/upper bounds, 'clamp' the value so that
     it satisfies lower <= value <= upper."""
     if (lower is not None) and (upper is not None) and (lower > upper):
-        raise ValueError("Cannot clamp with lower > upper: %r > %r" % (lower, upper))
+        raise ValueError(f"Cannot clamp with lower > upper: {lower!r} > {upper!r}")
     if lower is not None:
         value = max(lower, value)
     if upper is not None:

--- a/hypothesis-python/tests/nocover/test_testdecorators.py
+++ b/hypothesis-python/tests/nocover/test_testdecorators.py
@@ -16,6 +16,7 @@
 from hypothesis import HealthCheck, given, reject, settings
 from hypothesis.errors import InvalidArgument, Unsatisfiable
 from hypothesis.strategies import integers
+
 from tests.common.utils import raises
 
 

--- a/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
@@ -21,6 +21,7 @@ import pytest
 from hypothesis import given, strategies as st
 from hypothesis.errors import ResolutionFailed
 from hypothesis.internal.compat import ForwardRef
+
 from tests.common import utils
 
 skip_before_python37 = pytest.mark.skipif(

--- a/hypothesis-python/tests/nocover/test_uuids.py
+++ b/hypothesis-python/tests/nocover/test_uuids.py
@@ -16,6 +16,7 @@
 import pytest
 
 from hypothesis import given, strategies as st
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -22,8 +22,8 @@ from hypothesis.extra import numpy as nps
 
 
 def e(a, **kwargs):
-    rep = "{}({})".format(a.__name__, ", ".join("%s=%r" % it for it in kwargs.items()))
-    return pytest.param(a, kwargs, id=rep)
+    kw = ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
+    return pytest.param(a, kwargs, id=f"{a.__name__}({kw})")
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -22,7 +22,7 @@ from hypothesis.extra import numpy as nps
 
 
 def e(a, **kwargs):
-    rep = "%s(%s)" % (a.__name__, ", ".join("%s=%r" % it for it in kwargs.items()))
+    rep = "{}({})".format(a.__name__, ", ".join("%s=%r" % it for it in kwargs.items()))
     return pytest.param(a, kwargs, id=rep)
 
 

--- a/hypothesis-python/tests/numpy/test_fill_values.py
+++ b/hypothesis-python/tests/numpy/test_fill_values.py
@@ -15,6 +15,7 @@
 
 from hypothesis import given, strategies as st
 from hypothesis.extra.numpy import arrays
+
 from tests.common.debug import find_any, minimal
 
 

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -20,6 +20,7 @@ from hypothesis import assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as nps
 from hypothesis.strategies._internal import SearchStrategy
+
 from tests.common.debug import find_any
 
 STANDARD_TYPES = [

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -23,6 +23,7 @@ import pytest
 from hypothesis import HealthCheck, assume, given, note, settings, strategies as st
 from hypothesis.errors import InvalidArgument, Unsatisfiable
 from hypothesis.extra import numpy as nps
+
 from tests.common.debug import find_any, minimal
 from tests.common.utils import fails_with, flaky
 

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -568,7 +568,7 @@ def _broadcast_two_shapes(shape_a: nps.Shape, shape_b: nps.Shape) -> nps.Shape:
     for a, b in zip_longest(reversed(shape_a), reversed(shape_b), fillvalue=1):
         if a != b and (a != 1) and (b != 1):
             raise ValueError(
-                "shapes %r and %r are not broadcast-compatible" % (shape_a, shape_b)
+                f"shapes {shape_a!r} and {shape_b!r} are not broadcast-compatible"
             )
         result.append(a if a != 1 else b)
     return tuple(reversed(result))

--- a/hypothesis-python/tests/numpy/test_gufunc.py
+++ b/hypothesis-python/tests/numpy/test_gufunc.py
@@ -20,6 +20,7 @@ from pytest import param
 from hypothesis import example, given, note, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as nps
+
 from tests.common.debug import find_any, minimal
 
 

--- a/hypothesis-python/tests/numpy/test_sampled_from.py
+++ b/hypothesis-python/tests/numpy/test_sampled_from.py
@@ -17,6 +17,7 @@ from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as npst
 from hypothesis.strategies import data, sampled_from
+
 from tests.common.utils import fails_with
 
 

--- a/hypothesis-python/tests/pandas/test_argument_validation.py
+++ b/hypothesis-python/tests/pandas/test_argument_validation.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 from hypothesis import given, strategies as st
 from hypothesis.extra import pandas as pdst
+
 from tests.common.arguments import argument_validation_test, e
 
 BAD_ARGS = [

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from hypothesis import HealthCheck, given, reject, settings, strategies as st
 from hypothesis.extra import numpy as npst, pandas as pdst
+
 from tests.common.debug import find_any
 from tests.pandas.helpers import supported_by_pandas
 

--- a/hypothesis-python/tests/pandas/test_indexes.py
+++ b/hypothesis-python/tests/pandas/test_indexes.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import HealthCheck, given, reject, settings, strategies as st
 from hypothesis.errors import Unsatisfiable
 from hypothesis.extra import numpy as npst, pandas as pdst
+
 from tests.pandas.helpers import supported_by_pandas
 
 

--- a/hypothesis-python/tests/pandas/test_series.py
+++ b/hypothesis-python/tests/pandas/test_series.py
@@ -18,6 +18,7 @@ import pandas
 
 from hypothesis import assume, given, strategies as st
 from hypothesis.extra import numpy as npst, pandas as pdst
+
 from tests.common.debug import find_any
 from tests.pandas.helpers import supported_by_pandas
 

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -84,7 +84,7 @@ def get_line_num(token, result, skip_n=0):
                 return i
             else:
                 skipped += 1
-    assert False, "Token %r not found (skipped %r of planned %r skips)" % (
+    assert False, "Token {!r} not found (skipped {!r} of planned {!r} skips)".format(
         token,
         skipped,
         skip_n,

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -84,10 +84,8 @@ def get_line_num(token, result, skip_n=0):
                 return i
             else:
                 skipped += 1
-    assert False, "Token {!r} not found (skipped {!r} of planned {!r} skips)".format(
-        token,
-        skipped,
-        skip_n,
+    raise AssertionError(
+        f"Token {token!r} not found (skipped {skipped} of planned {skip_n} skips)"
     )
 
 

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis import example, given
 from hypothesis.strategies import integers
+
 from tests.common.utils import fails
 
 pytest_plugins = "pytester"

--- a/hypothesis-python/tests/pytest/test_runs.py
+++ b/hypothesis-python/tests/pytest/test_runs.py
@@ -15,6 +15,7 @@
 
 from hypothesis import given
 from hypothesis.strategies import integers
+
 from tests.common.utils import fails
 
 

--- a/hypothesis-python/tests/pytest/test_seeding.py
+++ b/hypothesis-python/tests/pytest/test_seeding.py
@@ -82,7 +82,7 @@ def test_failure(i):
     if target is None:
         assume(i not in seen)
     else:
-        target.write("%s\\n" % (i,))
+        target.write(f"{i}\\n")
         reject()
 """
 

--- a/hypothesis-python/tests/quality/test_deferred_strategies.py
+++ b/hypothesis-python/tests/quality/test_deferred_strategies.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 from hypothesis import strategies as st
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -43,6 +43,7 @@ from hypothesis.strategies import (
     text,
     tuples,
 )
+
 from tests.common.utils import no_shrink
 
 RUNS = 100

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -109,14 +109,10 @@ def define_test(specifier, predicate, condition=None, p=0.5, suppress_health_che
             event += "|"
             event += condition_string
 
-        description = ("P(%s) ~ %d / %d = %.2f < %.2f") % (
-            event,
-            successes,
-            RUNS,
-            successes / RUNS,
-            (required_runs / RUNS),
+        raise HypothesisFalsified(
+            f"P({event}) ~ {successes} / {RUNS} = {successes / RUNS:.2f} < "
+            f"{required_runs / RUNS:.2f} rejected"
         )
-        raise HypothesisFalsified(description + " rejected")
 
     return run_test
 
@@ -257,10 +253,9 @@ one_of_nested_strategy = one_of(
 
 for i in range(8):
     exec(
-        """test_one_of_flattens_branches_%d = define_test(
-        one_of_nested_strategy, lambda x: x == %d
+        f"""test_one_of_flattens_branches_{i} = define_test(
+        one_of_nested_strategy, lambda x: x == {i}
     )"""
-        % (i, i)
     )
 
 
@@ -270,10 +265,9 @@ xor_nested_strategy = just(0) | (
 
 for i in range(8):
     exec(
-        """test_xor_flattens_branches_%d = define_test(
-        xor_nested_strategy, lambda x: x == %d
+        f"""test_xor_flattens_branches_{i} = define_test(
+        xor_nested_strategy, lambda x: x == {i}
     )"""
-        % (i, i)
     )
 
 
@@ -296,10 +290,9 @@ one_of_nested_strategy_with_map = one_of(
 
 for i in (1, 4, 6, 16, 20, 24, 28, 32):
     exec(
-        """test_one_of_flattens_map_branches_%d = define_test(
-        one_of_nested_strategy_with_map, lambda x: x == %d
+        f"""test_one_of_flattens_map_branches_{i} = define_test(
+        one_of_nested_strategy_with_map, lambda x: x == {i}
     )"""
-        % (i, i)
     )
 
 
@@ -319,10 +312,9 @@ one_of_nested_strategy_with_flatmap = just(None).flatmap(
 
 for i in range(8):
     exec(
-        """test_one_of_flattens_flatmap_branches_%d = define_test(
-        one_of_nested_strategy_with_flatmap, lambda x: len(x) == %d
+        f"""test_one_of_flattens_flatmap_branches_{i} = define_test(
+        one_of_nested_strategy_with_flatmap, lambda x: len(x) == {i}
     )"""
-        % (i, i)
     )
 
 
@@ -340,10 +332,9 @@ xor_nested_strategy_with_flatmap = just(None).flatmap(
 
 for i in range(8):
     exec(
-        """test_xor_flattens_flatmap_branches_%d = define_test(
-        xor_nested_strategy_with_flatmap, lambda x: len(x) == %d
+        f"""test_xor_flattens_flatmap_branches_{i} = define_test(
+        xor_nested_strategy_with_flatmap, lambda x: len(x) == {i}
     )"""
-        % (i, i)
     )
 
 
@@ -357,10 +348,9 @@ one_of_nested_strategy_with_filter = one_of(
 
 for i in range(4):
     exec(
-        """test_one_of_flattens_filter_branches_%d = define_test(
-        one_of_nested_strategy_with_filter, lambda x: x == 2 * %d
+        f"""test_one_of_flattens_filter_branches_{i} = define_test(
+        one_of_nested_strategy_with_filter, lambda x: x == 2 * {i}
     )"""
-        % (i, i)
     )
 
 

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -25,6 +25,7 @@ from hypothesis import (
     strategies as st,
 )
 from hypothesis.internal.compat import ceil
+
 from tests.common.debug import minimal
 
 

--- a/hypothesis-python/tests/quality/test_normalization.py
+++ b/hypothesis-python/tests/quality/test_normalization.py
@@ -20,6 +20,7 @@ import pytest
 from hypothesis import strategies as st
 from hypothesis.errors import UnsatisfiedAssumption
 from hypothesis.internal.conjecture.shrinking import dfas
+
 from tests.quality.test_shrinking_order import iter_values
 
 

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -37,6 +37,7 @@ from hypothesis.strategies import (
     text,
     tuples,
 )
+
 from tests.common.debug import minimal
 from tests.common.utils import flaky
 

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -1,5 +1,3 @@
-autoflake
-black
 blacken-docs
 coverage
 django
@@ -12,17 +10,16 @@ flake8-comprehensions
 flake8-docstrings
 flake8-mutable
 ipython < 7.17  # drops support for Python 3.6
-isort
 lark-parser
 libcst
 mypy
 pip-tools
 pytest
 python-dateutil
-pyupgrade
 pyupio
 requests
 restructuredtext-lint
+shed
 sphinx
 sphinx-hoverxref
 sphinx-rtd-theme

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -18,7 +18,7 @@ attrs==20.3.0
     #   hypothesis (hypothesis-python/setup.py)
     #   pytest
 autoflake==1.4
-    # via -r requirements/tools.in
+    # via shed
 babel==2.9.0
     # via sphinx
 backcall==0.2.0
@@ -27,8 +27,8 @@ bandit==1.7.0
     # via flake8-bandit
 black==20.8b1
     # via
-    #   -r requirements/tools.in
     #   blacken-docs
+    #   shed
 blacken-docs==1.8.0
     # via -r requirements/tools.in
 bleach==3.2.1
@@ -43,10 +43,14 @@ click==7.1.2
     # via
     #   black
     #   pip-tools
+    #   pybetter
+    #   pyemojify
     #   pyupio
     #   safety
 colorama==0.4.4
     # via twine
+com2ann==0.1.1
+    # via shed
 coverage==5.3.1
     # via -r requirements/tools.in
 cryptography==3.3.1
@@ -115,7 +119,7 @@ ipython-genutils==0.2.0
 ipython==7.16.1
     # via -r requirements/tools.in
 isort==5.7.0
-    # via -r requirements/tools.in
+    # via shed
 jedi==0.18.0
     # via ipython
 jeepney==0.6.0
@@ -131,7 +135,10 @@ keyring==21.8.0
 lark-parser==0.11.1
     # via -r requirements/tools.in
 libcst==0.3.16
-    # via -r requirements/tools.in
+    # via
+    #   -r requirements/tools.in
+    #   pybetter
+    #   shed
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
@@ -178,6 +185,8 @@ py==1.10.0
     # via
     #   pytest
     #   tox
+pybetter==0.3.6.1
+    # via shed
 pycodestyle==2.6.0
     # via
     #   flake8
@@ -186,6 +195,8 @@ pycparser==2.20
     # via cffi
 pydocstyle==5.1.1
     # via flake8-docstrings
+pyemojify==0.2.0
+    # via pybetter
 pyflakes==2.2.0
     # via
     #   autoflake
@@ -195,6 +206,7 @@ pygithub==1.54.1
 pygments==2.7.3
     # via
     #   ipython
+    #   pybetter
     #   readme-renderer
     #   sphinx
 pyjwt==1.7.1
@@ -212,7 +224,7 @@ pytz==2020.5
     #   babel
     #   django
 pyupgrade==2.7.4
-    # via -r requirements/tools.in
+    # via shed
 pyupio==1.1.1
     # via -r requirements/tools.in
 pyyaml==5.3.1
@@ -245,6 +257,8 @@ safety==1.10.1
     # via pyupio
 secretstorage==3.3.0
     # via keyring
+shed==0.3.1
+    # via -r requirements/tools.in
 six==1.15.0
     # via
     #   bandit

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -136,8 +136,7 @@ def modified_files():
         diff_output = subprocess.check_output(command).decode("ascii")
         for l in diff_output.split("\n"):
             filepath = l.strip()
-            if filepath:
-                assert os.path.exists(filepath), filepath
+            if filepath and os.path.exists(filepath):
                 files.add(filepath)
     return files
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -130,11 +130,11 @@ def deploy():
 CURRENT_YEAR = datetime.utcnow().year
 
 
-HEADER = """
+HEADER = f"""
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis/
 #
-# Most of this work is copyright (C) 2013-%(year)s David R. MacIver
+# Most of this work is copyright (C) 2013-{CURRENT_YEAR} David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual
@@ -144,9 +144,7 @@ HEADER = """
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 #
-# END HEADER""".strip() % {
-    "year": CURRENT_YEAR
-}
+# END HEADER""".strip()
 
 
 @task()

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -20,12 +20,11 @@ import sys
 from datetime import datetime
 from glob import glob
 
-from coverage.config import CoverageConfig
-
 import hypothesistooling as tools
 import hypothesistooling.projects.conjecturerust as cr
 import hypothesistooling.projects.hypothesispython as hp
 import hypothesistooling.projects.hypothesisruby as hr
+from coverage.config import CoverageConfig
 from hypothesistooling import installers as install, releasemanagement as rm
 from hypothesistooling.scripts import pip_tool
 
@@ -218,19 +217,7 @@ def format():
                 o.write(source)
             o.write("\n")
 
-    pip_tool(
-        "autoflake",
-        "--recursive",
-        "--in-place",
-        "--exclude=compat.py",
-        "--remove-all-unused-imports",
-        "--remove-duplicate-keys",
-        "--remove-unused-variables",
-        *files_to_format,
-    )
-    pip_tool("pyupgrade", "--py36-plus", *files_to_format)
-    pip_tool("isort", *files_to_format)
-    pip_tool("black", "--target-version=py36", *files_to_format)
+    pip_tool("shed", *files_to_format, *doc_files_to_format)
 
 
 VALID_STARTS = (HEADER.split()[0], "#!/usr/bin/env python")

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -43,20 +43,15 @@ def task(if_changed=()):
         def wrapped(*args, **kwargs):
             if if_changed and tools.IS_PULL_REQUEST:
                 if not tools.has_changes(if_changed + BUILD_FILES):
-                    print(
-                        "Skipping task due to no changes in %s"
-                        % (", ".join(if_changed),)
-                    )
+                    changed = ", ".join(if_changed)
+                    print(f"Skipping task due to no changes in {changed}")
                     return
             fn(*args, **kwargs)
 
         wrapped.__name__ = fn.__name__
-
         name = fn.__name__.replace("_", "-")
-
         if name != "<lambda>":
             TASKS[name] = wrapped
-
         return wrapped
 
     return accept
@@ -406,9 +401,9 @@ standard_tox_task("nose")
 standard_tox_task("pytest43")
 
 for n in [22, 30, 31]:
-    standard_tox_task("django%d" % (n,))
+    standard_tox_task(f"django{n}")
 for n in [25, 100, 111]:
-    standard_tox_task("pandas%d" % (n,))
+    standard_tox_task(f"pandas{n}")
 
 standard_tox_task("coverage")
 standard_tox_task("conjecture-coverage")

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -85,7 +85,7 @@ MASTER = tools.hash_for_name("origin/master")
 
 def do_release(package):
     if not package.has_release():
-        print("No release for %s" % (package.__name__,))
+        print(f"No release for {package.__name__}")
         return
 
     os.chdir(package.BASE_DIR)
@@ -103,7 +103,7 @@ def do_release(package):
 
     tag_name = package.tag_name()
 
-    print("Creating tag %s" % (tag_name,))
+    print(f"Creating tag {tag_name}")
 
     tools.create_tag(tag_name)
     tools.push_tag(tag_name)
@@ -228,7 +228,7 @@ def format():
         "--remove-unused-variables",
         *files_to_format,
     )
-    pip_tool("pyupgrade", "--keep-percent-format", "--py36-plus", *files_to_format)
+    pip_tool("pyupgrade", "--py36-plus", *files_to_format)
     pip_tool("isort", *files_to_format)
     pip_tool("black", "--target-version=py36", *files_to_format)
 
@@ -247,7 +247,7 @@ def check_format():
         with open(f, encoding="utf-8") as i:
             start = i.read(n)
             if not any(start.startswith(s) for s in VALID_STARTS):
-                print("%s has incorrect start %r" % (f, start), file=sys.stderr)
+                print(f"{f} has incorrect start {start!r}", file=sys.stderr)
                 bad = True
     assert not bad
     check_not_changed()
@@ -369,7 +369,7 @@ ALIASES = {PYPY36: "pypy3", PYPY37: "pypy3"}
 
 for n in [PY36, PY37, PY38, PY39]:
     major, minor, patch = n.replace("-dev", ".").split(".")
-    ALIASES[n] = "python%s.%s" % (major, minor)
+    ALIASES[n] = f"python{major}.{minor}"
 
 
 python_tests = task(

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -19,9 +19,8 @@ import shutil
 import subprocess
 import sys
 
-import requests
-
 import hypothesistooling as tools
+import requests
 from hypothesistooling import releasemanagement as rm
 
 PACKAGE_NAME = "hypothesis-python"

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -126,7 +126,7 @@ def update_changelog_and_version():
     new_changelog_parts = [
         beginning.strip(),
         "",
-        ".. _v%s:" % (new_version_string),
+        f".. _v{new_version_string}:",
         "",
         border_for_new_version,
         heading_for_new_version,
@@ -192,10 +192,10 @@ def upload_distribution():
     with open(textfile) as f:
         lines = f.readlines()
     entries = [i for i, l in enumerate(lines) if CHANGELOG_HEADER.match(l)]
+    anchor = current_version().replace(".", "-")
     changelog_body = "".join(lines[entries[0] + 2 : entries[1]]).strip() + (
         "\n\n*[The canonical version of these notes (with links) is on readthedocs.]"
-        "(https://hypothesis.readthedocs.io/en/latest/changes.html#v%s)*"
-        % (current_version().replace(".", "-"),)
+        f"(https://hypothesis.readthedocs.io/en/latest/changes.html#v{anchor})*"
     )
 
     # Create a GitHub release, to trigger Zenodo DOI minting.  See

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -83,10 +83,9 @@ def build_distribution():
     current_dependency = rm.extract_assignment(CARGO_FILE, "conjecture")
 
     assert current_dependency == LOCAL_PATH_DEPENDENCY, (
-        "Cargo file in a bad state. Expected conjecture dependency to be %s "
-        "but it was instead %s"
-    ) % (LOCAL_PATH_DEPENDENCY, current_dependency)
-
+        "Cargo file in a bad state. Expected conjecture dependency to be "
+        f"{LOCAL_PATH_DEPENDENCY} but it was instead {current_dependency}"
+    )
     conjecture_version = cr.current_version()
 
     # Update to use latest version of conjecture-rust.
@@ -146,14 +145,12 @@ def cargo(*args):
         subprocess.check_call(("cargo",) + args)
 
 
-RUBY_TO_PRINT_VERSION = """
+RUBY_TO_PRINT_VERSION = f"""
 require 'rubygems'
-spec = Gem::Specification::load(%r)
+spec = Gem::Specification::load({GEMSPEC_FILE!r})
 puts spec.version
 """.strip().replace(
     "\n", "; "
-) % (
-    GEMSPEC_FILE,
 )
 
 

--- a/tooling/src/hypothesistooling/releasemanagement.py
+++ b/tooling/src/hypothesistooling/releasemanagement.py
@@ -85,7 +85,7 @@ def replace_assignment_in_string(contents, name, value):
     if count == 0:
         raise ValueError(f"Key {name} not found in {contents}")
     if count > 1:
-        raise ValueError("Key %s found %d times in %s" % (name, count, contents))
+        raise ValueError(f"Key {name} found {count} times in {contents}")
 
     return "\n".join(lines)
 
@@ -133,11 +133,11 @@ def parse_release_file_contents(release_contents, filename):
         release_contents = "\n".join(release_lines).strip()
     else:
         raise ValueError(
-            "%s does not start by specifying release type. The first "
+            f"{filename} does not start by specifying release type. The first "
             "line of the file should be RELEASE_TYPE: followed by one of "
             "major, minor, or patch, to specify the type of release that "
             "this is (i.e. which version number to increment). Instead the "
-            "first line was %r" % (filename, release_lines[0])
+            f"first line was {release_lines[0]!r}"
         )
 
     return release_type, release_contents
@@ -158,11 +158,7 @@ def update_markdown_changelog(changelog, name, version, entry):
     with open(changelog) as i:
         prev_contents = i.read()
 
-    title = "# {name} {version} ({date})\n\n".format(
-        name=name,
-        version=version,
-        date=release_date_string(),
-    )
+    title = f"# {name} {version} ({release_date_string()})\n\n"
 
     with open(changelog, "w") as o:
         o.write(title)
@@ -183,6 +179,6 @@ def commit_pending_release(project):
     tools.git(
         "commit",
         "-m",
-        "Bump %s version to %s and update changelog"
-        "\n\n[skip ci]" % (project.PACKAGE_NAME, project.current_version()),
+        f"Bump {project.PACKAGE_NAME} version to {project.current_version()} "
+        + "and update changelog\n\n[skip ci]",
     )

--- a/tooling/src/hypothesistooling/releasemanagement.py
+++ b/tooling/src/hypothesistooling/releasemanagement.py
@@ -48,7 +48,7 @@ def assignment_matcher(name):
     i.e. group 1 is the assignment, group 2 is the value. In the above
     example group 1 would be "  foo = " and group 2 would be "1"
     """
-    return re.compile(r"\A(\s*%s\s*=\s*)(.+)\Z" % (re.escape(name),))
+    return re.compile(r"\A(\s*{}\s*=\s*)(.+)\Z".format(re.escape(name)))
 
 
 def extract_assignment_from_string(contents, name):
@@ -61,7 +61,7 @@ def extract_assignment_from_string(contents, name):
         if match is not None:
             return match[2].strip()
 
-    raise ValueError("Key %s not found in %s" % (name, contents))
+    raise ValueError(f"Key {name} not found in {contents}")
 
 
 def extract_assignment(filename, name):
@@ -83,7 +83,7 @@ def replace_assignment_in_string(contents, name, value):
             lines[i] = match[1] + value
 
     if count == 0:
-        raise ValueError("Key %s not found in %s" % (name, contents))
+        raise ValueError(f"Key {name} not found in {contents}")
     if count > 1:
         raise ValueError("Key %s found %d times in %s" % (name, count, contents))
 
@@ -128,7 +128,7 @@ def parse_release_file_contents(release_contents, filename):
     if m is not None:
         release_type = m.group(1)
         if release_type not in VALID_RELEASE_TYPES:
-            raise ValueError("Unrecognised release type %r" % (release_type,))
+            raise ValueError(f"Unrecognised release type {release_type!r}")
         del release_lines[0]
         release_contents = "\n".join(release_lines).strip()
     else:
@@ -158,11 +158,11 @@ def update_markdown_changelog(changelog, name, version, entry):
     with open(changelog) as i:
         prev_contents = i.read()
 
-    title = "# %(name)s %(version)s (%(date)s)\n\n" % {
-        "name": name,
-        "version": version,
-        "date": release_date_string(),
-    }
+    title = "# {name} {version} ({date})\n\n".format(
+        name=name,
+        version=version,
+        date=release_date_string(),
+    )
 
     with open(changelog, "w") as o:
         o.write(title)

--- a/whole-repo-tests/test_deploy.py
+++ b/whole-repo-tests/test_deploy.py
@@ -15,9 +15,8 @@
 
 import os
 
-import pytest
-
 import hypothesistooling as tools
+import pytest
 from hypothesistooling import __main__ as main, releasemanagement as rm
 
 

--- a/whole-repo-tests/test_pyup_yml.py
+++ b/whole-repo-tests/test_pyup_yml.py
@@ -13,10 +13,9 @@
 #
 # END HEADER
 
+import hypothesistooling as tools
 import yaml
 from pyup.config import Config
-
-import hypothesistooling as tools
 
 
 def test_pyup_yml_is_valid():

--- a/whole-repo-tests/test_pyup_yml.py
+++ b/whole-repo-tests/test_pyup_yml.py
@@ -25,4 +25,4 @@ def test_pyup_yml_is_valid():
     config = Config()
     config.update_config(data)
 
-    assert config.is_valid_schedule(), "Schedule %r is invalid" % (config.schedule,)
+    assert config.is_valid_schedule(), f"Schedule {config.schedule!r} is invalid"

--- a/whole-repo-tests/test_release_files.py
+++ b/whole-repo-tests/test_release_files.py
@@ -13,9 +13,8 @@
 #
 # END HEADER
 
-import pytest
-
 import hypothesistooling as tools
+import pytest
 from hypothesistooling import releasemanagement as rm
 
 

--- a/whole-repo-tests/test_release_management.py
+++ b/whole-repo-tests/test_release_management.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import pytest
-
 from hypothesistooling.releasemanagement import (
     bump_version_info,
     parse_release_file_contents,

--- a/whole-repo-tests/test_release_management.py
+++ b/whole-repo-tests/test_release_management.py
@@ -75,12 +75,12 @@ def test_invalid_release():
 
 
 TEST_CHANGELOG = """
-# A test project 1.2.3 (%s)
+# A test project 1.2.3 ({})
 
 some stuff happened
 
 # some previous log entry
-""" % (
+""".format(
     release_date_string(),
 )
 

--- a/whole-repo-tests/test_release_management.py
+++ b/whole-repo-tests/test_release_management.py
@@ -73,15 +73,13 @@ def test_invalid_release():
         parse_release("")
 
 
-TEST_CHANGELOG = """
-# A test project 1.2.3 ({})
+TEST_CHANGELOG = f"""
+# A test project 1.2.3 ({release_date_string()})
 
 some stuff happened
 
 # some previous log entry
-""".format(
-    release_date_string(),
-)
+"""
 
 
 def test_update_changelog(tmpdir):

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -17,7 +17,6 @@ import os
 import subprocess
 
 import pytest
-
 from hypothesistooling.projects.hypothesispython import PYTHON_SRC
 from hypothesistooling.scripts import pip_tool, tool_path
 

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -83,9 +83,7 @@ def test_revealed_types(tmpdir, val, expect):
         "reveal_type(s)\n".format(val)
     )
     typ = get_mypy_analysed_type(str(f.realpath()), val)
-    assert (
-        typ == "hypothesis.strategies._internal.strategies.SearchStrategy[%s]" % expect
-    )
+    assert typ == f"hypothesis.strategies._internal.strategies.SearchStrategy[{expect}]"
 
 
 def test_data_object_type_tracing(tmpdir):


### PR DESCRIPTION
The main purpose of this PR, as the title notes, is update our autoformatting tooling (which closes #2780), and in the process update from %-formatting to f-strings.  We've been Python-3.6-or-later for a while now, after all!

In the process of this upgrade, and manually inspecting the diffs, I found a number of logical changes - including vacuous assertion in a test helper, overzealous assertion in our tooling, and more.  Those are in the first commit, if you want to review them separately.

Otherwise, I suggesting [marking files as reviewed](https://github.blog/2019-07-01-mark-files-as-viewed/) - each change is local, but there are 589 modified lines (across 189 files!) so the automated tracking lets you break up the work without losing track of where you got to.