### PR TITLE
`from_regex("", fullmatch=True)` should only produce empty strings

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug in :func:`~hypothesis.strategies.from_regex` that
+caused ``from_regex("", fullmatch=True)`` to unintentionally generate non-empty
+strings (:issue:`4982`).
+
+The only strings that completely match an empty regex pattern are empty
+strings.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
@@ -226,6 +226,11 @@ def regex_strategy(regex, fullmatch):
 
     parsed = sre_parse.parse(regex.pattern, flags=regex.flags)
 
+    if fullmatch:
+        if not parsed:
+            return st.just("" if is_unicode else b"")
+        return base_regex_strategy(regex, parsed).filter(regex.fullmatch)
+
     if not parsed:
         if is_unicode:
             return st.text()
@@ -244,9 +249,7 @@ def regex_strategy(regex, fullmatch):
     right_pad = base_padding_strategy
     left_pad = base_padding_strategy
 
-    if fullmatch:
-        right_pad = empty
-    elif parsed[-1][0] == sre.AT:
+    if parsed[-1][0] == sre.AT:
         if parsed[-1][1] == sre.AT_END_STRING:
             right_pad = empty
         elif parsed[-1][1] == sre.AT_END:
@@ -256,9 +259,7 @@ def regex_strategy(regex, fullmatch):
                 )
             else:
                 right_pad = st.one_of(empty, newline)
-    if fullmatch:
-        left_pad = empty
-    elif parsed[0][0] == sre.AT:
+    if parsed[0][0] == sre.AT:
         if parsed[0][1] == sre.AT_BEGINNING_STRING:
             left_pad = empty
         elif parsed[0][1] == sre.AT_BEGINNING:

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -432,6 +432,10 @@ def test_fullmatch_generates_example(pattern, matching_str):
 @pytest.mark.parametrize(
     "pattern,eqiv_pattern",
     [
+        (r"", r"\A\Z"),
+        (b"", br"\A\Z"),
+        (r"(?#comment)", r"\A\Z"),
+        (br"(?#comment)", br"\A\Z"),
         ("a", "\\Aa\\Z"),
         ("[Aa]", "\\A[Aa]\\Z"),
         ("[ab]*", "\\A[ab]*\\Z"),


### PR DESCRIPTION
Fixes #2982.

Most of `regex_strategy` is dedicated to figuring out how to apply leading/trailing padding, which is not relevant to `fullmatch` strategies. So it ended up being much cleaner to handle the full-match case as an early-exit that delegates to `base_regex_strategy`.