### PR TITLE
Use @proxies instead of deepcopy for mutated array helpers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch wraps some internal helper code in our proxies decorator to prevent
+mutations of method docstrings carrying over to other instances of the respective
+methods.

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -31,7 +31,7 @@ pip install fakeredis
 $PYTEST tests/redis/
 pip uninstall -y redis fakeredis
 
-pip install typing_extensions
+pip install 'typing_extensions!=3.10.0.1'
 $PYTEST tests/typing_extensions/
 if [ "$(python -c 'import sys; print(sys.version_info[:2] <= (3, 7))')" = "False" ] ; then
   # Required by importlib_metadata backport, which we don't want to break

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import math
-from copy import deepcopy
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -734,7 +733,11 @@ def nested_dtypes(
     ).filter(lambda d: max_itemsize is None or d.itemsize <= max_itemsize)
 
 
-valid_tuple_axes = deepcopy(_valid_tuple_axes)
+@proxies(_valid_tuple_axes)
+def valid_tuple_axes(*args, **kwargs):
+    return _valid_tuple_axes(*args, **kwargs)
+
+
 valid_tuple_axes.__doc__ = f"""
     Return a strategy for generating permissible tuple-values for the
     ``axis`` argument for a numpy sequential function (e.g.
@@ -745,7 +748,11 @@ valid_tuple_axes.__doc__ = f"""
     """
 
 
-mutually_broadcastable_shapes = deepcopy(_mutually_broadcastable_shapes)
+@proxies(_mutually_broadcastable_shapes)
+def mutually_broadcastable_shapes(*args, **kwargs):
+    return _mutually_broadcastable_shapes(*args, **kwargs)
+
+
 mutually_broadcastable_shapes.__doc__ = f"""
     {_mutually_broadcastable_shapes.__doc__}
 


### PR DESCRIPTION
In #3067 @Zac-HD commented that mutating the helper methods docstrings should not effect the original method. I had used `copy.deepcopy` for this and thought I had tested it... but clearly not, as Sphinx generation in #3065 demonstrates :facepalm: 

This PR simply wraps the `valid_tuple_axes` and `mutually_broadcastable_shapes` strategies in `@proxies` before mutating their `__doc__`, replacing the use of `deepcopy`. I've tested this works when `extra.array_api` also interfaces with the array helpers.