### PR TITLE
Quiet identity element search in binary-operation ghostwriter

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes rare cases where ``hypothesis write --binary-op`` could
+print :doc:`reproducing instructions <reproducing>` from the internal
+search for an identity element.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -96,7 +96,7 @@ from typing import (
 
 import black
 
-from hypothesis import find, strategies as st
+from hypothesis import Verbosity, find, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import get_type_hints
 from hypothesis.internal.reflection import is_mock
@@ -135,6 +135,12 @@ except {exceptions}:
 
 Except = Union[Type[Exception], Tuple[Type[Exception], ...]]
 RE_TYPES = (type(re.compile(".")), type(re.match(".", "abc")))
+_quietly_settings = settings(
+    database=None,
+    deadline=None,
+    derandomize=True,
+    verbosity=Verbosity.quiet,
+)
 
 
 def _dedupe_exceptions(exc: Tuple[Type[Exception], ...]) -> Tuple[Type[Exception], ...]:
@@ -1221,7 +1227,7 @@ def _make_binop_body(
         # that it's a good starting point to edit much of the rest.
         if identity is infer:
             try:
-                identity = find(operands, lambda x: True)
+                identity = find(operands, lambda x: True, settings=_quietly_settings)
             except Exception:
                 identity = "identity element here"  # type: ignore
         # If the repr of this element is invalid Python, stringify it - this

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
@@ -15,13 +15,20 @@
 
 import ast
 import json
+import operator
 import re
 import subprocess
 
 import pytest
 
 from hypothesis.errors import StopTest
-from hypothesis.extra.ghostwriter import equivalent, fuzz, idempotent, roundtrip
+from hypothesis.extra.ghostwriter import (
+    binary_operation,
+    equivalent,
+    fuzz,
+    idempotent,
+    roundtrip,
+)
 
 
 @pytest.mark.parametrize(
@@ -41,6 +48,8 @@ from hypothesis.extra.ghostwriter import equivalent, fuzz, idempotent, roundtrip
         ),
         # Imports submodule (importlib.import_module passes; __import__ fails)
         ("hypothesis.errors.StopTest", lambda: fuzz(StopTest)),
+        # Search for identity element does not print e.g. "You can use @seed ..."
+        ("--binary-op operator.add", lambda: binary_operation(operator.add)),
     ],
 )
 def test_cli_python_equivalence(cli, code):


### PR DESCRIPTION
Because printing "You can use seed() to reproduce..." doesn't really fit with the test code.