### PR TITLE
Improve explain-mode performance

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+The :ref:`explain phase <phases>` now requires shrinking to be enabled,
+and will be automatically skipped for deadline-exceeded errors.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -529,6 +529,7 @@ class StateForActualGivenExecution:
 
         self.files_to_propagate = set()
         self.failed_normally = False
+        self.failed_due_to_deadline = False
 
         self.explain_traces = defaultdict(set)
 
@@ -668,6 +669,7 @@ class StateForActualGivenExecution:
             trace = frozenset()
             if (
                 self.failed_normally
+                and not self.failed_due_to_deadline
                 and Phase.explain in self.settings.phases
                 and sys.gettrace() is None
                 and not PYPY
@@ -736,6 +738,9 @@ class StateForActualGivenExecution:
                 if trace:  # pragma: no cover
                     # Trace collection is explicitly disabled under coverage.
                     self.explain_traces[interesting_origin].add(trace)
+                if interesting_origin[0] == DeadlineExceeded:
+                    self.failed_due_to_deadline = True
+                    self.explain_traces.clear()
                 data.mark_interesting(interesting_origin)
 
     def run_engine(self):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -670,6 +670,7 @@ class StateForActualGivenExecution:
             if (
                 self.failed_normally
                 and not self.failed_due_to_deadline
+                and Phase.shrink in self.settings.phases
                 and Phase.explain in self.settings.phases
                 and sys.gettrace() is None
                 and not PYPY

--- a/hypothesis-python/src/hypothesis/internal/scrutineer.py
+++ b/hypothesis-python/src/hypothesis/internal/scrutineer.py
@@ -31,11 +31,13 @@ def should_trace_file(fname):
 
 
 class Tracer:
-    """A super-simple line coverage tracer."""
+    """A super-simple branch coverage tracer."""
+
+    __slots__ = ("branches", "_previous_location")
 
     def __init__(self):
         self.branches = set()
-        self.prev = None
+        self._previous_location = None
 
     def trace(self, frame, event, arg):
         if event == "call":
@@ -43,8 +45,9 @@ class Tracer:
         elif event == "line":
             fname = frame.f_code.co_filename
             if should_trace_file(fname):
-                self.branches.add((self.prev, (fname, frame.f_lineno)))
-                self.prev = (fname, frame.f_lineno)
+                current_location = (fname, frame.f_lineno)
+                self.branches.add((self._previous_location, current_location))
+                self._previous_location = current_location
 
 
 def get_explaining_locations(traces):

--- a/hypothesis-python/src/hypothesis/internal/scrutineer.py
+++ b/hypothesis-python/src/hypothesis/internal/scrutineer.py
@@ -94,6 +94,7 @@ EXPLANATION_STUB = (
     "Explanation:",
     "    These lines were always and only run by failing examples:",
 )
+HAD_TRACE = "    We didn't try to explain this, because sys.gettrace()="
 
 
 def make_report(explanations, cap_lines_at=5):
@@ -114,8 +115,9 @@ def make_report(explanations, cap_lines_at=5):
 
 def explanatory_lines(traces, settings):
     if Phase.explain in settings.phases and sys.gettrace() and not traces:
-        msg = "    We didn't try to explain this, because sys.gettrace()="
-        return defaultdict(lambda: [EXPLANATION_STUB[0], msg + repr(sys.gettrace())])
+        return defaultdict(
+            lambda: [EXPLANATION_STUB[0], HAD_TRACE + repr(sys.gettrace())]
+        )
     # Return human-readable report lines summarising the traces
     explanations = get_explaining_locations(traces)
     max_lines = 5 if settings.verbosity <= Verbosity.normal else 100

--- a/hypothesis-python/tests/cover/test_scrutineer.py
+++ b/hypothesis-python/tests/cover/test_scrutineer.py
@@ -19,60 +19,17 @@ import sys
 import pytest
 
 from hypothesis.internal.compat import PYPY
-from hypothesis.internal.scrutineer import HAD_TRACE, make_report
+from hypothesis.internal.scrutineer import HAD_TRACE
 
-BUG_MARKER = "# BUG"
-PRELUDE = """
+CODE_SAMPLE = """
 from hypothesis import Phase, given, settings, strategies as st
 
 @settings(phases=tuple(Phase), derandomize=True)
-"""
-
-
-def expected_reports(file_contents, fname):
-    # Takes the source code string with "# BUG" comments, and returns a list of
-    # multi-line report strings which we expect to see in explain-mode output.
-    # The list length is the number of explainable bugs, usually one.
-    explanations = {
-        i: {(fname, i)}
-        for i, line in enumerate(file_contents.splitlines())
-        if line.endswith(BUG_MARKER)
-    }
-    return ["\n".join(r) for k, r in make_report(explanations).items()]
-
-
-TRIVIAL = """
 @given(st.integers())
 def test_reports_branch_in_test(x):
     if x > 10:
         raise AssertionError  # BUG
 """
-MULTIPLE_BUGS = """
-@given(st.integers(), st.integers())
-def test_reports_branch_in_test(x, y):
-    if x > 10:
-        raise (AssertionError if x % 2 else Exception)  # BUG
-"""
-
-
-# We skip tracing for explanations under PyPy, where it has a large performance
-# impact, or if there is already a trace function (e.g. coverage or a debugger)
-@pytest.mark.skipif(PYPY or sys.gettrace(), reason="See comment")
-@pytest.mark.parametrize(
-    "code",
-    [
-        pytest.param(TRIVIAL, id="trivial"),
-        pytest.param(MULTIPLE_BUGS, id="multiple-bugs"),
-    ],
-)
-def test_explanations(code, testdir):
-    code = PRELUDE + code
-    test_file = str(testdir.makepyfile(code))
-    pytest_stdout = str(testdir.runpytest_inprocess(test_file, "--tb=native").stdout)
-    expected = expected_reports(code, fname=test_file)
-    assert len(expected) == code.count(BUG_MARKER)
-    for report in expected:
-        assert report in pytest_stdout
 
 
 @pytest.mark.skipif(PYPY, reason="Tracing is slow under PyPy")
@@ -85,9 +42,7 @@ def test_cannot_explain_message(testdir):
     try:
         if no_tracer:
             sys.settrace(lambda frame, event, arg: None)
-
-        code = PRELUDE + TRIVIAL
-        test_file = testdir.makepyfile(code)
+        test_file = testdir.makepyfile(CODE_SAMPLE)
         testdir.runpytest_inprocess(test_file, "--tb=native").stdout.re_match_lines(
             [r"Explanation:", re.escape(HAD_TRACE)], consecutive=True
         )

--- a/hypothesis-python/tests/cover/test_scrutineer.py
+++ b/hypothesis-python/tests/cover/test_scrutineer.py
@@ -19,7 +19,7 @@ import sys
 import pytest
 
 from hypothesis.internal.compat import PYPY
-from hypothesis.internal.scrutineer import make_report
+from hypothesis.internal.scrutineer import HAD_TRACE, make_report
 
 BUG_MARKER = "# BUG"
 PRELUDE = """
@@ -88,13 +88,8 @@ def test_cannot_explain_message(testdir):
 
         code = PRELUDE + TRIVIAL
         test_file = testdir.makepyfile(code)
-        result = testdir.runpytest_inprocess(test_file, "--tb=native")
-        result.stdout.re_match_lines(
-            [
-                r"Explanation:",
-                fr"""\s*{re.escape("We didn't try to explain this, because sys.gettrace()=")}.*""",
-            ],
-            consecutive=True,
+        testdir.runpytest_inprocess(test_file, "--tb=native").stdout.re_match_lines(
+            [r"Explanation:", re.escape(HAD_TRACE)], consecutive=True
         )
     finally:
         if no_tracer:

--- a/hypothesis-python/tests/nocover/test_scrutineer.py
+++ b/hypothesis-python/tests/nocover/test_scrutineer.py
@@ -1,0 +1,72 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import sys
+
+import pytest
+
+from hypothesis.internal.compat import PYPY
+from hypothesis.internal.scrutineer import make_report
+
+# We skip tracing for explanations under PyPy, where it has a large performance
+# impact, or if there is already a trace function (e.g. coverage or a debugger)
+pytestmark = pytest.mark.skipif(PYPY or sys.gettrace(), reason="See comment")
+
+BUG_MARKER = "# BUG"
+PRELUDE = """
+from hypothesis import Phase, given, settings, strategies as st
+
+@settings(phases=tuple(Phase), derandomize=True)
+"""
+TRIVIAL = """
+@given(st.integers())
+def test_reports_branch_in_test(x):
+    if x > 10:
+        raise AssertionError  # BUG
+"""
+MULTIPLE_BUGS = """
+@given(st.integers(), st.integers())
+def test_reports_branch_in_test(x, y):
+    if x > 10:
+        raise (AssertionError if x % 2 else Exception)  # BUG
+"""
+FRAGMENTS = (
+    pytest.param(TRIVIAL, id="trivial"),
+    pytest.param(MULTIPLE_BUGS, id="multiple-bugs"),
+)
+
+
+def get_reports(file_contents, *, testdir):
+    # Takes the source code string with "# BUG" comments, and returns a list of
+    # multi-line report strings which we expect to see in explain-mode output.
+    # The list length is the number of explainable bugs, usually one.
+    test_file = str(testdir.makepyfile(file_contents))
+    pytest_stdout = str(testdir.runpytest_inprocess(test_file, "--tb=native").stdout)
+
+    explanations = {
+        i: {(test_file, i)}
+        for i, line in enumerate(file_contents.splitlines())
+        if line.endswith(BUG_MARKER)
+    }
+    expected = ["\n".join(r) for k, r in make_report(explanations).items()]
+    return pytest_stdout, expected
+
+
+@pytest.mark.parametrize("code", FRAGMENTS)
+def test_explanations(code, testdir):
+    pytest_stdout, expected = get_reports(PRELUDE + code, testdir=testdir)
+    assert len(expected) == code.count(BUG_MARKER)
+    for report in expected:
+        assert report in pytest_stdout


### PR DESCRIPTION
This set of patches makes a few related changes to [explain-mode](https://hypothesis.readthedocs.io/en/latest/settings.html#controlling-what-runs), aimed at improving the test-time and user-facing performance.  I think this is the best fix #2989 is going to get.

- Move all the not-run-under-coverage tests to `nocover` (duh)
- Use `__slots__` and some micro-optimisations in the `Tracer` class
- Only run the tracer if shrinking is enabled, though still starting immediately after the first failure (i.e. often in keep-generating mode)
- Disable the tracer immediately if a `DeadlineExceeded` error is raised.  The performance overhead of tracing interacts badly with deadlines, and "explaining" it in terms of some line of code is almost certainly wrong anyway.