### PR TITLE
Include xpassing tests in the pytest test summary

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 
-addopts=--strict-markers --tb=native -p pytester --runpytest=subprocess --durations=20
+# -rfEX :: Print a summary of failures, errors, and xpasses (xfails that pass).
+addopts=--strict-markers --tb=native -p pytester --runpytest=subprocess --durations=20 -rfEX
 filterwarnings =
     ignore::hypothesis.errors.NonInteractiveExampleWarning

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -380,6 +380,7 @@ python_tests = task(
     if_changed=(
         hp.PYTHON_SRC,
         hp.PYTHON_TESTS,
+        os.path.join(tools.ROOT, "pytest.ini"),
         os.path.join(hp.HYPOTHESIS_PYTHON, "scripts"),
     )
 )


### PR DESCRIPTION
When an `xfail` test unexpectedly passes, pytest switches to yellow output and includes the number of xpassing tests in its result line. However, by default it doesn't tell you which tests xpassed, making them difficult to track down from build logs.