### PR TITLE
Improve error message when `@given()` is applied to an `async def` function

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release emits a more useful error message when :func:`@given() <hypothesis.given>`
+is applied to a coroutine function, i.e. one defined using ``async def`` (:issue:`3054`).
+
+This was previously only handled by the generic :obj:`~hypothesis.HealthCheck.return_value`
+health check, which doesn't direct you to use either :ref:`a custom executor <custom-function-execution>`
+or a library such as :pypi:`pytest-trio` or :pypi:`pytest-asyncio` to handle it for you.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1019,15 +1019,12 @@ def given(
 
             if getattr(test, "is_hypothesis_test", False):
                 raise InvalidArgument(
-                    (
-                        "You have applied @given to the test %s more than once, which "
-                        "wraps the test several times and is extremely slow. A "
-                        "similar effect can be gained by combining the arguments "
-                        "of the two calls to given. For example, instead of "
-                        "@given(booleans()) @given(integers()), you could write "
-                        "@given(booleans(), integers())"
-                    )
-                    % (test.__name__,)
+                    f"You have applied @given to the test {test.__name__} more than "
+                    "once, which wraps the test several times and is extremely slow. "
+                    "A similar effect can be gained by combining the arguments "
+                    "of the two calls to given. For example, instead of "
+                    "@given(booleans()) @given(integers()), you could write "
+                    "@given(booleans(), integers())"
                 )
 
             settings = wrapped_test._hypothesis_internal_use_settings
@@ -1042,9 +1039,9 @@ def given(
             runner = getattr(search_strategy, "runner", None)
             if isinstance(runner, TestCase) and test.__name__ in dir(TestCase):
                 msg = (
-                    "You have applied @given to the method %s, which is "
+                    f"You have applied @given to the method {test.__name__}, which is "
                     "used by the unittest runner but is not itself a test."
-                    "  This is not useful in any way." % test.__name__
+                    "  This is not useful in any way."
                 )
                 fail_health_check(settings, msg, HealthCheck.not_a_test_method)
             if bad_django_TestCase(runner):  # pragma: no cover

--- a/hypothesis-python/tests/cover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/cover/test_given_error_conditions.py
@@ -74,3 +74,16 @@ def test_given_is_not_a_class_decorator():
     class test_given_is_not_a_class_decorator:
         def __init__(self, i):
             pass
+
+
+def test_specific_error_for_coroutine_functions():
+    @settings(database=None)
+    @given(booleans())
+    async def foo(x):
+        pass
+
+    with pytest.raises(
+        InvalidArgument,
+        match="Hypothesis doesn't know how to run async test functions",
+    ):
+        foo()

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -543,7 +543,7 @@ def audit_conjecture_rust():
 def tasks():
     """Print a list of all task names supported by the build system."""
     for task_name in sorted(TASKS.keys()):
-        print(task_name)
+        print("    " + task_name)
 
 
 if __name__ == "__main__":
@@ -567,6 +567,11 @@ if __name__ == "__main__":
             "argument or as an environment variable TASK. "
             '(Use "./build.sh tasks" to list all supported task names.)'
         )
+        sys.exit(1)
+
+    if task_to_run not in TASKS:
+        print(f"\nUnknown task {task_to_run!r}.  Available tasks are:")
+        tasks()
         sys.exit(1)
 
     try:


### PR DESCRIPTION
This should prevent future confusion like #3054. 

While in the area, I also converted some `%`-formatting to f-strings, and made our build script print out the list of known tasks if you ask for an unknown task (so e.g. `make docs` will tell you that `make documentation` would work).