### PR TITLE
Upgrade `integers()` backend and filter rewriting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Engine changes need to be approved by DRMacIver, as per
 # https://github.com/HypothesisWorks/hypothesis/blob/master/guides/review.rst#engine-changes
-/hypothesis-python/src/hypothesis/internal/conjecture/ @DRMacIver
+/hypothesis-python/src/hypothesis/internal/conjecture/ @DRMacIver @Zac-HD
 
 # Changes to the paper also need to be approved by DRMacIver
 /paper.md @DRMacIver

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch lays more groundwork for filter rewriting (:issue:`2701`).
+There is no user-visible change... yet.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -267,6 +267,7 @@ def _get_strategies(
 
     This dict is used to construct our call to the `@given(...)` decorator.
     """
+    assert funcs, "Must pass at least one function"
     given_strategies: Dict[str, st.SearchStrategy] = {}
     for i, f in enumerate(funcs):
         params = _get_params(f)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -54,7 +54,7 @@ def dominance(left, right):
         return DominanceRelation.EQUAL
 
     if sort_key(right.buffer) < sort_key(left.buffer):
-        result = dominance(right, left)
+        result = dominance(left=right, right=left)
         if result == DominanceRelation.LEFT_DOMINATES:
             return DominanceRelation.RIGHT_DOMINATES
         else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -38,9 +38,6 @@ from hypothesis.internal.conjecture.junkdrawer import (
 from hypothesis.internal.conjecture.shrinking import Float, Integer, Lexical, Ordering
 from hypothesis.internal.conjecture.shrinking.learned_dfas import SHRINKING_DFAS
 
-if False:
-    from typing import Dict  # noqa
-
 
 def sort_key(buffer):
     """Returns a sort key such that "simpler" buffers are smaller than

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -56,6 +56,19 @@ BIASED_COIN_INNER_LABEL = calc_label_from_name("inside biased_coin()")
 SAMPLE_IN_SAMPLER_LABLE = calc_label_from_name("a sample() in Sampler")
 ONE_FROM_MANY_LABEL = calc_label_from_name("one more from many()")
 
+INT_SIZES = (8, 16, 32, 64, 128)
+INT_WEIGHTS = (4.0, 8.0, 1.0, 1.0, 0.5)
+
+
+def unbounded_integers(data):
+    size = INT_SIZES[Sampler(INT_WEIGHTS).sample(data)]
+    r = data.draw_bits(size)
+    sign = r & 1
+    r >>= 1
+    if sign:
+        r = -r
+    return int(r)
+
 
 def integer_range(data, lower, upper, center=None):
     assert lower <= upper
@@ -90,11 +103,10 @@ def integer_range(data, lower, upper, center=None):
 
     if bits > 24 and data.draw_bits(3):
         # For large ranges, we combine the uniform random distribution from draw_bits
-        # with the weighting scheme used by WideRangeIntStrategy with moderate chance.
-        # Cutoff at 2 ** 24 so unicode choice is uniform but 32bit distribution is not.
-        idx = Sampler([4.0, 8.0, 1.0, 1.0, 0.5]).sample(data)
-        sizes = [8, 16, 32, 64, 128]
-        bits = min(bits, sizes[idx])
+        # with a weighting scheme with moderate chance.  Cutoff at 2 ** 24 so that our
+        # choice of unicode characters is uniform but the 32bit distribution is not.
+        idx = Sampler(INT_WEIGHTS).sample(data)
+        bits = min(bits, INT_SIZES[idx])
 
     while probe > gap:
         data.start_example(INTEGER_RANGE_DRAW_LABEL)

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -82,8 +82,10 @@ def get_numeric_predicate_bounds(predicate: Predicate) -> ConstructivePredicate:
         and not predicate.keywords
     ):
         arg = predicate.args[0]
