### PR TITLE
Fixes an exception in from_type(Union[Literal["a"], Literal["b"]]).example() in Python 3.6

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@ their individual contributions.
 * `Alex Stapleton <https://www.github.com/public>`_
 * `Alex Willmer <https://github.com/moreati>`_ (alex@moreati.org.uk)
 * `Andrea Pierré <https://www.github.com/kir0ul>`_
+* `Ben Anhalt <https://github.com/benanhalt>`_
 * `Ben Peterson <https://github.com/killthrush>`_ (killthrush@hotmail.com)
 * `Benjamin Lee <https://github.com/Benjamin-Lee>`_ (benjamindlee@me.com)
 * `Benjamin Palmer <https://github.com/benjpalmer>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This patch fixes
+:func:`~hypothesis.strategies._internal.types.type_sorting_key`
+to avoid an exception due to type unions of the
+:pypi:`typing_extensions` ``Literal`` backport on Python 3.6.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,6 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
 This patch fixes an exception that occurs when using type unions of
 the :pypi:`typing_extensions` ``Literal`` backport on Python 3.6.
+
+Thanks to Ben Anhalt for identifying and fixing this bug.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,4 @@
 RELEASE_TYPE: minor
 
-This patch fixes
-:func:`~hypothesis.strategies._internal.types.type_sorting_key`
-to avoid an exception due to type unions of the
-:pypi:`typing_extensions` ``Literal`` backport on Python 3.6.
+This patch fixes an exception that occurs when using type unions of
+the :pypi:`typing_extensions` ``Literal`` backport on Python 3.6.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -61,7 +61,7 @@ except ImportError:
 
 def type_sorting_key(t):
     """Minimise to None, then non-container types, then container types."""
-    if not is_a_type(t):  # This branch is for Python < 3.8
+    if not (is_a_type(t) or is_typing_literal(t)):  # This branch is for Python < 3.8
         raise InvalidArgument(f"thing={t} must be a type")  # pragma: no cover
     if t is None or t is type(None):  # noqa: E721
         return (-1, repr(t))

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -80,8 +80,7 @@ def test_defaultdict(ex):
     assert all(isinstance(elem, int) for elem in ex.values())
 
 
-def test_union_of_Literals():
-    assert from_type(Union[Literal["hamster"], Literal["bunny"]]).example() in (
-        "hamster",
-        "bunny",
-    )
+@given(from_type(Union[Literal["hamster"], Literal["bunny"]]))
+def test_union_of_Literals(pet):
+    # See https://github.com/HypothesisWorks/hypothesis/pull/2886
+    assert pet in ("hamster", "bunny")

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -38,6 +38,9 @@ def test_typing_extensions_Literal_nested(data):
         (lit[lit[1], 2], {1, 2}),
         (lit[1, lit[2], 3], {1, 2, 3}),
         (lit[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
+        # See https://github.com/HypothesisWorks/hypothesis/pull/2886
+        (Union[Literal["hamster"], Literal["bunny"]], {"hamster", "bunny"}),
+        (Union[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
     ]
     literal_type, flattened_literals = data.draw(st.sampled_from(values))
     assert data.draw(st.from_type(literal_type)) in flattened_literals
@@ -78,9 +81,3 @@ def test_defaultdict(ex):
     assume(ex)
     assert all(isinstance(elem, int) for elem in ex)
     assert all(isinstance(elem, int) for elem in ex.values())
-
-
-@given(from_type(Union[Literal["hamster"], Literal["bunny"]]))
-def test_union_of_Literals(pet):
-    # See https://github.com/HypothesisWorks/hypothesis/pull/2886
-    assert pet in ("hamster", "bunny")

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -81,4 +81,7 @@ def test_defaultdict(ex):
 
 
 def test_union_of_Literals():
-    assert from_type(Union[Literal["hamster"], Literal["bunny"]]).example() in ("hamster", "bunny")
+    assert from_type(Union[Literal["hamster"], Literal["bunny"]]).example() in (
+        "hamster",
+        "bunny",
+    )

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -78,3 +78,7 @@ def test_defaultdict(ex):
     assume(ex)
     assert all(isinstance(elem, int) for elem in ex)
     assert all(isinstance(elem, int) for elem in ex.values())
+
+
+def test_union_of_Literals():
+    assert from_type(Union[Literal["hamster"], Literal["bunny"]]).example() in ("hamster", "bunny")


### PR DESCRIPTION
The test case in the first commit demonstrates the exception.

Thanks!