### PR TITLE
Allow `@rule()` xor `@invariant()` decorators on rule-based state machine methods.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release makes it an explicit error to apply :func:`~hypothesis.stateful.invariant`
+to a :func:`~hypothesis.stateful.rule` or :func:`~hypothesis.stateful.initialize` rule
+in :doc:`stateful testing <stateful>`.  Such a combination had unclear semantics,
+especially in combination with :func:`~hypothesis.stateful.precondition`, and was never
+meant to be allowed (:issue:`2681`).

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -537,6 +537,11 @@ def rule(*, targets=(), target=None, **kwargs):
         check_strategy(v, name=k)
 
     def accept(f):
+        if getattr(f, INVARIANT_MARKER, None):
+            raise InvalidDefinition(
+                "A function cannot be used for both a rule and an invariant.",
+                Settings.default,
+            )
         existing_rule = getattr(f, RULE_MARKER, None)
         existing_initialize_rule = getattr(f, INITIALIZE_RULE_MARKER, None)
         if existing_rule is not None or existing_initialize_rule is not None:
@@ -574,6 +579,11 @@ def initialize(*, targets=(), target=None, **kwargs):
         check_strategy(v, name=k)
 
     def accept(f):
+        if getattr(f, INVARIANT_MARKER, None):
+            raise InvalidDefinition(
+                "A function cannot be used for both a rule and an invariant.",
+                Settings.default,
+            )
         existing_rule = getattr(f, RULE_MARKER, None)
         existing_initialize_rule = getattr(f, INITIALIZE_RULE_MARKER, None)
         if existing_rule is not None or existing_initialize_rule is not None:
@@ -683,6 +693,11 @@ def invariant():
     """
 
     def accept(f):
+        if getattr(f, RULE_MARKER, None) or getattr(f, INITIALIZE_RULE_MARKER, None):
+            raise InvalidDefinition(
+                "A function cannot be used for both a rule and an invariant.",
+                Settings.default,
+            )
         existing_invariant = getattr(f, INVARIANT_MARKER, None)
         if existing_invariant is not None:
             raise InvalidDefinition(

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -654,6 +654,32 @@ def test_invariant_precondition():
     run_state_machine_as_test(Invariant)
 
 
+@pytest.mark.parametrize(
+    "decorators",
+    [
+        (invariant(), rule()),
+        (rule(), invariant()),
+        (invariant(), initialize()),
+        (initialize(), invariant()),
+        (invariant(), precondition(lambda self: True), rule()),
+        (rule(), precondition(lambda self: True), invariant()),
+        (precondition(lambda self: True), invariant(), rule()),
+        (precondition(lambda self: True), rule(), invariant()),
+    ],
+    ids=lambda x: "-".join(f.__qualname__.split(".")[0] for f in x),
+)
+def test_invariant_and_rule_are_incompatible(decorators):
+    """It's an error to apply @invariant and @rule to the same method."""
+
+    def method(self):
+        pass
+
+    for d in decorators[:-1]:
+        method = d(method)
+    with pytest.raises(InvalidDefinition):
+        decorators[-1](method)
+
+
 def test_invalid_rule_argument():
     """Rule kwargs that are not a Strategy are expected to raise an InvalidArgument error."""
     with pytest.raises(InvalidArgument):


### PR DESCRIPTION
In stateful testing, it doesn't make much sense to apply both these decorators, and if you did anyway there were weird interactions with preconditions.  See #2861.