### PR TITLE
Release rake dependency change

### DIFF
--- a/hypothesis-ruby/RELEASE.md
+++ b/hypothesis-ruby/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Moves rake from being a a runtime dependency to being a development dependency. Rake is used to run tests but is not required for consumers of hypothesis-ruby.

--- a/tooling/src/hypothesistooling/projects/hypothesisruby.py
+++ b/tooling/src/hypothesistooling/projects/hypothesisruby.py
@@ -103,7 +103,7 @@ def tag_name():
 
 def has_source_changes():
     """Returns True if any source files have changed."""
-    return tools.has_changes([RUST_SRC, RUBY_SRC]) or cr.has_release()
+    return tools.has_changes([RUST_SRC, RUBY_SRC, GEMSPEC_FILE]) or cr.has_release()
 
 
 def current_version():


### PR DESCRIPTION
This also makes sure that changes to the gemspec will be required to have a release file in the future. I wrote one for https://github.com/HypothesisWorks/hypothesis/pull/2903 but didn't commit it by mistake. This will catch such a mistake.