### PR TITLE
Update pinned dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           - check-pypy37
           - check-py38
           - check-py39
-          # - check-py310  # pending https://github.com/pytest-dev/pytest/issues/8539
+          - check-py310
           - check-quality
           - lint-ruby
           - check-ruby-tests

--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,8 @@ if [ -n "${GITHUB_ACTIONS-}" ] || [ -n "${CODESPACES-}" ] ; then
 else
     # Otherwise, we install it from scratch
     # NOTE: keep this version in sync with PYMAIN in tooling
-    "$SCRIPTS/ensure-python.sh" 3.8.8
-    PYTHON=$(pythonloc 3.8.8)/bin/python
+    "$SCRIPTS/ensure-python.sh" 3.8.10
+    PYTHON=$(pythonloc 3.8.10)/bin/python
 fi
 
 TOOL_REQUIREMENTS="$ROOT/requirements/tools.txt"

--- a/hypothesis-python/docs/development.rst
+++ b/hypothesis-python/docs/development.rst
@@ -2,10 +2,12 @@
 Ongoing Hypothesis development
 ==============================
 
-Hypothesis development is managed by me, `David R. MacIver <https://www.drmaciver.com>`_.
-I am the primary author of Hypothesis.
+Hypothesis development is managed by `David R. MacIver <https://www.drmaciver.com>`_
+and `Zac Hatfield-Dodds <https://zhd.dev>`_, respectively the first author and lead
+maintainer.
 
-*However*, I no longer do unpaid feature development on Hypothesis. My roles as leader of the project are:
+*However*, these roles don't include unpaid feature development on Hypothesis.
+Our roles as leaders of the project are:
 
 1. Helping other people do feature development on Hypothesis
 2. Fixing bugs and other code health issues
@@ -17,7 +19,8 @@ I am the primary author of Hypothesis.
 So all new features must either be sponsored or implemented by someone else.
 That being said, the maintenance team takes an active role in shepherding pull requests and
 helping people write a new feature (see :gh-file:`CONTRIBUTING.rst` for
-details and :pull:`154` for an example of how the process goes). This isn't
+details and :gh-link:`these examples of how the process goes
+<pulls?q=is%3Apr+is%3Amerged+mentored>`). This isn't
 "patches welcome", it's "we will help you write a patch".
 
 

--- a/hypothesis-python/docs/support.rst
+++ b/hypothesis-python/docs/support.rst
@@ -10,7 +10,8 @@ sees them.
 
 For bugs and enhancements, please file an issue on the :issue:`GitHub issue tracker <>`.
 Note that as per the :doc:`development policy <development>`, enhancements will probably not get
-implemented unless you're willing to pay for development or implement them yourself (with assistance from me). Bugs
+implemented unless you're willing to pay for development or implement them yourself
+(with assistance from the maintainers). Bugs
 will tend to get fixed reasonably promptly, though it is of course on a best effort basis.
 
 To see the versions of Python, optional dependencies, test runners, and operating systems Hypothesis

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -88,14 +88,15 @@ extras["all"] = sorted(
 setuptools.setup(
     name="hypothesis",
     version=__version__,
-    author="David R. MacIver",
+    author="David R. MacIver and Zac Hatfield-Dodds",
     author_email="david@drmaciver.com",
     packages=setuptools.find_packages(SOURCE),
     package_dir={"": SOURCE},
     package_data={"hypothesis": ["py.typed", "vendor/tlds-alpha-by-domain.txt"]},
-    url="https://github.com/HypothesisWorks/hypothesis/tree/master/hypothesis-python",
+    url="https://hypothesis.works",
     project_urls={
-        "Website": "https://hypothesis.works",
+        "Source": "https://github.com/HypothesisWorks/hypothesis/tree/master/hypothesis-python",
+        "Changelog": "https://hypothesis.readthedocs.io/en/latest/changes.html",
         "Documentation": "https://hypothesis.readthedocs.io",
         "Issues": "https://github.com/HypothesisWorks/hypothesis/issues",
     },

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -13,7 +13,6 @@
 #
 # END HEADER
 
-import sys
 from inspect import getfullargspec
 
 import attr
@@ -116,8 +115,7 @@ def test_composite_edits_annotations():
 @pytest.mark.parametrize("nargs", [1, 2, 3])
 def test_given_edits_annotations(nargs):
     spec_given = getfullargspec(given(*(nargs * [st.none()]))(pointless_composite))
-    expected = None if sys.version_info[:2] < (3, 10) else type(None)
-    assert spec_given.annotations.pop("return") == expected
+    assert spec_given.annotations.pop("return") is None
     assert len(spec_given.annotations) == 3 - nargs
 
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -756,12 +756,7 @@ def test_compat_get_type_hints_aware_of_None_default():
     find_any(strategy, lambda x: x.a is not None)
 
     assert typing.get_type_hints(constructor)["a"] == typing.Optional[str]
-    annotation = inspect.signature(constructor).parameters["a"].annotation
-    assert annotation == str or (
-        # See https://bugs.python.org/issue43006
-        annotation == typing.Optional[str]
-        and sys.version_info[:2] >= (3, 10)
-    )
+    assert inspect.signature(constructor).parameters["a"].annotation == str
 
 
 _ValueType = typing.TypeVar("_ValueType")

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import dataclasses
-import sys
 import typing
 
 import pytest
@@ -103,7 +102,6 @@ class NestedDict(typing.TypedDict):
     inner: A
 
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 10), reason="see issue #2897")
 @given(from_type(NestedDict))
 def test_typeddict_with_nested_value(value):
     assert type(value) == dict

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -8,7 +8,7 @@ attrs==20.3.0
     # via hypothesis (hypothesis-python/setup.py)
 coverage==5.5
     # via -r requirements/coverage.in
