### PR TITLE
Use shallow checkouts in CI for Windows and MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -114,7 +114,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
We currently do full checkouts in CI builds, because some of our tasks need to interact with `master`.

This is an experiment to see if we can get away with shallow checkouts on Windows and MacOS, and whether it actually speeds up builds by a meaningful amount.