### PR TITLE
Fix for inline `given()` on bound methods

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`961`, where calling ``given()`` inline on a
+bound method would fail to handle the ``self`` argument correctly.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -28,7 +28,6 @@ import types
 import warnings
 import zlib
 from collections import defaultdict
-from inspect import getfullargspec
 from io import StringIO
 from random import Random
 from typing import Any, BinaryIO, Callable, Hashable, List, Optional, TypeVar, Union
@@ -83,6 +82,7 @@ from hypothesis.internal.reflection import (
     define_function_signature,
     function_digest,
     get_pretty_function_description,
+    getfullargspec_except_self as getfullargspec,
     impersonate,
     is_mock,
     proxies,

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 import pytest
 from pytest import raises
 
-from hypothesis import strategies as st
+from hypothesis import given, strategies as st
 from hypothesis.internal import reflection
 from hypothesis.internal.reflection import (
     arg_string,
@@ -676,3 +676,14 @@ def test_too_many_posargs_fails():
 def test_overlapping_posarg_kwarg_fails():
     with pytest.raises(TypeError):
         st.times(time.min, time.max, st.none(), timezones=st.just(None)).validate()
+
+
+def test_inline_given_handles_self():
+    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/961
+    class Cls:
+        def method(self, **kwargs):
+            assert isinstance(self, Cls)
+            assert kwargs["k"] is sentinel
+
+    sentinel = object()
+    given(k=st.just(sentinel))(Cls().method)()


### PR DESCRIPTION
Fixes #961.