### PR TITLE
Register all core strategy functions through `@defines_strategy`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch strengthens some internal import-time consistency checks for the
+built-in strategies.
+
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -120,12 +120,20 @@ __all__ = [
 
 
 def _check_exports(_public):
-    assert set(_strategies).issubset(__all__), (
-        set(_strategies) - set(__all__),
-        set(__all__) - set(_strategies),
-    )
-
     assert set(__all__) == _public, (set(__all__) - _public, _public - set(__all__))
+
+    # Verify that all exported strategy functions were registered with
+    # @declares_strategy.
+    exported_strategies = set(__all__) - {
+        "DataObject",
+        "SearchStrategy",
+        "composite",
+        "register_type_strategy",
+    }
+    assert set(_strategies) == exported_strategies, (
+        set(_strategies) - exported_strategies,
+        exported_strategies - set(_strategies),
+    )
 
 
 _check_exports({n for n in dir() if n[0] not in "_@"})

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -118,10 +118,15 @@ __all__ = [
     "SearchStrategy",
 ]
 
-assert set(_strategies).issubset(__all__), (
-    set(_strategies) - set(__all__),
-    set(__all__) - set(_strategies),
-)
-_public = {n for n in dir() if n[0] not in "_@"}
-assert set(__all__) == _public, (set(__all__) - _public, _public - set(__all__))
-del _public
+
+def _check_exports(_public):
+    assert set(_strategies).issubset(__all__), (
+        set(_strategies) - set(__all__),
+        set(__all__) - set(_strategies),
+    )
+
+    assert set(__all__) == _public, (set(__all__) - _public, _public - set(__all__))
+
+
+_check_exports({n for n in dir() if n[0] not in "_@"})
+del _check_exports

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -883,6 +883,7 @@ if sys.version_info[:2] >= (3, 8):  # pragma: no cover
 
 
 @cacheable
+@defines_strategy(never_lazy=True)
 def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     """Looks up the appropriate search strategy for the given type.
 
@@ -1323,6 +1324,7 @@ def decimals(
     return strat | (sampled_from(special) if special else nothing())
 
 
+@defines_strategy(never_lazy=True)
 def recursive(
     base: SearchStrategy[Ex],
     extend: Callable[[SearchStrategy[Any]], SearchStrategy[T]],
@@ -1528,6 +1530,7 @@ def complex_numbers(
     return constrained_complex()
 
 
+@defines_strategy(never_lazy=True)
 def shared(
     base: SearchStrategy[Ex],
     *,
@@ -1668,6 +1671,7 @@ class DataStrategy(SearchStrategy):
 
 
 @cacheable
+@defines_strategy(never_lazy=True)
 def data() -> SearchStrategy[DataObject]:
     """This isn't really a normal strategy, but instead gives you an object
     which can be used to draw data interactively from other strategies.
@@ -1732,6 +1736,7 @@ def register_type_strategy(
 
 
 @cacheable
+@defines_strategy(never_lazy=True)
 def deferred(definition: Callable[[], SearchStrategy[Ex]]) -> SearchStrategy[Ex]:
     """A deferred strategy allows you to write a strategy that references other
     strategies that have not yet been defined. This allows for the easy

--- a/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
@@ -70,6 +70,7 @@ class JustStrategy(SampledFromStrategy):
         return self._transform(self.value)
 
 
+@defines_strategy(never_lazy=True)
 def just(value: T) -> SearchStrategy[T]:
     """Return a strategy which only generates ``value``.
 
@@ -123,6 +124,7 @@ NOTHING = Nothing()
 
 
 @cacheable
+@defines_strategy(never_lazy=True)
 def nothing() -> SearchStrategy:
     """This strategy never successfully draws a value and will always reject on
     an attempt to draw.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -47,6 +47,7 @@ from hypothesis.internal.conjecture.utils import (
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.lazyformat import lazyformat
 from hypothesis.internal.reflection import get_pretty_function_description
+from hypothesis.strategies._internal.utils import defines_strategy
 from hypothesis.utils.conventions import UniqueIdentifier
 
 Ex = TypeVar("Ex", covariant=True)
@@ -714,6 +715,7 @@ def one_of(*args: SearchStrategy[Any]) -> SearchStrategy[Any]:
     raise NotImplementedError
 
 
+@defines_strategy(never_lazy=True)
 def one_of(*args):  # noqa: F811
     # Mypy workaround alert:  Any is too loose above; the return parameter
     # should be the union of the input parameters.  Unfortunately, Mypy <=0.600

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -35,25 +35,33 @@ from tests.common.debug import assert_all_examples, find_any
 from tests.common.utils import fails_with, temp_registered
 
 # Build a set of all types output by core strategies
-blacklist = [
+blocklist = {
     "builds",
+    "data",
+    "deferred",
     "from_regex",
     "from_type",
     "ip_addresses",
     "iterables",
+    "just",
+    "nothing",
+    "one_of",
     "permutations",
     "random_module",
     "randoms",
+    "recursive",
     "runner",
     "sampled_from",
+    "shared",
     "timezone_keys",
     "timezones",
-]
+}
+assert set(_strategies).issuperset(blocklist), blocklist.difference(_strategies)
 types_with_core_strat = set()
 for thing in (
     getattr(st, name)
     for name in sorted(_strategies)
-    if name in dir(st) and name not in blacklist
+    if name in dir(st) and name not in blocklist
 ):
     for n in range(3):
         try:


### PR DESCRIPTION
We have some assertions and tests that assume all of our strategy functions were decorated with `@defines_strategy`, which has the side-effect of adding their names to a global `_strategies` dict. However, not all of our exported strategies actually end up in that dict.

In particular, the current version of the decorator always applies a layer of `LazyStrategy` indirection. There are several strategy functions that don't use that lazy-wrapping layer (whether deliberately or accidentally), so they also aren't registered in `_strategies`.

This PR therefore adds a `never_lazy` flag to `@defines_strategy`, and adds `@defines_strategy(never_lazy=True)` to all of the core strategy functions that are currently unregistered.

In practice, the biggest effect of this change is that `hypothesis.strategies` will now refuse to export anything that isn't a registered strategy function, and isn't on an exemption list of things that aren't strategy functions.