### PR TITLE
Fix off-by-one error in `st.slices()`, and allow `step=None`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release allows :func:`~hypothesis.strategies.slices` to generate ``step=None``,

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,6 @@
 RELEASE_TYPE: minor
 
 This release allows :func:`~hypothesis.strategies.slices` to generate ``step=None``,
+and fixes an off-by-one error where the ``start`` index could be equal to ``size``.
+This works fine for all Python sequences and Numpy arrays, but is undefined behaviour
+in the `Array API standard <https://data-apis.org/>`__ (see :pull:`3065`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1901,12 +1901,9 @@ def slices(draw: Any, size: int) -> slice:
     if size == 0:
         step = draw(none() | integers().filter(bool))
         return slice(None, None, step)
-
-    min_start = min_stop = 0
-    max_start = max_stop = size
     # For slices start is inclusive and stop is exclusive
-    start = draw(integers(min_start, max_start) | none())
-    stop = draw(integers(min_stop, max_stop) | none())
+    start = draw(integers(0, size - 1) | none())
+    stop = draw(integers(0, size) | none())
 
     # Limit step size to be reasonable
     if start is None and stop is None:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1904,7 +1904,6 @@ def slices(draw: Any, size: int) -> slice:
 
     min_start = min_stop = 0
     max_start = max_stop = size
-    min_step = 1
     # For slices start is inclusive and stop is exclusive
     start = draw(integers(min_start, max_start) | none())
     stop = draw(integers(min_stop, max_stop) | none())
@@ -1919,14 +1918,16 @@ def slices(draw: Any, size: int) -> slice:
     else:
         max_step = abs(start - stop)
 
-    step = draw(integers(min_step, max_step or 1))
+    step = draw(integers(1, max_step or 1))
 
-    if (stop or 0) < (start or 0):
+    if (draw(booleans()) and start == stop) or (stop or 0) < (start or 0):
         step *= -1
 
     if draw(booleans()) and start is not None:
         start -= size
     if draw(booleans()) and stop is not None:
         stop -= size
+    if (not draw(booleans())) and step == 1:
+        step = None
 
     return slice(start, stop, step)

--- a/hypothesis-python/tests/cover/test_slices.py
+++ b/hypothesis-python/tests/cover/test_slices.py
@@ -64,19 +64,21 @@ def test_slices_will_shrink(size):
     sliced = minimal(st.slices(size))
     assert sliced.start == 0 or sliced.start is None
     assert sliced.stop == 0 or sliced.stop is None
-    assert sliced.step == 1
+    assert sliced.step is None
 
 
 @given(st.integers(1, 1000))
 @settings(deadline=None)
 def test_step_will_be_negative(size):
-    find_any(st.slices(size), lambda x: x.step < 0, settings(max_examples=10 ** 6))
+    find_any(
+        st.slices(size), lambda x: (x.step or 1) < 0, settings(max_examples=10 ** 6)
+    )
 
 
 @given(st.integers(1, 1000))
 @settings(deadline=None)
 def test_step_will_be_positive(size):
-    find_any(st.slices(size), lambda x: x.step > 0)
+    find_any(st.slices(size), lambda x: (x.step or 1) > 0)
 
 
 @pytest.mark.parametrize("size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])

--- a/hypothesis-python/tests/cover/test_slices.py
+++ b/hypothesis-python/tests/cover/test_slices.py
@@ -33,8 +33,8 @@ def test_stop_stays_within_bounds(size):
 @use_several_sizes
 def test_start_stay_within_bounds(size):
     assert_all_examples(
-        st.slices(size),
-        lambda x: x.start is None or (x.start >= -size and x.start <= size),
+        st.slices(size).filter(lambda x: x.start is not None),
+        lambda x: range(size)[x.start] or True,  # no IndexError raised
     )
 
 


### PR DESCRIPTION
The motivation here is that we discovered in  https://github.com/HypothesisWorks/hypothesis/pull/3065#issuecomment-915346847 that the `.start` index could be *equal* to the `size` argument, which isn't a valid index.  Python and Numpy collections are fine with this - an out-of-range slice just selects no elements - but it's undefined behaviour in the Array API standard and therefore an `IndexError` in `numpy.array_api`.

And then while poking at `slices()` I made it generate a wider variety of `step` arguments too.