### PR TITLE
Rewrite simple filters for bounded `integers()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This release lays the groundwork for automatic rewriting of simple filters,
+for example converting ``integers().filter(lambda x: x > 9)`` to
+``integers(min_value=10)``.
+
+Note that this is **not supported yet**, and we will continue to recommend
+writing the efficient form directly wherever possible - predicate rewriting
+is provided mainly for the benefit of downstream libraries which would
+otherwise have to implement it for themselves (e.g. :pypi:`pandera` and
+:pypi:`icontract-hypothesis`).  See :issue:`2701` for details.

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -1,0 +1,118 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""Tools for understanding predicates, to satisfy them by construction.
+
+For example::
+
+    integers().filter(lamda x: x >= 0) -> integers(min_value=0)
+
+This is intractable in general, but reasonably easy for simple cases involving
+numeric bounds, strings with length or regex constraints, and collection lengths -
+and those are precisely the most common cases.  When they arise in e.g. Pandas
+dataframes, it's also pretty painful to do the constructive version by hand in
+a library; so we prefer to share all the implementation effort here.
+See https://github.com/HypothesisWorks/hypothesis/issues/2701 for details.
+"""
+
+import math
+import operator
+from decimal import Decimal
+from fractions import Fraction
+from functools import partial
+from typing import Any, Callable, Mapping, Optional, Tuple, TypeVar
+
+from hypothesis.internal.compat import ceil, floor
+
+Ex = TypeVar("Ex")
+Predicate = Callable[[Ex], bool]
+
+ConstructivePredicate = Tuple[Mapping[str, Any], Optional[Predicate]]
+"""Return kwargs to the appropriate strategy, and the predicate if needed.
+
+For example::
+
+    integers().filter(lambda x: x >= 0)
+    -> {"min_value": 0"}, None
+
+    integers().filter(lambda x: x >= 0 and x % 7)
+    -> {"min_value": 0"}, lambda x: x % 7
+
+At least in principle - for now we usually return the predicate unchanged
+if needed.
+
+We have a separate get-predicate frontend for each "group" of strategies; e.g.
+for each numeric type, for strings, for bytes, for collection sizes, etc.
+"""
+
+
+def get_numeric_predicate_bounds(predicate: Predicate) -> ConstructivePredicate:
+    """Shared logic for understanding numeric bounds.
+
+    We then specialise this in the other functions below, to ensure that e.g.
+    all the values are representable in the types that we're planning to generate
+    so that the strategy validation doesn't complain.
+    """
+    if (
+        type(predicate) is partial
+        and len(predicate.args) == 1
+        and not predicate.keywords
+    ):
+        arg = predicate.args[0]
+        if (isinstance(arg, Decimal) and Decimal.is_snan(arg)) or not isinstance(
+            arg, (int, float, Fraction, Decimal)
+        ):
+            return {}, predicate
+        options = {
+            # We're talking about op(arg, x) - the reverse of our usual intuition!
+            operator.lt: {"min_value": arg, "exclude_min": True},  # lambda x: arg < x
+            operator.le: {"min_value": arg},  # lambda x: arg <= x
+            operator.eq: {"min_value": arg, "max_value": arg},  # lambda x: arg == x
+            operator.ge: {"max_value": arg},  # lambda x: arg >= x
+            operator.gt: {"max_value": arg, "exclude_max": True},  # lambda x: arg > x
+        }
+        if predicate.func in options:
+            return options[predicate.func], None
+
+    # TODO: handle lambdas by AST analysis
+
+    return {}, predicate
+
+
+def get_integer_predicate_bounds(predicate: Predicate) -> ConstructivePredicate:
+    kwargs, predicate = get_numeric_predicate_bounds(predicate)
+
+    if "min_value" in kwargs:
+        if kwargs["min_value"] == -math.inf:
+            del kwargs["min_value"]
+        elif math.isinf(kwargs["min_value"]):
+            return {}, lambda _: False
+        elif kwargs["min_value"] != int(kwargs["min_value"]):
+            kwargs["min_value"] = ceil(kwargs["min_value"])
+        elif kwargs.get("exclude_min", False):
+            kwargs["min_value"] = int(kwargs["min_value"]) + 1
+
+    if "max_value" in kwargs:
+        if kwargs["max_value"] == math.inf:
+            del kwargs["max_value"]
+        elif math.isinf(kwargs["max_value"]):
+            return {}, lambda _: False
+        elif kwargs["max_value"] != int(kwargs["max_value"]):
+            kwargs["max_value"] = floor(kwargs["max_value"])
+        elif kwargs.get("exclude_max", False):
+            kwargs["max_value"] = int(kwargs["max_value"]) - 1
+
+    kwargs = {k: v for k, v in kwargs.items() if k in {"min_value", "max_value"}}
+    return kwargs, predicate

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -715,7 +715,6 @@ class FilteredStrategy(SearchStrategy):
         assert not isinstance(self.filtered_strategy, FilteredStrategy)
 
         self.__condition = None
-        self.__validated = False
 
     def calc_is_empty(self, recur):
         return recur(self.filtered_strategy)
@@ -735,24 +734,40 @@ class FilteredStrategy(SearchStrategy):
         return self._cached_repr
 
     def do_validate(self):
+        # Start by validating our inner filtered_strategy.  If this was a LazyStrategy,
+        # validation also reifies it so that subsequent calls to e.g. `.filter()` will
+        # be passed through.
         self.filtered_strategy.validate()
+        # So now we have a reified inner strategy, we'll replay all our saved
+        # predicates in case some or all of them can be rewritten.  Note that this
+        # replaces the `fresh` strategy too!
         fresh = self.filtered_strategy
         for cond in self.flat_conditions:
             fresh = fresh.filter(cond)
         if isinstance(fresh, FilteredStrategy):
+            # In this case we have at least some non-rewritten filter predicates,
+            # so we just re-initialize the strategy.
             FilteredStrategy.__init__(
                 self, fresh.filtered_strategy, fresh.flat_conditions
             )
         else:
+            # But if *all* the predicates were rewritten... well, do_validate() is
+            # an in-place method so we still just re-initialize the strategy!
             FilteredStrategy.__init__(self, fresh, ())
 
     def filter(self, condition):
-        # Allow strategy rewriting to 'see through' an unhandled predicate.
+        # If we can, it's more efficient to rewrite our strategy to satisfy the
+        # condition.  We therefore exploit the fact that the order of predicates
+        # doesn't matter (`f(x) and g(x) == g(x) and f(x)`) by attempting to apply
+        # condition directly to our filtered strategy as the inner-most filter.
         out = self.filtered_strategy.filter(condition)
+        # If it couldn't be rewritten, we'll get a new FilteredStrategy - and then
+        # combine the conditions of each in our expected newest=last order.
         if isinstance(out, FilteredStrategy):
             return FilteredStrategy(
                 out.filtered_strategy, self.flat_conditions + out.flat_conditions
             )
+        # But if it *could* be rewritten, we can return the more efficient form!
         return FilteredStrategy(out, self.flat_conditions)
 
     @property

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -484,7 +484,7 @@ def test_chained_filter(x):
 
 def test_chained_filter_tracks_all_conditions():
     s = ds.integers().filter(bool).filter(lambda x: x % 3)
-    assert len(s.flat_conditions) == 2
+    assert len(s.wrapped_strategy.flat_conditions) == 2
 
 
 @pytest.mark.parametrize("version", [4, 6])

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -1,0 +1,121 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import decimal
+import math
+import operator
+from functools import partial
+
+import pytest
+
+from hypothesis import given, strategies as st
+from hypothesis.errors import Unsatisfiable
+from hypothesis.strategies._internal.lazy import LazyStrategy
+from hypothesis.strategies._internal.numbers import BoundedIntStrategy
+from hypothesis.strategies._internal.strategies import FilteredStrategy
+
+from tests.common.utils import fails_with
+
+
+@pytest.mark.parametrize(
+    "strategy, predicate, start, end",
+    [
+        # Integers with integer bounds
+        (st.integers(1, 5), partial(operator.lt, 3), 4, 5),  # lambda x: 3 < x
+        (st.integers(1, 5), partial(operator.le, 3), 3, 5),  # lambda x: 3 <= x
+        (st.integers(1, 5), partial(operator.eq, 3), 3, 3),  # lambda x: 3 == x
+        (st.integers(1, 5), partial(operator.ge, 3), 1, 3),  # lambda x: 3 >= x
+        (st.integers(1, 5), partial(operator.gt, 3), 1, 2),  # lambda x: 3 > x
+        # Integers with non-integer bounds
+        (st.integers(1, 5), partial(operator.lt, 3.5), 4, 5),
+        (st.integers(1, 5), partial(operator.le, 3.5), 4, 5),
+        (st.integers(1, 5), partial(operator.ge, 3.5), 1, 3),
+        (st.integers(1, 5), partial(operator.gt, 3.5), 1, 3),
+        (st.integers(1, 5), partial(operator.lt, -math.inf), 1, 5),
+        (st.integers(1, 5), partial(operator.gt, math.inf), 1, 5),
+    ],
+)
+@given(data=st.data())
+def test_filter_rewriting(data, strategy, predicate, start, end):
+    s = strategy.filter(predicate)
+    assert isinstance(s, LazyStrategy)
+    assert isinstance(s.wrapped_strategy, BoundedIntStrategy)
+    assert s.wrapped_strategy.start == start
+    assert s.wrapped_strategy.end == end
+    value = data.draw(s)
+    assert predicate(value)
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        st.integers(1, 5).filter(partial(operator.lt, 6)),
+        st.integers(1, 5).filter(partial(operator.eq, 3.5)),
+        st.integers(1, 5).filter(partial(operator.eq, "can't compare to strings")),
+        st.integers(1, 5).filter(partial(operator.ge, 0)),
+        st.integers(1, 5).filter(partial(operator.lt, math.inf)),
+        st.integers(1, 5).filter(partial(operator.gt, -math.inf)),
+    ],
+)
+@fails_with(Unsatisfiable)
+@given(data=st.data())
+def test_rewrite_unsatisfiable_filter(data, s):
+    data.draw(s)
+
+
+@given(st.integers(0, 2).filter(partial(operator.ne, 1)))
+def test_unhandled_operator(x):
+    assert x in (0, 2)
+
+
+def test_rewriting_does_not_compare_decimal_snan():
+    s = st.integers(1, 5).filter(partial(operator.eq, decimal.Decimal("snan")))
+    s.wrapped_strategy
+    with pytest.raises(decimal.InvalidOperation):
+        s.example()
+
+
+def mod2(x):
+    return x % 2
+
+
+@given(
+    data=st.data(),
+    predicates=st.permutations(
+        [
+            partial(operator.lt, 1),
+            partial(operator.le, 2),
+            partial(operator.ge, 4),
+            partial(operator.gt, 5),
+            mod2,
+        ]
+    ),
+)
+def test_rewrite_filter_chains_with_some_unhandled(data, predicates):
+    # Set up our strategy
+    s = st.integers(1, 5)
+    for p in predicates:
+        s = s.filter(p)
+
+    # Whatever value we draw is in fact valid for these strategies
+    value = data.draw(s)
+    for p in predicates:
+        assert p(value), f"p={p!r}, value={value}"
+
+    # No matter the order of the filters, we get the same resulting structure
+    unwrapped = s.wrapped_strategy
+    assert isinstance(unwrapped, FilteredStrategy)
+    assert isinstance(unwrapped.filtered_strategy, BoundedIntStrategy)
+    assert unwrapped.flat_conditions == (mod2,)

--- a/hypothesis-python/tests/cover/test_filtered_strategy.py
+++ b/hypothesis-python/tests/cover/test_filtered_strategy.py
@@ -38,7 +38,7 @@ def test_filter_conditions_may_be_empty():
     s.condition(0)
 
 
-def test_flattens_nested_filteredstrategy():
+def test_nested_filteredstrategy_flattens_conditions():
     s = FilteredStrategy(
         FilteredStrategy(st.text(), conditions=(bool,)),
         conditions=(len,),

--- a/hypothesis-python/tests/cover/test_filtered_strategy.py
+++ b/hypothesis-python/tests/cover/test_filtered_strategy.py
@@ -15,6 +15,7 @@
 
 import hypothesis.strategies as st
 from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.strategies._internal.strategies import FilteredStrategy
 
 
 def test_filter_iterations_are_marked_as_discarded():
@@ -25,3 +26,22 @@ def test_filter_iterations_are_marked_as_discarded():
     assert data.draw(x) == 0
 
     assert data.has_discards
+
+
+def test_filtered_branches_are_all_filtered():
+    s = FilteredStrategy(st.integers() | st.text(), (bool,))
+    assert all(isinstance(x, FilteredStrategy) for x in s.branches)
+
+
+def test_filter_conditions_may_be_empty():
+    s = FilteredStrategy(st.integers(), conditions=())
+    s.condition(0)
+
+
+def test_flattens_nested_filteredstrategy():
+    s = FilteredStrategy(
+        FilteredStrategy(st.text(), conditions=(bool,)),
+        conditions=(len,),
+    )
+    assert s.filtered_strategy is st.text()
+    assert s.flat_conditions == (bool, len)


### PR DESCRIPTION
This pull request is the first piece of #2701.

It demonstrates that the concept works, handles the tricky interactions with LazyStrategy and chained filters (though `one_of()` is left for future work), and provides obvious locations for future contributions - such as copying this logic for `floats()`.  Further discussion of how the overall plan can be broken down into pull requests can be found at #2701, along with next steps.