### PR TITLE
Use a single `Sampler` instance for all wide-range integer draws

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch slightly improves the performance of some internal code for
+generating integers.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -56,12 +56,9 @@ BIASED_COIN_INNER_LABEL = calc_label_from_name("inside biased_coin()")
 SAMPLE_IN_SAMPLER_LABLE = calc_label_from_name("a sample() in Sampler")
 ONE_FROM_MANY_LABEL = calc_label_from_name("one more from many()")
 
-INT_SIZES = (8, 16, 32, 64, 128)
-INT_WEIGHTS = (4.0, 8.0, 1.0, 1.0, 0.5)
-
 
 def unbounded_integers(data):
-    size = INT_SIZES[Sampler(INT_WEIGHTS).sample(data)]
+    size = INT_SIZES[INT_SIZES_SAMPLER.sample(data)]
     r = data.draw_bits(size)
     sign = r & 1
     r >>= 1
@@ -105,7 +102,7 @@ def integer_range(data, lower, upper, center=None):
         # For large ranges, we combine the uniform random distribution from draw_bits
         # with a weighting scheme with moderate chance.  Cutoff at 2 ** 24 so that our
         # choice of unicode characters is uniform but the 32bit distribution is not.
-        idx = Sampler(INT_WEIGHTS).sample(data)
+        idx = INT_SIZES_SAMPLER.sample(data)
         bits = min(bits, INT_SIZES[idx])
 
     while probe > gap:
@@ -380,6 +377,10 @@ class Sampler:
             return alternate
         else:
             return base
+
+
+INT_SIZES = (8, 16, 32, 64, 128)
+INT_SIZES_SAMPLER = Sampler((4.0, 8.0, 1.0, 1.0, 0.5))
 
 
 class many:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -53,7 +53,7 @@ def combine_labels(*labels: int) -> int:
 INTEGER_RANGE_DRAW_LABEL = calc_label_from_name("another draw in integer_range()")
 BIASED_COIN_LABEL = calc_label_from_name("biased_coin()")
 BIASED_COIN_INNER_LABEL = calc_label_from_name("inside biased_coin()")
-SAMPLE_IN_SAMPLER_LABLE = calc_label_from_name("a sample() in Sampler")
+SAMPLE_IN_SAMPLER_LABEL = calc_label_from_name("a sample() in Sampler")
 ONE_FROM_MANY_LABEL = calc_label_from_name("one more from many()")
 
 
@@ -368,7 +368,7 @@ class Sampler:
         self.table.sort()
 
     def sample(self, data):
-        data.start_example(SAMPLE_IN_SAMPLER_LABLE)
+        data.start_example(SAMPLE_IN_SAMPLER_LABEL)
         i = integer_range(data, 0, len(self.table) - 1)
         base, alternate, alternate_chance = self.table[i]
         use_alternate = biased_coin(data, alternate_chance)


### PR DESCRIPTION
Setting up a `Sampler` is somewhat non-trivial, and there's no reason to do it every time we want to choose an integer width.