### PR TITLE
Remove various obsolete helper functions from `compat.py`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch removes some old internal helper code that previously existed
+to make Python 2 compatibility easier.
+
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -204,7 +204,7 @@ else:
 
             if item.get_closest_marker("parametrize") is not None:
                 # Give every parametrized test invocation a unique database key
-                key = item.nodeid.encode("utf-8")
+                key = item.nodeid.encode()
                 item.obj.hypothesis.inner_test._hypothesis_internal_add_digest = key
 
             store = StoringReporter(item.config)

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -24,10 +24,6 @@ PYPY = platform.python_implementation() == "PyPy"
 WINDOWS = platform.system() == "Windows"
 
 
-def bit_length(n):
-    return n.bit_length()
-
-
 def str_to_bytes(s):
     return s.encode(a_good_encoding())
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -171,10 +171,6 @@ def update_code_location(code, newfile, newlineno):
     return type(code)(*unpacked)
 
 
-def get_stream_enc(stream, default=None):
-    return getattr(stream, "encoding", None) or default
-
-
 # Under Python 2, math.floor and math.ceil returned floats, which cannot
 # represent large integers - eg `float(2**53) == float(2**53 + 1)`.
 # We therefore implement them entirely in (long) integer operations.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -24,10 +24,6 @@ PYPY = platform.python_implementation() == "PyPy"
 WINDOWS = platform.system() == "Windows"
 
 
-def str_to_bytes(s):
-    return s.encode(a_good_encoding())
-
-
 def escape_unicode_characters(s):
     return codecs.encode(s, "unicode_escape").decode("ascii")
 
@@ -42,17 +38,6 @@ def int_to_bytes(i, size):
 
 def int_to_byte(i):
     return bytes([i])
-
-
-def a_good_encoding():
-    return "utf-8"
-
-
-def to_unicode(x):
-    if isinstance(x, str):
-        return x
-    else:
-        return x.decode(a_good_encoding())
 
 
 def qualname(f):
@@ -184,12 +169,6 @@ def update_code_location(code, newfile, newlineno):
     unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile
     unpacked[CODE_FIELD_ORDER.index("co_firstlineno")] = newlineno
     return type(code)(*unpacked)
-
-
-def cast_unicode(s, encoding=None):
-    if isinstance(s, bytes):
-        return s.decode(encoding or a_good_encoding(), "replace")
-    return s
 
 
 def get_stream_enc(stream, default=None):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -21,7 +21,7 @@ from typing import Dict
 import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
-from hypothesis.internal.compat import bit_length, int_from_bytes, int_to_bytes
+from hypothesis.internal.compat import int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 
@@ -1024,7 +1024,7 @@ class ConjectureData:
 
         self.blocks.add_endpoint(self.index)
 
-        assert bit_length(result) <= n
+        assert result.bit_length() <= n
         return result
 
     def draw_bytes(self, n):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
@@ -326,11 +326,7 @@ def normalize(
             runner, previous.buffer, current.buffer, shrinking_predicate
         )
 
-        name = (
-            base_name
-            + "-"
-            + hashlib.sha256(repr(new_dfa).encode("utf-8")).hexdigest()[:10]
-        )
+        name = base_name + "-" + hashlib.sha256(repr(new_dfa).encode()).hexdigest()[:10]
 
         # If there is a name collision this DFA should already be being
         # used for shrinking, so we should have already been able to shrink

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -21,14 +21,14 @@ import sys
 from collections import OrderedDict, abc
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import floor, int_from_bytes, qualname, str_to_bytes
+from hypothesis.internal.compat import floor, int_from_bytes, qualname
 from hypothesis.internal.floats import int_to_float
 
 LABEL_MASK = 2 ** 64 - 1
 
 
 def calc_label_from_name(name: str) -> int:
-    hashed = hashlib.sha384(str_to_bytes(name)).digest()
+    hashed = hashlib.sha384(name.encode("utf-8")).digest()
     return int_from_bytes(hashed[:8])
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -21,13 +21,7 @@ import sys
 from collections import OrderedDict, abc
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import (
-    bit_length,
-    floor,
-    int_from_bytes,
-    qualname,
-    str_to_bytes,
-)
+from hypothesis.internal.compat import floor, int_from_bytes, qualname, str_to_bytes
 from hypothesis.internal.floats import int_to_float
 
 LABEL_MASK = 2 ** 64 - 1
@@ -95,7 +89,7 @@ def integer_range(data, lower, upper, center=None):
 
     assert gap > 0
 
