### PR TITLE
AST-based filter rewriting for lambdas

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release automatically rewrites some simple filters, such as
+``integers().filter(lambda x: x > 9)`` to the more efficient
+``integers(min_value=10)``, based on the AST of the predicate.
+
+We continue to recommend using the efficient form directly wherever
+possible, but this should be useful for e.g. :pypi:`pandera` "``Checks``"
+where you already have a simple predicate and translating manually
+is really annoying.  See :issue:`2701` for ideas about floats and
+simple text strategies.

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -110,7 +110,7 @@ def comp_to_kwargs(x: ast.AST, op: ast.AST, y: ast.AST, *, argname: str) -> dict
         if a is ARG:
             return {"min_value": b, "exclude_min": True}
         return {"max_value": a, "exclude_max": True}
-    raise ValueError("Unhandled comparison operator")
+    raise ValueError("Unhandled comparison operator")  # e.g. ast.Ne
 
 
 def merge_preds(*con_predicates: ConstructivePredicate) -> ConstructivePredicate:
@@ -131,16 +131,12 @@ def merge_preds(*con_predicates: ConstructivePredicate) -> ConstructivePredicate
                 base["min_value"] = kw["min_value"]
             elif kw["min_value"] == base["min_value"]:
                 base["exclude_min"] |= kw.get("exclude_min", False)
-            else:
-                base["exclude_min"] = False
         if "max_value" in kw:
             if kw["max_value"] < base["max_value"]:
                 base["exclude_max"] = kw.get("exclude_max", False)
                 base["max_value"] = kw["max_value"]
             elif kw["max_value"] == base["max_value"]:
                 base["exclude_max"] |= kw.get("exclude_max", False)
-            else:
-                base["exclude_max"] = False
 
     if not base["exclude_min"]:
         del base["exclude_min"]
