### PR TITLE
add .hypothesis to invalid tests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,6 +36,7 @@ their individual contributions.
 * `Cristi Cobzarenco <https://github.com/cristicbz>`_ (cristi@reinfer.io)
 * `Damon Francisco <https://github.com/dtfrancisco>`_ (damontfrancisco@yahoo.com)
 * `Daniel J. West <https://github.com/danieljwest>`_
+* `Daniel Knell <https://github.com/danielknell>`_ (contact@danielknell.co.uk)
 * `David Bonner <https://github.com/rascalking>`_ (dbonner@gmail.com)
 * `David Chudzicki <https://github.com/dchudz>`_ (dchudz@gmail.com)
 * `David Mascharka <https://github.com/davidmascharka>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch adds a `.hypothesis` property to invalid test functions, bringing
-them inline with valid tests and fixing a bug where `pytest-asyncio` would
+This patch adds a ``.hypothesis`` property to invalid test functions, bringing
+them inline with valid tests and fixing a bug where :pypi:`pytest-asyncio` would
 swallow the real error message and mistakenly raise a version incompatibility
 error.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch adds a `.hypothesis` property to invalid test functions, bringing
+them inline with valid tests and fixing a bug where `pytest-asyncio` would
+swallow the real error message and mistakenly raise a version incompatibility
+error.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -239,7 +239,19 @@ def is_invalid_test(name, original_argspec, given_arguments, given_kwargs):
         def wrapped_test(*arguments, **kwargs):
             raise InvalidArgument(message)
 
+        def _get_fuzz_target() -> Callable[
+            [Union[bytes, bytearray, memoryview, BinaryIO]], Optional[bytes]
+        ]:
+            def fuzz_one_input(
+                buffer: Union[bytes, bytearray, memoryview, BinaryIO]
+            ) -> Optional[bytes]:
+                return None
+
+            fuzz_one_input.__doc__ = HypothesisHandle.fuzz_one_input.__doc__
+            return fuzz_one_input
+
         wrapped_test.is_hypothesis_test = True
+        wrapped_test.hypothesis = HypothesisHandle(wrapped_test, _get_fuzz_target, given_kwargs)
         return wrapped_test
 
     if not (given_arguments or given_kwargs):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -240,7 +240,11 @@ def is_invalid_test(test, original_argspec, given_arguments, given_kwargs):
             raise InvalidArgument(message)
 
         wrapped_test.is_hypothesis_test = True
-        wrapped_test.hypothesis = HypothesisHandle(test, wrapped_test, given_kwargs)
+        wrapped_test.hypothesis = HypothesisHandle(
+            inner_test=test,
+            get_fuzz_target=wrapped_test,
+            given_kwargs=given_kwargs,
+        )
         return wrapped_test
 
     if not (given_arguments or given_kwargs):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -251,7 +251,11 @@ def is_invalid_test(name, original_argspec, given_arguments, given_kwargs):
             return fuzz_one_input
 
         wrapped_test.is_hypothesis_test = True
-        wrapped_test.hypothesis = HypothesisHandle(wrapped_test, _get_fuzz_target, given_kwargs)
+        wrapped_test.hypothesis = HypothesisHandle(
+            wrapped_test, 
+            _get_fuzz_target, 
+            given_kwargs,
+        )
         return wrapped_test
 
     if not (given_arguments or given_kwargs):

--- a/hypothesis-python/tests/cover/test_fuzz_one_input.py
+++ b/hypothesis-python/tests/cover/test_fuzz_one_input.py
@@ -24,8 +24,6 @@ from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.shrinker import sort_key
 
-from tests.common.utils import raises
-
 
 @pytest.mark.parametrize(
     "buffer_type",
@@ -166,7 +164,6 @@ def test_fuzzing_invalid_test_raises_error():
     def invalid_test(s):
         pass
 
-    with raises(InvalidArgument) as e:
-        invalid_test.hypothesis.fuzz_one_input(b"abc")
-
-    assert "Too many positional arguments" in e.value.args[0]
+    with pytest.raises(InvalidArgument, match="Too many positional arguments"):
+        # access the property to check error happens during setup
+        invalid_test.hypothesis.fuzz_one_input

--- a/hypothesis-python/tests/cover/test_fuzz_one_input.py
+++ b/hypothesis-python/tests/cover/test_fuzz_one_input.py
@@ -21,7 +21,10 @@ import pytest
 
 from hypothesis import Phase, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.shrinker import sort_key
+
+from tests.common.utils import raises
 
 
 @pytest.mark.parametrize(
@@ -155,3 +158,15 @@ def test_fuzz_one_input_does_not_add_redundant_entries_to_database(buffers, db_s
     (saved_examples,) = db.data.values()
     assert seen == buffers
     assert len(saved_examples) == db_size
+
+
+def test_fuzzing_invalid_test_raises_error():
+    # Invalid: @given with too many positional arguments
+    @given(st.integers(), st.integers())
+    def invalid_test(s):
+        pass
+
+    with raises(InvalidArgument) as e:
+        invalid_test.hypothesis.fuzz_one_input(b"abc")
+
+    assert "Too many positional arguments" in e.value.args[0]

--- a/hypothesis-python/tests/nocover/test_modify_inner_test.py
+++ b/hypothesis-python/tests/nocover/test_modify_inner_test.py
@@ -18,6 +18,9 @@ from functools import wraps
 import pytest
 
 from hypothesis import given, strategies as st
+from hypothesis.errors import InvalidArgument
+
+from tests.common.utils import raises
 
 
 def always_passes(*args, **kwargs):
@@ -62,3 +65,39 @@ def test_can_replace_when_parametrized(x, y):
 
 
 test_can_replace_when_parametrized.hypothesis.inner_test = always_passes
+
+
+def test_can_replace_when_original_is_invalid():
+    # Invalid: @given with too many positional arguments
+    @given(st.integers(), st.integers())
+    def invalid_test(x):
+        assert False
+
+    invalid_test.hypothesis.inner_test = always_passes
+
+    # Even after replacing the inner test, calling the wrapper should still
+    # fail.
+    with raises(InvalidArgument) as e:
+        invalid_test()
+
+    assert "Too many positional arguments" in e.value.args[0]
+
+
+def test_inner_is_original_even_when_invalid():
+    def invalid_test(x):
+        assert False
+
+    original = invalid_test
+
+    # Invalid: @given with no arguments
+    invalid_test = given()(invalid_test)
+
+    assert invalid_test.hypothesis.inner_test == original
+
+    # Verify that the test is actually invalid
+    with raises(InvalidArgument) as e:
+        invalid_test()
+
+    assert "given must be called with at least one argument" in e.value.args[0]
+
+    assert invalid_test.hypothesis.inner_test == original

--- a/hypothesis-python/tests/nocover/test_modify_inner_test.py
+++ b/hypothesis-python/tests/nocover/test_modify_inner_test.py
@@ -20,8 +20,6 @@ import pytest
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
 
-from tests.common.utils import raises
-
 
 def always_passes(*args, **kwargs):
     """Stand-in for a fixed version of an inner test.
@@ -77,10 +75,8 @@ def test_can_replace_when_original_is_invalid():
 
     # Even after replacing the inner test, calling the wrapper should still
     # fail.
-    with raises(InvalidArgument) as e:
+    with pytest.raises(InvalidArgument, match="Too many positional arguments"):
         invalid_test()
-
-    assert "Too many positional arguments" in e.value.args[0]
 
 
 def test_inner_is_original_even_when_invalid():
@@ -92,12 +88,11 @@ def test_inner_is_original_even_when_invalid():
     # Invalid: @given with no arguments
     invalid_test = given()(invalid_test)
 
-    assert invalid_test.hypothesis.inner_test == original
-
     # Verify that the test is actually invalid
-    with raises(InvalidArgument) as e:
+    with pytest.raises(
+        InvalidArgument,
+        match="given must be called with at least one argument",
+    ):
         invalid_test()
-
-    assert "given must be called with at least one argument" in e.value.args[0]
 
     assert invalid_test.hypothesis.inner_test == original


### PR DESCRIPTION
adds `.hypothesis` to invalid tests.

this fixes #2966

I'm not quite sure where (or how) I should test it, I couldn't find any tests using .hypothesis other than the ones swapping the test function and that won't work here without making the invalid tests far more complicated...

all existing tests seem to pass.