### PR TITLE
Syntax-highlight ghostwritten code in the terminal using Rich 

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+If :pypi:`rich` is installed, the :command:`hypothesis write` command
+will use it to syntax-highlight the :doc:`Ghostwritten <ghostwriter>`
+code.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -57,7 +57,7 @@ assert __version__ is not None
 
 
 extras = {
-    "cli": ["click>=7.0", "black>=19.10b0"],
+    "cli": ["click>=7.0", "black>=19.10b0", "rich>=9.0.0"],
     "codemods": ["libcst>=0.3.16"],
     "ghostwriter": ["black>=19.10b0"],
     "pytz": ["pytz>=2014.1"],

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -239,4 +239,14 @@ else:
             sys.stderr.write(MESSAGE.format("black"))
             sys.exit(1)
 
-        print(getattr(ghostwriter, writer)(*func, except_=except_ or (), style=style))
+        code = getattr(ghostwriter, writer)(*func, except_=except_ or (), style=style)
+        try:
+            from rich.console import Console
+            from rich.syntax import Syntax
+        except ImportError:
+            print(code)
+        else:
+            Console().print(
+                Syntax(code, lexer_name="python", background_color="default"),
+                soft_wrap=True,
+            )


### PR DESCRIPTION
Because syntax-highlighting makes a much better first impression, like the modern and usable tool that the Ghostwriter is.

[Rich](https://rich.readthedocs.io/en/stable/) is smart enough to work across essentially all of the various terminals and operating systems that people might be using, and also disables the highlighting if you redirect output into a file.  I've added an optional dependency on Rich, but also ensured that the CLI will gracefully degrade (to builtin `print()`) if it isn't available.