### PR TITLE
Tiny ghostwriter fixes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the :doc:`Ghostwriter's <ghostwriter>` handling
+of strategies to generate various fiddly types including frozensets,
+keysviews, valuesviews, regex matches and patterns, and so on.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -396,6 +396,9 @@ def get_pretty_function_description(f):
         # their module as __self__.  This might include c-extensions generally?
         if not (self is None or inspect.isclass(self) or inspect.ismodule(self)):
             return f"{self!r}.{name}"
+    elif getattr(dict, name, object()) is f:
+        # special case for keys/values views in from_type() / ghostwriter output
+        return f"dict.{name}"
     return name
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -340,7 +340,7 @@ _global_type_lookup: typing.Dict[
         st.none() | st.integers(),
     ),
     range: st.one_of(
-        st.integers(min_value=0).map(range),
+        st.builds(range, st.integers(min_value=0)),
         st.builds(range, st.integers(), st.integers()),
         st.builds(range, st.integers(), st.integers(), st.integers().filter(bool)),
     ),

--- a/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
@@ -1,14 +1,14 @@
 # This test code was written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
 
-import hypothesis.extra.numpy as npst
 import numpy
 from hypothesis import given, strategies as st
+from hypothesis.extra.numpy import mutually_broadcastable_shapes
 
 
 @given(
     data=st.data(),
-    shapes=npst.mutually_broadcastable_shapes(signature="(n?,k),(k,m?)->(n?,m?)"),
+    shapes=mutually_broadcastable_shapes(signature="(n?,k),(k,m?)->(n?,m?)"),
     types=st.sampled_from(numpy.matmul.types).filter(lambda sig: "O" not in sig),
 )
 def test_gufunc_matmul(data, shapes, types):


### PR DESCRIPTION
This is a collection of tiny patches to improve the output of `hypothesis write black`.

- Improved magic detection of which module contents to test (based on `__module__` and `__package__`)
- Fixed `st.`-rewriting bug (`frozensets()` -> `st.frozensets()`, not `st.frozenst.sets()`)
- Improved detection of required imports - of `sampled_from(...)` values, extras strategies, etc.

