### PR TITLE
Default to checking stateful invariants only after initialization

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release teaches :class:`~hypothesis.stateful.RuleBasedStateMachine` to avoid
+checking :func:`~hypothesis.stateful.invariant`\ s until all
+:func:`~hypothesis.stateful.initialize` rules have been run.  You can enable checking
+of specific invariants for incompletely initialized machines by using
+``@invariant(check_during_init=True)`` (:issue:`2868`).
+
+In previous versions, it was possible if awkward to implement this behaviour
+using :func:`~hypothesis.stateful.precondition` and an auxiliary variable.

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -333,6 +333,8 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
 
     def check_invariants(self):
         for invar in self.invariants():
+            if self._initialize_rules_to_run and not invar.check_during_init:
+                continue
             if not all(precond(self) for precond in invar.preconditions):
                 continue
             invar.function(self)
@@ -670,9 +672,10 @@ def precondition(precond):
 class Invariant:
     function = attr.ib()
     preconditions = attr.ib()
+    check_during_init = attr.ib()
 
 
-def invariant():
+def invariant(*, check_during_init=False):
     """Decorator to apply an invariant for rules in a RuleBasedStateMachine.
     The decorated function will be run after every rule and can raise an
     exception to indicate failed invariants.
@@ -685,7 +688,13 @@ def invariant():
             @invariant()
             def is_nonzero(self):
                 assert self.state != 0
+
+    By default, invariants are only checked after all
+    :func:`@initialize() <hypothesis.stateful.initialize>` rules have been run.
+    Pass ``check_during_init=True`` for invariants which can also be checked
+    during initialization.
     """
+    check_type(bool, check_during_init, "check_during_init")
 
     def accept(f):
         existing_invariant = getattr(f, INVARIANT_MARKER, None)
@@ -695,13 +704,17 @@ def invariant():
                 Settings.default,
             )
         preconditions = getattr(f, PRECONDITIONS_MARKER, ())
-        rule = Invariant(function=f, preconditions=preconditions)
+        invar = Invariant(
+            function=f,
+            preconditions=preconditions,
+            check_during_init=check_during_init,
+        )
 
         @proxies(f)
         def invariant_wrapper(*args, **kwargs):
             return f(*args, **kwargs)
 
-        setattr(invariant_wrapper, INVARIANT_MARKER, rule)
+        setattr(invariant_wrapper, INVARIANT_MARKER, invar)
         return invariant_wrapper
 
     return accept

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -720,7 +720,7 @@ def test_explicit_invariant_call_with_precondition():
         run_state_machine_as_test(BadPrecondition)
 
 
-def test_invariant_checks_initial_state():
+def test_invariant_checks_initial_state_if_no_initialize_rules():
     """Invariants are checked before any rules run."""
 
     class BadPrecondition(RuleBasedStateMachine):
@@ -1190,3 +1190,41 @@ def test_multiple_precondition_bug():
             raise AssertionError("This invariant runs, even though it shouldn't.")
 
     run_state_machine_as_test(MultiplePreconditionMachine)
+
+
+class TrickyInitMachine(RuleBasedStateMachine):
+    @initialize()
+    def init_a(self):
+        self.a = 0
+
+    @rule()
+    def inc(self):
+        self.a += 1
+
+    @invariant()
+    def check_a_positive(self):
+        # This will fail if run before the init_a method, but without
+        # @invariant(check_during_init=True) it will only run afterwards.
+        assert self.a >= 0
+
+
+def test_invariants_are_checked_after_init_steps():
+    run_state_machine_as_test(TrickyInitMachine)
+
+
+def test_invariants_can_be_checked_during_init_steps():
+    class UndefinedMachine(TrickyInitMachine):
+        @invariant(check_during_init=True)
+        def check_a_defined(self):
+            # This will fail because `a` is undefined before the init rule.
+            self.a
+
+    with pytest.raises(AttributeError):
+        run_state_machine_as_test(UndefinedMachine)
+
+
+def test_check_during_init_must_be_boolean():
+    invariant(check_during_init=False)
+    invariant(check_during_init=True)
+    with pytest.raises(InvalidArgument):
+        invariant(check_during_init="not a bool")


### PR DESCRIPTION
Per #2860, it's possible but awkward to give all invariants a precondition of "all initialize rules have been run" - but this is almost always the desired behaviour.

This PR therefore makes that the default behaviour, and adds an argument `@invariant(check_during_init=True)` to restore the previous behaviour of unconditionally checking invariants, which fixes #2868.