### PR TITLE
Resolve pytest warnings about the deprecated --strict flag

### DIFF
--- a/hypothesis-python/tests/pytest/test_mark.py
+++ b/hypothesis-python/tests/pytest/test_mark.py
@@ -31,7 +31,9 @@ def test_bar():
 
 def test_can_select_mark(testdir):
     script = testdir.makepyfile(TESTSUITE)
-    result = testdir.runpytest(script, "--verbose", "--strict", "-m", "hypothesis")
+    result = testdir.runpytest(
+        script, "--verbose", "--strict-markers", "-m", "hypothesis"
+    )
     out = "\n".join(result.stdout.lines)
     assert "1 passed, 1 deselected" in out
 
@@ -53,6 +55,8 @@ class TestStuff(TestCase):
 
 def test_can_select_mark_on_unittest(testdir):
     script = testdir.makepyfile(UNITTEST_TESTSUITE)
-    result = testdir.runpytest(script, "--verbose", "--strict", "-m", "hypothesis")
+    result = testdir.runpytest(
+        script, "--verbose", "--strict-markers", "-m", "hypothesis"
+    )
     out = "\n".join(result.stdout.lines)
     assert "1 passed, 1 deselected" in out

--- a/hypothesis-python/tests/pytest/test_seeding.py
+++ b/hypothesis-python/tests/pytest/test_seeding.py
@@ -48,7 +48,7 @@ def test_runs_repeatably_when_seed_is_set(seed, testdir):
 
     results = [
         testdir.runpytest(
-            script, "--verbose", "--strict", "--hypothesis-seed", str(seed)
+            script, "--verbose", "--strict-markers", "--hypothesis-seed", str(seed)
         )
         for _ in range(2)
     ]
@@ -94,7 +94,7 @@ def test_repeats_healthcheck_when_following_seed_instruction(testdir, tmpdir):
 
     script = testdir.makepyfile(health_check_test)
 
-    initial = testdir.runpytest(script, "--verbose", "--strict")
+    initial = testdir.runpytest(script, "--verbose", "--strict-markers")
 
     match = CONTAINS_SEED_INSTRUCTION.search("\n".join(initial.stdout.lines))
     initial_output = "\n".join(initial.stdout.lines)
@@ -102,12 +102,14 @@ def test_repeats_healthcheck_when_following_seed_instruction(testdir, tmpdir):
     match = CONTAINS_SEED_INSTRUCTION.search(initial_output)
     assert match is not None
 
-    rerun = testdir.runpytest(script, "--verbose", "--strict", match.group(0))
+    rerun = testdir.runpytest(script, "--verbose", "--strict-markers", match.group(0))
     rerun_output = "\n".join(rerun.stdout.lines)
 
     assert "FailedHealthCheck" in rerun_output
     assert "--hypothesis-seed" not in rerun_output
 
-    rerun2 = testdir.runpytest(script, "--verbose", "--strict", "--hypothesis-seed=10")
+    rerun2 = testdir.runpytest(
+        script, "--verbose", "--strict-markers", "--hypothesis-seed=10"
+    )
     rerun2_output = "\n".join(rerun2.stdout.lines)
     assert "FailedHealthCheck" not in rerun2_output

--- a/hypothesis-python/tests/pytest/test_skipping.py
+++ b/hypothesis-python/tests/pytest/test_skipping.py
@@ -45,6 +45,8 @@ def test_no_falsifying_example_if_pytest_skip(testdir):
     continue running the test and shrink process, nor should it print anything
     about falsifying examples."""
     script = testdir.makepyfile(PYTEST_TESTSUITE)
-    result = testdir.runpytest(script, "--verbose", "--strict", "-m", "hypothesis")
+    result = testdir.runpytest(
+        script, "--verbose", "--strict-markers", "-m", "hypothesis"
+    )
     out = "\n".join(result.stdout.lines)
     assert "Falsifying example" not in out

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -92,7 +92,7 @@ commands =
     pip install .[zoneinfo]
     python -m coverage --version
     python -m coverage debug sys
-    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/conjecture tests/datetime tests/numpy tests/pandas tests/lark --ff {posargs}
+    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict-markers tests/cover tests/conjecture tests/datetime tests/numpy tests/pandas tests/lark --ff {posargs}
     python -m coverage report -m --fail-under=100 --show-missing --skip-covered
     python scripts/validate_branch_check.py
 
@@ -106,7 +106,7 @@ whitelist_externals=
 setenv=
     HYPOTHESIS_INTERNAL_COVERAGE=true
 commands =
-    python -m coverage run --rcfile=.coveragerc --source=hypothesis.internal.conjecture -m pytest -n0 --strict tests/conjecture
+    python -m coverage run --rcfile=.coveragerc --source=hypothesis.internal.conjecture -m pytest -n0 --strict-markers tests/conjecture
     python -m coverage report -m --fail-under=100 --show-missing --skip-covered
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 
-addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20
+addopts=--strict-markers --tb=native -p pytester --runpytest=subprocess --durations=20
 filterwarnings =
     ignore::hypothesis.errors.NonInteractiveExampleWarning


### PR DESCRIPTION
As of pytest 6.2, `--strict` is a deprecated alias for `--strict-markers`, which was renamed to reflect the flag's actual narrow behaviour.

https://docs.pytest.org/en/stable/deprecations.html#the-strict-command-line-option

This gets rid of an annoying warning that would appear when running pytest, making it harder to view the actual test results.