### PR TITLE
Make BasicIndexStrategy generate indices that include Ellipsis with other index items

### DIFF
--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -1092,6 +1092,15 @@ def test_basic_indices_can_generate_non_tuples():
     )
 
 
+def test_basic_indices_can_generate_indices_with_not_only_ellipsis():
+    find_any(
+        nps.basic_indices(shape=(0, 0, 0, 0, 0)).filter(
+            lambda idx: isinstance(idx, tuple) and Ellipsis in idx
+        ),
+        lambda idx: len(idx) > 1,
+    )
+
+
 def test_basic_indices_can_generate_long_ellipsis():
     # Runs of slice(None) - such as [0,:,:,:,0] - can be replaced by e.g. [0,...,0]
     find_any(


### PR DESCRIPTION
In #3065 we discovered `BasicIndexStrategy` doesn't generate indices that are mixed in with anything else, only `[...]` and `[(...,)]`. I haven't fixed this yet, just added a failing test.

- [ ] Fix `BasicIndexStrategy` so that the test passes
- [ ] Review `test_basic_indices_replaces_whole_axis_slices_with_ellipsis`
- [ ] `RELEASE.rst`

 @Zac-HD  Let me know if I've misunderstood behaviour here heh.

---

I just tried this and it was fine:
```
>> nps.basic_indices((3, 3, 3,), allow_ellipsis=True).filter(lambda idx: isinstance(idx, tuple) and Ellipsis in idx).example()
(Ellipsis, 0, slice(2, None, -2), slice(-1, None, -1))
```

So it's to do with the shape sides being 0... I have no idea what 0-sized dims even means, sorry!

```
>>> nps.basic_indices((0, 0, 0,), allow_ellipsis=True).filter(lambda idx: isinstance(idx, tuple) and Ellipsis in idx).example()
(Ellipsis,)  # and only this
```