### PR TITLE
Enable coloured terminal output in CI logs via `PY_COLORS=1` 🌈

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: Hypothesis CI
 
+env:
+  # Tell pytest and other tools to produce coloured terminal output.
+  # Make sure this is also in the "passenv" section of the tox config.
+  PY_COLORS: 1
+
 on:
   push:
     branches: [ master ]

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -12,6 +12,8 @@ passenv=
     LC_ALL
     COVERAGE_FILE
     TOXENV
+    # Allow CI builds (or user builds) to force coloured terminal output.
+    PY_COLORS
 setenv=
     brief: HYPOTHESIS_PROFILE=speedy
 commands =


### PR DESCRIPTION
This should make CI log output easier to navigate.