### PR TITLE
Distinguish exceptions by `__cause__` or `__context__`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,18 @@
+RELEASE_TYPE: minor
+
+This release teaches Hypothesis to distinguish between errors based on the
+`__cause__ or __context__ of otherwise identical exceptions
+<https://docs.python.org/3/library/exceptions.html>`__, which is particularly
+useful when internal errors can be wrapped by a library-specific or semantically
+appropriate exception such as:
+
+.. code-block:: python
+
+    try:
+        do_the_thing(foo, timeout=10)
+    except Exception as err:
+        raise FooError("Failed to do the thing") from err
+
+Earlier versions of Hypothesis only see the ``FooError``, while we can now
+distinguish a ``FooError`` raised because of e.g. an internal assertion from
+one raised because of a ``TimeoutExceeded`` exception.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -70,6 +70,7 @@ from hypothesis.internal.conjecture.engine import ConjectureRunner, sort_key
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
     escalate_hypothesis_internal_error,
+    get_interesting_origin,
     get_trimmed_traceback,
 )
 from hypothesis.internal.healthcheck import fail_health_check
@@ -721,10 +722,7 @@ class StateForActualGivenExecution:
                 info.__expected_exception = e
                 verbose_report(info.__expected_traceback)
 
-                origin = traceback.extract_tb(tb)[-1]
-                filename = origin[0]
-                lineno = origin[1]
-                data.mark_interesting((type(e), filename, lineno))
+                data.mark_interesting(get_interesting_origin(e))
 
     def run_engine(self):
         """Run the test function many times, on database input and generated

--- a/hypothesis-python/tests/nocover/test_interesting_origin.py
+++ b/hypothesis-python/tests/nocover/test_interesting_origin.py
@@ -1,0 +1,62 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import pytest
+
+from hypothesis import given, strategies as st
+from hypothesis.errors import MultipleFailures
+
+
+def go_wrong_naive(a, b):
+    try:
+        assert a + b < 100
+        a / b
+    except Exception:
+        # Hiding the actual problem is terrible, but this pattern can make sense
+        # if you're raising a library-specific or semantically meaningful error.
+        raise ValueError("Something went wrong")
+
+
+def go_wrong_with_cause(a, b):
+    try:
+        assert a + b < 100
+        a / b
+    except Exception as err:
+        # Explicit chaining is the *right way* to change exception type.
+        raise ValueError("Something went wrong") from err
+
+
+def go_wrong_coverup(a, b):
+    try:
+        assert a + b < 100
+        a / b
+    except Exception:
+        # This pattern SHOULD be local enough that it never distinguishes
+        # errors in practice... but if it does, we're ready.
+        raise ValueError("Something went wrong") from None
+
+
+@pytest.mark.parametrize(
+    "function",
+    [go_wrong_naive, go_wrong_with_cause, go_wrong_coverup],
+    ids=lambda f: f.__name__,
+)
+def test_can_generate_specified_version(function):
+    try:
+        given(st.integers(), st.integers())(function)()
+    except MultipleFailures:
+        pass
+    else:
+        raise AssertionError("Expected MultipleFailures")


### PR DESCRIPTION
Closes #2781.