### PR TITLE
Improve handling of self-referential `recursive()` strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2794`, where nesting :func:`~hypothesis.strategies.deferred`
+strategies within :func:`~hypothesis.strategies.recursive` strategies could
+trigger an internal assertion.  While it was always possible to get the same
+results from a more sensible strategy, the convoluted form now works too.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
@@ -66,13 +66,13 @@ class LimitedStrategy(SearchStrategy):
 
     @contextmanager
     def capped(self, max_templates):
-        assert not self.currently_capped
         try:
+            was_capped = self.currently_capped
             self.currently_capped = True
             self.marker = max_templates
             yield
         finally:
-            self.currently_capped = False
+            self.currently_capped = was_capped
 
 
 class RecursiveStrategy(SearchStrategy):

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -156,3 +156,15 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
         thread.join()
 
     assert not errors
+
+
+SELF_REF = st.recursive(
+    st.deferred(lambda: st.booleans() | SELF_REF),
+    lambda s: st.lists(s, min_size=1),
+)
+
+
+@given(SELF_REF)
+def test_self_ref_regression(_):
+    # See https://github.com/HypothesisWorks/hypothesis/issues/2794
+    pass


### PR DESCRIPTION
Fixes #2794 in the obvious way.