### PR TITLE
Add support for `Annotated` types

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -131,6 +131,7 @@ their individual contributions.
 * `Tyler Nickerson <https://www.github.com/nmbrgts>`_
 * `Vidya Rani <https://www.github.com/vidyarani-dg>`_ (vidyarani.d.g@gmail.com)
 * `Vincent Michel <https://www.github.com/vxgmichel>`_ (vxgmichel@gmail.com)
+* `Vytautas Strimaitis <https://www.github.com/vstrimaitis>`_
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)
 * `Wilfred Hughes <https://www.github.com/wilfred>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
 This release teaches :func:`~hypothesis.strategies.from_type` how to see 
-through :class:`python:typing.Annotated`.  Thanks to Vytautas Strimaitis
+through :obj:`python:typing.Annotated`.  Thanks to Vytautas Strimaitis
 for reporting and fixing :issue:`2919`!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds support for annotated types (i.e. ``typing_extensions.Annotated`` and ``typing.Annotated``).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -65,13 +65,16 @@ try:
     def is_annotated_instance(thing):
         return isinstance(thing, _AnnotatedAlias)
 
+
 except ImportError:
     try:
         from typing_extensions import AnnotatedMeta
 
         def is_annotated_instance(thing):
             return isinstance(thing, AnnotatedMeta)
+
     except ImportError:
+
         def is_annotated_instance(thing):
             return False
 
@@ -127,10 +130,7 @@ def is_typing_literal(thing):
 
 
 def is_annotated_type(thing):
-    return (
-        is_annotated_instance(thing)
-        and getattr(thing, "__args__", None) is not None
-    )
+    return is_annotated_instance(thing) and getattr(thing, "__args__", None) is not None
 
 
 def has_type_arguments(type_):
@@ -435,6 +435,7 @@ if sys.version_info[:2] >= (3, 9):  # pragma: no cover
 
 try:  # pragma: no cover
     import numpy as np
+
     from hypothesis.extra.numpy import array_dtypes, array_shapes, arrays, scalar_dtypes
 
     _global_type_lookup[np.dtype] = array_dtypes()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -418,7 +418,6 @@ if sys.version_info[:2] >= (3, 9):  # pragma: no cover
 
 try:  # pragma: no cover
     import numpy as np
-
     from hypothesis.extra.numpy import array_dtypes, array_shapes, arrays, scalar_dtypes
 
     _global_type_lookup[np.dtype] = array_dtypes()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -60,7 +60,7 @@ except ImportError:
     _GenericAlias = ()
 
 try:
-    from typing_extensions import _AnnotatedAlias
+    from typing_extensions import _AnnotatedAlias  # type: ignore
 
     def is_annotated_instance(thing):
         return isinstance(thing, _AnnotatedAlias)
@@ -68,7 +68,7 @@ try:
 
 except ImportError:
     try:
-        from typing_extensions import AnnotatedMeta
+        from typing_extensions import AnnotatedMeta  # type: ignore
 
         def is_annotated_instance(thing):
             return isinstance(thing, AnnotatedMeta)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -60,7 +60,7 @@ except ImportError:
     _GenericAlias = ()
 
 try:
-    from typing import _AnnotatedAlias
+    from typing import _AnnotatedAlias  # type: ignore
 except ImportError:
     try:
         from typing_extensions import _AnnotatedAlias

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -110,6 +110,13 @@ def is_typing_literal(thing):
     )
 
 
+def is_annotated_type(thing):
+    return (
+        type(thing).__name__ in {"AnnotatedMeta", "_AnnotatedAlias"}
+        and getattr(thing, "__args__", None) is not None
+    )
+
+
 def has_type_arguments(type_):
     """Decides whethere or not this type has applied type arguments."""
     args = getattr(type_, "__args__", None)
@@ -195,6 +202,10 @@ def from_typing_type(thing):
             else:
                 literals.append(arg)
         return st.sampled_from(literals)
+    if is_annotated_type(thing):
+        args = thing.__args__
+        annotated_type = args[0]
+        return st.from_type(annotated_type)
     # Now, confirm that we're dealing with a generic type as we expected
     if sys.version_info[:2] < (3, 9) and not isinstance(
         thing, typing_root_type

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -66,7 +66,9 @@ except ImportError:
         from typing_extensions import _AnnotatedAlias
     except ImportError:
         try:
-            from typing_extensions import AnnotatedMeta as _AnnotatedAlias  # type: ignore
+            from typing_extensions import (  # type: ignore
+                AnnotatedMeta as _AnnotatedAlias
+            )
 
             assert sys.version_info[:2] == (3, 6)
         except ImportError:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -60,14 +60,14 @@ except ImportError:
     _GenericAlias = ()
 
 try:
-    from typing_extensions import _AnnotatedAlias  # type: ignore
+    from typing_extensions import _AnnotatedAlias
 except ImportError:
     try:
         from typing_extensions import AnnotatedMeta as _AnnotatedAlias  # type: ignore
 
         assert sys.version_info[:2] == (3, 6)
     except ImportError:
-        _AnnotatedAlias = ()  # type: ignore
+        _AnnotatedAlias = ()
 
 
 def is_annotated_instance(thing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -59,6 +59,22 @@ try:
 except ImportError:
     _GenericAlias = ()
 
+try:
+    from typing_extensions import _AnnotatedAlias
+
+    def is_annotated_instance(thing):
+        return isinstance(thing, _AnnotatedAlias)
+
+except ImportError:
+    try:
+        from typing_extensions import AnnotatedMeta
+
+        def is_annotated_instance(thing):
+            return isinstance(thing, AnnotatedMeta)
+    except ImportError:
+        def is_annotated_instance(thing):
+            return False
+
 
 def type_sorting_key(t):
     """Minimise to None, then non-container types, then container types."""
@@ -112,7 +128,7 @@ def is_typing_literal(thing):
 
 def is_annotated_type(thing):
     return (
-        type(thing).__name__ in {"AnnotatedMeta", "_AnnotatedAlias"}
+        is_annotated_instance(thing)
         and getattr(thing, "__args__", None) is not None
     )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -67,7 +67,7 @@ except ImportError:
     except ImportError:
         try:
             from typing_extensions import (  # type: ignore
-                AnnotatedMeta as _AnnotatedAlias
+                AnnotatedMeta as _AnnotatedAlias,
             )
 
             assert sys.version_info[:2] == (3, 6)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -64,10 +64,11 @@ try:
 except ImportError:
     try:
         from typing_extensions import AnnotatedMeta as _AnnotatedAlias  # type: ignore
-        
+
         assert sys.version_info[:2] == (3, 6)
     except ImportError:
         _AnnotatedAlias = ()  # type: ignore
+
 
 def is_annotated_instance(thing):
     # TODO: this should handle `typing.Annotated` too, for when `typing_extensions` is not installed.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -217,7 +217,8 @@ def from_typing_type(thing):
             else:
                 literals.append(arg)
         return st.sampled_from(literals)
-    if is_annotated_type(thing):
+    if is_annotated_type(thing):  # pragma: no cover
+        # This requires Python 3.9+ or the typing_extensions package
         args = thing.__args__
         assert args, "it's impossible to make an annotated type with no args"
         annotated_type = args[0]

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -204,6 +204,7 @@ def from_typing_type(thing):
         return st.sampled_from(literals)
     if is_annotated_type(thing):
         args = thing.__args__
+        assert args, "it's impossible to make an annotated type with no args"
         annotated_type = args[0]
         return st.from_type(annotated_type)
     # Now, confirm that we're dealing with a generic type as we expected

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -60,19 +60,17 @@ except ImportError:
     _GenericAlias = ()
 
 try:
-    from typing_extensions import _AnnotatedAlias
+    from typing import _AnnotatedAlias
 except ImportError:
     try:
-        from typing_extensions import AnnotatedMeta as _AnnotatedAlias  # type: ignore
-
-        assert sys.version_info[:2] == (3, 6)
+        from typing_extensions import _AnnotatedAlias
     except ImportError:
-        _AnnotatedAlias = ()
+        try:
+            from typing_extensions import AnnotatedMeta as _AnnotatedAlias  # type: ignore
 
-
-def is_annotated_instance(thing):
-    # TODO: this should handle `typing.Annotated` too, for when `typing_extensions` is not installed.
-    return isinstance(thing, _AnnotatedAlias)
+            assert sys.version_info[:2] == (3, 6)
+        except ImportError:
+            _AnnotatedAlias = ()
 
 
 def type_sorting_key(t):
@@ -126,7 +124,10 @@ def is_typing_literal(thing):
 
 
 def is_annotated_type(thing):
-    return is_annotated_instance(thing) and getattr(thing, "__args__", None) is not None
+    return (
+        isinstance(thing, _AnnotatedAlias)
+        and getattr(thing, "__args__", None) is not None
+    )
 
 
 def has_type_arguments(type_):

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -34,6 +34,8 @@ if sys.version_info < (3, 7):
     collect_ignore_glob.append("cover/*py37*")
 if sys.version_info < (3, 8):
     collect_ignore_glob.append("cover/*py38*")
+if sys.version_info < (3, 9):
+    collect_ignore_glob.append("cover/*py39*")
 
 
 def pytest_configure(config):

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -19,7 +19,6 @@ import sys
 import time as time_module
 
 import pytest
-
 from hypothesis.internal.detection import is_hypothesis_test
 
 from tests.common import TIME_INCREMENT

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -19,6 +19,7 @@ import sys
 import time as time_module
 
 import pytest
+
 from hypothesis.internal.detection import is_hypothesis_test
 
 from tests.common import TIME_INCREMENT

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -34,25 +34,25 @@ def test_typing_Final(data):
 
 
 @pytest.mark.parametrize(
-    "annotated_type,expected_strategy",
+    "annotated_type,expected_strategy_repr",
     [
-        (typing_extensions.Annotated[int, "foo"], st.integers()),
-        (typing_extensions.Annotated[typing.List[float], "foo"], st.lists(st.floats())),
+        (typing_extensions.Annotated[int, "foo"], "integers()"),
+        (typing_extensions.Annotated[typing.List[float], "foo"], "lists(floats())"),
         (
             typing_extensions.Annotated[typing_extensions.Annotated[str, "foo"], "bar"],
-            st.text(),
+            "text()",
         ),
         (
             typing_extensions.Annotated[
                 typing_extensions.Annotated[typing.List[typing.Dict[str, bool]], "foo"],
                 "bar",
             ],
-            st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
+            "lists(dictionaries(keys=text(), values=booleans()))",
         ),
     ],
 )
-def test_typing_Annotated(annotated_type, expected_strategy):
-    assert st.from_type(annotated_type) == expected_strategy
+def test_typing_Annotated(annotated_type, expected_strategy_repr):
+    assert repr(st.from_type(annotated_type)) == expected_strategy_repr
 
 
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -18,7 +18,6 @@ import sys
 import typing
 
 import pytest
-import typing_extensions
 
 from hypothesis import given, strategies as st
 from hypothesis.strategies import from_type
@@ -31,28 +30,6 @@ from tests.common.utils import temp_registered
 def test_typing_Final(data):
     value = data.draw(from_type(typing.Final[int]))
     assert isinstance(value, int)
-
-
-@pytest.mark.parametrize(
-    "annotated_type,expected_strategy_repr",
-    [
-        (typing_extensions.Annotated[int, "foo"], "integers()"),
-        (typing_extensions.Annotated[typing.List[float], "foo"], "lists(floats())"),
-        (
-            typing_extensions.Annotated[typing_extensions.Annotated[str, "foo"], "bar"],
-            "text()",
-        ),
-        (
-            typing_extensions.Annotated[
-                typing_extensions.Annotated[typing.List[typing.Dict[str, bool]], "foo"],
-                "bar",
-            ],
-            "lists(dictionaries(keys=text(), values=booleans()))",
-        ),
-    ],
-)
-def test_typing_Annotated(annotated_type, expected_strategy_repr):
-    assert repr(st.from_type(annotated_type)) == expected_strategy_repr
 
 
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -16,9 +16,9 @@
 import dataclasses
 import sys
 import typing
-import typing_extensions
 
 import pytest
+import typing_extensions
 
 from hypothesis import given, strategies as st
 from hypothesis.strategies import from_type

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -16,6 +16,7 @@
 import dataclasses
 import sys
 import typing
+import typing_extensions
 
 import pytest
 
@@ -30,6 +31,28 @@ from tests.common.utils import temp_registered
 def test_typing_Final(data):
     value = data.draw(from_type(typing.Final[int]))
     assert isinstance(value, int)
+
+
+@pytest.mark.parametrize(
+    "annotated_type,expected_strategy",
+    [
+        (typing_extensions.Annotated[int, "foo"], st.integers()),
+        (typing_extensions.Annotated[typing.List[float], "foo"], st.lists(st.floats())),
+        (
+            typing_extensions.Annotated[typing_extensions.Annotated[str, "foo"], "bar"],
+            st.text(),
+        ),
+        (
+            typing_extensions.Annotated[
+                typing_extensions.Annotated[typing.List[typing.Dict[str, bool]], "foo"],
+                "bar",
+            ],
+            st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
+        ),
+    ],
+)
+def test_typing_Annotated(annotated_type, expected_strategy):
+    assert st.from_type(annotated_type) == expected_strategy
 
 
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -33,4 +33,4 @@ from hypothesis import strategies as st
     ],
 )
 def test_typing_Annotated(annotated_type, expected_strategy):
-    assert st.from_type(annotated_type) == expected_strategy
+    assert repr(st.from_type(annotated_type)) == repr(expected_strategy)

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -16,6 +16,7 @@
 import typing
 
 import pytest
+
 from hypothesis import strategies as st
 
 

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -34,4 +34,4 @@ from hypothesis import strategies as st
     ],
 )
 def test_typing_Annotated(annotated_type, expected_strategy):
-    assert repr(st.from_type(annotated_type)) == repr(expected_strategy)
+    assert st.from_type(annotated_type) == expected_strategy

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -21,18 +21,18 @@ from hypothesis import strategies as st
 
 
 @pytest.mark.parametrize(
-    "annotated_type,expected_strategy",
+    "annotated_type,expected_strategy_repr",
     [
-        (typing.Annotated[int, "foo"], st.integers()),
-        (typing.Annotated[typing.List[float], "foo"], st.lists(st.floats())),
-        (typing.Annotated[typing.Annotated[str, "foo"], "bar"], st.text()),
+        (typing.Annotated[int, "foo"], "integers()"),
+        (typing.Annotated[typing.List[float], "foo"], "lists(floats())"),
+        (typing.Annotated[typing.Annotated[str, "foo"], "bar"], "text()"),
         (
             typing.Annotated[
                 typing.Annotated[typing.List[typing.Dict[str, bool]], "foo"], "bar"
             ],
-            st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
+            "lists(dictionaries(keys=text(), values=booleans()))",
         ),
     ],
 )
-def test_typing_Annotated(annotated_type, expected_strategy):
-    assert st.from_type(annotated_type) == expected_strategy
+def test_typing_Annotated(annotated_type, expected_strategy_repr):
+    assert repr(st.from_type(annotated_type)) == expected_strategy_repr

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -16,7 +16,6 @@
 import typing
 
 import pytest
-
 from hypothesis import strategies as st
 
 
@@ -27,7 +26,9 @@ from hypothesis import strategies as st
         (typing.Annotated[typing.List[float], "foo"], st.lists(st.floats())),
         (typing.Annotated[typing.Annotated[str, "foo"], "bar"], st.text()),
         (
-            typing.Annotated[typing.Annotated[typing.List[typing.Dict[str, bool]], "foo"], "bar"],
+            typing.Annotated[
+                typing.Annotated[typing.List[typing.Dict[str, bool]], "foo"], "bar"
+            ],
             st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
         ),
     ],

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -1,0 +1,36 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import typing
+
+import pytest
+
+from hypothesis import strategies as st
+
+
+@pytest.mark.parametrize(
+    "annotated_type,expected_strategy",
+    [
+        (typing.Annotated[int, "foo"], st.integers()),
+        (typing.Annotated[typing.List[float], "foo"], st.lists(st.floats())),
+        (typing.Annotated[typing.Annotated[str, "foo"], "bar"], st.text()),
+        (
+            typing.Annotated[typing.Annotated[typing.List[typing.Dict[str, bool]], "foo"], "bar"],
+            st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
+        ),
+    ],
+)
+def test_typing_Annotated(annotated_type, expected_strategy):
+    assert st.from_type(annotated_type) == expected_strategy

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -17,10 +17,9 @@ import collections
 from typing import Dict, List, Union
 
 import pytest
-from typing_extensions import Annotated, DefaultDict, Literal, NewType, Type, TypedDict
-
 from hypothesis import assume, given, strategies as st
 from hypothesis.strategies import from_type
+from typing_extensions import Annotated, DefaultDict, Literal, NewType, Type, TypedDict
 
 
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -95,4 +95,4 @@ def test_defaultdict(ex):
     ],
 )
 def test_typing_extensions_Annotated(annotated_type, expected_strategy):
-    assert repr(st.from_type(annotated_type)) == repr(expected_strategy)
+    assert st.from_type(annotated_type) == expected_strategy

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -96,4 +96,4 @@ def test_defaultdict(ex):
     ],
 )
 def test_typing_extensions_Annotated(annotated_type, expected_strategy):
-    assert st.from_type(annotated_type) == expected_strategy
+    assert repr(st.from_type(annotated_type)) == repr(expected_strategy)

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -17,9 +17,10 @@ import collections
 from typing import Dict, List, Union
 
 import pytest
+from typing_extensions import Annotated, DefaultDict, Literal, NewType, Type, TypedDict
+
 from hypothesis import assume, given, strategies as st
 from hypothesis.strategies import from_type
-from typing_extensions import Annotated, DefaultDict, Literal, NewType, Type, TypedDict
 
 
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -14,10 +14,10 @@
 # END HEADER
 
 import collections
-from typing import Union
+from typing import Dict, List, Union
 
 import pytest
-from typing_extensions import DefaultDict, Literal, NewType, Type, TypedDict
+from typing_extensions import Annotated, DefaultDict, Literal, NewType, Type, TypedDict
 
 from hypothesis import assume, given, strategies as st
 from hypothesis.strategies import from_type
@@ -81,3 +81,19 @@ def test_defaultdict(ex):
     assume(ex)
     assert all(isinstance(elem, int) for elem in ex)
     assert all(isinstance(elem, int) for elem in ex.values())
+
+
+@pytest.mark.parametrize(
+    "annotated_type,expected_strategy",
+    [
+        (Annotated[int, "foo"], st.integers()),
+        (Annotated[List[float], "foo"], st.lists(st.floats())),
+        (Annotated[Annotated[str, "foo"], "bar"], st.text()),
+        (
+            Annotated[Annotated[List[Dict[str, bool]], "foo"], "bar"],
+            st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
+        ),
+    ],
+)
+def test_typing_extensions_Annotated(annotated_type, expected_strategy):
+    assert st.from_type(annotated_type) == expected_strategy

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -84,16 +84,16 @@ def test_defaultdict(ex):
 
 
 @pytest.mark.parametrize(
-    "annotated_type,expected_strategy",
+    "annotated_type,expected_strategy_repr",
     [
-        (Annotated[int, "foo"], st.integers()),
-        (Annotated[List[float], "foo"], st.lists(st.floats())),
-        (Annotated[Annotated[str, "foo"], "bar"], st.text()),
+        (Annotated[int, "foo"], "integers()"),
+        (Annotated[List[float], "foo"], "lists(floats())"),
+        (Annotated[Annotated[str, "foo"], "bar"], "text()"),
         (
             Annotated[Annotated[List[Dict[str, bool]], "foo"], "bar"],
-            st.lists(st.dictionaries(keys=st.text(), values=st.booleans())),
+            "lists(dictionaries(keys=text(), values=booleans()))",
         ),
     ],
 )
-def test_typing_extensions_Annotated(annotated_type, expected_strategy):
-    assert st.from_type(annotated_type) == expected_strategy
+def test_typing_extensions_Annotated(annotated_type, expected_strategy_repr):
+    assert repr(st.from_type(annotated_type)) == expected_strategy_repr


### PR DESCRIPTION
This update enables `hypothesis` to generate data for types wrapped in `typing_extension.Annotated` and `typing.Annotated`. It fixes #2919.

I have some concerns about the testing part, mainly the fact that I'm using `repr` to compare the strategies returned by `st.from_type` and the expected one. I'm guessing there should be a better way, but I couldn't find it quickly. Any suggestions @Zac-HD?

