### PR TITLE
Implement `return_value` healthcheck in stateful testing

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,14 @@
+RELEASE_TYPE: minor
+
+This release makes :doc:`stateful testing <stateful>` more likely to tell you
+if you do something unexpected and unsupported:
+
+- The :obj:`~hypothesis.HealthCheck.return_value` health check now applies to
+  :func:`~hypothesis.stateful.rule` and :func:`~hypothesis.stateful.initialize`
+  rules, if they don't have ``target`` bundles, as well as
+  :func:`~hypothesis.stateful.invariant`.
+- Using a :func:`~hypothesis.stateful.consumes` bundle as a ``target`` is
+  deprecated, and will be an error in a future version.
+
+If existing code triggers these new checks, check for related bugs and
+misunderstandings - these patterns *never* had any effect.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -185,8 +185,8 @@ def target(observation: Union[int, float], *, label: str = "") -> Union[int, flo
 
     if label in context.data.target_observations:
         raise InvalidArgument(
-            "Calling target(%r, label=%r) would overwrite target(%r, label=%r)"
-            % (observation, label, context.data.target_observations[label], label)
+            f"Calling target({observation!r}, label={label!r}) would overwrite "
+            f"target({context.data.target_observations[label]!r}, label={label!r})"
         )
     else:
         context.data.target_observations[label] = observation

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -260,9 +260,9 @@ def is_invalid_test(test, original_argspec, given_arguments, given_kwargs):
     if len(given_arguments) > len(original_argspec.args):
         args = tuple(given_arguments)
         return invalid(
-            "Too many positional arguments for %s() were passed to @given "
-            "- expected at most %d arguments, but got %d %r"
-            % (test.__name__, len(original_argspec.args), len(args), args)
+            f"Too many positional arguments for {test.__name__}() were passed to "
+            f"@given - expected at most {int(len(original_argspec.args))} "
+            f"arguments, but got {int(len(args))} {args!r}"
         )
 
     if infer in given_arguments:
@@ -281,8 +281,8 @@ def is_invalid_test(test, original_argspec, given_arguments, given_kwargs):
     if extra_kwargs and not original_argspec.varkw:
         arg = extra_kwargs[0]
         return invalid(
-            "%s() got an unexpected keyword argument %r, from `%s=%r` in @given"
-            % (test.__name__, arg, arg, given_kwargs[arg])
+            f"{test.__name__}() got an unexpected keyword argument {arg!r}, "
+            f"from `{arg}={given_kwargs[arg]!r}` in @given"
         )
     if original_argspec.defaults or original_argspec.kwonlydefaults:
         return invalid("Cannot apply @given to a function with defaults.")
@@ -329,9 +329,8 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs):
         if example.args:
             if len(example.args) > len(original_argspec.args):
                 raise InvalidArgument(
-                    "example has too many arguments for test. "
-                    "Expected at most %d but got %d"
-                    % (len(original_argspec.args), len(example.args))
+                    "example has too many arguments for test. Expected at most "
+                    f"{len(original_argspec.args)} but got {len(example.args)}"
                 )
             example_kwargs.update(
                 dict(zip(original_argspec.args[-len(example.args) :], example.args))
@@ -779,10 +778,8 @@ class StateForActualGivenExecution:
             )
         else:
             if runner.valid_examples == 0:
-                raise Unsatisfiable(
-                    "Unable to satisfy assumptions of hypothesis %s."
-                    % (get_pretty_function_description(self.test),)
-                )
+                rep = get_pretty_function_description(self.test)
+                raise Unsatisfiable(f"Unable to satisfy assumptions of {rep}")
 
         if not self.falsifying_examples:
             return
