### PR TITLE
Exclude `tests/quality/` from Windows CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
         pip install -r requirements/test.txt fakeredis typing-extensions
         pip install hypothesis-python/[all]
     - name: Run tests
-      run: python -m pytest --numprocesses auto hypothesis-python/tests/
+      run: python -m pytest --numprocesses auto hypothesis-python/tests/ --ignore-glob=hypothesis-python/tests/quality/*.py
 
   test-osx:
     runs-on: macos-latest


### PR DESCRIPTION
Quality tests are slow enough that we exclude them from our normal Linux/Mac builds, and instead rely on a dedicated `check-quality` task that runs as a separate CI action (on Linux only).

Windows builds sidestep `./build.sh` and invoke `pytest hypothesis-python/tests/` directly to run all of the tests. In doing so, they implicitly include the quality suite, which greatly increases build times.

We should be able to get away with testing them only in the `check-quality` CI action, so excluding quality tests from Windows builds should give us a significant speedup to some of our slowest actions.
