### PR TITLE
Produce a coverage report even if the test suite fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,16 @@ jobs:
           deps-${{ runner.os }}
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
+      # Invoke the magic `always` function to run on both success and failure.
+      if: ${{ always() && endsWith(matrix.task, '-coverage') }}
+      with:
+        name: ${{ matrix.task }}-data
+        path: |
+          hypothesis-python/.coverage*
+          !hypothesis-python/.coveragerc
+          hypothesis-python/branch-check
 
   test-win:
     runs-on: windows-latest

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -89,11 +89,17 @@ whitelist_externals=
     rm
 setenv=
     HYPOTHESIS_INTERNAL_COVERAGE=true
-commands =
+commands_pre =
     rm -f branch-check
     pip install .[zoneinfo]
     python -m coverage --version
     python -m coverage debug sys
+    # Explicitly erase any old .coverage file so the report never sees it.
+    python -m coverage erase
+# Produce a coverage report even if the test suite fails.
+# (The tox task will still count as failed.)
+ignore_errors = true
+commands =
     python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict-markers tests/cover tests/conjecture tests/datetime tests/numpy tests/pandas tests/lark --ff {posargs}
     python -m coverage report -m --fail-under=100 --show-missing --skip-covered
     python scripts/validate_branch_check.py
@@ -103,10 +109,11 @@ commands =
 deps =
     -r../requirements/test.txt
     -r../requirements/coverage.txt
-whitelist_externals=
-    rm
 setenv=
     HYPOTHESIS_INTERNAL_COVERAGE=true
+commands_pre =
+    python -m coverage erase
+ignore_errors = true
 commands =
     python -m coverage run --rcfile=.coveragerc --source=hypothesis.internal.conjecture -m pytest -n0 --strict-markers tests/conjecture
     python -m coverage report -m --fail-under=100 --show-missing --skip-covered


### PR DESCRIPTION
It's annoying to wait for a coverage build to complete, only to find that you don't get a report because one of the tests is failing (or flaky).

This PR tells tox to keep running subsequent tasks even if the test suite itself fails, so that we always get a coverage report.

(I've also tried adding the `.coverage` file as a build artifact, so that we can download it for local inspection if desired.)