### PR TITLE
Scrutineer: integrating opportunistic fault-localisation with PBT

### DIFF
--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -5,6 +5,7 @@ include =
     **/.tox/*/lib/*/site-packages/hypothesis/**/*.py
 omit =
     **/pytestplugin.py
+    **/scrutineer.py
     **/strategytests.py
     **/compat*.py
     **/extra/__init__.py

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release adds :ref:`the explain phase <phases>`, in which Hypothesis
+attempts to explain *why* your test failed by pointing to suspicious lines
+of code (i.e. those which were always, and only, run on failing inputs).
+We plan to include "generalising" failing examples in this phase in a
+future release (:issue:`2192`).

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -687,6 +687,8 @@ providing extra information and convenient access to config options.
   :ref:`override the current verbosity level <verbose-output>`.
 - ``pytest --hypothesis-seed=<an int>`` can be used to
   :ref:`reproduce a failure with a particular seed <reproducing-with-seed>`.
+- ``pytest --hypothesis-explain`` can be used to
+  :ref:`temporarily enable the explain phase <phases>`.
 
 Finally, all tests that are defined with Hypothesis automatically have
 ``@pytest.mark.hypothesis`` applied to them.  See :ref:`here for information

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -52,7 +52,7 @@ Available settings
 Controlling what runs
 ~~~~~~~~~~~~~~~~~~~~~
 
-Hypothesis divides tests into five logically distinct phases:
+Hypothesis divides tests into logically distinct phases:
 
 1. Running explicit examples :ref:`provided with the @example decorator <providing-explicit-examples>`.
 2. Rerunning a selection of previously failing examples to reproduce a previously seen error
@@ -60,6 +60,11 @@ Hypothesis divides tests into five logically distinct phases:
 4. Mutating examples for :ref:`targeted property-based testing <targeted-search>`.
 5. Attempting to shrink an example found in previous phases (other than phase 1 - explicit examples cannot be shrunk).
    This turns potentially large and complicated examples which may be hard to read into smaller and simpler ones.
+6. Attempting to explain the cause of the failure, by identifying suspicious lines of code
+   (e.g. the earliest lines which are never run on passing inputs, and always run on failures).
+   This relies on :func:`python:sys.settrace`, and is therefore automatically disabled on
+   PyPy or if you are using :pypi:`coverage` or a debugger.  If there are no clearly
+   suspicious lines of code, :pep:`we refuse the temptation to guess <20>`.
 
 The phases setting provides you with fine grained control over which of these run,
 with each phase corresponding to a value on the :class:`~hypothesis.Phase` enum:
@@ -71,7 +76,7 @@ with each phase corresponding to a value on the :class:`~hypothesis.Phase` enum:
 3. ``Phase.generate`` controls whether new examples will be generated.
 4. ``Phase.target`` controls whether examples will be mutated for targeting.
 5. ``Phase.shrink`` controls whether examples will be shrunk.
-
+6. ``Phase.explain`` controls whether Hypothesis attempts to explain test failures.
 
 The phases argument accepts a collection with any subset of these. e.g.
 ``settings(phases=[Phase.generate, Phase.shrink])`` will generate new examples

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -432,6 +432,7 @@ class Phase(IntEnum):
     generate = 2
     target = 3
     shrink = 4
+    explain = 5
 
     def __repr__(self):
         return f"Phase.{self.name}"
@@ -523,7 +524,9 @@ def _validate_phases(phases):
 
 settings._define_setting(
     "phases",
-    default=tuple(Phase),
+    # We leave the `explain` phase disabled by default, for speed and brevity
+    # TODO: consider default-enabling this in CI?
+    default=_validate_phases(set(Phase) - {Phase.explain}),
     description=(
         "Control which phases should be run. "
         "See :ref:`the full documentation for more details <phases>`"

--- a/hypothesis-python/src/hypothesis/internal/scrutineer.py
+++ b/hypothesis-python/src/hypothesis/internal/scrutineer.py
@@ -1,0 +1,122 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import sys
+from collections import defaultdict
+from functools import lru_cache, reduce
+from itertools import groupby
+from pathlib import Path
+
+from hypothesis._settings import Phase, Verbosity
+from hypothesis.internal.escalation import is_hypothesis_file
+
+
+@lru_cache(maxsize=None)
+def should_trace_file(fname):
+    # fname.startswith("<") indicates runtime code-generation via compile,
+    # e.g. compile("def ...", "<string>", "exec") in e.g. attrs methods.
+    return not (is_hypothesis_file(fname) or fname.startswith("<"))
+
+
+class Tracer:
+    """A super-simple line coverage tracer."""
+
+    def __init__(self):
+        self.branches = set()
+        self.prev = None
+
+    def trace(self, frame, event, arg):
+        if event == "call":
+            return self.trace
+        elif event == "line":
+            fname = frame.f_code.co_filename
+            if should_trace_file(fname):
+                self.branches.add((self.prev, (fname, frame.f_lineno)))
+                self.prev = (fname, frame.f_lineno)
+
+
+def get_explaining_locations(traces):
+    # Traces is a dict[interesting_origin | None, set[frozenset[tuple[str, int]]]]
+    # Each trace in the set might later become a Counter instead of frozenset.
+    if not traces:
+        return {}
+
+    unions = {origin: set().union(*values) for origin, values in traces.items()}
+    seen_passing = {None}.union(*unions.pop(None, set()))
+
+    always_failing_never_passing = {
+        origin: reduce(set.intersection, [set().union(*v) for v in values])
+        - seen_passing
+        for origin, values in traces.items()
+        if origin is not None
+    }
+
+    # Build the observed parts of the control-flow graph for each origin
+    cf_graphs = {origin: defaultdict(set) for origin in unions}
+    for origin, seen_arcs in unions.items():
+        for src, dst in seen_arcs:
+            cf_graphs[origin][src].add(dst)
+        assert cf_graphs[origin][None], "Expected start node with >=1 successor"
+
+    # For each origin, our explanation is the always_failing_never_passing lines
+    # which are reachable from the start node (None) without passing through another
+    # AFNP line.  So here's a whatever-first search with early stopping:
+    explanations = defaultdict(set)
+    for origin in unions:
+        queue = {None}
+        seen = set()
+        while queue:
+            assert queue.isdisjoint(seen), f"Intersection: {queue & seen}"
+            src = queue.pop()
+            seen.add(src)
+            if src in always_failing_never_passing[origin]:
+                explanations[origin].add(src)
+            else:
+                queue.update(cf_graphs[origin][src] - seen)
+
+    return explanations
+
+
+LIB_DIR = str(Path(sys.executable).parent / "lib")
+EXPLANATION_STUB = (
+    "Explanation:",
+    "    These lines were always and only run by failing examples:",
+)
+
+
+def make_report(explanations, cap_lines_at=5):
+    report = defaultdict(list)
+    for origin, locations in explanations.items():
+        assert locations  # or else we wouldn't have stored the key, above.
+        report_lines = [
+            "        {}:{}".format(k, ", ".join(map(str, sorted(l for _, l in v))))
+            for k, v in groupby(locations, lambda kv: kv[0])
+        ]
+        report_lines.sort(key=lambda line: (line.startswith(LIB_DIR), line))
+        if len(report_lines) > cap_lines_at + 1:
+            msg = "        (and {} more with settings.verbosity >= verbose)"
+            report_lines[cap_lines_at:] = [msg.format(len(report_lines[cap_lines_at:]))]
+        report[origin] = list(EXPLANATION_STUB) + report_lines
+    return report
+
+
+def explanatory_lines(traces, settings):
+    if Phase.explain in settings.phases and sys.gettrace() and not traces:
+        msg = "    We didn't try to explain this, because sys.gettrace()="
+        return defaultdict(lambda: [EXPLANATION_STUB[0], msg + repr(sys.gettrace())])
+    # Return human-readable report lines summarising the traces
+    explanations = get_explaining_locations(traces)
+    max_lines = 5 if settings.verbosity <= Verbosity.normal else 100
+    return make_report(explanations, cap_lines_at=max_lines)

--- a/hypothesis-python/tests/cover/test_phases.py
+++ b/hypothesis-python/tests/cover/test_phases.py
@@ -51,8 +51,8 @@ def test_sorts_and_dedupes_phases(arg, expected):
     assert settings(phases=arg).phases == expected
 
 
-def test_phases_default_to_all():
-    assert settings().phases == tuple(Phase)
+def test_phases_default_to_all_except_explain():
+    assert settings().phases + (Phase.explain,) == tuple(Phase)
 
 
 def test_does_not_reuse_saved_examples_if_reuse_not_in_phases():

--- a/hypothesis-python/tests/cover/test_scrutineer.py
+++ b/hypothesis-python/tests/cover/test_scrutineer.py
@@ -1,0 +1,74 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import sys
+
+import pytest
+
+from hypothesis.internal.compat import PYPY
+from hypothesis.internal.scrutineer import make_report
+
+BUG_MARKER = "# BUG"
+PRELUDE = """
+from hypothesis import Phase, given, settings, strategies as st
+
+@settings(phases=tuple(Phase), derandomize=True)
+"""
+
+
+def expected_reports(file_contents, fname):
+    # Takes the source code string with "# BUG" comments, and returns a list of
+    # multi-line report strings which we expect to see in explain-mode output.
+    # The list length is the number of explainable bugs, usually one.
+    explanations = {
+        i: {(fname, i)}
+        for i, line in enumerate(file_contents.splitlines())
+        if line.endswith(BUG_MARKER)
+    }
+    return ["\n".join(r) for k, r in make_report(explanations).items()]
+
+
+TRIVIAL = """
+@given(st.integers())
+def test_reports_branch_in_test(x):
+    if x > 10:
+        raise AssertionError  # BUG
+"""
+MULTIPLE_BUGS = """
+@given(st.integers(), st.integers())
+def test_reports_branch_in_test(x, y):
+    if x > 10:
+        raise (AssertionError if x % 2 else Exception)  # BUG
+"""
+
+
+# We skip tracing for explanations under PyPy, where it has a large performance
+# impact, or if there is already a trace function (e.g. coverage or a debugger)
+@pytest.mark.skipif(PYPY or sys.gettrace(), reason="See comment")
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(TRIVIAL, id="trivial"),
+        pytest.param(MULTIPLE_BUGS, id="multiple-bugs"),
+    ],
+)
+def test_explanations(code, testdir):
+    code = PRELUDE + code
+    test_file = str(testdir.makepyfile(code))
+    pytest_stdout = str(testdir.runpytest_inprocess(test_file, "--tb=native").stdout)
+    expected = expected_reports(code, fname=test_file)
+    assert len(expected) == code.count(BUG_MARKER)
+    for report in expected:
+        assert report in pytest_stdout


### PR DESCRIPTION
I'm currently working on [a paper about integrating fault localisation with property-based testing](https://zhd.dev/phd/scrutineer.html) - TLDR, it's pretty easy for PBT libraries to suggest where to start debugging test failures.

It turns out that my simple baseline version is also reliable, useful, and easy to interpret.  On that basis I thought it makes sense to ship it, albeit disabled-by-default.  I've tried this on a variety of toy examples and some real bugs in `black`; reviews and/or feedback on how this works for your problems would be most welcome 🙂 

------------

Future plans for other PRs: adding fancier techniques, if they're reliable and fast and actually work better; and integration with generalised examples (#2192).  As currently planned, all of these would go in a single "explain phase" - they share a purpose and workflow and therefore aren't individually configurable.