### PR TITLE
Wrap array_shapes in @defines_strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch wraps the `array_shapes` NumPy strategy in `@defines_strategy()` so that
+the strategy has a pretty repr.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch wraps the `array_shapes` NumPy strategy in `@defines_strategy()` so that
-the strategy has a pretty repr.
+This patch fixes the repr of :func:`~hypothesis.extra.numpy.array_shapes`.

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -82,6 +82,7 @@ def check_valid_dims(dims, name):
         )
 
 
+@defines_strategy()
 def array_shapes(
     *,
     min_dims: int = 1,


### PR DESCRIPTION
For #3067  I wrapped all the strategies in `array_helpers.py` in `@defines_strategy()`... except `array_shapes` :man_facepalming: :woman_facepalming: :facepalm: 

I would write a test for this, but if the idea is to only have one place testing `array_helpers.py` stuff then this is covered in #3065 (how I caught this).