### PR TITLE
Handle all builtin types in `st.from_type()`, including via `Type[...]` and `ForwardRef(...)`

### DIFF
--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -20,5 +20,6 @@ exclude_lines =
     def __copy__
     def __deepcopy__
     except ImportError:
+    if PYPY:
     if TYPE_CHECKING:
     assert all\(.+\)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release :func:`registers <hypothesis.strategies.register_type_strategy>` the
+remaining builtin types, and teaches :func:`~hypothesis.strategies.from_type` to
+try resolving :class:`~python:typing.ForwardRef` and :class:`~python:typing.Type`
+references to built-in types.

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -31,7 +31,7 @@ intermediate steps of your test. That's where the ``note`` function comes in:
     ... def test_shuffle_is_noop(ls, r):
     ...     ls2 = list(ls)
     ...     r.shuffle(ls2)
-    ...     note("Shuffle: %r" % (ls2))
+    ...     note(f"Shuffle: {ls2!r}")
     ...     assert ls == ls2
     ...
     >>> try:
@@ -120,7 +120,7 @@ You can also mark custom events in a test using the ``event`` function:
 
   @given(st.integers().filter(lambda x: x % 2 == 0))
   def test_even_integers(i):
-      event("i mod 3 = %d" % (i % 3,))
+      event(f"i mod 3 = {i%3}")
 
 
 You will then see output like:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -160,7 +160,7 @@ def convert_keyword_arguments(function, args, kwargs):
             elif arg_name in defaults:
                 new_args.append(defaults[arg_name])
             else:
-                raise TypeError("No value provided for argument %r" % (arg_name))
+                raise TypeError(f"No value provided for argument {arg_name!r}")
 
     if kwargs and not (argspec.varkw or argspec.kwonlyargs):
         if len(kwargs) > 1:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -116,7 +116,7 @@ def required_args(target, args=(), kwargs=()):
             else target
         )
     except TypeError:  # pragma: no cover
-        return None
+        return set()
     # self appears in the argspec of __init__ and bound methods, but it's an
     # error to explicitly supply it - so we might skip the first argument.
     skip_self = int(inspect.isclass(target) or inspect.ismethod(target))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -822,7 +822,7 @@ def builds(
             "infer was passed as a positional argument to "
             "builds(), but is only allowed as a keyword arg"
         )
-    required = required_args(target, args, kwargs) or set()
+    required = required_args(target, args, kwargs)
     to_infer = {k for k, v in kwargs.items() if v is infer}
     if required or to_infer:
         if isinstance(target, type) and attr.has(target):
@@ -1054,13 +1054,10 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         return sampled_from(thing)
     # If we know that builds(thing) will fail, give a better error message
     required = required_args(thing)
-    if required and not any(
-        [
-            required.issubset(get_type_hints(thing)),
-            attr.has(thing),
-            # NamedTuples are weird enough that we need a specific check for them.
-            is_typed_named_tuple(thing),
-        ]
+    if required and not (
+        required.issubset(get_type_hints(thing))
+        or attr.has(thing)
+        or is_typed_named_tuple(thing)  # weird enough that we have a specific check
     ):
         raise ResolutionFailed(
             "Could not resolve %r to a strategy; consider "

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -233,7 +233,7 @@ def lists(
     if unique_by is not None:
         if not (callable(unique_by) or isinstance(unique_by, tuple)):
             raise InvalidArgument(
-                "unique_by=%r is not a callable or tuple of callables" % (unique_by)
+                f"unique_by={unique_by!r} is not a callable or tuple of callables"
             )
         if callable(unique_by):
             unique_by = (unique_by,)
@@ -241,7 +241,7 @@ def lists(
             raise InvalidArgument("unique_by is empty")
         for i, f in enumerate(unique_by):
             if not callable(f):
-                raise InvalidArgument("unique_by[%i]=%r is not a callable" % (i, f))
+                raise InvalidArgument(f"unique_by[{i}]={f!r} is not a callable")
         # Note that lazy strategies automatically unwrap when passed to a defines_strategy
         # function.
         tuple_suffixes = None
@@ -1060,8 +1060,8 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         or is_typed_named_tuple(thing)  # weird enough that we have a specific check
     ):
         raise ResolutionFailed(
-            "Could not resolve %r to a strategy; consider "
-            "using register_type_strategy" % (thing,)
+            f"Could not resolve {thing!r} to a strategy; consider "
+            "using register_type_strategy"
         )
     # Finally, try to build an instance by calling the type object.  Unlike builds(),
     # this block *does* try to infer strategies for arguments with default values.
@@ -1089,8 +1089,8 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     subclasses = thing.__subclasses__()
     if not subclasses:
         raise ResolutionFailed(
-            "Could not resolve %r to a strategy, because it is an abstract type "
-            "without any subclasses. Consider using register_type_strategy" % (thing,)
+            f"Could not resolve {thing!r} to a strategy, because it is an abstract "
+            "type without any subclasses. Consider using register_type_strategy"
         )
     return sampled_from(subclasses).flatmap(from_type)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -324,13 +324,13 @@ def floats(
         allow_nan = bool(min_value is None and max_value is None)
     elif allow_nan and (min_value is not None or max_value is not None):
         raise InvalidArgument(
-            "Cannot have allow_nan=%r, with min_value or max_value" % (allow_nan)
+            f"Cannot have allow_nan={allow_nan!r}, with min_value or max_value"
         )
 
     if width not in (16, 32, 64):
         raise InvalidArgument(
-            "Got width=%r, but the only valid values are the integers 16, "
-            "32, and 64." % (width,)
+            f"Got width={width!r}, but the only valid values "
+            "are the integers 16, 32, and 64."
         )
 
     check_valid_bound(min_value, "min_value")
@@ -409,8 +409,8 @@ def floats(
     elif allow_infinity:
         if min_value is not None and max_value is not None:
             raise InvalidArgument(
-                "Cannot have allow_infinity=%r, with both min_value and "
-                "max_value" % (allow_infinity)
+                f"Cannot have allow_infinity={allow_infinity!r}, "
+                "with both min_value and max_value"
             )
     elif min_value == math.inf:
         raise InvalidArgument("allow_infinity=False excludes min_value=inf")

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -780,7 +780,7 @@ class MappedSearchStrategy(SearchStrategy):
     def pack(self, x):
         """Take a value produced by the underlying mapped_strategy and turn it
         into a value suitable for outputting from this strategy."""
-        raise NotImplementedError("%s.pack()" % (self.__class__.__name__))
+        raise NotImplementedError(f"{self.__class__.__name__}.pack()")
 
     def do_draw(self, data: ConjectureData) -> Ex:
         for _ in range(3):


### PR DESCRIPTION
While working on #2892 and #2896, it occurred to me that (absent a registered strategy to the contrary) it's safe to assume that forward-references to the name of a builtin type does in fact refer to that builtin.  This PR implements exactly that logic... and registers all the remaining builtin types, so that we can write the obvious tests.