-    bits = bit_length(gap)
+    bits = gap.bit_length()
     probe = gap + 1
 
     if bits > 24 and data.draw_bits(3):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -28,7 +28,7 @@ LABEL_MASK = 2 ** 64 - 1
 
 
 def calc_label_from_name(name: str) -> int:
-    hashed = hashlib.sha384(name.encode("utf-8")).digest()
+    hashed = hashlib.sha384(name.encode()).digest()
     return int_from_bytes(hashed[:8])
 
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -30,8 +30,6 @@ from typing import Callable, TypeVar
 from hypothesis.internal.compat import (
     is_typed_named_tuple,
     qualname,
-    str_to_bytes,
-    to_unicode,
     update_code_location,
 )
 from hypothesis.vendor.pretty import pretty
@@ -70,11 +68,11 @@ def function_digest(function):
     """
     hasher = hashlib.sha384()
     try:
-        hasher.update(to_unicode(inspect.getsource(function)).encode("utf-8"))
+        hasher.update(inspect.getsource(function).encode("utf-8"))
     except (OSError, TypeError):
         pass
     try:
-        hasher.update(str_to_bytes(function.__name__))
+        hasher.update(function.__name__.encode("utf-8"))
     except AttributeError:
         pass
     try:
@@ -82,7 +80,7 @@ def function_digest(function):
     except AttributeError:
         pass
     try:
-        hasher.update(str_to_bytes(repr(inspect.getfullargspec(function))))
+        hasher.update(repr(inspect.getfullargspec(function)).encode("utf-8"))
     except TypeError:
         pass
     try:
@@ -452,7 +450,7 @@ def source_exec_as_module(source):
 
     result = ModuleType(
         "hypothesis_temporary_module_%s"
-        % (hashlib.sha384(str_to_bytes(source)).hexdigest(),)
+        % (hashlib.sha384(source.encode("utf-8")).hexdigest(),)
     )
     assert isinstance(source, str)
     exec(source, result.__dict__)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -68,19 +68,19 @@ def function_digest(function):
     """
     hasher = hashlib.sha384()
     try:
-        hasher.update(inspect.getsource(function).encode("utf-8"))
+        hasher.update(inspect.getsource(function).encode())
     except (OSError, TypeError):
         pass
     try:
-        hasher.update(function.__name__.encode("utf-8"))
+        hasher.update(function.__name__.encode())
     except AttributeError:
         pass
     try:
-        hasher.update(function.__module__.__name__.encode("utf-8"))
+        hasher.update(function.__module__.__name__.encode())
     except AttributeError:
         pass
     try:
-        hasher.update(repr(inspect.getfullargspec(function)).encode("utf-8"))
+        hasher.update(repr(inspect.getfullargspec(function)).encode())
     except TypeError:
         pass
     try:
@@ -450,7 +450,7 @@ def source_exec_as_module(source):
 
     result = ModuleType(
         "hypothesis_temporary_module_%s"
-        % (hashlib.sha384(source.encode("utf-8")).hexdigest(),)
+        % (hashlib.sha384(source.encode()).hexdigest(),)
     )
     assert isinstance(source, str)
     exec(source, result.__dict__)

--- a/hypothesis-python/src/hypothesis/reporting.py
+++ b/hypothesis-python/src/hypothesis/reporting.py
@@ -50,7 +50,7 @@ def to_text(textish):
     if inspect.isfunction(textish):
         textish = textish()
     if isinstance(textish, bytes):
-        textish = textish.decode("utf-8")
+        textish = textish.decode()
     return textish
 
 

