### PR TITLE
Fix existing tests that accidentally enable `Phase.explain`

### DIFF
--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -17,7 +17,7 @@ import contextlib
 import sys
 from io import StringIO
 
-from hypothesis._settings import Phase
+from hypothesis import Phase, settings
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.reflection import proxies
@@ -49,7 +49,7 @@ except ModuleNotFoundError:
         ), f"Expected to raise an exception ({expected_exception!r}) but didn't"
 
 
-no_shrink = tuple(set(Phase) - {Phase.shrink})
+no_shrink = tuple(set(settings.default.phases) - {Phase.shrink})
 
 
 def flaky(max_runs, min_passes):

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -124,7 +124,7 @@ def test_too_small_to_be_useful_coin():
 @settings(
     deadline=None,
     suppress_health_check=HealthCheck.all(),
-    phases=[Phase.explicit] if IN_COVERAGE_TESTS else tuple(Phase),
+    phases=[Phase.explicit] if IN_COVERAGE_TESTS else settings.default.phases,
 )
 @given(st.lists(st.fractions(min_value=0, max_value=1), min_size=1))
 def test_sampler_distribution(weights):

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -75,6 +75,12 @@ branches = st.builds(Branch, bits=st.integers(1, 64))
 writes = st.builds(Write, value=st.binary(min_size=1), child=nodes)
 
 
+# Remember what the default phases are with no test running, so that we can
+# run an outer test with non-default phases and then restore the defaults for
+# the inner test.
+_default_phases = settings.default.phases
+
+
 def run_language_test_for(root, data, seed):
     random.seed(seed)
 
@@ -106,7 +112,9 @@ def run_language_test_for(root, data, seed):
             database=None,
             suppress_health_check=HealthCheck.all(),
             verbosity=Verbosity.quiet,
-            phases=list(Phase),
+            # Restore the global default phases, so that we don't inherit the
+            # phases setting from the outer test.
+            phases=_default_phases,
         ),
     )
     try:
@@ -120,7 +128,7 @@ def run_language_test_for(root, data, seed):
 @settings(
     suppress_health_check=HealthCheck.all(),
     deadline=None,
-    phases=set(Phase) - {Phase.shrink},
+    phases=set(settings.default.phases) - {Phase.shrink},
 )
 @given(st.data())
 def test_explore_an_arbitrary_language(data):

--- a/hypothesis-python/tests/nocover/test_lstar.py
+++ b/hypothesis-python/tests/nocover/test_lstar.py
@@ -29,7 +29,7 @@ def byte_order(draw):
 @given(st.sets(st.integers(0, 255)), byte_order())
 # This test doesn't even use targeting at all, but for some reason the
 # pareto optimizer makes it much slower.
-@settings(phases=set(Phase) - {Phase.target})
+@settings(phases=set(settings.default.phases) - {Phase.target})
 def test_learning_always_changes_generation(chars, order):
     learner = LStar(lambda s: len(s) == 1 and s[0] in chars)
     for c in order:


### PR DESCRIPTION
As noted in #2989, we should not be using `set(Phase) - {...}` to disable specific phases, because this has the side-effect of accidentally enabling the off-by-default `Phase.explain`.

I've changed the offending code to use `set(settings.default.phase)`, which should be more reliable.