### PR TITLE
Avoid/ignore unhelpful numpy warnings in `test_can_minimize_float_arrays`

### DIFF
--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -67,8 +67,9 @@ def test_can_minimize_large_arrays():
 
 
 @flaky(max_runs=50, min_passes=1)
+@np.errstate(over="ignore", invalid="ignore")
 def test_can_minimize_float_arrays():
-    x = minimal(nps.arrays(float, 50), lambda t: t.sum() >= 1.0)
+    x = minimal(nps.arrays(float, 50), lambda t: np.nansum(t) >= 1.0)
     assert x.sum() in (1, 50)
 
 


### PR DESCRIPTION
```
=============================== warnings summary ===============================
hypothesis-python/tests/numpy/test_gen_data.py::test_can_minimize_float_arrays
  /home/runner/work/hypothesis/hypothesis/hypothesis-python/.tox/coverage/lib/python3.8/site-packages/numpy/core/_methods.py:47: RuntimeWarning: invalid value encountered in reduce
    return umr_sum(a, axis, dtype, out, keepdims, initial, where)

hypothesis-python/tests/numpy/test_gen_data.py::test_can_minimize_float_arrays
  /home/runner/work/hypothesis/hypothesis/hypothesis-python/.tox/coverage/lib/python3.8/site-packages/numpy/core/_methods.py:47: RuntimeWarning: overflow encountered in reduce
    return umr_sum(a, axis, dtype, out, keepdims, initial, where)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

These warnings clog up our test output, and aren't actually telling us anything useful.

Generating and shrinking large/infinite values and NaNs is part of Hypothesis's job, so we don't actually want to avoid them entirely. So instead we just tell numpy not to warn us about them.
