### PR TITLE
Simplify the `do_filtered_draw` hook

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch cleans up some internal code related to filtering strategies.
+
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -166,11 +166,11 @@ class UniqueListStrategy(ListStrategy):
         def not_yet_in_unique_list(val):
             return all(key(val) not in seen for key, seen in zip(self.keys, seen_sets))
 
-        filtered = self.element_strategy.filter(not_yet_in_unique_list)
+        filtered = self.element_strategy._filter_for_filtered_draw(
+            not_yet_in_unique_list
+        )
         while elements.more():
-            value = filtered.filtered_strategy.do_filtered_draw(
-                data=data, filter_strategy=filtered
-            )
+            value = filtered.do_filtered_draw(data)
             if value is filter_not_satisfied:
                 elements.reject()
             else:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -167,11 +167,6 @@ class LazyStrategy(SearchStrategy):
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)
 
-    def do_filtered_draw(self, data, filter_strategy):
-        return self.wrapped_strategy.do_filtered_draw(
-            data=data, filter_strategy=filter_strategy
-        )
-
     @property
     def label(self):
         return self.wrapped_strategy.label

--- a/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
@@ -15,11 +15,9 @@
 
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal.strategies import (
-    FilteredStrategy,
     SampledFromStrategy,
     SearchStrategy,
     T,
-    filter_not_satisfied,
     is_simple_data,
 )
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
@@ -54,16 +52,10 @@ class JustStrategy(SampledFromStrategy):
     def calc_is_cacheable(self, recur):
         return is_simple_data(self.value)
 
-    def do_draw(self, data):
-        result = self._transform(self.value)
-        if result is filter_not_satisfied:
-            data.note_event(f"Aborted test because unable to satisfy {self!r}")
-            data.mark_invalid()
-        return result
-
-    def do_filtered_draw(self, data, filter_strategy):
-        if isinstance(filter_strategy, FilteredStrategy):
-            return self._transform(self.value, filter_strategy.flat_conditions)
+    def do_filtered_draw(self, data):
+        # The parent class's `do_draw` implementation delegates directly to
+        # `do_filtered_draw`, which we can greatly simplify in this case since
+        # we have exactly one value. (This also avoids drawing any data.)
         return self._transform(self.value)
 
 

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -132,8 +132,8 @@ def stupid_sampled_sets(draw):
 
 @given(stupid_sampled_sets())
 def test_efficient_sets_of_samples_with_chained_transformations_slow_path(x):
-    # This exercises the standard .do_filtered_draw method, rather than the
-    # special logic in UniqueSampledListStrategy, to the same if slower effect.
+    # This deliberately exercises the standard filtering logic without going
+    # through the special-case handling of UniqueSampledListStrategy.
     assert x == {x * 2 for x in range(20) if x % 3}
 
 
@@ -155,7 +155,7 @@ def test_transformed_just_strategy():
     assert s.do_draw(data) == 2
     sf = s.filter(lambda x: False)
     assert isinstance(sf, JustStrategy)
-    assert sf.do_filtered_draw(data, sf) == filter_not_satisfied
+    assert sf.do_filtered_draw(data) == filter_not_satisfied
     with pytest.raises(StopTest):
         sf.do_draw(data)
 

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -19,7 +19,8 @@ from collections import namedtuple
 import pytest
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.strategies import booleans, integers, just, tuples
+from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.strategies import booleans, integers, just, none, tuples
 
 from tests.common.debug import assert_no_examples
 
@@ -46,6 +47,18 @@ def test_just_strategy_uses_repr():
             return "ABCDEFG"
 
     assert repr(just(WeirdRepr())) == f"just({WeirdRepr()!r})"
+
+
+def test_just_strategy_does_not_draw():
+    data = ConjectureData.for_buffer(b"")
+    s = just("hello")
+    assert s.do_draw(data) == "hello"
+
+
+def test_none_strategy_does_not_draw():
+    data = ConjectureData.for_buffer(b"")
+    s = none()
+    assert s.do_draw(data) is None
 
 
 def test_can_map():

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -24,6 +24,7 @@ from hypothesis import __version__, reproduce_failure, seed, settings as Setting
 from hypothesis.control import current_build_context
 from hypothesis.database import ExampleDatabase
 from hypothesis.errors import DidNotReproduce, Flaky, InvalidArgument, InvalidDefinition
+from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.stateful import (
     Bundle,
     RuleBasedStateMachine,
@@ -384,8 +385,9 @@ def test_saves_failing_example_in_database():
 
 
 def test_can_run_with_no_db():
-    with raises(AssertionError):
-        run_state_machine_as_test(DepthMachine, settings=Settings(database=None))
+    with deterministic_PRNG():
+        with raises(AssertionError):
+            run_state_machine_as_test(DepthMachine, settings=Settings(database=None))
 
 
 def test_stateful_double_rule_is_forbidden(recwarn):


### PR DESCRIPTION
This is a small piece of cleanup that I've been meaning to do for a while.

Originally, the `do_filtered_draw` hook was added as a lightweight way for individual strategies to make filtering more efficient (specifically `sampled_from` in #1904), without having to fully override `.filter` with a custom strategy.

(At the time, no non-trivial strategy had a custom `.filter` implementation, so this was worthwhile.)

Over time, a few things changed:

- The hook was also used by `UniqueListStrategy` (#1891)
- Unique lists of `sampled_from` were further specialized to `UniqueSampledListStrategy` (#2031), bypassing the generic code in `UniqueListStrategy`
- More non-trivial implementations of `.filter` were added to rewrite simple filters on `integers()` into bounds updates (#2853)

All together, these developments mean that the original design of `do_filtered_draw` is now more of a liability, adding confusion for little gain.

---

This PR therefore greatly simplifies the design of `do_filtered_draw` by omitting the `filter_strategy` argument, and changing its contract to simply be “like `do_draw`, but if filtering fails then return a sentinel instead of throwing”.

Furthermore, most strategies now no longer have a `do_filtered_draw` method at all. Instead they have a `_filter_for_filtered_draw` method, which returns an object (currently always `FilteredStrategy`) that implements `do_filtered_draw`.

(Note that `SampledFromStrategy` still has a `do_filtered_draw` method, but currently it never actually gets called by `UniqueListStrategy` because of the `UniqueFilteredListStrategy` specialization. I've left it as-is for now, partly because it *would* work if needed, and partly to avoid having to merge that code back into `SampledFromStrategy.do_draw` for no real benefit.)