```diff
--- before.py
+++ after.py
@@ -2,16 +2,18 @@
 # and is provided under the Creative Commons Zero public domain dedication.
 
 import black
+import re
 import typing
 from asyncio.events import AbstractEventLoop
-from black import BracketTracker, Line, Mode, PathSpec, Report
+from black import BracketTracker, Line, Mode, Report
 from blib2to3.pytree import Leaf, Node
 from click.core import Context, Option, Parameter
 from collections import ChainMap
 from concurrent.futures._base import Executor
 from hypothesis import given, strategies as st
-from numpy import dtype
+from hypothesis.extra.numpy import array_dtypes
 from pathlib import Path
+from pathspec.pathspec import PathSpec
 
 # TODO: replace st.nothing() with appropriate strategies
 
@@ -24,10 +26,10 @@
     sources=st.one_of(
         st.lists(st.builds(Path)),
         st.sets(st.builds(Path)),
-        st.frozenst.sets(st.builds(Path)),
+        st.frozensets(st.builds(Path)),
         st.dictionaries(keys=st.builds(Path), values=st.builds(Path)),
-        st.dictionaries(keys=st.builds(Path), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.builds(Path)).map(values),
+        st.dictionaries(keys=st.builds(Path), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.builds(Path)).map(dict.values),
         st.iterables(st.builds(Path)),
         st.dictionaries(keys=st.builds(Path), values=st.builds(Path)).map(ChainMap),
     ),
@@ -256,36 +258,6 @@
 
 
 @given(
-    msg=st.text(),
-    type=st.one_of(st.none(), st.integers()),
-    value=st.one_of(st.none(), st.text()),
-    context=st.tuples(st.text(), st.tuples(st.integers(), st.integers())),
-)
-def test_fuzz_ParseError(msg, type, value, context):
-    black.ParseError(msg=msg, type=type, value=value, context=context)
-
-
-@given(patterns=st.nothing())
-def test_fuzz_PathSpec(patterns):
-    black.PathSpec(patterns=patterns)
-
-
-@given(
-    max_workers=st.none(),
-    mp_context=st.none(),
-    initializer=st.none(),
-    initargs=st.just(()),
-)
-def test_fuzz_ProcessPoolExecutor(max_workers, mp_context, initializer, initargs):
-    black.ProcessPoolExecutor(
-        max_workers=max_workers,
-        mp_context=mp_context,
-        initializer=initializer,
-        initargs=initargs,
-    )
-
-
-@given(
     type=st.integers(), value=st.text(), newlines=st.integers(), consumed=st.integers()
 )
 def test_fuzz_ProtoComment(type, value, newlines, consumed):
@@ -352,40 +324,6 @@
 
 
 @given(
-    max_workers=st.none(),
-    thread_name_prefix=st.just(""),
-    initializer=st.none(),
-    initargs=st.just(()),
-)
-def test_fuzz_ThreadPoolExecutor(
-    max_workers, thread_name_prefix, initializer, initargs
-):
-    black.ThreadPoolExecutor(
-        max_workers=max_workers,
-        thread_name_prefix=thread_name_prefix,
-        initializer=initializer,
-        initargs=initargs,
-    )
-
-
-@given(
-    name=st.nothing(),
-    bound=st.none(),
-    covariant=st.booleans(),
-    contravariant=st.booleans(),
-)
-def test_fuzz_TypeVar(name, bound, covariant, contravariant):
-    black.TypeVar(
-        name=name, bound=bound, covariant=covariant, contravariant=contravariant
-    )
-
-
-@given(funcobj=st.nothing())
-def test_fuzz_abstractmethod(funcobj):
-    black.abstractmethod(funcobj=funcobj)
-
-
-@given(
     new_line=st.from_type(Line),
     old_line=st.from_type(Line),
     leaves=st.lists(st.builds(Leaf)),
@@ -436,10 +374,10 @@
         st.binary(),
         st.lists(st.integers()),
         st.sets(st.integers()),
-        st.frozenst.sets(st.integers()),
+        st.frozensets(st.integers()),
         st.dictionaries(keys=st.integers(), values=st.integers()),
-        st.dictionaries(keys=st.integers(), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.integers()).map(values),
+        st.dictionaries(keys=st.integers(), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.integers()).map(dict.values),
         st.dictionaries(keys=st.integers(), values=st.integers()).map(ChainMap),
     ),
 )
@@ -454,11 +392,6 @@
     black.cancel(tasks=tasks)
 
 
-@given(typ=st.nothing(), val=st.nothing())
-def test_fuzz_cast(typ, val):
-    black.cast(typ=typ, val=val)
-
-
 @given(ancestor=st.builds(Node), descendant=st.one_of(st.builds(Leaf), st.builds(Node)))
 def test_fuzz_child_towards(ancestor, descendant):
     black.child_towards(ancestor=ancestor, descendant=descendant)
@@ -484,37 +417,11 @@
     black.contains_pragma_comment(comment_list=comment_list)
 
 
-@given(func=st.nothing())
-def test_fuzz_contextmanager(func):
-    black.contextmanager(func=func)
-
-
 @given(node=st.builds(Node))
 def test_fuzz_convert_one_fmt_off_pair(node):
     black.convert_one_fmt_off_pair(node=node)
 
 
-@given(
-    _cls=st.none(),
-    init=st.booleans(),
-    repr=st.booleans(),
-    eq=st.booleans(),
-    order=st.booleans(),
-    unsafe_hash=st.booleans(),
-    frozen=st.booleans(),
-)
-def test_fuzz_dataclass(_cls, init, repr, eq, order, unsafe_hash, frozen):
-    black.dataclass(
-        _cls=_cls,
-        init=init,
-        repr=repr,
-        eq=eq,
-        order=order,
-        unsafe_hash=unsafe_hash,
-        frozen=frozen,
-    )
-
-
 @given(src=st.binary())
 def test_fuzz_decode_bytes(src):
     black.decode_bytes(src=src)
@@ -525,15 +432,15 @@
     features=st.one_of(
         st.lists(st.sampled_from(black.Feature)),
         st.sets(st.sampled_from(black.Feature)),
-        st.frozenst.sets(st.sampled_from(black.Feature)),
+        st.frozensets(st.sampled_from(black.Feature)),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
         ),
         st.dictionaries(keys=st.sampled_from(black.Feature), values=st.none()).map(
-            keys
+            dict.keys
         ),
         st.dictionaries(keys=st.integers(), values=st.sampled_from(black.Feature)).map(
-            values
+            dict.values
         ),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
@@ -581,37 +488,16 @@
 
 
 @given(
-    default=st.nothing(),
-    default_factory=st.nothing(),
-    init=st.booleans(),
-    repr=st.booleans(),
-    hash=st.none(),
-    compare=st.booleans(),
-    metadata=st.none(),
-)
-def test_fuzz_field(default, default_factory, init, repr, hash, compare, metadata):
-    black.field(
-        default=default,
-        default_factory=default_factory,
-        init=init,
-        repr=repr,
-        hash=hash,
-        compare=compare,
-        metadata=metadata,
-    )
-
-
-@given(
     cache=st.dictionaries(
         keys=st.builds(Path), values=st.tuples(st.floats(), st.integers())
     ),
     sources=st.one_of(
         st.lists(st.builds(Path)),
         st.sets(st.builds(Path)),
-        st.frozenst.sets(st.builds(Path)),
+        st.frozensets(st.builds(Path)),
         st.dictionaries(keys=st.builds(Path), values=st.builds(Path)),
-        st.dictionaries(keys=st.builds(Path), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.builds(Path)).map(values),
+        st.dictionaries(keys=st.builds(Path), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.builds(Path)).map(dict.values),
         st.iterables(st.builds(Path)),
         st.dictionaries(keys=st.builds(Path), values=st.builds(Path)).map(ChainMap),
     ),
@@ -624,10 +510,10 @@
     srcs=st.one_of(
         st.lists(st.text()),
         st.sets(st.text()),
-        st.frozenst.sets(st.text()),
+        st.frozensets(st.text()),
         st.dictionaries(keys=st.text(), values=st.text()),
-        st.dictionaries(keys=st.text(), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.text()).map(values),
+        st.dictionaries(keys=st.text(), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.text()).map(dict.values),
         st.iterables(st.text()),
         st.dictionaries(keys=st.text(), values=st.text()).map(ChainMap),
     )
@@ -640,10 +526,10 @@
     path_search_start=st.one_of(
         st.lists(st.text()),
         st.sets(st.text()),
-        st.frozenst.sets(st.text()),
+        st.frozensets(st.text()),
         st.dictionaries(keys=st.text(), values=st.text()),
-        st.dictionaries(keys=st.text(), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.text()).map(values),
+        st.dictionaries(keys=st.text(), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.text()).map(dict.values),
         st.iterables(st.text()),
         st.dictionaries(keys=st.text(), values=st.text()).map(ChainMap),
     )
@@ -657,11 +543,6 @@
     black.first_leaf_column(node=node)
 
 
-@given(x=st.just(0))
-def test_fuzz_float(x):
-    black.float(x)
-
-
 @given(src_contents=st.text(), fast=st.booleans(), mode=st.from_type(Mode))
 def test_fuzz_format_file_contents(src_contents, fast, mode):
     black.format_file_contents(src_contents=src_contents, fast=fast, mode=mode)
@@ -703,10 +584,10 @@
     paths=st.one_of(
         st.lists(st.builds(Path)),
         st.sets(st.builds(Path)),
-        st.frozenst.sets(st.builds(Path)),
+        st.frozensets(st.builds(Path)),
         st.dictionaries(keys=st.builds(Path), values=st.builds(Path)),
-        st.dictionaries(keys=st.builds(Path), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.builds(Path)).map(values),
+        st.dictionaries(keys=st.builds(Path), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.builds(Path)).map(dict.values),
         st.iterables(st.builds(Path)),
         st.dictionaries(keys=st.builds(Path), values=st.builds(Path)).map(ChainMap),
     ),
@@ -947,10 +828,10 @@
         st.binary(),
         st.lists(st.integers()),
         st.sets(st.integers()),
-        st.frozenst.sets(st.integers()),
+        st.frozensets(st.integers()),
         st.dictionaries(keys=st.integers(), values=st.integers()),
-        st.dictionaries(keys=st.integers(), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.integers()).map(values),
+        st.dictionaries(keys=st.integers(), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.integers()).map(dict.values),
         st.dictionaries(keys=st.integers(), values=st.integers()).map(ChainMap),
     ),
 )
@@ -963,15 +844,15 @@
     _features=st.one_of(
         st.lists(st.sampled_from(black.Feature)),
         st.sets(st.sampled_from(black.Feature)),
-        st.frozenst.sets(st.sampled_from(black.Feature)),
+        st.frozensets(st.sampled_from(black.Feature)),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
         ),
         st.dictionaries(keys=st.sampled_from(black.Feature), values=st.none()).map(
-            keys
+            dict.keys
         ),
         st.dictionaries(keys=st.integers(), values=st.sampled_from(black.Feature)).map(
-            values
+            dict.values
         ),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
@@ -987,17 +868,17 @@
     target_versions=st.one_of(
         st.lists(st.sampled_from(black.TargetVersion)),
         st.sets(st.sampled_from(black.TargetVersion)),
-        st.frozenst.sets(st.sampled_from(black.TargetVersion)),
+        st.frozensets(st.sampled_from(black.TargetVersion)),
         st.dictionaries(
             keys=st.sampled_from(black.TargetVersion),
             values=st.sampled_from(black.TargetVersion),
         ),
         st.dictionaries(
             keys=st.sampled_from(black.TargetVersion), values=st.none()
-        ).map(keys),
+        ).map(dict.keys),
         st.dictionaries(
             keys=st.integers(), values=st.sampled_from(black.TargetVersion)
-        ).map(values),
+        ).map(dict.values),
         st.iterables(st.sampled_from(black.TargetVersion)),
         st.dictionaries(
             keys=st.sampled_from(black.TargetVersion),
@@ -1024,11 +905,6 @@
     black.list_comments(prefix=prefix, is_endmarker=is_endmarker)
 
 
-@given(maxsize=st.just(128), typed=st.booleans())
-def test_fuzz_lru_cache(maxsize, typed):
-    black.lru_cache(maxsize=maxsize, typed=typed)
-
-
 @given(content=st.text())
 def test_fuzz_make_comment(content):
     black.make_comment(content=content)
@@ -1107,7 +983,7 @@
         st.builds(set),
         st.binary().map(memoryview),
         array_dtypes(),
-        st.integers(min_value=0).map(range),
+        st.builds(range, st.integers(min_value=0)),
         st.builds(range, st.integers(), st.integers()),
         st.builds(range, st.integers(), st.integers(), st.integers().filter(bool)),
         st.text(),
@@ -1193,26 +1069,21 @@
     )
 
 
-@given(obj=st.nothing())
-def test_fuzz_replace(obj):
-    black.replace(obj=obj)
-
-
 @given(
     line=st.from_type(Line),
     line_length=st.integers(),
     features=st.one_of(
         st.lists(st.sampled_from(black.Feature)),
         st.sets(st.sampled_from(black.Feature)),
-        st.frozenst.sets(st.sampled_from(black.Feature)),
+        st.frozensets(st.sampled_from(black.Feature)),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
         ),
         st.dictionaries(keys=st.sampled_from(black.Feature), values=st.none()).map(
-            keys
+            dict.keys
         ),
         st.dictionaries(keys=st.integers(), values=st.sampled_from(black.Feature)).map(
-            values
+            dict.values
         ),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
@@ -1222,10 +1093,10 @@
         st.binary(),
         st.lists(st.integers()),
         st.sets(st.integers()),
-        st.frozenst.sets(st.integers()),
+        st.frozensets(st.integers()),
         st.dictionaries(keys=st.integers(), values=st.integers()),
-        st.dictionaries(keys=st.integers(), values=st.none()).map(keys),
-        st.dictionaries(keys=st.integers(), values=st.integers()).map(values),
+        st.dictionaries(keys=st.integers(), values=st.none()).map(dict.keys),
+        st.dictionaries(keys=st.integers(), values=st.integers()).map(dict.values),
         st.dictionaries(keys=st.integers(), values=st.integers()).map(ChainMap),
     ),
 )
@@ -1246,15 +1117,15 @@
     features=st.one_of(
         st.lists(st.sampled_from(black.Feature)),
         st.sets(st.sampled_from(black.Feature)),
-        st.frozenst.sets(st.sampled_from(black.Feature)),
+        st.frozensets(st.sampled_from(black.Feature)),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
         ),
         st.dictionaries(keys=st.sampled_from(black.Feature), values=st.none()).map(
-            keys
+            dict.keys
         ),
         st.dictionaries(keys=st.integers(), values=st.sampled_from(black.Feature)).map(
-            values
+            dict.values
         ),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
@@ -1315,15 +1186,15 @@
     features=st.one_of(
         st.lists(st.sampled_from(black.Feature)),
         st.sets(st.sampled_from(black.Feature)),
-        st.frozenst.sets(st.sampled_from(black.Feature)),
+        st.frozensets(st.sampled_from(black.Feature)),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
         ),
         st.dictionaries(keys=st.sampled_from(black.Feature), values=st.none()).map(
-            keys
+            dict.keys
         ),
         st.dictionaries(keys=st.integers(), values=st.sampled_from(black.Feature)).map(
-            values
+            dict.values
         ),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
@@ -1362,15 +1233,15 @@
     features=st.one_of(
         st.lists(st.sampled_from(black.Feature)),
         st.sets(st.sampled_from(black.Feature)),
-        st.frozenst.sets(st.sampled_from(black.Feature)),
+        st.frozensets(st.sampled_from(black.Feature)),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
         ),
         st.dictionaries(keys=st.sampled_from(black.Feature), values=st.none()).map(
-            keys
+            dict.keys
         ),
         st.dictionaries(keys=st.integers(), values=st.sampled_from(black.Feature)).map(
-            values
+            dict.values
         ),
         st.dictionaries(
             keys=st.sampled_from(black.Feature), values=st.sampled_from(black.Feature)
@@ -1381,23 +1252,11 @@
     black.transform_line(line=line, mode=mode, features=features)
 
 
-@given(type_num=st.integers())
-def test_fuzz_type_repr(type_num):
-    black.type_repr(type_num=type_num)
-
-
 @given(node=st.one_of(st.builds(Leaf), st.builds(Node)))
 def test_fuzz_unwrap_singleton_parenthesis(node):
     black.unwrap_singleton_parenthesis(node=node)
 
 
-@given(appname=st.none(), appauthor=st.none(), version=st.none(), opinion=st.booleans())
-def test_fuzz_user_cache_dir(appname, appauthor, version, opinion):
-    black.user_cache_dir(
-        appname=appname, appauthor=appauthor, version=version, opinion=opinion
-    )
-
-
 @given(leaf=st.builds(Leaf), complex_subscript=st.booleans())
 def test_fuzz_whitespace(leaf, complex_subscript):
     black.whitespace(leaf=leaf, complex_subscript=complex_subscript)
@@ -1416,14 +1275,3 @@
 def test_fuzz_wrap_stream_for_windows(f):
     black.wrap_stream_for_windows(f=f)
 
-
-@given(
-    wrapped=st.nothing(),
-    assigned=st.just(
-        ("__module__", "__name__", "__qualname__", "__doc__", "__annotations__")
-    ),
-    updated=st.just(("__dict__",)),
-)
-def test_fuzz_wraps(wrapped, assigned, updated):
-    black.wraps(wrapped=wrapped, assigned=assigned, updated=updated)
-
```