### PR TITLE
Annotate `tuples()` elements using overloads

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch improves the :func:`~hypothesis.strategies.tuples` strategy
+type annotations, to preserve the element types for up to length-five
+tuples (:issue:`3005`).
+
+As for :func:`~hypothesis.strategies.one_of`, this is the best we can do
+before a `planned extension <https://mail.python.org/archives/list/typing-sig@python.org/thread/LOQFV3IIWGFDB7F5BDX746EZJG4VVBI3/>`__
+to :pep:`646` is released, hopefully in Python 3.11.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -13,13 +13,20 @@
 #
 # END HEADER
 
+from typing import Any, Tuple, overload
+
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
 from hypothesis.internal.conjecture.utils import combine_labels
 from hypothesis.strategies._internal.strategies import (
+    T3,
+    T4,
+    T5,
+    Ex,
     MappedSearchStrategy,
     SearchStrategy,
+    T,
     check_strategy,
     filter_not_satisfied,
 )
@@ -44,10 +51,7 @@ class TupleStrategy(SearchStrategy):
         )
 
     def __repr__(self):
-        if len(self.element_strategies) == 1:
-            tuple_string = f"{self.element_strategies[0]!r},"
-        else:
-            tuple_string = ", ".join(map(repr, self.element_strategies))
+        tuple_string = ", ".join(map(repr, self.element_strategies))
         return f"TupleStrategy(({tuple_string}))"
 
     def calc_has_reusable_values(self, recur):
@@ -60,9 +64,59 @@ class TupleStrategy(SearchStrategy):
         return any(recur(e) for e in self.element_strategies)
 
 
+@overload
+def tuples() -> SearchStrategy[Tuple[()]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def tuples(a1: SearchStrategy[Ex]) -> SearchStrategy[Tuple[Ex]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def tuples(
+    a1: SearchStrategy[Ex], a2: SearchStrategy[T]
+) -> SearchStrategy[Tuple[Ex, T]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def tuples(
+    a1: SearchStrategy[Ex], a2: SearchStrategy[T], a3: SearchStrategy[T3]
+) -> SearchStrategy[Tuple[Ex, T, T3]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def tuples(
+    a1: SearchStrategy[Ex],
+    a2: SearchStrategy[T],
+    a3: SearchStrategy[T3],
+    a4: SearchStrategy[T4],
+) -> SearchStrategy[Tuple[Ex, T, T3, T4]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def tuples(
+    a1: SearchStrategy[Ex],
+    a2: SearchStrategy[T],
+    a3: SearchStrategy[T3],
+    a4: SearchStrategy[T4],
+    a5: SearchStrategy[T5],
+) -> SearchStrategy[Tuple[Ex, T, T3, T4, T5]]:
+    raise NotImplementedError
+
+
+@overload  # noqa: F811
+def tuples(*args: SearchStrategy[Any]) -> SearchStrategy[Tuple]:
+    raise NotImplementedError
+
+
 @cacheable
 @defines_strategy()
-def tuples(*args: SearchStrategy) -> SearchStrategy[tuple]:
+def tuples(*args):  # noqa: F811
     """Return a strategy which generates a tuple of the same length as args by
     generating the value at index i from args[i].
 

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -72,6 +72,17 @@ def get_mypy_analysed_type(fname, val):
             "one_of(integers(), text(), none(), binary(), builds(list), builds(dict))",
             "Any",
         ),
+        ("tuples()", "Tuple[]"),  # Should be `Tuple[()]`, but this is what mypy prints
+        ("tuples(integers())", "Tuple[int]"),
+        ("tuples(integers(), text())", "Tuple[int, str]"),
+        (
+            "tuples(integers(), text(), integers(), text(), integers())",
+            "Tuple[int, str, int, str, int]",
+        ),
+        (
+            "tuples(text(), text(), text(), text(), text(), text())",
+            "tuple[Any]",  # note lower-case; this is the arbitrary-length *args case
+        ),
     ],
 )
 def test_revealed_types(tmpdir, val, expect):


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/3005#issuecomment-854417951 - until [a planned extension](https://mail.python.org/archives/list/typing-sig@python.org/thread/LOQFV3IIWGFDB7F5BDX746EZJG4VVBI3/) to [PEP-646](https://www.python.org/dev/peps/pep-0646/) (i.e. type-level operators over variadic generics), this is the best we can do.  And it's been good enough in `one_of()` for years - it turns out that `n` is *usually* pretty small.