@@ -167,9 +163,6 @@ def numeric_bounds_from_ast(
 
     See also https://greentreesnakes.readthedocs.io/en/latest/
     """
-    while isinstance(tree, ast.Expr):
-        tree = tree.value
-
     if isinstance(tree, ast.Compare):
         ops = tree.ops
         vals = tree.comparators
@@ -237,7 +230,7 @@ def get_numeric_predicate_bounds(predicate: Predicate) -> ConstructivePredicate:
         else:
             source = inspect.getsource(predicate)
         tree: ast.AST = ast.parse(source)
-    except Exception:  # pragma: no cover
+    except Exception:
         return unchanged
 
     # Dig down to the relevant subtree - our tree is probably a Module containing

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -27,6 +27,8 @@ a library; so we prefer to share all the implementation effort here.
 See https://github.com/HypothesisWorks/hypothesis/issues/2701 for details.
 """
 
+import ast
+import inspect
 import math
 import operator
 from decimal import Decimal
@@ -35,6 +37,7 @@ from functools import partial
 from typing import Any, Callable, Dict, NamedTuple, Optional, TypeVar
 
 from hypothesis.internal.compat import ceil, floor
+from hypothesis.internal.reflection import extract_lambda_source
 
 Ex = TypeVar("Ex")
 Predicate = Callable[[Ex], bool]
@@ -49,7 +52,7 @@ class ConstructivePredicate(NamedTuple):
         -> {"min_value": 0"}, None
 
         integers().filter(lambda x: x >= 0 and x % 7)
-        -> {"min_value": 0"}, lambda x: x % 7
+        -> {"min_value": 0}, lambda x: x % 7
 
     At least in principle - for now we usually return the predicate unchanged
     if needed.
@@ -64,6 +67,135 @@ class ConstructivePredicate(NamedTuple):
     @classmethod
     def unchanged(cls, predicate):
         return cls({}, predicate)
+
+
+ARG = object()
+
+
+def convert(node, argname):
+    if isinstance(node, ast.Name):
+        if node.id != argname:
+            raise ValueError("Non-local variable")
+        return ARG
+    return ast.literal_eval(node)
+
+
+def comp_to_kwargs(a, op, b, *, argname=None):
+    """ """
+    if isinstance(a, ast.Name) == isinstance(b, ast.Name):
+        raise ValueError("Can't analyse this comparison")
+    a = convert(a, argname)
+    b = convert(b, argname)
+    assert (a is ARG) != (b is ARG)
+
+    if isinstance(op, ast.Lt):
+        if a is ARG:
+            return {"max_value": b, "exclude_max": True}
+        return {"min_value": a, "exclude_min": True}
+    elif isinstance(op, ast.LtE):
+        if a is ARG:
+            return {"max_value": b}
+        return {"min_value": a}
+    elif isinstance(op, ast.Eq):
+        if a is ARG:
+            return {"min_value": b, "max_value": b}
+        return {"min_value": a, "max_value": a}
+    elif isinstance(op, ast.GtE):
+        if a is ARG:
+            return {"min_value": b}
+        return {"max_value": a}
+    elif isinstance(op, ast.Gt):
+        if a is ARG:
+            return {"min_value": b, "exclude_min": True}
+        return {"max_value": a, "exclude_max": True}
+    raise ValueError("Unhandled comparison operator")
+
+
+def tidy(kwargs):
+    if not kwargs["exclude_min"]:
+        del kwargs["exclude_min"]
+        if kwargs["min_value"] == -math.inf:
+            del kwargs["min_value"]
+    if not kwargs["exclude_max"]:
+        del kwargs["exclude_max"]
+        if kwargs["max_value"] == math.inf:
+            del kwargs["max_value"]
+    return kwargs
+
+
+def merge_kwargs(*rest):
+    base = {
+        "min_value": -math.inf,
+        "max_value": math.inf,
+        "exclude_min": False,
+        "exclude_max": False,
+    }
+    for kw in rest:
+        if "min_value" in kw:
+            if kw["min_value"] > base["min_value"]:
+                base["exclude_min"] = kw.get("exclude_min", False)
+                base["min_value"] = kw["min_value"]
+            elif kw["min_value"] == base["min_value"]:
+                base["exclude_min"] |= kw.get("exclude_min", False)
+            else:
+                base["exclude_min"] = False
+        if "max_value" in kw:
+            if kw["max_value"] < base["max_value"]:
+                base["exclude_max"] = kw.get("exclude_max", False)
+                base["max_value"] = kw["max_value"]
+            elif kw["max_value"] == base["max_value"]:
+                base["exclude_max"] |= kw.get("exclude_max", False)
+            else:
+                base["exclude_max"] = False
+    return tidy(base)
+
+
+def numeric_bounds_from_ast(tree, *, argname=None):
+    """Take an AST; return a dict of bounds or None.
+
+    >>> lambda x: x >= 0
+    {"min_value": 0}
+    >>> lambda x: x < 10
+    {"max_value": 10, "exclude_max": True}
+    >>> lambda x: x >= y
+    None
+    """
+    while isinstance(tree, ast.Module) and len(tree.body) == 1:
+        tree = tree.body[0]
+    if isinstance(tree, ast.Expr):
+        tree = tree.value
+
+    if isinstance(tree, ast.Lambda) and len(tree.args.args) == 1:
+        assert argname is None
+        return numeric_bounds_from_ast(tree.body, argname=tree.args.args[0].arg)
+
+    if isinstance(tree, ast.FunctionDef) and len(tree.args.args) == 1:
+        assert argname is None
+        if len(tree.body) != 1 or not isinstance(tree.body[0], ast.Return):
+            return None
+        return numeric_bounds_from_ast(
+            tree.body[0].value, argname=tree.args.args[0].arg
+        )
+
+    if isinstance(tree, ast.Compare):
+        ops = tree.ops
+        vals = tree.comparators
+        comparisons = [(tree.left, ops[0], vals[0])]
+        for i, (op, val) in enumerate(zip(ops[1:], vals[1:]), start=1):
+            comparisons.append((vals[i - 1], op, val))
+        try:
+            bounds = [comp_to_kwargs(*x, argname=argname) for x in comparisons]
+        except ValueError:
+            return None
+        return merge_kwargs(*bounds)
+
+    if isinstance(tree, ast.BoolOp) and isinstance(tree.op, ast.And):
+        bounds = [
+            numeric_bounds_from_ast(node, argname=argname) for node in tree.values
+        ]
+        return merge_kwargs(*bounds)
+
+    return None
 
 
 UNSATISFIABLE = ConstructivePredicate.unchanged(lambda _: False)
@@ -99,7 +231,17 @@ def get_numeric_predicate_bounds(predicate: Predicate) -> ConstructivePredicate:
         if predicate.func in options:
             return ConstructivePredicate(options[predicate.func], None)
 
-    # TODO: handle lambdas by AST analysis
+    try:
+        if predicate.__name__ == "<lambda>":
+            source = extract_lambda_source(predicate)
+        else:
+            source = inspect.getsource(predicate)
+        kwargs = numeric_bounds_from_ast(ast.parse(source))
+    except Exception:
+        pass
+    else:
+        if kwargs is not None:
+            return ConstructivePredicate(kwargs, None)
 
     return ConstructivePredicate.unchanged(predicate)
 

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -22,6 +22,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import Unsatisfiable
+from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal.lazy import LazyStrategy
 from hypothesis.strategies._internal.numbers import IntegersStrategy
 from hypothesis.strategies._internal.strategies import FilteredStrategy
@@ -70,7 +71,14 @@ from tests.common.utils import fails_with
         (st.integers(), lambda x: 3 < x, 4, None),
         # More complicated lambdas
         (st.integers(), lambda x: 0 < x < 5, 1, 4),
+        (st.integers(), lambda x: 0 < x >= 1, 1, None),
+        (st.integers(), lambda x: 1 > x <= 0, None, 0),
+        (st.integers(), lambda x: x > 0 and x > 0, 1, None),
+        (st.integers(), lambda x: x < 1 and x < 1, None, 0),
+        (st.integers(), lambda x: x > 1 and x > 0, 2, None),
+        (st.integers(), lambda x: x < 1 and x < 2, None, 0),
     ],
+    ids=get_pretty_function_description,
 )
 @given(data=st.data())
 def test_filter_rewriting(data, strategy, predicate, start, end):
@@ -165,14 +173,27 @@ def test_rewrite_filter_chains_with_some_unhandled(data, predicates):
         assert pred is mod2 or pred.__name__ == "<lambda>"
 
 
+class NotAFunction:
+    def __call__(self, bar):
+        return True
+
+
+lambda_without_source = eval("lambda x: x > 2", {}, {})
+
+
 @pytest.mark.parametrize(
     "start, end, predicate",
     [
         (1, 4, lambda x: 0 < x < 5 and x % 7),
+        (0, 9, lambda x: 0 <= x < 10 and x % 3),
         (1, None, lambda x: 0 < x <= Y),
         (None, None, lambda x: x == x),
         (None, None, lambda x: 1 == 1),
         (None, None, lambda x: 1 <= 2),
+        (None, None, lambda x: x != 0),
+        (None, None, NotAFunction()),
+        (None, None, lambda_without_source),
+        (None, None, lambda x, y=2: x >= 0),
     ],
 )
 @given(data=st.data())

--- a/hypothesis-python/tests/cover/test_filtered_strategy.py
+++ b/hypothesis-python/tests/cover/test_filtered_strategy.py
@@ -19,7 +19,8 @@ from hypothesis.strategies._internal.strategies import FilteredStrategy
 
 
 def test_filter_iterations_are_marked_as_discarded():
-    x = st.integers(0, 255).filter(lambda x: x == 0)
+    variable_equal_to_zero = 0  # non-local references disables filter-rewriting
+    x = st.integers(0, 255).filter(lambda x: x == variable_equal_to_zero)
 
     data = ConjectureData.for_buffer([2, 1, 0])
 


### PR DESCRIPTION
This is the last big step for rewriting numeric scalar filters (see #2701); after this and the early parts of #2907 Pandera checks will be a lot more efficient for free :tada: 