### PR TITLE
Report statistics summary via `pytest-html`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+If you use :pypi:`pytest-html`, Hypothesis now includes the
+:ref:`summary statistics for each test <statistics>` in the HTML report,
+whether or not the ``--hypothesis-show-statistics`` argument was passed
+to show them in the command-line output.

--- a/hypothesis-python/docs/extras.rst
+++ b/hypothesis-python/docs/extras.rst
@@ -30,8 +30,10 @@ There are separate pages for :doc:`django` and :doc:`numpy`.
 
     .. tip::
 
-        For new projects, we recommend using :pypi:`icontract` and
-        :pypi:`icontract-hypothesis` over :pypi:`dpcontracts`.
+        For new projects, we recommend using either :pypi:`deal` or :pypi:`icontract`
+        and :pypi:`icontract-hypothesis` over :pypi:`dpcontracts`.
+        They're generally more powerful tools for design-by-contract programming,
+        and have substantially nicer Hypothesis integration too!
 
 .. automodule:: hypothesis.extra.lark
    :members:

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -42,6 +42,15 @@ Others provide a function to infer a strategy from some other schema:
 * :pypi:`hypothesis-pb` - infer strategies from `Protocol Buffer
   <https://developers.google.com/protocol-buffers/>`_ schemas.
 
+Or some other custom integration, such as a :ref:`"hypothesis" entry point <entry-points>`:
+
+* :pypi:`deal` is a design-by-contract library with built-in Hypothesis support.
+* :pypi:`icontract-hypothesis` infers strategies from :pypi:`icontract` code contracts.
+* :pypi:`Pandera` schemas all have a ``.strategy()`` method, which returns a strategy for
+  matching :class:`~pandas:pandas.DataFrame`\ s.
+* :pypi:`Pydantic` automatically registers constrained types - so
+  :func:`~hypothesis.strategies.builds` and :func:`~hypothesis.strategies.from_type`
+  "just work" regardless of the underlying implementation.
 
 -----------------
 Other cool things
@@ -77,20 +86,13 @@ fail - by trying all kinds of inputs and reporting whatever happens.
 implement functor, applicative, monad, and other laws; allowing a declarative
 approach to be combined with traditional pythonic code.
 
-:pypi:`icontract-hypothesis` infers the Hypothesis strategies based on the
-contracts (specified using :pypi:`icontract`) so that the code can be
-automatically tested.
-It also supports a :doc:`ghostwriter <ghostwriter>` for test files and IDE integrations such as
-`icontract-hypothesis-vim <https://github.com/mristin/icontract-hypothesis-vim>`_,
+:pypi:`icontract-hypothesis` includes a :doc:`ghostwriter <ghostwriter>` for test files
+and IDE integrations such as `icontract-hypothesis-vim <https://github.com/mristin/icontract-hypothesis-vim>`_,
 `icontract-hypothesis-pycharm <https://github.com/mristin/icontract-hypothesis-pycharm>`_,
 and
-`icontract-hypothesis-vscode <https://github.com/mristin/icontract-hypothesis-vscode>`_.
-Even if you do not use any contracts in your code at all, you can use
-:pypi:`icontract-hypothesis` to run smoke tests as it will automatically infer
-the inputs to the functions based on :func:`~hypothesis.strategies.from_type`.
-This is particularly handy if you use :pypi:`icontract-hypothesis` from within
-your IDE so that you can repeatedly run a smoke test of a function during the
-development with only a couple of key strokes.
+`icontract-hypothesis-vscode <https://github.com/mristin/icontract-hypothesis-vscode>`_ -
+you can run a quick 'smoke test' with only a few keystrokes for any type-annotated
+function, even if it doesn't have any contracts!
 
 --------------------
 Writing an extension

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -219,6 +219,13 @@ else:
                 # --junitxml not passed, or Pytest 4.5 (before add_global_property)
                 # We'll fail xunit2 xml schema checks, upgrade pytest if you care.
                 report.user_properties.append((name, item.hypothesis_statistics))
+            # If there's an HTML report, include our summary stats for each test
+            stats = base64.b64decode(item.hypothesis_statistics.encode()).decode()
+            pytest_html = item.config.pluginmanager.getplugin("html")
+            if pytest_html is not None:  # pragma: no cover
+                report.extra = getattr(report, "extra", []) + [
+                    pytest_html.extras.text(stats, name="Hypothesis stats")
+                ]
 
     def pytest_terminal_summary(terminalreporter):
         if not terminalreporter.config.getoption(PRINT_STATISTICS_OPTION):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -718,6 +718,10 @@ def sampled_from(elements):
     the list. So e.g. ``sampled_from([10, 1])`` will shrink by trying to replace
     1 values with 10, and ``sampled_from([1, 10])`` will shrink by trying to
     replace 10 values with 1.
+
+    It is an error to sample from an empty sequence, because returning :func:`nothing`
+    makes it too easy to silently drop parts of compound strategies.  If you need
+    that behaviour, use ``sampled_from(seq) if seq else nothing()``.
     """
     values = check_sample(elements, "sampled_from")
     if not values:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 
 addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20
 filterwarnings =
-    ignore:The `.example()` method is good for exploring strategies, but should only be used interactively
+    ignore::hypothesis.errors.NonInteractiveExampleWarning

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -392,6 +392,9 @@ def check_examples3():
 @task()
 def check_whole_repo_tests():
     install.ensure_shellcheck()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", hp.HYPOTHESIS_PYTHON]
+    )
     subprocess.check_call([sys.executable, "-m", "pytest", tools.REPO_TESTS])
 
 


### PR DESCRIPTION
A tiny always-on integration with pytest-html, where reporting our statistics summary doesn't take up space like it would on the command-line.

Note that this PR does not include automated tests, because there's only one very simple line of code, and it would be painful to check anything meaningful even if we set up another virtualenv and CI job with `pytest-html` installed.  Assuming you have `pytest-html` installed locally, you can run e.g. `pytest hypothesis-python/tests/cover/test_complex_numbers.py --html=report.html` in the repo root, and see that the report now has stats in the previously-empty "links" column, which open as a plain-text document:

![image](https://user-images.githubusercontent.com/12229877/107191569-75b24280-6a40-11eb-9968-fe05a259aca8.png)
![image](https://user-images.githubusercontent.com/12229877/107191611-8367c800-6a40-11eb-9a17-f25696c31d65.png)

I imagine that this will be more interesting when the tests are *failing*, and you don't need to re-run any tests to get the statistics.  I'd like to include statistics in `--junit-xml` reports too, but they don't support annotating individual tests!