### PR TITLE
Improve error message for recursive forward references with PEP585 builtin generics

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the error message for :issue:`3016`, where :pep:`585`
+builtin generics with self-referential forward-reference strings cannot be
+resolved to a strategy by :func:`~hypothesis.strategies.from_type`.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1007,7 +1007,15 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
                 else:
                     literals.append(arg)
             return sampled_from(literals)
-        raise InvalidArgument(f"thing={thing} must be a type")
+        if isinstance(thing, str):
+            # See https://github.com/HypothesisWorks/hypothesis/issues/3016
+            raise InvalidArgument(
+                f"Got {thing!r} as a type annotation, but the forward-reference "
+                "could not be resolved from a string to a type.  Consider using "
+                "`from __future__ import annotations` instead of forward-reference "
+                "strings."
+            )
+        raise InvalidArgument(f"thing={thing!r} must be a type")  # pragma: no cover
     # Now that we know `thing` is a type, the first step is to check for an
     # explicitly registered strategy.  This is the best (and hopefully most
     # common) way to resolve a type to a strategy.  Note that the value in the

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -13,11 +13,13 @@
 #
 # END HEADER
 
+import dataclasses
 import typing
 
 import pytest
 
 from hypothesis import strategies as st
+from hypothesis.errors import InvalidArgument
 
 
 @pytest.mark.parametrize(
@@ -36,3 +38,16 @@ from hypothesis import strategies as st
 )
 def test_typing_Annotated(annotated_type, expected_strategy_repr):
     assert repr(st.from_type(annotated_type)) == expected_strategy_repr
+
+
+@dataclasses.dataclass
+class User:
+    id: int
+    following: list["User"]  # works with typing.List
+
+
+def test_string_forward_ref_message():
+    # See https://github.com/HypothesisWorks/hypothesis/issues/3016
+    s = st.builds(User)
+    with pytest.raises(InvalidArgument, match="`from __future__ import annotations`"):
+        s.example()


### PR DESCRIPTION
Closes #3016; we'll need [CPython changes](https://bugs.python.org/issue41370) to actually get this working instead of just improving the error message.

I think what happened is that the builtin generics changes assumed that annotations would always be stored as strings, and the runtime introspection use-case just didn't arise until now.