### PR TITLE
Improve error message for `from_type(Type["int"])`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the error message when :func:`~hypothesis.strategies.from_type`
+fails to resolve a forward-reference inside a :class:`python:typing.Type`
+such as ``Type["int"]`` (:issue:`2565`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -596,31 +596,12 @@ class StateForActualGivenExecution:
                                     for v in args:
                                         printer.pretty(v)
                                         # We add a comma unconditionally because
-                                        # generated arguments will always be
-                                        # kwargs, so there will always be more
-                                        # to come.
+                                        # generated arguments will always be kwargs,
+                                        # so there will always be more to come.
                                         printer.text(",")
                                         printer.breakable()
 
-                                    # We need to make sure to print these in the
-                                    # argument order for Python 2 and older versions
-                                    # of Python 3.5. In modern versions this isn't
-                                    # an issue because kwargs is ordered.
-                                    arg_order = {
-                                        v: i
-                                        for i, v in enumerate(
-                                            getfullargspec(self.test).args
-                                        )
-                                    }
-                                    for i, (k, v) in enumerate(
-                                        sorted(
-                                            kwargs.items(),
-                                            key=lambda t: (
-                                                arg_order.get(t[0], float("inf")),
-                                                t[0],
-                                            ),
-                                        )
-                                    ):
+                                    for i, (k, v) in enumerate(kwargs.items()):
                                         printer.text(k)
                                         printer.text("=")
                                         printer.pretty(v)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -127,7 +127,7 @@ def has_type_arguments(type_):
 def is_generic_type(type_):
     """Decides whethere a given type is generic or not."""
     # The ugly truth is that `MyClass`, `MyClass[T]`, and `MyClass[int]` are very different.
-    # In different python versions the might have the same type (3.6)
+    # In different python versions they might have the same type (3.6)
     # or it can be regular type vs `_GenericAlias` (3.7+)
     # We check for `MyClass[T]` and `MyClass[int]` with the first condition,
     # while the second condition is for `MyClass` in `python3.7+`.
@@ -480,12 +480,11 @@ def resolve_Type(thing):
     if getattr(args[0], "__origin__", None) is typing.Union:
         args = args[0].__args__
     # Duplicate check from from_type here - only paying when needed.
-    for a in args:  # pragma: no cover  # only on Python 3.6
+    for a in args:
         if type(a) == ForwardRef:
             raise ResolutionFailed(
-                "thing=%s cannot be resolved.  Upgrading to "
-                "python>=3.6 may fix this problem via improvements "
-                "to the typing module." % (thing,)
+                f"Cannot find the type referenced by {thing} - try using "
+                f"st.register_type_strategy({thing}, st.from_type(...))"
             )
     return st.sampled_from(sorted(args, key=type_sorting_key))
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -603,6 +603,12 @@ def test_cannot_resolve_abstract_class_with_no_concrete_subclass(instance):
     assert False, "test body unreachable as strategy cannot resolve"
 
 
+@fails_with(ResolutionFailed)
+@given(st.from_type(typing.Type["ConcreteFoo"]))
+def test_cannot_resolve_type_with_forwardref(instance):
+    assert False, "test body unreachable as strategy cannot resolve"
+
+
 @pytest.mark.parametrize("typ", [typing.Hashable, typing.Sized])
 @given(data=st.data())
 def test_inference_on_generic_collections_abc_aliases(typ, data):

--- a/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
@@ -19,7 +19,7 @@ We need these test to make sure ``TypeVar('X', bound='MyType')`` works correctly
 There was a problem previously that ``bound='MyType'`` was resolved as ``ForwardRef('MyType')``
 which is not a real type. And ``hypothesis`` was not able to generate any meaningful values out of it.
 
-Right here we test different possible outcomes for different Python versions (excluding ``3.5``):
+Right here we test different possible outcomes for different Python versions:
 - Regular case, when ``'MyType'`` can be imported
 - Alias case, when we use type aliases for ``'MyType'``
 - ``if TYPE_CHECKING:`` case, when ``'MyType'`` only exists during type checking and is not importable at all


### PR DESCRIPTION
Sadly this closes #2565, because `Type` objects don't track the module they were defined in - and we therefore can't get the globals in which to look up the forward reference.

Upside, at least I managed to improve the error message and write a covering test :confused: 