### PR TITLE
Bump required pytest version to 4.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
       matrix:
         task:
           - check-nose
-          - check-pytest43
+          - check-pytest46
           - check-django31
           - check-django30
           - check-django22

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+The Hypothesis :pypi:`pytest` plugin now requires pytest version 4.6 or later.
+If the plugin detects an earlier version of pytest, it will automatically
+deactivate itself.
+
+`(4.6.x is the earliest pytest branch that still accepts community bugfixes.)
+<https://docs.pytest.org/en/stable/py27-py34-deprecation.html>`__
+
+Hypothesis-based tests should continue to work in earlier versions of
+pytest, but enhanced integrations provided by the plugin
+(such as ``--hypothesis-show-statistics`` and other command-line flags)
+will no longer be available in obsolete pytest versions.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -65,7 +65,7 @@ extras = {
     "lark": ["lark-parser>=0.6.5"],
     "numpy": ["numpy>=1.9.0"],
     "pandas": ["pandas>=0.25"],
-    "pytest": ["pytest>=4.3"],
+    "pytest": ["pytest>=4.6"],
     "dpcontracts": ["dpcontracts>=0.4"],
     "redis": ["redis>=3.0.0"],
     # zoneinfo is an odd one: every dependency is conditional, because they're

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -46,15 +46,15 @@ class StoringReporter:
 
 # Avoiding distutils.version.LooseVersion due to
 # https://github.com/HypothesisWorks/hypothesis/issues/2490
-if tuple(map(int, pytest.__version__.split(".")[:2])) < (4, 3):  # pragma: no cover
+if tuple(map(int, pytest.__version__.split(".")[:2])) < (4, 6):  # pragma: no cover
     import warnings
 
     from hypothesis.errors import HypothesisWarning
 
     PYTEST_TOO_OLD_MESSAGE = """
-        You are using Pytest version %s.  Hypothesis tests work with any test
-        runner, but our Pytest plugin requires Pytest  4.3 or newer.
-        Note that the Pytest developers no longer support this version either!
+        You are using pytest version %s. Hypothesis tests work with any test
+        runner, but our pytest plugin requires pytest 4.6 or newer.
+        Note that the pytest developers no longer support your version either!
         Disabling the Hypothesis pytest plugin...
     """
     warnings.warn(PYTEST_TOO_OLD_MESSAGE % (pytest.__version__,), HypothesisWarning)

--- a/hypothesis-python/tests/pytest/test_skipping.py
+++ b/hypothesis-python/tests/pytest/test_skipping.py
@@ -13,8 +13,6 @@
 #
 # END HEADER
 
-import pytest
-
 pytest_plugins = "pytester"
 
 
@@ -36,10 +34,6 @@ def test_to_be_skipped(xs):
 """
 
 
-@pytest.mark.skipif(
-    pytest.__version__.startswith("3.0"),
-    reason="Pytest 3.0 predates a Skipped exception type, so we can't hook into it.",
-)
 def test_no_falsifying_example_if_pytest_skip(testdir):
     """If ``pytest.skip() is called during a test, Hypothesis should not
     continue running the test and shrink process, nor should it print anything

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -76,7 +76,7 @@ def test_prints_statistics_given_option_with_junitxml(testdir):
     assert "< 10% of examples satisfied assumptions" in out
 
 
-@pytest.mark.skipif(LooseVersion(pytest.__version__) < "4.6", reason="too old")
+@pytest.mark.skipif(LooseVersion(pytest.__version__) < "5.4.0", reason="too old")
 def test_prints_statistics_given_option_under_xdist_with_junitxml(testdir):
     out = get_output(
         testdir, TESTSUITE, PRINT_STATISTICS_OPTION, "-n", "2", "--junit-xml=out.xml"

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -71,11 +71,11 @@ deps =
 commands=
     nosetests tests/cover/test_testdecorators.py
 
-[testenv:pytest43]
+[testenv:pytest46]
 deps =
     -r../requirements/test.txt
 commands=
-    pip install pytest==4.3 pytest-xdist==1.25 pytest-forked==0.2
+    pip install pytest==4.6 pytest-xdist==1.34
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -368,7 +368,7 @@ def standard_tox_task(name):
 
 
 standard_tox_task("nose")
-standard_tox_task("pytest43")
+standard_tox_task("pytest46")
 
 for n in [22, 30, 31]:
     standard_tox_task(f"django{n}")


### PR DESCRIPTION
Motivated by #2863, but also a fine idea in general since 4.6 is the earliest version semi-supported by the pytest maintainers.