### PR TITLE
Tidying up stateful testing

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch refactors some internals of :class:`~hypothesis.stateful.RuleBasedStateMachine`.
+There is no change to the public API or behaviour.

--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -9,6 +9,14 @@ not just data but entire tests. You specify a number of primitive
 actions that can be combined together, and then Hypothesis will
 try to find sequences of those actions that result in a failure.
 
+.. tip::
+
+    Before reading this reference documentation, we recommend reading
+    `How not to Die Hard with Hypothesis <https://hypothesis.works/articles/how-not-to-die-hard-with-hypothesis/>`__
+    and `An Introduction to Rule-Based Stateful Testing <https://hypothesis.works/articles/rule-based-stateful-testing/>`__,
+    in that order. The implementation details will make more sense once you've seen
+    them used in practice, and know *why* each method or decorator is available.
+
 .. note::
 
   This style of testing is often called *model-based testing*, but in Hypothesis

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -677,11 +677,8 @@ class StateForActualGivenExecution:
             if result is not None:
                 fail_health_check(
                     self.settings,
-                    (
-                        "Tests run under @given should return None, but "
-                        "%s returned %r instead."
-                    )
-                    % (self.test.__name__, result),
+                    "Tests run under @given should return None, but "
+                    f"{self.test.__name__} returned {result!r} instead.",
                     HealthCheck.return_value,
                 )
         except UnsatisfiedAssumption:

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -39,7 +39,7 @@ from typing import Dict, Optional
 
 import attr
 import lark
-from lark.grammar import NonTerminal, Terminal
+from lark.grammar import NonTerminal, Terminal  # type: ignore
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.utils import calc_label_from_name

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -592,10 +592,10 @@ def rule(*, targets=(), target=None, **kwargs):
 def initialize(*, targets=(), target=None, **kwargs):
     """Decorator for RuleBasedStateMachine.
 
-    An initialize decorator behaves like a rule, but the decorated
-    method is called at most once in a run. All initialize decorated
-    methods will be called before any rule decorated methods, in an
-    arbitrary order.
+    An initialize decorator behaves like a rule, but all ``@initialize()`` decorated
+    methods will be called before any ``@rule()`` decorated methods, in an arbitrary
+    order.  Each ``@initialize()`` method will be called exactly once per run, unless
+    one raises an exception - after which only the ``.teardown()`` method will be run.
     """
     converted_targets = _convert_targets(targets, target)
     for k, v in kwargs.items():

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -216,11 +216,9 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
     executed.
     """
 
-    _rules_per_class = {}  # type: Dict[type, List[classmethod]]
-    _invariants_per_class = {}  # type: Dict[type, List[classmethod]]
-    _base_rules_per_class = {}  # type: Dict[type, List[classmethod]]
-    _initializers_per_class = {}  # type: Dict[type, List[classmethod]]
-    _base_initializers_per_class = {}  # type: Dict[type, List[classmethod]]
+    _rules_per_class: Dict[type, List[classmethod]] = {}
+    _invariants_per_class: Dict[type, List[classmethod]] = {}
+    _initializers_per_class: Dict[type, List[classmethod]] = {}
 
     def __init__(self):
         if not self.rules():
@@ -268,13 +266,11 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
         except KeyError:
             pass
 
+        cls._initializers_per_class[cls] = []
         for _, v in inspect.getmembers(cls):
             r = getattr(v, INITIALIZE_RULE_MARKER, None)
             if r is not None:
-                cls.define_initialize_rule(
-                    r.targets, r.function, r.arguments, r.precondition
-                )
-        cls._initializers_per_class[cls] = cls._base_initializers_per_class.pop(cls, [])
+                cls._initializers_per_class[cls].append(r)
         return cls._initializers_per_class[cls]
 
     @classmethod
@@ -284,11 +280,11 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
         except KeyError:
             pass
 
+        cls._rules_per_class[cls] = []
         for _, v in inspect.getmembers(cls):
             r = getattr(v, RULE_MARKER, None)
             if r is not None:
-                cls.define_rule(r.targets, r.function, r.arguments, r.precondition)
-        cls._rules_per_class[cls] = cls._base_rules_per_class.pop(cls, [])
+                cls._rules_per_class[cls].append(r)
         return cls._rules_per_class[cls]
 
     @classmethod
@@ -305,30 +301,6 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
                 target.append(i)
         cls._invariants_per_class[cls] = target
         return cls._invariants_per_class[cls]
-
-    @classmethod
-    def define_initialize_rule(cls, targets, function, arguments, precondition=None):
-        converted_arguments = {}
-        for k, v in arguments.items():
-            converted_arguments[k] = v
-        if cls in cls._initializers_per_class:
-            target = cls._initializers_per_class[cls]
-        else:
-            target = cls._base_initializers_per_class.setdefault(cls, [])
-
-        return target.append(Rule(targets, function, converted_arguments, precondition))
-
-    @classmethod
-    def define_rule(cls, targets, function, arguments, precondition=None):
-        converted_arguments = {}
-        for k, v in arguments.items():
-            converted_arguments[k] = v
-        if cls in cls._rules_per_class:
-            target = cls._rules_per_class[cls]
-        else:
-            target = cls._base_rules_per_class.setdefault(cls, [])
-
-        return target.append(Rule(targets, function, converted_arguments, precondition))
 
     def _print_step(self, rule, data, result):
         self.step_count = getattr(self, "step_count", 0) + 1

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -125,6 +125,14 @@ class PreconditionMachine(RuleBasedStateMachine):
         self.num = num / self.num
 
 
+TestPrecondition = PreconditionMachine.TestCase
+TestPrecondition.settings = Settings(TestPrecondition.settings, max_examples=10)
+
+
+def test_picks_up_settings_at_first_use_of_testcase():
+    assert TestPrecondition.settings.max_examples == 10
+
+
 class RoseTreeStateMachine(RuleBasedStateMachine):
     nodes = Bundle("nodes")
 
@@ -450,53 +458,6 @@ def test_machine_with_no_terminals_is_invalid():
 
     with raises(InvalidDefinition):
         NonTerminalMachine.TestCase().runTest()
-
-
-class DynamicMachine(RuleBasedStateMachine):
-    @rule(value=Bundle("hi"))
-    def test_stuff(x):
-        pass
-
-
-DynamicMachine.define_rule(targets=(), function=lambda self: 1, arguments={})
-
-
-class IntAdder(RuleBasedStateMachine):
-    pass
-
-
-IntAdder.define_rule(
-    targets=("ints",), function=lambda self, x: x, arguments={"x": integers()}
-)
-
-IntAdder.define_rule(
-    targets=("ints",),
-    function=lambda self, x, y: x,
-    arguments={"x": integers(), "y": Bundle("ints")},
-)
-
-
-TestDynamicMachine = DynamicMachine.TestCase
-TestIntAdder = IntAdder.TestCase
-TestPrecondition = PreconditionMachine.TestCase
-
-
-for test_case in (TestDynamicMachine, TestIntAdder, TestPrecondition):
-    test_case.settings = Settings(test_case.settings, max_examples=10)
-
-
-def test_picks_up_settings_at_first_use_of_testcase():
-    assert TestDynamicMachine.settings.max_examples == 10
-
-
-def test_new_rules_are_picked_up_before_and_after_rules_call():
-    class Foo(RuleBasedStateMachine):
-        pass
-
-    Foo.define_rule(targets=(), function=lambda self: 1, arguments={})
-    assert len(Foo.rules()) == 1
-    Foo.define_rule(targets=(), function=lambda self: 2, arguments={})
-    assert len(Foo.rules()) == 2
 
 
 def test_minimizes_errors_in_teardown():
@@ -1053,16 +1014,6 @@ state.fail_eventually()
 state.teardown()
 """
     )
