### PR TITLE
Test against Django 3.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
           - lint-conjecture-rust
           - check-nose
           - check-pytest46
+          - check-django32
           - check-django31
-          - check-django30
           - check-django22
           - check-pandas111
           - check-pandas100

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -53,16 +53,16 @@ commands =
     pip install django~=2.2.0
     python -m tests.django.manage test tests.django
 
-[testenv:django30]
-commands =
-    pip install .[pytz]
-    pip install django~=3.0.10
-    python -m tests.django.manage test tests.django
-
 [testenv:django31]
 commands =
     pip install .[pytz]
     pip install django~=3.1.1
+    python -m tests.django.manage test tests.django
+
+[testenv:django32]
+commands =
+    pip install .[pytz]
+    pip install django~=3.2.0
     python -m tests.django.manage test tests.django
 
 [testenv:nose]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -414,7 +414,7 @@ def standard_tox_task(name):
 standard_tox_task("nose")
 standard_tox_task("pytest46")
 
-for n in [22, 30, 31]:
+for n in [22, 31, 32]:
     standard_tox_task(f"django{n}")
 for n in [25, 100, 111]:
     standard_tox_task(f"pandas{n}")


### PR DESCRIPTION
And drop tests on the now-EOL Django 3.0; closes #2928.