### PR TITLE
Bounded `integers` should shrink towards positive values

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug that caused :func:`~hypothesis.strategies.integers`
+to shrink towards negative values instead of positive values in some cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -89,7 +89,7 @@ def integer_range(data, lower, upper, center=None):
     elif center == lower:
         above = True
     else:
-        above = boolean(data)
+        above = not boolean(data)
 
     if above:
         gap = upper - center

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -298,14 +298,15 @@ def test_is_not_ascii(x):
 
 
 @fails
-@given(text())
+@given(text(min_size=2))
 @settings(max_examples=100, derandomize=True)
 def test_can_find_string_with_duplicates(s):
     assert len(set(s)) == len(s)
 
 
 @fails
-@given(text())
+@given(text(min_size=1))
+@settings(derandomize=True)
 def test_has_ascii(x):
     if not x:
         return

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -33,15 +33,20 @@ class interval(SearchStrategy):
         return integer_range(data, self.lower, self.upper, center=self.center)
 
 
-@pytest.mark.parametrize("inter", [(0, 5, 10), (-10, 10, 10), (0, 1, 1), (1, 1, 2)])
-def test_intervals_shrink_to_center(inter):
-    lower, center, upper = inter
+@pytest.mark.parametrize(
+    "lower_center_upper",
+    [(0, 5, 10), (-10, 10, 10), (0, 1, 1), (1, 1, 2), (-10, 0, 10), (-10, 5, 10)],
+    ids=repr,
+)
+def test_intervals_shrink_to_center(lower_center_upper):
+    lower, center, upper = lower_center_upper
     s = interval(lower, upper, center)
     assert minimal(s, lambda x: True) == center
     if lower < center:
         assert minimal(s, lambda x: x < center) == center - 1
     if center < upper:
         assert minimal(s, lambda x: x > center) == center + 1
+        assert minimal(s, lambda x: x != center) == center + 1
 
 
 def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -46,6 +46,19 @@ def test_integers_from_minimizes_leftwards():
     assert minimal(integers(min_value=101)) == 101
 
 
+def test_minimize_bounded_integers_to_zero():
+    assert minimal(integers(-10, 10)) == 0
+
+
+def test_minimize_bounded_integers_to_positive():
+    zero = 0
+
+    def not_zero(x):
+        return x != zero
+
+    assert minimal(integers(-10, 10).filter(not_zero)) == 1
+
+
 def test_minimal_fractions_1():
     assert minimal(fractions()) == Fraction(0)
 


### PR DESCRIPTION
Our docs say that `integers` should shrink towards positive values, but currently that isn't actually true for instances that have lower+upper bounds that span across zero.

Double bounded `integers` delegates to `integer_range`, which detects ranges that cross the designated centre value and draws a “sign bit” to determine whether to generate values upwards or downwards from the centre.

But the code in question interprets a drawn value of 0 as “below” instead of “above”, so shrinking tends to produce values below the centre if possible.

This patch negates the above/below flag, so that a drawn value 0 is treated as “above”, giving the intended behaviour.