### PR TITLE
Ensure `filter` appears in repr of `just(...).filter(...)`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`2964`, where ``.map()`` and ``.filter()`` methods
+were omitted from the ``repr()`` of :func:`~hypothesis.strategies.just` and
+:func:`~hypothesis.strategies.sampled_from` strategies, since
+:ref:`version 5.43.7 <v5.43.7>`.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
@@ -43,9 +43,13 @@ class JustStrategy(SampledFromStrategy):
         return self.elements[0]
 
     def __repr__(self):
+        suffix = "".join(
+            f".{name}({get_pretty_function_description(f)})"
+            for name, f in self._transformations
+        )
         if self.value is None:
-            return "none()"
-        return f"just({get_pretty_function_description(self.value)})"
+            return "none()" + suffix
+        return f"just({get_pretty_function_description(self.value)}){suffix}"
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -15,6 +15,8 @@
 
 from collections import OrderedDict
 
+import pytest
+
 from hypothesis import given, strategies as st
 from hypothesis.control import reject
 from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
@@ -105,3 +107,15 @@ def test_repr_evals_to_thing_with_same_repr(strategy):
     via_eval = eval(r, strategy_globals)
     r2 = repr(via_eval)
     assert r == r2
+
+
+@pytest.mark.parametrize(
+    "r",
+    [
+        "none().filter(foo).map(bar)",
+        "just(1).filter(foo).map(bar)",
+        "sampled_from([1, 2, 3]).filter(foo).map(bar)",
+    ],
+)
+def test_sampled_transform_reprs(r):
+    assert repr(eval(r, strategy_globals)) == r


### PR DESCRIPTION
Fixes #2964.