### PR TITLE
Teach the Ghostwriter to look for more roundtrips

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch teaches :command:`hypothesis write` to check for possible roundtrips
+in several more cases, such as by looking for an inverse in the module which
+defines the function to test.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -682,8 +682,20 @@ def magic(
                 inverse_name = readname.format(*match.groups())
                 for other in sorted(
                     n for n in by_name if n.split(".")[-1] == inverse_name
-                )[:1]:
+                ):
                     make_(_make_roundtrip_body, (by_name.pop(name), by_name.pop(other)))
+                    break
+                else:
+                    try:
+                        other_func = getattr(
+                            sys.modules[_get_module(by_name[name])],
+                            inverse_name,
+                        )
+                        _get_params(other_func)  # we want to skip if this fails
+                    except Exception:
+                        pass
+                    else:
+                        make_(_make_roundtrip_body, (by_name.pop(name), other_func))
 
     # Look for equivalent functions: same name, all required arguments of any can
     # be found in all signatures, and if all have return-type annotations they match.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -1140,6 +1140,7 @@ def _make_ufunc_body(func, *, except_, style):
         type_assert=_assert_eq(style, "result.dtype.char", "expected_dtype"),
     )
 
+    qname = _get_qualname(func, include_module=True)
     return _make_test_body(
         func,
         test_body=dedent(body).strip(),
@@ -1149,7 +1150,6 @@ def _make_ufunc_body(func, *, except_, style):
         given_strategies={
             "data": st.data(),
             "shapes": shapes,
-            "types": f"sampled_from({_get_qualname(func, include_module=True)}.types)"
-            ".filter(lambda sig: 'O' not in sig)",
+            "types": f"sampled_from([sig for sig in {qname}.types if 'O' not in sig])",
         },
     )

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -588,6 +588,11 @@ ROUNDTRIP_PAIRS = (
     (r"(.+)2(.+?)(_.+)?", "{1}2{0}{2}"),
     # Common in e.g. the colorsys module
     (r"(.+)_to_(.+)", "{1}_to_{0}"),
+    # Sockets patterns
+    (r"(inet|if)_(.+)to(.+)", "{0}_{2}to{1}"),
+    (r"(\w)to(\w)(.+)", "{1}to{0}{2}"),
+    (r"send(.+)", "recv{}"),
+    (r"send(.+)", "receive{}"),
 )
 
 
@@ -657,9 +662,12 @@ def magic(
     by_name = {}
     for f in functions:
         try:
+            _get_params(f)
             by_name[_get_qualname(f, include_module=True)] = f
         except Exception:
-            pass  # e.g. Pandas 'CallableDynamicDoc' object has no attribute '__name__'
+            # usually inspect.signature on C code such as socket.inet_aton, sometimes
+            # e.g. Pandas 'CallableDynamicDoc' object has no attribute '__name__'
+            pass
     if not by_name:
         return (
             f"# Found no testable functions in\n"

--- a/hypothesis-python/tests/ghostwriter/recorded/magic_base64_roundtrip.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/magic_base64_roundtrip.txt
@@ -1,0 +1,14 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import base64
+from hypothesis import given, strategies as st
+
+# TODO: replace st.nothing() with an appropriate strategy
+
+
+@given(altchars=st.none(), s=st.nothing(), validate=st.booleans())
+def test_roundtrip_b64encode_b64decode(altchars, s, validate):
+    value0 = base64.b64encode(s=s, altchars=altchars)
+    value1 = base64.b64decode(s=value0, altchars=altchars, validate=validate)
+    assert s == value1, (s, value1)

--- a/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/magic_gufunc.txt
@@ -9,7 +9,7 @@ from hypothesis.extra.numpy import mutually_broadcastable_shapes
 @given(
     data=st.data(),
     shapes=mutually_broadcastable_shapes(signature="(n?,k),(k,m?)->(n?,m?)"),
-    types=st.sampled_from(numpy.matmul.types).filter(lambda sig: "O" not in sig),
+    types=st.sampled_from([sig for sig in numpy.matmul.types if "O" not in sig]),
 )
 def test_gufunc_matmul(data, shapes, types):
     input_shapes, expected_shape = shapes

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -70,6 +70,7 @@ def add(a: float, b: float) -> float:
         ("fuzz_classmethod", ghostwriter.fuzz(A_Class.a_classmethod)),
         ("fuzz_ufunc", ghostwriter.fuzz(numpy.add)),
         ("magic_gufunc", ghostwriter.magic(numpy.matmul)),
+        ("magic_base64_roundtrip", ghostwriter.magic(base64.b64encode)),
         ("re_compile", ghostwriter.fuzz(re.compile)),
         (
             "re_compile_except",

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -17,6 +17,7 @@ import ast
 import enum
 import json
 import re
+import socket
 import unittest
 import unittest.mock
 from decimal import Decimal
@@ -187,6 +188,11 @@ def takes_frozensets(a: FrozenSet[int], b: FrozenSet[int]) -> None:
 def test_ghostwriter_fuzz(func, ex):
     source_code = ghostwriter.fuzz(func, except_=ex)
     get_test_function(source_code)
+
+
+def test_socket_module():
+    source_code = ghostwriter.magic(socket)
+    exec(source_code, {})
 
 
 def test_binary_op_also_handles_frozensets():


### PR DESCRIPTION
Specifically, if looking at a function `f` check the module that defined it for an inverse function `g`, plus some more regex patterns for `socket`-like APIs, and a performance boost for gufunc tests.

A follow-up PR based on https://github.com/Zac-HD/hypothesis/compare/ghostwriter...ghost2 will add docstring-based detection of allowed exceptions and move assertions outside the `except` clauses we generate.