@@ -1001,8 +998,8 @@ def given(
                 def wrapped_test(*arguments, **kwargs):
                     __tracebackhide__ = True
                     raise InvalidArgument(
-                        "passed %s=infer for %s, but %s has no type annotation"
-                        % (name, test.__name__, name)
+                        f"passed {name}=infer for {test.__name__}, but {name} has "
+                        "no type annotation"
                     )
 
                 return wrapped_test
@@ -1297,8 +1294,8 @@ def find(
 
     if not isinstance(specifier, SearchStrategy):
         raise InvalidArgument(
-            "Expected SearchStrategy but got %r of type %s"
-            % (specifier, type(specifier).__name__)
+            f"Expected SearchStrategy but got {specifier!r} of "
+            f"type {type(specifier).__name__}"
         )
     specifier.validate()
 

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -18,6 +18,10 @@ class HypothesisException(Exception):
     """Generic parent class for exceptions thrown by Hypothesis."""
 
 
+class _Trimmable(HypothesisException):
+    """Hypothesis can trim these tracebacks even if they're raised internally."""
+
+
 class CleanupFailed(HypothesisException):
     """At least one cleanup task failed and no other exception was raised."""
 
@@ -40,7 +44,7 @@ class NoSuchExample(HypothesisException):
         super().__init__(f"No examples found of condition {condition_string}{extra}")
 
 
-class Unsatisfiable(HypothesisException):
+class Unsatisfiable(_Trimmable):
     """We ran out of time or examples before we could find enough examples
     which satisfy the assumptions of this hypothesis.
 
@@ -53,7 +57,7 @@ class Unsatisfiable(HypothesisException):
     """
 
 
-class Flaky(HypothesisException):
+class Flaky(_Trimmable):
     """This function appears to fail non-deterministically: We have seen it
     fail when passed this example at least once, but a subsequent invocation
     did not fail.
@@ -70,7 +74,7 @@ class Flaky(HypothesisException):
     """
 
 
-class InvalidArgument(HypothesisException, TypeError):
+class InvalidArgument(_Trimmable, TypeError):
     """Used to indicate that the arguments to a Hypothesis function were in
     some manner incorrect."""
 
@@ -88,7 +92,7 @@ class InvalidState(HypothesisException):
     """The system is not in a state where you were allowed to do that."""
 
 
-class InvalidDefinition(HypothesisException, TypeError):
+class InvalidDefinition(_Trimmable, TypeError):
     """Used to indicate that a class definition was not well put together and
     has something wrong with it."""
 
@@ -97,7 +101,7 @@ class HypothesisWarning(HypothesisException, Warning):
     """A generic warning issued by Hypothesis."""
 
 
-class FailedHealthCheck(HypothesisWarning):
+class FailedHealthCheck(_Trimmable):
     """Raised when a test fails a preliminary healthcheck that occurs before
     execution."""
 
@@ -129,12 +133,12 @@ class Frozen(HypothesisException):
     after freeze() has been called."""
 
 
-class MultipleFailures(HypothesisException):
+class MultipleFailures(_Trimmable):
     """Indicates that Hypothesis found more than one distinct bug when testing
     your code."""
 
 
-class DeadlineExceeded(HypothesisException):
+class DeadlineExceeded(_Trimmable):
     """Raised when an individual test body has taken too long to run."""
 
     def __init__(self, runtime, deadline):

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -144,10 +144,10 @@ else:
             # decorators were applied, and raise an error if they were.
             if getattr(item.obj, "is_hypothesis_strategy_function", False):
                 raise InvalidArgument(
-                    "%s is a function that returns a Hypothesis strategy, but pytest "
-                    "has collected it as a test function.  This is useless as the "
-                    "function body will never be executed.  To define a test "
-                    "function, use @given instead of @composite." % (item.nodeid,)
+                    f"{item.nodeid} is a function that returns a Hypothesis strategy, "
+                    "but pytest has collected it as a test function.  This is useless "
+                    "as the function body will never be executed.  To define a test "
+                    "function, use @given instead of @composite."
                 )
             message = "Using `@%s` on a test without `@given` is completely pointless."
             for name, attribute in [

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -409,8 +409,8 @@ class TreeRecordingObserver(DataObserver):
                 or new_transition.status != Status.VALID
             ):
                 raise Flaky(
-                    "Inconsistent test results! Test case was %r on first run but %r on second"
-                    % (node.transition, new_transition)
+                    f"Inconsistent test results! Test case was {node.transition!r} "
+                    f"on first run but {new_transition!r} on second"
                 )
         else:
             node.transition = new_transition

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -47,11 +47,6 @@ from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report, report
 
-# Tell pytest to omit the body of this module from tracebacks
-# https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
-__tracebackhide__ = True
-
-
 MAX_SHRINKS = 500
 CACHE_SIZE = 10000
 MUTATION_POOL_SIZE = 100

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
@@ -310,14 +310,14 @@ def normalize(
 
         if not allowed_to_update:
             raise FailedToNormalise(
-                "Shrinker failed to normalize %r to %r and we are not allowed to learn new DFAs."
-                % (previous.buffer, current.buffer)
+                f"Shrinker failed to normalize {previous.buffer!r} to "
+                f"{current.buffer!r} and we are not allowed to learn new DFAs."
             )
 
         if dfas_added >= max_dfas:
             raise FailedToNormalise(
-                "Test function is too hard to learn: Added %d DFAs and still not done."
-                % (dfas_added,)
+                f"Test function is too hard to learn: Added {dfas_added} "
+                "DFAs and still not done."
             )
 
         dfas_added += 1

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -117,28 +117,24 @@ def check_sample(values, strategy_name):
     if "numpy" in sys.modules and isinstance(values, sys.modules["numpy"].ndarray):
         if values.ndim != 1:
             raise InvalidArgument(
-                (
-                    "Only one-dimensional arrays are supported for sampling, "
-                    "and the given value has {ndim} dimensions (shape "
-                    "{shape}).  This array would give samples of array slices "
-                    "instead of elements!  Use np.ravel(values) to convert "
-                    "to a one-dimensional array, or tuple(values) if you "
-                    "want to sample slices."
-                ).format(ndim=values.ndim, shape=values.shape)
+                "Only one-dimensional arrays are supported for sampling, "
+                f"and the given value has {values.ndim} dimensions (shape "
+                f"{values.shape}).  This array would give samples of array slices "
+                "instead of elements!  Use np.ravel(values) to convert "
+                "to a one-dimensional array, or tuple(values) if you "
+                "want to sample slices."
             )
     elif not isinstance(values, (OrderedDict, abc.Sequence, enum.EnumMeta)):
         raise InvalidArgument(
-            "Cannot sample from {values}, not an ordered collection. "
-            "Hypothesis goes to some length to ensure that the {strategy} "
+            f"Cannot sample from {values!r}, not an ordered collection. "
+            f"Hypothesis goes to some length to ensure that the {strategy_name} "
             "strategy has stable results between runs. To replay a saved "
             "example, the sampled values must have the same iteration order "
             "on every run - ruling out sets, dicts, etc due to hash "
             "randomisation. Most cases can simply use `sorted(values)`, but "
             "mixed types or special values such as math.nan require careful "
             "handling - and note that when simplifying an example, "
-            "Hypothesis treats earlier values as simpler.".format(
-                values=repr(values), strategy=strategy_name
-            )
+            "Hypothesis treats earlier values as simpler."
         )
     if isinstance(values, range):
         return values

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -76,11 +76,8 @@ if IN_COVERAGE_TESTS:
         # function, one for our actual caller, so we want to go two extra
         # stack frames up.
         caller = sys._getframe(depth + 2)
-        local_description = "%s at %s:%d" % (
-            name,
-            pretty_file_name(caller.f_code.co_filename),
-            caller.f_lineno,
-        )
+        fname = pretty_file_name(caller.f_code.co_filename)
+        local_description = f"{name} at {fname}:{caller.f_lineno}"
         try:
             description_stack.append(local_description)
             description = " in ".join(reversed(description_stack)) + " passed"

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -23,11 +23,10 @@ from typing import Dict
 import hypothesis
 from hypothesis.errors import (
     DeadlineExceeded,
-    Flaky,
     HypothesisException,
-    MultipleFailures,
     StopTest,
     UnsatisfiedAssumption,
+    _Trimmable,
 )
 
 
@@ -92,10 +91,10 @@ def get_trimmed_traceback(exception=None):
     # was raised inside Hypothesis (and is not a MultipleFailures)
     if hypothesis.settings.default.verbosity >= hypothesis.Verbosity.debug or (
         is_hypothesis_file(traceback.extract_tb(tb)[-1][0])
-        and not isinstance(exception, (Flaky, MultipleFailures))
+        and not isinstance(exception, _Trimmable)
     ):
         return tb
-    while tb is not None and (
+    while tb.tb_next is not None and (
         # If the frame is from one of our files, it's been added by Hypothesis.
         is_hypothesis_file(getframeinfo(tb.tb_frame)[0])
         # But our `@proxies` decorator overrides the source location,

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -156,8 +156,7 @@ def convert_keyword_arguments(function, args, kwargs):
         else:
             bad_kwarg = next(iter(kwargs))
             raise TypeError(
-                "%s() got an unexpected keyword argument %r"
-                % (function.__name__, bad_kwarg)
+                f"{function.__name__}() got an unexpected keyword argument {bad_kwarg!r}"
             )
     return tuple(new_args), kwargs
 
@@ -175,8 +174,7 @@ def convert_positional_arguments(function, args, kwargs):
         for k in new_kwargs.keys():
             if k not in argspec.args and k not in argspec.kwonlyargs:
                 raise TypeError(
-                    "%s() got an unexpected keyword argument %r"
-                    % (function.__name__, k)
+                    f"{function.__name__}() got an unexpected keyword argument {k!r}"
                 )
     if len(args) < len(argspec.args):
         for i in range(len(args), len(argspec.args) - len(argspec.defaults or ())):
@@ -188,9 +186,8 @@ def convert_positional_arguments(function, args, kwargs):
 
     if len(args) > len(argspec.args) and not argspec.varargs:
         raise TypeError(
-            "{}() takes at most {} positional arguments ({} given)".format(
-                function.__name__, len(argspec.args), len(args)
-            )
+            f"{function.__name__}() takes at most {len(argspec.args)} "
+            f"positional arguments ({len(args)} given)"
         )
 
     for arg, name in zip(args, argspec.args):
@@ -435,10 +432,8 @@ def source_exec_as_module(source):
     except KeyError:
         pass
 
-    result = ModuleType(
-        "hypothesis_temporary_module_%s"
-        % (hashlib.sha384(source.encode()).hexdigest(),)
-    )
+    hexdigest = hashlib.sha384(source.encode()).hexdigest()
+    result = ModuleType("hypothesis_temporary_module_" + hexdigest)
     assert isinstance(source, str)
     exec(source, result.__dict__)
     eval_cache[source] = result

--- a/hypothesis-python/src/hypothesis/internal/validation.py
+++ b/hypothesis-python/src/hypothesis/internal/validation.py
@@ -38,8 +38,7 @@ def check_type(typ, arg, name):
                 assert typ is not SearchStrategy, "use check_strategy instead"
 
         raise InvalidArgument(
-            "Expected %s but got %s=%r (type=%s)"
-            % (typ_string, name, arg, type(arg).__name__)
+            f"Expected {typ_string} but got {name}={arg!r} (type={type(arg).__name__})"
         )
 
 
@@ -92,8 +91,8 @@ def try_convert(typ, value, name):
         return typ(value)
     except (TypeError, ValueError, ArithmeticError):
         raise InvalidArgument(
-            "Cannot convert %s=%r of type %s to type %s"
-            % (name, value, type(value).__name__, typ.__name__)
+            f"Cannot convert {name}={value!r} of type "
+            f"{type(value).__name__} to type {typ.__name__}"
         )
 
 
@@ -122,8 +121,7 @@ def check_valid_interval(lower_bound, upper_bound, lower_name, upper_name):
         return
     if upper_bound < lower_bound:
         raise InvalidArgument(
-            "Cannot have %s=%r < %s=%r"
-            % (upper_name, upper_bound, lower_name, lower_bound)
+            f"Cannot have {upper_name}={upper_bound!r} < {lower_name}={lower_bound!r}"
         )
 
 

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -58,13 +58,11 @@ class DomainNameStrategy(st.SearchStrategy):
             value = maximum
         elif not isinstance(value, int):
             raise InvalidArgument(
-                "Expected integer but %s is a %s"
-                % (variable_name, type(value).__name__)
+                f"Expected integer but {variable_name} is a {type(value).__name__}"
             )
         elif not minimum <= value <= maximum:
             raise InvalidArgument(
-                "Invalid value %r < %s=%r < %r"
-                % (minimum, variable_name, value, maximum)
+                f"Invalid value {minimum!r} < {variable_name}={value!r} < {maximum!r}"
             )
         return value
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -524,6 +524,13 @@ def _convert_targets(targets, target):
                 )
             raise InvalidArgument(msg % (t, type(t)))
         while isinstance(t, Bundle):
+            if isinstance(t, BundleConsumer):
+                note_deprecation(
+                    f"Using consumes({t.name}) doesn't makes sense in this context.  "
+                    "This will be an error in a future version of Hypothesis.",
+                    since="RELEASEDAY",
+                    has_codemod=False,
+                )
             t = t.name
         converted_targets.append(t)
     return tuple(converted_targets)

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -82,17 +82,10 @@ def describe_statistics(stats_dict):
             t["drawtime"] / t["runtime"] if t["runtime"] > 0 else 0 for t in cases
         )
         lines.append(
-            "  - during {} phase ({:.2f} seconds):\n"
-            "    - Typical runtimes: {}, ~ {:.0f}% in data generation\n"
-            "    - {} passing examples, {} failing examples, {} invalid examples".format(
-                phase,
-                d["duration-seconds"],
-                ms,
-                drawtime_percent,
-                statuses["valid"],
-                statuses["interesting"],
-                statuses["invalid"] + statuses["overrun"],
-            )
+            f"  - during {phase} phase ({d['duration-seconds']:.2f} seconds):\n"
+            f"    - Typical runtimes: {ms}, ~ {drawtime_percent:.0f}% in data generation\n"
+            f"    - {statuses['valid']} passing examples, {statuses['interesting']} "
+            f"failing examples, {statuses['invalid'] + statuses['overrun']} invalid examples"
         )
         # If we've found new distinct failures in this phase, report them
         distinct_failures = d["distinct-failures"] - prev_failures

--- a/hypothesis-python/src/hypothesis/strategies/_internal/attrs.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/attrs.py
@@ -89,7 +89,7 @@ def from_attrs_attribute(attrib, target):
     if strat.is_empty:
         raise ResolutionFailed(
             "Cannot infer a strategy from the default, validator, type, or "
-            "converter for attribute=%r of class=%r" % (attrib, target)
+            f"converter for attribute={attrib!r} of class={target!r}"
         )
     return strat
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -161,9 +161,9 @@ class ListStrategy(SearchStrategy):
             )
         if self.element_strategy.is_empty and 0 < self.max_size < float("inf"):
             raise InvalidArgument(
-                "Cannot create a collection of max_size=%r, because no "
-                "elements can be drawn from the element strategy %r"
-                % (self.max_size, self.element_strategy)
+                f"Cannot create a collection of max_size={self.max_size!r}, "
+                "because no elements can be drawn from the element strategy "
+                f"{self.element_strategy!r}"
             )
 
     def calc_is_empty(self, recur):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -445,7 +445,7 @@ def fixed_dictionaries(
         if set(mapping) & set(optional):
             raise InvalidArgument(
                 "The following keys were in both mapping and optional, "
-                "which is invalid: %r" % (set(mapping) & set(optional))
+                f"which is invalid: {set(mapping) & set(optional)!r}"
             )
         return FixedAndOptionalKeysDictStrategy(mapping, optional)
     return FixedKeysDictStrategy(mapping)
@@ -554,9 +554,9 @@ def characters(
     overlap = set(blacklist_characters).intersection(whitelist_characters)
     if overlap:
         raise InvalidArgument(
-            "Characters %r are present in both whitelist_characters=%r, and "
-            "blacklist_characters=%r"
-            % (sorted(overlap), whitelist_characters, blacklist_characters)
+            f"Characters {sorted(overlap)!r} are present in both "
+            f"whitelist_characters={whitelist_characters!r}, and "
+            f"blacklist_characters={blacklist_characters!r}"
         )
     blacklist_categories = as_general_categories(
         blacklist_categories, "blacklist_categories"
@@ -577,9 +577,9 @@ def characters(
     both_cats = set(blacklist_categories or ()).intersection(whitelist_categories or ())
     if both_cats:
         raise InvalidArgument(
-            "Categories %r are present in both whitelist_categories=%r, and "
-            "blacklist_categories=%r"
-            % (sorted(both_cats), whitelist_categories, blacklist_categories)
+            f"Categories {sorted(both_cats)!r} are present in both "
+            f"whitelist_categories={whitelist_categories!r}, and "
+            f"blacklist_categories={blacklist_categories!r}"
         )
 
     return OneCharStringStrategy(
@@ -628,14 +628,13 @@ def text(
         if non_string:
             raise InvalidArgument(
                 "The following elements in alphabet are not unicode "
-                "strings:  %r" % (non_string,)
+                f"strings:  {non_string!r}"
             )
         not_one_char = [c for c in alphabet if len(c) != 1]
         if not_one_char:
             raise InvalidArgument(
-                "The following elements in alphabet are not of length "
-                "one, which leads to violation of size constraints:  %r"
-                % (not_one_char,)
+                "The following elements in alphabet are not of length one, "
+                f"which leads to violation of size constraints:  {not_one_char!r}"
             )
         char_strategy = (
             characters(whitelist_categories=(), whitelist_characters=alphabet)
@@ -996,8 +995,8 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
             strategy = strat_or_callable
         if not isinstance(strategy, SearchStrategy):
             raise ResolutionFailed(
-                "Error: %s was registered for %r, but returned non-strategy %r"
-                % (thing, nicerepr(strat_or_callable), strategy)
+                f"Error: {thing} was registered for {nicerepr(strat_or_callable)}, "
+                f"but returned non-strategy {strategy!r}"
             )
         if strategy.is_empty:
             raise ResolutionFailed(f"Error: {thing!r} resolved to an empty strategy")
@@ -1188,16 +1187,16 @@ def fractions(
 
     if max_denominator is not None:
         if max_denominator < 1:
-            raise InvalidArgument("max_denominator=%r must be >= 1" % max_denominator)
+            raise InvalidArgument(f"max_denominator={max_denominator!r} must be >= 1")
         if min_value is not None and min_value.denominator > max_denominator:
             raise InvalidArgument(
-                "The min_value=%r has a denominator greater than the "
-                "max_denominator=%r" % (min_value, max_denominator)
+                f"The min_value={min_value!r} has a denominator greater than the "
+                f"max_denominator={max_denominator!r}"
             )
         if max_value is not None and max_value.denominator > max_denominator:
             raise InvalidArgument(
-                "The max_value=%r has a denominator greater than the "
-                "max_denominator=%r" % (max_value, max_denominator)
+                f"The max_value={max_value!r} has a denominator greater than the "
+                f"max_denominator={max_denominator!r}"
             )
 
     if min_value is not None and min_value == max_value:
@@ -1297,7 +1296,7 @@ def decimals(
     # Convert min_value and max_value to Decimal values, and validate args
     check_valid_integer(places, "places")
     if places is not None and places < 0:
-        raise InvalidArgument("places=%r may not be negative" % places)
+        raise InvalidArgument(f"places={places!r} may not be negative")
     min_value = _as_finite_decimal(min_value, "min_value", allow_infinity)
     max_value = _as_finite_decimal(max_value, "max_value", allow_infinity)
     check_valid_interval(min_value, max_value, "min_value", "max_value")
@@ -1543,15 +1542,15 @@ def complex_numbers(
         allow_infinity = bool(max_magnitude is None)
     elif allow_infinity and max_magnitude is not None:
         raise InvalidArgument(
-            "Cannot have allow_infinity=%r with max_magnitude=%r"
-            % (allow_infinity, max_magnitude)
+            f"Cannot have allow_infinity={allow_infinity!r} with "
+            f"max_magnitude={max_magnitude!r}"
         )
     if allow_nan is None:
         allow_nan = bool(min_magnitude == 0 and max_magnitude is None)
     elif allow_nan and not (min_magnitude == 0 and max_magnitude is None):
         raise InvalidArgument(
-            "Cannot have allow_nan=%r, min_magnitude=%r max_magnitude=%r"
-            % (allow_nan, min_magnitude, max_magnitude)
+            f"Cannot have allow_nan={allow_nan!r}, min_magnitude={min_magnitude!r} "
+            f"max_magnitude={max_magnitude!r}"
         )
     allow_kw = {"allow_nan": allow_nan, "allow_infinity": allow_infinity}
 
@@ -1721,8 +1720,8 @@ class DataStrategy(SearchStrategy):
 
     def __not_a_first_class_strategy(self, name):
         raise InvalidArgument(
-            "Cannot call %s on a DataStrategy. You should probably be using "
-            "@composite for whatever it is you're trying to do." % (name,)
+            f"Cannot call {name} on a DataStrategy. You should probably "
+            "be using @composite for whatever it is you're trying to do."
         )
 
 
@@ -1877,7 +1876,7 @@ def functions(
     if not callable(like):
         raise InvalidArgument(
             "The first argument to functions() must be a callable to imitate, "
-            "but got non-callable like=%r" % (nicerepr(like),)
+            f"but got non-callable like={nicerepr(like)!r}"
         )
 
     if returns is None:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -222,8 +222,8 @@ def datetimes(
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     if not isinstance(timezones, SearchStrategy):
         raise InvalidArgument(
-            "timezones=%r must be a SearchStrategy that can provide tzinfo "
-            "for datetimes (either None or dt.tzinfo objects)" % (timezones,)
+            f"timezones={timezones!r} must be a SearchStrategy that can "
+            "provide tzinfo for datetimes (either None or dt.tzinfo objects)"
         )
     return DatetimeStrategy(min_value, max_value, timezones, allow_imaginary)
 
@@ -259,9 +259,9 @@ def times(
     check_type(dt.time, min_value, "min_value")
     check_type(dt.time, max_value, "max_value")
     if min_value.tzinfo is not None:
-        raise InvalidArgument("min_value=%r must not have tzinfo" % min_value)
+        raise InvalidArgument(f"min_value={min_value!r} must not have tzinfo")
     if max_value.tzinfo is not None:
-        raise InvalidArgument("max_value=%r must not have tzinfo" % max_value)
+        raise InvalidArgument(f"max_value={max_value!r} must not have tzinfo")
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     return TimeStrategy(min_value, max_value, timezones)
 

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -500,7 +500,7 @@ def _default_pprint(obj, p, cycle):
         return
     p.begin_group(1, "<")
     p.pretty(klass)
-    p.text(" at 0x%x" % id(obj))
+    p.text(f" at 0x{id(obj):x}")
     if cycle:
         p.text(" ...")
     elif p.verbose:
@@ -737,7 +737,7 @@ def _function_pprint(obj, p, cycle):
     mod = obj.__module__
     if mod and mod not in ("__builtin__", "builtins", "exceptions"):
         name = mod + "." + name
-    p.text("<function %s>" % name)
+    p.text(f"<function {name}>")
 
 
 def _exception_pprint(obj, p, cycle):

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -38,7 +38,7 @@ from hypothesis.stateful import (
 )
 from hypothesis.strategies import binary, data, integers, just, lists
 
-from tests.common.utils import capture_out
+from tests.common.utils import capture_out, validate_deprecation
 from tests.nocover.test_stateful import DepthMachine
 
 NO_BLOB_SETTINGS = Settings(print_blob=False)
@@ -1083,3 +1083,11 @@ def test_check_during_init_must_be_boolean():
     invariant(check_during_init=True)
     with pytest.raises(InvalidArgument):
         invariant(check_during_init="not a bool")
+
+
+def test_deprecated_target_consumes_bundle():
+    # It would be nicer to raise this error at runtime, but the internals make
+    # this sadly impractical.  Most InvalidDefinition errors happen at, well,
+    # definition-time already anyway, so it's not *worse* than the status quo.
+    with validate_deprecation():
+        rule(target=consumes(Bundle("b")))

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -846,11 +846,11 @@ def test_can_manually_call_initialize_rule():
         @initialize()
         def initialize(self):
             self.initialize_called_counter += 1
-            return self.initialize_called_counter
 
         @rule()
         def fail_eventually(self):
-            assert self.initialize() <= 2
+            self.initialize()
+            assert self.initialize_called_counter <= 2
 
     StateMachine.TestCase.settings = NO_BLOB_SETTINGS
     with capture_out() as o:

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -10,7 +10,7 @@ flake8-bugbear
 flake8-comprehensions
 flake8-docstrings
 flake8-mutable
-ipython < 7.17  # drops support for Python 3.6
+ipython
 lark-parser
 libcst
 mypy
@@ -26,7 +26,6 @@ sphinx-rtd-theme
 sphinx-selective-exclude
 toml
 tox
-traitlets < 5.0   # drops support for Python 3.6
 twine
 types-click
 types-pkg_resources

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -54,9 +54,7 @@ coverage==5.5
 cryptography==3.4.8
     # via secretstorage
 decorator==5.0.9
-    # via
-    #   ipython
-    #   traitlets
+    # via ipython
 distlib==0.3.2
     # via virtualenv
 django==3.2.7
@@ -111,10 +109,8 @@ importlib-metadata==4.8.1
     #   twine
 iniconfig==1.1.1
     # via pytest
-ipython==7.16.1
+ipython==7.27.0
     # via -r requirements/tools.in
-ipython-genutils==0.2.0
-    # via traitlets
 isort==5.9.3
     # via shed
 jedi==0.18.0
@@ -136,6 +132,8 @@ libcst==0.3.20
     #   shed
 markupsafe==2.0.1
     # via jinja2
+matplotlib-inline==0.1.3
+    # via ipython
 mccabe==0.6.1
     # via flake8
 mypy==0.910
@@ -248,7 +246,6 @@ six==1.16.0
     #   python-dateutil
     #   readme-renderer
     #   tox
-    #   traitlets
     #   virtualenv
 smmap==4.0.0
     # via gitdb
@@ -300,10 +297,10 @@ tox==3.24.3
     # via -r requirements/tools.in
 tqdm==4.62.2
     # via twine
-traitlets==4.3.3
+traitlets==5.1.0
     # via
-    #   -r requirements/tools.in
     #   ipython
+    #   matplotlib-inline
 twine==3.4.2
     # via -r requirements/tools.in
 types-click==7.1.5


### PR DESCRIPTION
Closes #3070, and adds `FailedHealthCheck` to our list of exception types where we might say "even though this was raised inside Hypothesis, it's OK to trim the traceback" (with some refactoring).

Also closes #3072, because they were inspired by the same digging session and are easier to communicate as a set.