-        if (isinstance(arg, Decimal) and Decimal.is_snan(arg)) or not isinstance(
-            arg, (int, float, Fraction, Decimal)
+        if (
+            (isinstance(arg, Decimal) and Decimal.is_snan(arg))
+            or not isinstance(arg, (int, float, Fraction, Decimal))
+            or math.isnan(arg)
         ):
             return ConstructivePredicate.unchanged(predicate)
         options = {

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -97,7 +97,7 @@ def ip_addresses(
     """
     if v is not None:
         check_type(int, v, "v")
-        if v != 4 and v != 6:
+        if v not in (4, 6):
             raise InvalidArgument(f"v={v!r}, but only v=4 or v=6 are valid")
     if network is None:
         # We use the reserved-address registries to boost the chance

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -652,6 +652,12 @@ class OneOfStrategy(SearchStrategy):
         else:
             return [self]
 
+    def filter(self, condition):
+        return FilteredStrategy(
+            OneOfStrategy([s.filter(condition) for s in self.original_strategies]),
+            conditions=(),
+        )
+
 
 @overload
 def one_of(args: Sequence[SearchStrategy[Any]]) -> SearchStrategy[Any]:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -87,10 +87,7 @@ def is_a_new_type(thing):
     # than an actual type, but we can check whether that thing matches.
     return (
         hasattr(thing, "__supertype__")
-        and (
-            getattr(thing, "__module__", None) == "typing"
-            or getattr(thing, "__module__", None) == "typing_extensions"
-        )
+        and getattr(thing, "__module__", None) in ("typing", "typing_extensions")
         and inspect.isfunction(thing)
     )
 

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -576,7 +576,7 @@ def _set_pprinter_factory(start, end, basetype):
 
         if cycle:
             return p.text(start + "..." + end)
-        if len(obj) == 0:
+        if not obj:
             # Special case.
             p.text(basetype.__name__ + "()")
         else:
@@ -815,7 +815,7 @@ def _ordereddict_pprint(obj, p, cycle):
     with p.group(len(name) + 1, name + "(", ")"):
         if cycle:
             p.text("...")
-        elif len(obj):
+        elif obj:
             p.pretty(list(obj.items()))
 
 
@@ -833,7 +833,7 @@ def _counter_pprint(obj, p, cycle):
     with p.group(len(name) + 1, name + "(", ")"):
         if cycle:
             p.text("...")
-        elif len(obj):
+        elif obj:
             p.pretty(dict(obj))
 
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -113,8 +113,6 @@ def slow_shrinker():
 
 @pytest.mark.parametrize("n", [1, 5])
 def test_terminates_shrinks(n, monkeypatch):
-    from hypothesis.internal.conjecture import engine
-
     db = InMemoryExampleDatabase()
 
     def generate_new_examples(self):
@@ -123,7 +121,7 @@ def test_terminates_shrinks(n, monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner, "generate_new_examples", generate_new_examples
     )
-    monkeypatch.setattr(engine, "MAX_SHRINKS", n)
+    monkeypatch.setattr(engine_module, "MAX_SHRINKS", n)
 
     runner = ConjectureRunner(
         slow_shrinker(),

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -363,15 +363,13 @@ def test_decimal_is_in_bounds(x):
 
 
 def test_float_can_find_max_value_inf():
-    assert minimal(ds.floats(max_value=math.inf), lambda x: math.isinf(x)) == float(
-        "inf"
-    )
-    assert minimal(ds.floats(min_value=0.0), lambda x: math.isinf(x)) == math.inf
+    assert minimal(ds.floats(max_value=math.inf), math.isinf) == float("inf")
+    assert minimal(ds.floats(min_value=0.0), math.isinf) == math.inf
 
 
 def test_float_can_find_min_value_inf():
     minimal(ds.floats(), lambda x: x < 0 and math.isinf(x))
-    minimal(ds.floats(min_value=-math.inf, max_value=0.0), lambda x: math.isinf(x))
+    minimal(ds.floats(min_value=-math.inf, max_value=0.0), math.isinf)
 
 
 def test_can_find_none_list():

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -579,7 +579,7 @@ def _broadcast_shapes(*shapes):
     input shapes together.
 
     Raises ValueError if the shapes are not broadcast-compatible"""
-    assert len(shapes)
+    assert shapes, "Must pass >=1 shapes to broadcast"
     return reduce(_broadcast_two_shapes, shapes, ())
 
 

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -29,7 +29,7 @@ import re
 
 from hypothesis import HealthCheck, settings as Settings
 from hypothesis.errors import UnsatisfiedAssumption
-from hypothesis.internal import reflection as reflection
+from hypothesis.internal import reflection
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.strategies import (
     booleans,

--- a/hypothesis-python/tests/quality/test_integers.py
+++ b/hypothesis-python/tests/quality/test_integers.py
@@ -28,7 +28,7 @@ from hypothesis import (
 )
 from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
 from hypothesis.internal.conjecture.engine import ConjectureRunner
-from hypothesis.strategies._internal.numbers import WideRangeIntStrategy
+from hypothesis.internal.conjecture.utils import INT_SIZES
 
 
 @st.composite
@@ -112,7 +112,7 @@ def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
     #   have power of two sizes, so it may be up to a factor of two more than
     #   that.
     bits_needed = 1 + n.bit_length()
-    actual_bits_needed = min(s for s in WideRangeIntStrategy.sizes if s >= bits_needed)
+    actual_bits_needed = min(s for s in INT_SIZES if s >= bits_needed)
     bytes_needed = actual_bits_needed // 8
     # 3 extra bytes: two for the sampler, one for the capping value.
     assert len(v.buffer) == 3 + bytes_needed

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -6,7 +6,7 @@
 #
 attrs==20.3.0
     # via hypothesis (hypothesis-python/setup.py)
-coverage==5.4
+coverage==5.5
     # via -r requirements/coverage.in
 lark-parser==0.11.2
     # via -r requirements/coverage.in
@@ -14,7 +14,7 @@ numpy==1.20.1
     # via
     #   -r requirements/coverage.in
     #   pandas
-pandas==1.2.2
+pandas==1.2.3
     # via -r requirements/coverage.in
 python-dateutil==2.8.1
     # via pandas

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -29,7 +29,7 @@ black==20.8b1
     # via
     #   blacken-docs
     #   shed
-blacken-docs==1.9.2
+blacken-docs==1.10.0
     # via -r requirements/tools.in
 bleach==3.3.0
     # via readme-renderer
@@ -49,7 +49,7 @@ colorama==0.4.4
     # via twine
 com2ann==0.1.1
     # via shed
-coverage==5.4
+coverage==5.5
     # via -r requirements/tools.in
 cryptography==3.4.6
     # via secretstorage
@@ -76,7 +76,7 @@ flake8-2020==1.6.0
     # via -r requirements/tools.in
 flake8-bandit==2.1.2
     # via -r requirements/tools.in
-flake8-bugbear==20.11.1
+flake8-bugbear==21.3.2
     # via -r requirements/tools.in
 flake8-comprehensions==3.3.1
     # via -r requirements/tools.in
@@ -98,7 +98,7 @@ flake8==3.8.4
     #   flake8-polyfill
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.13
+gitpython==3.1.14
     # via bandit
 idna==2.10
     # via requests
@@ -156,7 +156,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==5.5.0
+pip-tools==6.0.0
     # via -r requirements/tools.in
 pkginfo==1.7.0
     # via twine
@@ -164,7 +164,7 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.17
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -188,7 +188,7 @@ pyflakes==2.2.0
     # via
     #   autoflake
     #   flake8
-pygments==2.8.0
+pygments==2.8.1
     # via
     #   ipython
     #   pybetter
@@ -253,7 +253,7 @@ sphinx-rtd-theme==0.5.1
     # via -r requirements/tools.in
 sphinx-selective-exclude==1.0.3
     # via -r requirements/tools.in
-sphinx==3.5.1
+sphinx==3.5.2
     # via
     #   -r requirements/tools.in
     #   sphinx-rtd-theme
@@ -281,9 +281,9 @@ toml==0.10.2
     #   black
     #   pytest
     #   tox
-tox==3.22.0
+tox==3.23.0
     # via -r requirements/tools.in
-tqdm==4.58.0
+tqdm==4.59.0
     # via twine
 traitlets==4.3.3
     # via


### PR DESCRIPTION
This PR refactors the implementation of `integers()`, so that it consists only of an `IntegersStrategy` class instead of various combinations, maps, and filters over separate classes for bounded and unbounded integers.

Data-generation is logically unchanged, with negligible performance changes in runtime and memory usage - the real motivation here is to empower runtime introspection for filter-rewriting (#2701) and prototyping symbolic execution.