### PR TITLE
Adds `Cargo.lock` to `.gitignore` in `rust/`

### DIFF
--- a/conjecture-rust/.gitignore
+++ b/conjecture-rust/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock


### PR DESCRIPTION
Closes #3061