-lark-parser==0.11.2
+lark-parser==0.11.3
     # via -r requirements/coverage.in
 numpy==1.20.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,7 +32,7 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-xdist==2.2.1
     # via -r requirements/test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/test.in
     #   pytest-forked

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -19,13 +19,13 @@ attrs==20.3.0
     #   pytest
 autoflake==1.4
     # via shed
-babel==2.9.0
+babel==2.9.1
     # via sphinx
 backcall==0.2.0
     # via ipython
 bandit==1.7.0
     # via flake8-bandit
-black==20.8b1
+black==21.5b0
     # via
     #   blacken-docs
     #   shed
@@ -61,7 +61,7 @@ decorator==5.0.7
     #   traitlets
 distlib==0.3.1
     # via virtualenv
-django==3.2
+django==3.2.1
     # via -r requirements/tools.in
 docutils==0.16
     # via
@@ -129,7 +129,7 @@ jinja2==2.11.3
     # via sphinx
 keyring==23.0.1
     # via twine
-lark-parser==0.11.2
+lark-parser==0.11.3
     # via -r requirements/tools.in
 libcst==0.3.18
     # via
@@ -157,7 +157,7 @@ parso==0.8.2
     # via jedi
 pathspec==0.8.1
     # via black
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
 pep517==0.10.0
     # via pip-tools
@@ -197,7 +197,7 @@ pyflakes==2.3.1
     # via
     #   autoflake
     #   flake8
-pygments==2.8.1
+pygments==2.9.0
     # via
     #   ipython
     #   pybetter
@@ -205,7 +205,7 @@ pygments==2.8.1
     #   sphinx
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.3
+pytest==6.2.4
     # via -r requirements/tools.in
 python-dateutil==2.8.1
     # via -r requirements/tools.in
@@ -213,7 +213,7 @@ pytz==2021.1
     # via
     #   babel
     #   django
-pyupgrade==2.13.0
+pyupgrade==2.14.0
     # via shed
 pyyaml==5.4.1
     # via
@@ -237,7 +237,7 @@ rfc3986==1.4.0
     # via twine
 secretstorage==3.3.1
     # via keyring
-shed==0.3.4
+shed==0.3.5
     # via -r requirements/tools.in
 six==1.15.0
     # via
@@ -302,12 +302,9 @@ traitlets==4.3.3
 twine==3.4.1
     # via -r requirements/tools.in
 typed-ast==1.4.3
+    # via mypy
+typing-extensions==3.10.0.0
     # via
-    #   black
-    #   mypy
-typing-extensions==3.7.4.3
-    # via
-    #   black
     #   libcst
     #   mypy
     #   typing-inspect


### PR DESCRIPTION
Pre-merge checklist 

- [x] work out what in `shed` is breaking the type annotations
     - [x] wait for a fix to https://github.com/psf/black/issues/2181 or just skip the update for now
- [x] update our "ongoing development" and "support" docs pages, they're out of date
- [x] similarly update the contributing docs parts to point to the guides on github and a recent mentored sprint PR
- [x] fix #2897 (thanks to the pytest release)