### PR TITLE
Remove `compat.py` and other files from the coverage blocklist

### DIFF
--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -6,7 +6,6 @@ include =
 omit =
     **/pytestplugin.py
     **/scrutineer.py
-    **/.tox/*/lib/*/site-packages/hypothesis/internal/coverage.py
 
 [report]
 exclude_lines =

--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -7,7 +7,6 @@ omit =
     **/pytestplugin.py
     **/scrutineer.py
     **/strategytests.py
-    **/compat*.py
     **/extra/__init__.py
     **/.tox/*/lib/*/site-packages/hypothesis/internal/coverage.py
 

--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -6,8 +6,6 @@ include =
 omit =
     **/pytestplugin.py
     **/scrutineer.py
-    **/strategytests.py
-    **/extra/__init__.py
     **/.tox/*/lib/*/site-packages/hypothesis/internal/coverage.py
 
 [report]

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch reduces the amount of internal code excluded from our test suite's
+code coverage checks.
+
+There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -42,7 +42,9 @@ def int_to_byte(i):
 def qualname(f):
     try:
         return f.__qualname__
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
+        # It's unclear whether this fallback is actually needed by anything,
+        # but it probably doesn't hurt either.
         return f.__name__
 
 
@@ -51,7 +53,7 @@ try:
     # typing backport on PyPI.  Use if possible; or fall back to older names.
     typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
     ForwardRef = typing.ForwardRef  # type: ignore
-except AttributeError:
+except AttributeError:  # pragma: no cover
     typing_root_type = (typing.TypingMeta, typing.TypeVar)  # type: ignore
     try:
         typing_root_type += (typing._Union,)  # type: ignore
@@ -119,7 +121,9 @@ def get_type_hints(thing):
                         hints[p.name] = typing.Optional[p.annotation]
                     else:
                         hints[p.name] = p.annotation
-    except (AttributeError, TypeError, NameError):
+                else:  # pragma: no cover
+                    pass
+    except (AttributeError, TypeError, NameError):  # pragma: no cover
         pass
 
     return hints
@@ -141,30 +145,31 @@ def update_code_location(code, newfile, newlineno):
         # added to facilitate future-proof code.  See BPO-37032 for details.
         return code.replace(co_filename=newfile, co_firstlineno=newlineno)
 
-    # This field order is accurate for 3.5 - 3.7, but not 3.8 when a new field
-    # was added for positional-only arguments.  However it also added a .replace()
-    # method that we use instead of field indices, so they're fine as-is.
-    CODE_FIELD_ORDER = [
-        "co_argcount",
-        "co_kwonlyargcount",
-        "co_nlocals",
-        "co_stacksize",
-        "co_flags",
-        "co_code",
-        "co_consts",
-        "co_names",
-        "co_varnames",
-        "co_filename",
-        "co_name",
-        "co_firstlineno",
-        "co_lnotab",
-        "co_freevars",
-        "co_cellvars",
-    ]
-    unpacked = [getattr(code, name) for name in CODE_FIELD_ORDER]
-    unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile
-    unpacked[CODE_FIELD_ORDER.index("co_firstlineno")] = newlineno
-    return type(code)(*unpacked)
+    else:  # pragma: no cover
+        # This field order is accurate for 3.5 - 3.7, but not 3.8 when a new field
+        # was added for positional-only arguments.  However it also added a .replace()
+        # method that we use instead of field indices, so they're fine as-is.
+        CODE_FIELD_ORDER = [
+            "co_argcount",
+            "co_kwonlyargcount",
+            "co_nlocals",
+            "co_stacksize",
+            "co_flags",
+            "co_code",
+            "co_consts",
+            "co_names",
+            "co_varnames",
+            "co_filename",
+            "co_name",
+            "co_firstlineno",
+            "co_lnotab",
+            "co_freevars",
+            "co_cellvars",
+        ]
+        unpacked = [getattr(code, name) for name in CODE_FIELD_ORDER]
+        unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile
+        unpacked[CODE_FIELD_ORDER.index("co_firstlineno")] = newlineno
+        return type(code)(*unpacked)
 
 
 # Under Python 2, math.floor and math.ceil returned floats, which cannot
@@ -190,9 +195,10 @@ def ceil(x):
 def bad_django_TestCase(runner):
     if runner is None or "django.test" not in sys.modules:
         return False
