### PR TITLE
Run the main non-coverage tests with `-nauto` instead of `-n2`

### DIFF
--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -13,7 +13,7 @@ for k, v in sorted(dict(os.environ).items()):
 pip install .
 
 
-PYTEST="python -m pytest -n2"
+PYTEST="python -m pytest -nauto"
 
 # Run all the no-extra-dependency tests for this version (except slow nocover tests)
 $PYTEST tests/cover tests/pytest


### PR DESCRIPTION
This is mainly intended to speed up Mac builds on CI, since GitHub's runners apparently have 3 cores allocated.

It should also speed up local builds on most machines.

(I'm not sure where the original `-n2` came from, but it predates the move to GitHub Actions for CI.)