### PR TITLE
Avoid a flaky warning caused by multi-threaded DB access

### DIFF
--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -137,6 +137,7 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
 
     errors = []
 
+    @settings(database=None)
     @given(data=st.data())
     def test(data):
         try:


### PR DESCRIPTION
I've noticed that we occasionally see a warning about an uncaught exception thrown on one of the worker threads in `test_drawing_from_recursive_strategy_is_thread_safe`.

Unfortunately I don't have an example handy, but from memory at least one of the exceptions involved was due to threads not being able to access the database file. Since the database isn't relevant to this test, I've disabled it in the hopes that it will get rid of the warning.