### PR TITLE
Speed up some slow `nocover/` tests

### DIFF
--- a/hypothesis-python/tests/nocover/test_imports.py
+++ b/hypothesis-python/tests/nocover/test_imports.py
@@ -18,9 +18,8 @@ from hypothesis.strategies import *
 
 
 def test_can_star_import_from_hypothesis():
-    @given(lists(integers()))
-    @settings(max_examples=10000, verbosity=Verbosity.quiet)
-    def f(x):
-        pass
-
-    f()
+    find(
+        lists(integers()),
+        lambda x: sum(x) > 1,
+        settings=settings(max_examples=10000, verbosity=Verbosity.quiet),
+    )

--- a/hypothesis-python/tests/nocover/test_lstar.py
+++ b/hypothesis-python/tests/nocover/test_lstar.py
@@ -14,7 +14,7 @@
 # END HEADER
 
 import hypothesis.strategies as st
-from hypothesis import example, given
+from hypothesis import Phase, example, given, settings
 from hypothesis.internal.conjecture.dfa.lstar import LStar
 
 
@@ -27,6 +27,9 @@ def byte_order(draw):
 
 @example({0}, [1])
 @given(st.sets(st.integers(0, 255)), byte_order())
+# This test doesn't even use targeting at all, but for some reason the
+# pareto optimizer makes it much slower.
+@settings(phases=set(Phase) - {Phase.target})
 def test_learning_always_changes_generation(chars, order):
     learner = LStar(lambda s: len(s) == 1 and s[0] in chars)
     for c in order:

--- a/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
@@ -35,8 +35,8 @@ skip_before_python37 = pytest.mark.skipif(
 @given(st.data())
 def test_mutually_recursive_types_with_typevar(data):
     # The previously-failing example from the issue
-    A = Dict[str, "B"]  # noqa: F821 - an undefined name is the whole point!
-    B = Union[List[str], A]
+    A = Dict[bool, "B"]  # noqa: F821 - an undefined name is the whole point!
+    B = Union[List[bool], A]
 
     with pytest.raises(ResolutionFailed, match=r"Could not resolve ForwardRef\('B'\)"):
         data.draw(st.from_type(A))
@@ -55,8 +55,8 @@ def test_mutually_recursive_types_with_typevar(data):
 def test_mutually_recursive_types_with_typevar_alternate(data):
     # It's not particularly clear why this version passed when the previous
     # test failed, but different behaviour means we add both to the suite.
-    C = Union[List[str], "D"]  # noqa: F821 - an undefined name is the whole point!
-    D = Dict[str, C]
+    C = Union[List[bool], "D"]  # noqa: F821 - an undefined name is the whole point!
+    D = Dict[bool, C]
 
     with pytest.raises(ResolutionFailed, match=r"Could not resolve ForwardRef\('D'\)"):
         data.draw(st.from_type(C))


### PR DESCRIPTION
I took a look at the list of longest-running tests in the `nocover/` suite, and found quite a bit of low-hanging fruit.

Some of these tests went from ~20–30 seconds to ~1 second or less, with no loss of quality that I'm aware of.