### PR TITLE
Enable CI caching on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.8"
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache
+        key: deps-${{ runner.os }}-${{ hashFiles('requirements/tools.txt') }}-${{ matrix.task }}
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,7 @@ jobs:
       with:
         path: |
           ~/.cache
+          ~/Library/Caches/pip
         key: deps-${{ runner.os }}-${{ hashFiles('requirements/tools.txt') }}-${{ matrix.task }}
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh


### PR DESCRIPTION
According to https://github.com/HypothesisWorks/hypothesis/pull/2736#issuecomment-754582115, CI caching was originally not enabled on MacOS because it wasn't one of the slowest tasks, so the extra effort to get it working would not have improved build times.

Well, now it is one of the slowest tasks! So here's an attempt to fix that.