### PR TITLE
Auto-configuration of default ghostwriter style - pytest if installed, else unittest

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch teaches :command:`hypothesis write` to default to ghostwriting
+tests with ``--style=pytest`` only if :pypi:`pytest` is installed, or
+``--style=unittest`` otherwise.

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -47,6 +47,11 @@ from difflib import get_close_matches
 from functools import partial
 from multiprocessing import Pool
 
+try:
+    import pytest
+except ImportError:
+    pytest = None  # type: ignore
+
 MESSAGE = """
 The Hypothesis command-line interface requires the `{}` package,
 which you do not have installed.  Run:
@@ -190,7 +195,7 @@ else:
     @click.option(
         "--style",
         type=click.Choice(["pytest", "unittest"]),
-        default="pytest",
+        default="pytest" if pytest else "unittest",
         help="pytest-style function, or unittest-style method?",
     )
     @click.option(

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -698,9 +698,11 @@ def magic(
     for name, func in sorted(by_name.items()):
         hints = get_type_hints(func)
         hints.pop("return", None)
-        if len(hints) == len(_get_params(func)) == 2:
+        params = _get_params(func)
+        if len(hints) == len(params) == 2:
             a, b = hints.values()
-            if a == b:
+            arg1, arg2 = params
+            if a == b and len(arg1) == len(arg2) <= 3:
                 imp, body = _make_binop_body(func, except_=except_, style=style)
                 imports |= imp
                 parts.append(body)


### PR DESCRIPTION
Because if you're using unittest and don't even have pytest installed, life is easier (which is the whole point!) if the ghostwriter can guess that you want unittest style by default.  Of course you can still pass `--style=pytest` if you want to.

Also tunes the binary-operator detection heuristic a little, adding a check that the argument names are short and of equal length, based on my experiments with type-annotated codebases such as `black`.