-    if not isinstance(runner, sys.modules["django.test"].TransactionTestCase):
-        return False
+    else:  # pragma: no cover
+        if not isinstance(runner, sys.modules["django.test"].TransactionTestCase):
+            return False
 
-    from hypothesis.extra.django._impl import HypothesisTestCase
+        from hypothesis.extra.django._impl import HypothesisTestCase
 
-    return not isinstance(runner, HypothesisTestCase)
+        return not isinstance(runner, HypothesisTestCase)

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import codecs
-import importlib
 import inspect
 import platform
 import sys
@@ -124,9 +123,6 @@ def get_type_hints(thing):
         pass
 
     return hints
-
-
-importlib_invalidate_caches = getattr(importlib, "invalidate_caches", lambda: ())
 
 
 def update_code_location(code, newfile, newlineno):

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -44,7 +44,7 @@ def pretty_file_name(f):
         pass
 
     parts = f.split(os.path.sep)
-    if "hypothesis" in parts:
+    if "hypothesis" in parts:  # pragma: no branch
         parts = parts[-parts[::-1].index("hypothesis") :]
     result = os.path.sep.join(parts)
     pretty_file_name_cache[f] = result
@@ -107,7 +107,7 @@ if IN_COVERAGE_TESTS:
         return accept
 
 
-else:
+else:  # pragma: no cover
 
     def check_function(f):
         return f

--- a/hypothesis-python/tests/cover/test_compat.py
+++ b/hypothesis-python/tests/cover/test_compat.py
@@ -1,0 +1,41 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import math
+
+import pytest
+
+from hypothesis.internal.compat import ceil, floor
+
+floor_ceil_values = [
+    -10.7,
+    -10.3,
+    -0.5,
+    -0.0,
+    0,
+    0.5,
+    10.3,
+    10.7,
+]
+
+
+@pytest.mark.parametrize("value", floor_ceil_values)
+def test_our_floor_agrees_with_math_floor(value):
+    assert floor(value) == math.floor(value)
+
+
+@pytest.mark.parametrize("value", floor_ceil_values)
+def test_our_ceil_agrees_with_math_ceil(value):
+    assert ceil(value) == math.ceil(value)

--- a/hypothesis-python/tests/nocover/test_compat.py
+++ b/hypothesis-python/tests/nocover/test_compat.py
@@ -13,6 +13,8 @@
 #
 # END HEADER
 
+import math
+
 from hypothesis import given, strategies as st
 from hypothesis.internal.compat import (
     ceil,
@@ -60,17 +62,13 @@ def test_to_bytes_in_big_endian_order(x, y):
 
 @given(st.fractions())
 def test_ceil(x):
-    """The compat ceil function always has the Python 3 semantics.
-
-    Under Python 2, math.ceil returns a float, which cannot represent large
-    integers - for example, `float(2**53) == float(2**53 + 1)` - and this
-    is obviously incorrect for unlimited-precision integer operations.
-    """
     assert isinstance(ceil(x), int)
     assert x <= ceil(x) < x + 1
+    assert ceil(x) == math.ceil(x)
 
 
 @given(st.fractions())
 def test_floor(x):
     assert isinstance(floor(x), int)
     assert x - 1 < floor(x) <= x
+    assert floor(x) == math.floor(x)

--- a/hypothesis-python/tests/numpy/test_floor_ceil.py
+++ b/hypothesis-python/tests/numpy/test_floor_ceil.py
@@ -1,0 +1,53 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import math
+
+import numpy as np
+import pytest
+
+from hypothesis.internal.compat import ceil, floor
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # These are strings so that the test names are easier to read.
+        "2**64+1",
+        "2**64-1",
+        "2**63+1",
+        "2**53+1",
+        "-2**53-1",
+        "-2**63+1",
+        "-2**63-1",
+        "-2**64+1",
+        "-2**64-1",
+    ],
+)
+def test_our_floor_and_ceil_avoid_numpy_rounding(value):
+    a = np.array([eval(value)])
+
+    f = floor(a)
+    c = ceil(a)
+
+    assert type(f) == int
+    assert type(c) == int
+
+    # Using math.floor or math.ceil for these values would give an incorrect
+    # result.
+    assert (math.floor(a) > a) or (math.ceil(a) < a)
+
+    assert f <= a <= c
+    assert f + 1 > a > c - 1


### PR DESCRIPTION
Follow-up to #3001, which removed some dead code but didn't manage to get far enough to be able to update the blocklist.

Most of the new annotations should be pretty uncontroversial.