-
-
-def test_new_initialize_rules_are_picked_up_before_and_after_rules_call():
-    class Foo(RuleBasedStateMachine):
-        pass
-
-    Foo.define_initialize_rule(targets=(), function=lambda self: 1, arguments={})
-    assert len(Foo.initialize_rules()) == 1
-    Foo.define_initialize_rule(targets=(), function=lambda self: 2, arguments={})
-    assert len(Foo.initialize_rules()) == 2
 
 
 def test_steps_printed_despite_pytest_fail(capsys):

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -8,7 +8,7 @@ attrs==20.3.0
     # via hypothesis (hypothesis-python/setup.py)
 coverage==5.4
     # via -r requirements/coverage.in
-lark-parser==0.11.1
+lark-parser==0.11.2
     # via -r requirements/coverage.in
 numpy==1.20.1
     # via

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -51,7 +51,7 @@ com2ann==0.1.1
     # via shed
 coverage==5.4
     # via -r requirements/tools.in
-cryptography==3.4.5
+cryptography==3.4.6
     # via secretstorage
 decorator==4.4.2
     # via
@@ -59,7 +59,7 @@ decorator==4.4.2
     #   traitlets
 distlib==0.3.1
     # via virtualenv
-django==3.1.6
+django==3.1.7
     # via -r requirements/tools.in
 docutils==0.16
     # via
@@ -120,9 +120,9 @@ jeepney==0.6.0
     #   secretstorage
 jinja2==2.11.3
     # via sphinx
-keyring==22.0.1
+keyring==22.3.0
     # via twine
-lark-parser==0.11.1
+lark-parser==0.11.2
     # via -r requirements/tools.in
 libcst==0.3.17
     # via
@@ -138,7 +138,7 @@ mypy-extensions==0.4.3
     #   black
     #   mypy
     #   typing-inspect
-mypy==0.800
+mypy==0.812
     # via -r requirements/tools.in
 packaging==20.9
     # via
@@ -188,7 +188,7 @@ pyflakes==2.2.0
     # via
     #   autoflake
     #   flake8
-pygments==2.7.4
+pygments==2.8.0
     # via
     #   ipython
     #   pybetter
@@ -210,7 +210,7 @@ pyyaml==5.4.1
     # via
     #   bandit
     #   libcst
-readme-renderer==28.0
+readme-renderer==29.0
     # via twine
 regex==2020.11.13
     # via black
@@ -253,7 +253,7 @@ sphinx-rtd-theme==0.5.1
     # via -r requirements/tools.in
 sphinx-selective-exclude==1.0.3
     # via -r requirements/tools.in
-sphinx==3.4.3
+sphinx==3.5.1
     # via
     #   -r requirements/tools.in
     #   sphinx-rtd-theme
@@ -281,9 +281,9 @@ toml==0.10.2
     #   black
     #   pytest
     #   tox
-tox==3.21.4
+tox==3.22.0
     # via -r requirements/tools.in
-tqdm==4.56.2
+tqdm==4.58.0
     # via twine
 traitlets==4.3.3
     # via


### PR DESCRIPTION
This PR contains the docs suggested in #2860, along with some refactoring of `RuleBasedStateMachine`, intended to make it easier to work on e.g. the issues discussed in #2861.

(the `define_*` classmethods were a holdover from `GenericStateMachine`, which was removed in Hypothesis 5.0.0)