### PR TITLE
Clean up qualname logic (plus a user-visible ghostwriter tweak)

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch teaches :doc:`the Ghostwriter <ghostwriter>` how to find
+:np-ref:`custom ufuncs <ufuncs.html>` from *any* module that defines them,
+and that ``yaml.unsafe_load()`` does not undo ``yaml.safe_load()``.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -66,7 +66,6 @@ from hypothesis.internal.compat import (
     bad_django_TestCase,
     get_type_hints,
     int_from_bytes,
-    qualname,
 )
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
@@ -1045,11 +1044,12 @@ def given(
             if bad_django_TestCase(runner):  # pragma: no cover
                 # Covered by the Django tests, but not the pytest coverage task
                 raise InvalidArgument(
-                    "You have applied @given to a method on %s, but this "
+                    "You have applied @given to a method on "
+                    f"{type(runner).__qualname__}, but this "
                     "class does not inherit from the supported versions in "
                     "`hypothesis.extra.django`.  Use the Hypothesis variants "
                     "to ensure that each example is run in a separate "
-                    "database transaction." % qualname(type(runner))
+                    "database transaction."
                 )
 
             state = StateForActualGivenExecution(

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -39,15 +39,6 @@ def int_to_byte(i):
     return bytes([i])
 
 
-def qualname(f):
-    try:
-        return f.__qualname__
-    except AttributeError:  # pragma: no cover
-        # It's unclear whether this fallback is actually needed by anything,
-        # but it probably doesn't hurt either.
-        return f.__name__
-
-
 try:
     # These types are new in Python 3.7, but also (partially) backported to the
     # typing backport on PyPI.  Use if possible; or fall back to older names.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -271,7 +271,7 @@ def calculated_example_property(cls):
         return result
 
     lazy_calculate.__name__ = cls.__name__
-    lazy_calculate.__qualname__ = getattr(cls, "__qualname__", cls.__name__)
+    lazy_calculate.__qualname__ = cls.__qualname__
     return property(lazy_calculate)
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -21,7 +21,7 @@ import sys
 from collections import OrderedDict, abc
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import floor, int_from_bytes, qualname
+from hypothesis.internal.compat import floor, int_from_bytes
 from hypothesis.internal.floats import int_to_float
 
 LABEL_MASK = 2 ** 64 - 1
@@ -33,7 +33,7 @@ def calc_label_from_name(name: str) -> int:
 
 
 def calc_label_from_cls(cls: type) -> int:
-    return calc_label_from_name(qualname(cls))
+    return calc_label_from_name(cls.__qualname__)
 
 
 def combine_labels(*labels: int) -> int:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -27,24 +27,11 @@ from tokenize import detect_encoding
 from types import ModuleType
 from typing import Callable, TypeVar
 
-from hypothesis.internal.compat import (
-    is_typed_named_tuple,
-    qualname,
-    update_code_location,
-)
+from hypothesis.internal.compat import is_typed_named_tuple, update_code_location
 from hypothesis.vendor.pretty import pretty
 
 C = TypeVar("C", bound=Callable)
 READTHEDOCS = os.environ.get("READTHEDOCS", None) == "True"
-
-
-def fully_qualified_name(f):
-    """Returns a unique identifier for f pointing to the module it was defined
-    on, and an containing functions."""
-    if f.__module__ is not None:
-        return f.__module__ + "." + qualname(f)
-    else:
-        return qualname(f)
 
 
 def is_mock(obj):

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -26,6 +26,7 @@ from collections.abc import Iterable
 from copy import copy
 from functools import lru_cache
 from io import StringIO
+from operator import attrgetter
 from typing import Any, Dict, List
 from unittest import TestCase
 
@@ -36,7 +37,6 @@ from hypothesis._settings import HealthCheck, Verbosity, settings as Settings
 from hypothesis.control import current_build_context
 from hypothesis.core import given
 from hypothesis.errors import InvalidArgument, InvalidDefinition
-from hypothesis.internal.compat import qualname
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.reflection import function_digest, nicerepr, proxies
 from hypothesis.internal.validation import check_type
@@ -361,14 +361,16 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
             runTest.is_hypothesis_test = True
 
         StateMachineTestCase.__name__ = state_machine_class.__name__ + ".TestCase"
-        StateMachineTestCase.__qualname__ = qualname(state_machine_class) + ".TestCase"
+        StateMachineTestCase.__qualname__ = (
+            state_machine_class.__qualname__ + ".TestCase"
+        )
         return StateMachineTestCase
 
 
 @attr.s()
 class Rule:
     targets = attr.ib()
-    function = attr.ib(repr=qualname)
+    function = attr.ib(repr=attrgetter("__qualname__"))
     arguments = attr.ib()
     preconditions = attr.ib()
     bundles = attr.ib(init=False)

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -30,7 +30,6 @@ from hypothesis.internal.reflection import (
     convert_keyword_arguments,
     convert_positional_arguments,
     define_function_signature,
-    fully_qualified_name,
     function_digest,
     get_pretty_function_description,
     is_mock,
@@ -512,29 +511,6 @@ def test_define_function_signature_validates_function_name():
 class Container:
     def funcy(self):
         pass
-
-
-def test_fully_qualified_name():
-    assert (
-        fully_qualified_name(test_copying_preserves_argspec)
-        == "tests.cover.test_reflection.test_copying_preserves_argspec"
-    )
-    assert (
-        fully_qualified_name(Container.funcy)
-        == "tests.cover.test_reflection.Container.funcy"
-    )
-    assert (
-        fully_qualified_name(fully_qualified_name)
-        == "hypothesis.internal.reflection.fully_qualified_name"
-    )
-
-
-def test_qualname_of_function_with_none_module_is_name():
-    def f():
-        pass
-
-    f.__module__ = None
-    assert fully_qualified_name(f)[-1] == "f"
 
 
 def test_can_proxy_functions_with_mixed_args_and_varargs():

--- a/hypothesis-python/tests/nocover/test_compat.py
+++ b/hypothesis-python/tests/nocover/test_compat.py
@@ -16,24 +16,7 @@
 import math
 
 from hypothesis import given, strategies as st
-from hypothesis.internal.compat import (
-    ceil,
-    floor,
-    int_from_bytes,
-    int_to_bytes,
-    qualname,
-)
-
-
-class Foo:
-    def bar(self):
-        pass
-
-
-def test_qualname():
-    assert qualname(Foo.bar) == "Foo.bar"
-    assert qualname(Foo().bar) == "Foo.bar"
-    assert qualname(qualname) == "qualname"
+from hypothesis.internal.compat import ceil, floor, int_from_bytes, int_to_bytes
 
 
 @given(st.binary())


### PR DESCRIPTION
Almost all of this PR is the qualname cleanup I promised in https://github.com/HypothesisWorks/hypothesis/pull/3004#discussion_r644062244 - it turned out to be pretty easy, because `full_qualified_name()` had no callers outside of our tests (!!), and every other use of `x.__qualname__` is in a context where I could verify by inspection that the attribute would always be present.  (in Python 2 there might only be a `__name__` on types; in Python 3 that only happens for weird things like Numpy ufuncs and we only see those in the ghostwriter)

Then after reviewing all the ghostwriter logic about qualified names, I found two small user-visible changes which became the changelog for this release: avoiding treading `safe_load`/`unsafe_load` as a roundtrip, and looking on *any* module for ufuncs rather than a restricted list.  This is basically unrelated from our developer perspective, but there's still only one *user-visible* change 😉 