### PR TITLE
Fix given decorator type hint when decorating async functions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,7 +58,7 @@ their individual contributions.
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
-* `Humberto Rocha <https://github.com/humrochagf`_
+* `Humberto Rocha <https://github.com/humrochagf>`_
 * `Ilya Lebedev <https://github.com/melevir>`_ (melevir@gmail.com)
 * `Israel Fruchter <https://github.com/fruch>`_
 * `Jack Massey <https://github.com/massey101>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,6 +58,7 @@ their individual contributions.
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
+* `Humberto Rocha <https://github.com/humrochagf`_
 * `Ilya Lebedev <https://github.com/melevir>`_ (melevir@gmail.com)
 * `Israel Fruchter <https://github.com/fruch>`_
 * `Jack Massey <https://github.com/massey101>`_

--- a/guides/documentation.rst
+++ b/guides/documentation.rst
@@ -88,4 +88,4 @@ which should:
 - finish with a note of thanks from the maintainers:
   "Thanks to <your name> for this bug fix / feature / contribution"
   (depending on which it is).  If this is your first contribution,
-  don't forget to add yourself to contributors.rst!
+  don't forget to add yourself to AUTHORS.rst!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
 This release fixes the type hint for the
-:func:`@given() <hypotesis.given>` decorator
+:func:`@given() <hypothesis.given>` decorator
 when decorating an ``async`` function (:issue:`3099`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes the type hint for the
+:func:`@given() <hypotesis.given>` decorator
+when decorating an ``async`` function (:issue:`3099`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -34,12 +34,12 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    Coroutine,
     Hashable,
     List,
     Optional,
     TypeVar,
     Union,
-    Coroutine,
 )
 from unittest import TestCase
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -30,7 +30,17 @@ import zlib
 from collections import defaultdict
 from io import StringIO
 from random import Random
-from typing import Any, BinaryIO, Callable, Hashable, List, Optional, TypeVar, Union
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    Hashable,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    Coroutine,
+)
 from unittest import TestCase
 
 import attr
@@ -941,7 +951,9 @@ class HypothesisHandle:
 def given(
     *_given_arguments: Union[SearchStrategy, InferType],
     **_given_kwargs: Union[SearchStrategy, InferType],
-) -> Callable[[Callable[..., None]], Callable[..., None]]:
+) -> Callable[
+    [Callable[..., Union[None, Coroutine[Any, Any, None]]]], Callable[..., None]
+]:
     """A decorator for turning a test function that accepts arguments into a
     randomized test.
 


### PR DESCRIPTION
Async functions are Callables that return a Coroutine, so to support a proper annotation in this particular case I added to the decorated Callable type hint the possible return of a `Coroutine[Any, Any, None]`.

Please note that the returned coroutine is conforming with the same requirement as a normal Callable (it should return None as well)

Fixes: #3099 