### PR TITLE
fixes #3080

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -29,7 +29,7 @@ import sys
 import typing
 import uuid
 from pathlib import PurePath
-from types import FunctionType
+from types import FunctionType, GenericAlias
 
 from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
@@ -81,7 +81,7 @@ def type_sorting_key(t):
         raise InvalidArgument(f"thing={t} must be a type")  # pragma: no cover
     if t is None or t is type(None):  # noqa: E721
         return (-1, repr(t))
-    if not isinstance(t, type):  # pragma: no cover
+    if isinstance(t, GenericAlias):  # pragma: no cover
         # Some generics in the typing module are not actually types in 3.7
         return (2, repr(t))
     return (int(issubclass(t, collections.abc.Container)), repr(t))

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -17,6 +17,7 @@ import collections
 from typing import Dict, List, Union
 
 import pytest
+from typing import Union
 from typing_extensions import Annotated, DefaultDict, Literal, NewType, Type, TypedDict
 
 from hypothesis import assume, given, strategies as st
@@ -64,6 +65,11 @@ def test_typing_extensions_Type_int():
 @given(from_type(Type[Union[str, list]]))
 def test_typing_extensions_Type_Union(ex):
     assert ex in (str, list)
+
+@pytest.mark.parametrize("type_", [Union[list[str], str]])
+def test_generic_aliases_are_handled(type_):
+    # previously raised `TypeError`
+    assert isinstance(from_type(type_).example(), (list, str)) 
 
 
 def test_resolves_NewType():


### PR DESCRIPTION
Fixed the guard against generic aliases that are not really types and added a test against the `TypeError` that was previously raised by passing a instance of `GenericAlias` into`issubclass`