--- a/hypothesis-python/tests/cover/test_float_nastiness.py
+++ b/hypothesis-python/tests/cover/test_float_nastiness.py
@@ -21,7 +21,6 @@ import pytest
 
 from hypothesis import assume, given, strategies as st
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import WINDOWS
 from hypothesis.internal.floats import (
     float_of,
     float_to_int,
@@ -84,10 +83,6 @@ def test_half_bounded_generates_zero():
     find_any(st.floats(max_value=1.0), lambda x: x == 0.0)
 
 
-@pytest.mark.xfail(
-    WINDOWS,
-    reason=("Seems to be triggering a floating point bug on 2.7 + windows + x64"),
-)
 @given(st.floats(max_value=-0.0))
 def test_half_bounded_respects_sign_of_upper_bound(x):
     assert math.copysign(1, x) == -1

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -86,7 +86,7 @@ def test_respects_alphabet_if_string(xs):
 
 @given(text())
 def test_can_encode_as_utf8(s):
-    s.encode("utf-8")
+    s.encode()
 
 
 @given(text(characters(blacklist_characters="\n")))

--- a/hypothesis-python/tests/nocover/test_regex.py
+++ b/hypothesis-python/tests/nocover/test_regex.py
@@ -56,9 +56,9 @@ def conservative_regex(draw):
 
 
 CONSERVATIVE_REGEX = conservative_regex()
-FLAGS = st.sets(st.sampled_from([getattr(re, "A", 0), re.I, re.M, re.S])).map(
-    lambda flag_set: reduce(int.__or__, flag_set, 0)
-)
+FLAGS = st.sets(
+    st.sampled_from([re.ASCII, re.IGNORECASE, re.MULTILINE, re.DOTALL])
+).map(lambda flag_set: reduce(int.__or__, flag_set, 0))
 
 
 @given(st.data())

--- a/hypothesis-python/tests/nocover/test_strategy_state.py
+++ b/hypothesis-python/tests/nocover/test_strategy_state.py
@@ -109,11 +109,8 @@ class HypothesisSpec(RuleBasedStateMachine):
     @rule(target=strategies, source=strategies, level=integers(1, 10), mixer=text())
     def filtered_strategy(s, source, level, mixer):
         def is_good(x):
-            return bool(
-                Random(hashlib.sha384((mixer + repr(x)).encode()).digest()).randint(
-                    0, level
-                )
-            )
+            seed = hashlib.sha384((mixer + repr(x)).encode()).digest()
+            return bool(Random(seed).randint(0, level))
 
         return source.filter(is_good)
 

--- a/hypothesis-python/tests/nocover/test_strategy_state.py
+++ b/hypothesis-python/tests/nocover/test_strategy_state.py
@@ -110,9 +110,9 @@ class HypothesisSpec(RuleBasedStateMachine):
     def filtered_strategy(s, source, level, mixer):
         def is_good(x):
             return bool(
-                Random(
-                    hashlib.sha384((mixer + repr(x)).encode("utf-8")).digest()
-                ).randint(0, level)
+                Random(hashlib.sha384((mixer + repr(x)).encode()).digest()).randint(
+                    0, level
+                )
             )
 
         return source.filter(is_good)
@@ -155,7 +155,7 @@ class HypothesisSpec(RuleBasedStateMachine):
 
         def do_map(value):
             rep = repr(value)
-            random = Random(hashlib.sha384((mixer + rep).encode("utf-8")).digest())
+            random = Random(hashlib.sha384((mixer + rep).encode()).digest())
             if random.random() <= p:
                 return result1
             else:

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -108,7 +108,7 @@ def test_can_unicode_strings_without_decode_error(arr):
 def test_unicode_string_dtypes_need_not_be_utf8():
     def cannot_encode(string):
         try:
-            string.encode("utf-8")
+            string.encode()
             return False
         except UnicodeEncodeError:
             return True

--- a/tooling/scripts/tool-hash.py
+++ b/tooling/scripts/tool-hash.py
@@ -19,4 +19,4 @@ import hashlib
 import sys
 
 if __name__ == "__main__":
-    print(hashlib.sha384(sys.stdin.read().encode("utf-8")).hexdigest()[:10])
+    print(hashlib.sha384(sys.stdin.read().encode()).hexdigest()[:10])

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -192,6 +192,7 @@ def format():
     config.from_file(os.path.join(hp.BASE_DIR, ".coveragerc"), our_file=True)
     pattern = "|".join(l for l in config.exclude_list if "pragma" not in l)
     unused_pragma_pattern = re.compile(f"({pattern}).*# pragma: no cover")
+    utf8_encoding_pattern = re.compile(r'\.(en|de)code\("utf-8"\)')
 
     for f in files_to_format:
         lines = []
@@ -208,10 +209,10 @@ def format():
                 if "END HEADER" in l and not header_done:
                     lines = []
                     header_done = True
-                elif unused_pragma_pattern.search(l) is not None:
-                    lines.append(l.replace("# pragma: no cover", ""))
                 else:
-                    lines.append(l)
+                    if unused_pragma_pattern.search(l) is not None:
+                        lines.append(l.replace("# pragma: no cover", ""))
+                    lines.append(utf8_encoding_pattern.sub(r".\1code()", l))
         source = "".join(lines).strip()
         with open(f, "w", encoding="utf-8") as o:
             if shebang is not None:


### PR DESCRIPTION
Most of these are left over from the Python 2 days, and never attracted enough attention to be cleaned up since then.

