### PR TITLE
Fix docs, and selftest compatibility with `pytest-randomly`

### DIFF
--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -195,8 +195,7 @@ for your data type, returns a new strategy for it. So for example:
     ... from pprint import pprint
     >>> json = recursive(
     ...     none() | booleans() | floats() | text(printable),
-    ...     lambda children: lists(children, 1)
-    ...     | dictionaries(text(printable), children, min_size=1),
+    ...     lambda children: lists(children) | dictionaries(text(printable), children),
     ... )
     >>> pprint(json.example())
     [[1.175494351e-38, ']', 1.9, True, False, '.M}Xl', ''], True]

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -20,6 +20,7 @@ import time as time_module
 
 import pytest
 
+from hypothesis._settings import is_in_ci
 from hypothesis.internal.detection import is_hypothesis_test
 
 from tests.common import TIME_INCREMENT
@@ -95,6 +96,12 @@ def pytest_runtest_call(item):
     # This hookwrapper checks for PRNG state leaks from Hypothesis tests.
     # See: https://github.com/HypothesisWorks/hypothesis/issues/1919
     if not (hasattr(item, "obj") and is_hypothesis_test(item.obj)):
+        yield
+    elif "pytest_randomly" in sys.modules:
+        # See https://github.com/HypothesisWorks/hypothesis/issues/3041 - this
+        # branch exists to make it easier on external contributors, but should
+        # never run in our CI (because that would disable the check entirely).
+        assert not is_in_ci()
         yield
     else:
         # We start by peturbing the state of the PRNG, because repeatedly


### PR DESCRIPTION
Closes #3042 - `min_size` is now a keyword-only argument.

Closes #3041 - to make running Hypothesis' selftest suite easier for external contributors, we now skip our random-seed checks if `pytest-randomly` is installed.  To ensure that we don't inadvertently disable those checks, crash if running our self-tests in CI with `pytest-randomly` installed.