### PR TITLE
docs: calrify the description of data_too_large health check

### DIFF
--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -461,8 +461,9 @@ class HealthCheck(Enum):
         return list(HealthCheck)
 
     data_too_large = 1
-    """Check for when the typical size of the examples you are generating
-    exceeds the maximum allowed size too often."""
+    """Check for when the typical size of the examples you are generating too
+    often exceed the maximum amount of random data hypothesis is able to
+    generate."""
 
     filter_too_much = 2
     """Check for when the test is filtering out too many examples, either


### PR DESCRIPTION
fixes: #3032 

updates the description of `HealthCheck.data_too_large` from:

> Check for when the typical size of the examples you are generating exceeds the maximum allowed size too often.

to:

> Check for when the typical size of the examples you are generating too often exceed the maximum amount of random data hypothesis is able to generate.

making it clearer that it's about running out of random data.