### PR TITLE
Fix abstract type bug

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.strategies.from_type` with
+:mod:`abstract types <python:abc>` which have either required but
+non-type-annotated arguments to ``__init__``, or where
+:func:`~hypothesis.strategies.from_type` can handle some concrete
+subclasses but not others.


### PR DESCRIPTION
This is a pair of a subtle bug and some smarter behaviour:

- if we had an abstract type with required-and-unannotated parameters, we'd incorrectly raise `ResolutionFailed` as if we were about to use `st.builds()` (which we, correctly, only try for non-abstract types)
- `return sampled_from(subclasses).flatmap(from_type)` is suboptimal - we can check which subclasses can be resolved and just use those... but maintain it as a fallback in case we can't resolve any now but will be able to when we actually draw values.

This is definitely a rare combination of cases to hit, but if we're going to support it let's do it *right*.