### PR TITLE
Fix flaky coverage of fragments in the `urls` strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release adjusts some internal code to help make our test suite more
+reliable.
+
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -233,7 +233,7 @@ def _for_text(field):
         # Not maximally efficient, but it makes pathological cases rarer.
         # If you want a challenge: extend https://qntm.org/greenery to
         # compute intersections of the full Python regex language.
-        return st.one_of(*[st.from_regex(r) for r in regexes])
+        return st.one_of(*(st.from_regex(r) for r in regexes))
     # If there are no (usable) regexes, we use a standard text strategy.
     min_size, max_size = length_bounds_from_validators(field)
     strategy = st.text(

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1489,5 +1489,5 @@ def integer_array_indices(
         )
 
     return result_shape.flatmap(
-        lambda index_shape: st.tuples(*[array_for(index_shape, size) for size in shape])
+        lambda index_shape: st.tuples(*(array_for(index_shape, size) for size in shape))
     )

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -180,7 +180,7 @@ def numeric_bounds_from_ast(
 
     if isinstance(tree, ast.BoolOp) and isinstance(tree.op, ast.And):
         return merge_preds(
-            *[numeric_bounds_from_ast(node, argname, fallback) for node in tree.values]
+            *(numeric_bounds_from_ast(node, argname, fallback) for node in tree.values)
         )
 
     return fallback

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -142,6 +142,25 @@ def domains(
     )
 
 
+# The `urls()` strategy uses this to generate URL fragments (e.g. "#foo").
+# It has been extracted to top-level so that we can test it independently
+# of `urls()`, which helps with getting non-flaky coverage of the lambda.
+_url_fragments_strategy = (
+    st.lists(
+        st.builds(
+            lambda char, encode: f"%{ord(char):02X}"
+            if (encode or char not in FRAGMENT_SAFE_CHARACTERS)
+            else char,
+            st.characters(min_codepoint=0, max_codepoint=255),
+            st.booleans(),
+        ),
+        min_size=1,
+    )
+    .map("".join)
+    .map("#{}".format)
+)
+
+
 @defines_strategy(force_reusable_values=True)
 def urls() -> st.SearchStrategy[str]:
     """A strategy for :rfc:`3986`, generating http/https URLs."""
@@ -152,20 +171,6 @@ def urls() -> st.SearchStrategy[str]:
     schemes = st.sampled_from(["http", "https"])
     ports = st.integers(min_value=0, max_value=2 ** 16 - 1).map(":{}".format)
     paths = st.lists(st.text(string.printable).map(url_encode)).map("/".join)
-    fragments = (
-        st.lists(
-            st.builds(
-                lambda char, encode: f"%{ord(char):02X}"
-                if (encode or char not in FRAGMENT_SAFE_CHARACTERS)
-                else char,
-                st.characters(min_codepoint=0, max_codepoint=255),
-                st.booleans(),
-            ),
-            min_size=1,
-        )
-        .map("".join)
-        .map("#{}".format)
-    )
 
     return st.builds(
         "{}://{}{}/{}{}".format,
@@ -173,5 +178,5 @@ def urls() -> st.SearchStrategy[str]:
         domains(),
         st.just("") | ports,
         paths,
-        st.just("") | fragments,
+        st.just("") | _url_fragments_strategy,
     )

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -112,7 +112,7 @@ class DomainNameStrategy(st.SearchStrategy):
             .filter(lambda tld: len(tld) + 2 <= self.max_length)
             .flatmap(
                 lambda tld: st.tuples(
-                    *[st.sampled_from([c.lower(), c.upper()]) for c in tld]
+                    *(st.sampled_from([c.lower(), c.upper()]) for c in tld)
                 ).map("".join)
             )
         )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -40,7 +40,7 @@ class TupleStrategy(SearchStrategy):
 
     def calc_label(self):
         return combine_labels(
-            self.class_label, *[s.label for s in self.element_strategies]
+            self.class_label, *(s.label for s in self.element_strategies)
         )
 
     def __repr__(self):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -762,7 +762,7 @@ class BuildsStrategy(SearchStrategy):
     def do_draw(self, data):
         try:
             return self.target(
-                *[data.draw(a) for a in self.args],
+                *(data.draw(a) for a in self.args),
                 **{k: data.draw(v) for k, v in self.kwargs.items()},
             )
         except TypeError as err:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -638,7 +638,7 @@ class OneOfStrategy(SearchStrategy):
 
     def calc_label(self):
         return combine_labels(
-            self.class_label, *[p.label for p in self.original_strategies]
+            self.class_label, *(p.label for p in self.original_strategies)
         )
 
     def do_draw(self, data: ConjectureData) -> Ex:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ attrs==21.2.0
     # via
     #   hypothesis (hypothesis-python/setup.py)
     #   pytest
-execnet==1.8.0
+execnet==1.8.1
     # via pytest-xdist
 iniconfig==1.1.1
     # via pytest

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -59,7 +59,7 @@ decorator==5.0.9
     # via
     #   ipython
     #   traitlets
-distlib==0.3.1
+distlib==0.3.2
     # via virtualenv
 django==3.2.3
     # via -r requirements/tools.in
@@ -107,7 +107,7 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.0.1
+importlib-metadata==4.3.1
     # via
     #   keyring
     #   twine
@@ -213,7 +213,7 @@ pytz==2021.1
     # via
     #   babel
     #   django
-pyupgrade==2.18.1
+pyupgrade==2.19.0
     # via shed
 pyyaml==5.4.1
     # via
@@ -293,7 +293,7 @@ toml==0.10.2
     #   tox
 tox==3.23.1
     # via -r requirements/tools.in
-tqdm==4.60.0
+tqdm==4.61.0
     # via twine
 traitlets==4.3.3
     # via
@@ -310,9 +310,9 @@ typing-extensions==3.10.0.0
     #   typing-inspect
 typing-inspect==0.6.0
     # via libcst
-urllib3==1.26.4
+urllib3==1.26.5
     # via requests
-virtualenv==20.4.6
+virtualenv==20.4.7
     # via tox
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -79,11 +79,11 @@ def codespell(*files):
 def lint():
     pip_tool(
         "flake8",
-        *[f for f in tools.all_files() if f.endswith(".py")],
+        *(f for f in tools.all_files() if f.endswith(".py")),
         "--config",
         os.path.join(tools.ROOT, ".flake8"),
     )
-    codespell(*[f for f in tools.all_files() if not f.endswith("by-domain.txt")])
+    codespell(*(f for f in tools.all_files() if not f.endswith("by-domain.txt")))
 
 
 HEAD = tools.hash_for_name("HEAD")
@@ -364,7 +364,7 @@ PY38 = PYMAIN = "3.8.10"  # Sync PYMAIN minor version with GH Actions main.yml
 PY39 = "3.9.5"
 PY310 = "3.10-dev"
 PYPY36 = "pypy3.6-7.3.3"
-PYPY37 = "pypy3.7-7.3.4"
+PYPY37 = "pypy3.7-7.3.5"
 
 
 # ALIASES are the executable names for each Python version

--- a/whole-repo-tests/test_rst_is_valid.py
+++ b/whole-repo-tests/test_rst_is_valid.py
@@ -33,7 +33,7 @@ ALL_RST = [
 
 
 def test_passes_rst_lint():
-    pip_tool("rst-lint", *[f for f in ALL_RST if not is_sphinx(f)])
+    pip_tool("rst-lint", *(f for f in ALL_RST if not is_sphinx(f)))
 
 
 def test_passes_flake8():


### PR DESCRIPTION
We are occasionally seeing flaky coverage in `provisional.py`. According to https://github.com/HypothesisWorks/hypothesis/pull/2992#issuecomment-850978280 this is because we are not reliably generating URLs that contain a fragment component.