### PR TITLE
Produce more helpful output from `validate_branch_check.py`

### DIFF
--- a/hypothesis-python/scripts/validate_branch_check.py
+++ b/hypothesis-python/scripts/validate_branch_check.py
@@ -26,6 +26,10 @@ if __name__ == "__main__":
     for d in data:
         checks[d["name"]].add(d["value"])
 
+    if not checks:
+        print("No branches found in the branch-check file?")
+        sys.exit(1)
+
     always_true = []
     always_false = []
 
@@ -42,17 +46,20 @@ if __name__ == "__main__":
 
     if failure:
         print("Some branches were not properly covered.")
-        print()
 
     if always_true:
-        print("The following were always True:")
         print()
+        print("The following were always True:")
         for c in always_true:
             print(f"  * {c}")
     if always_false:
-        print("The following were always False:")
         print()
+        print("The following were always False:")
         for c in always_false:
             print(f"  * {c}")
     if failure:
         sys.exit(1)
+
+    print(
+        f"""Successfully validated {len(checks)} branch{"es" if len(checks) > 1 else ""}."""
+    )

--- a/whole-repo-tests/test_validate_branch_check.py
+++ b/whole-repo-tests/test_validate_branch_check.py
@@ -1,0 +1,98 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import json
+import os
+import subprocess
+import sys
+
+from hypothesistooling.projects.hypothesispython import BASE_DIR
+
+BRANCH_CHECK = "branch-check"
+VALIDATE_BRANCH_CHECK = os.path.join(BASE_DIR, "scripts", "validate_branch_check.py")
+
+
+def write_entries(tmp_path, entries):
+    with open(tmp_path / BRANCH_CHECK, "w") as f:
+        f.writelines([json.dumps(entry) + "\n" for entry in entries])
+
+
+def run_validate_branch_check(tmp_path, *, check, **kwargs):
+    return subprocess.run(
+        [sys.executable, VALIDATE_BRANCH_CHECK],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=check,
+        **kwargs,
+    )
+
+
+def test_validates_branches(tmp_path):
+    write_entries(
+        tmp_path,
+        [
+            {"name": name, "value": value}
+            for name in ("first", "second", "third")
+            for value in (False, True)
+        ],
+    )
+
+    output = run_validate_branch_check(tmp_path, check=True)
+    assert output.stdout == "Successfully validated 3 branches.\n"
+
+
+def test_validates_one_branch(tmp_path):
+    write_entries(
+        tmp_path, [{"name": "sole", "value": value} for value in (False, True)]
+    )
+
+    output = run_validate_branch_check(tmp_path, check=True)
+    assert output.stdout == "Successfully validated 1 branch.\n"
+
+
+def test_fails_on_zero_branches(tmp_path):
+    write_entries(tmp_path, [])
+
+    output = run_validate_branch_check(tmp_path, check=False)
+    assert output.returncode == 1
+    assert output.stdout == "No branches found in the branch-check file?\n"
+
+
+def test_reports_uncovered_branches(tmp_path):
+    write_entries(
+        tmp_path,
+        [
+            {"name": "branch that is always taken", "value": True},
+            {"name": "some other branch that is never taken", "value": False},
+            {"name": "covered branch", "value": True},
+            {"name": "covered branch", "value": False},
+        ],
+    )
+
+    output = run_validate_branch_check(tmp_path, check=False)
+    assert output.returncode == 1
+    assert output.stdout == "\n".join(
+        [
+            "Some branches were not properly covered.",
+            "",
+            "The following were always True:",
+            "  * branch that is always taken",
+            "",
+            "The following were always False:",
+            "  * some other branch that is never taken",
+            "",
+        ]
+    )


### PR DESCRIPTION
This makes a few related improvements to our custom branch-coverage checker:

- When checking succeeds, we now print an explicit message that includes the number of branches checked.
- When the `branch-check` file is empty, we now fail with a message instead of silently succeeding.
- Line breaks are now a little nicer when reporting failures.
- Tests!