### PR TITLE
Ensure `dtype=None` fails in both `xps.arrays()` and `xps.from_dtype()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes ``None`` being inferred as the float64 dtype in
+:func:`~xps.from_dtype()` and :func:`~xps.arrays()` from the
+:ref:`Array API extra <array-api>`.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -130,7 +130,11 @@ def find_castable_builtin_for_dtype(
         return int
 
     float_dtypes, float_stubs = partition_attributes_and_stubs(xp, FLOAT_NAMES)
-    if dtype in float_dtypes:
+    # None equals NumPy's xp.float64 object, so we specifically skip it here to
+    # ensure that InvalidArgument is still raised. xp.float64 is in fact an
+    # alias of np.dtype('float64'), and its equality with None is meant to be
+    # deprecated at some point - see https://github.com/numpy/numpy/issues/18434.
+    if dtype is not None and dtype in float_dtypes:
         return float
 
     stubs.extend(int_stubs)

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -141,7 +141,7 @@ def find_castable_builtin_for_dtype(
     stubs.extend(float_stubs)
     if len(stubs) > 0:
         warn_on_missing_dtypes(xp, stubs)
-    raise InvalidArgument("dtype {dtype} not recognised in {xp.__name__}")
+    raise InvalidArgument(f"dtype={dtype} not recognised in {xp.__name__}")
 
 
 @check_function

--- a/hypothesis-python/tests/array_api/test_argument_validation.py
+++ b/hypothesis-python/tests/array_api/test_argument_validation.py
@@ -28,6 +28,8 @@ def e(a, **kwargs):
 @pytest.mark.parametrize(
     ("function", "kwargs"),
     [
+        e(xps.arrays, dtype=1, shape=5),
+        e(xps.arrays, dtype=None, shape=5),
         e(xps.arrays, dtype=xp.int8, shape=(0.5,)),
         e(xps.arrays, dtype=xp.int8, shape=1, fill=3),
         e(xps.arrays, dtype=xp.int8, shape=1, elements="not a strategy"),
@@ -40,6 +42,7 @@ def e(a, **kwargs):
         e(xps.array_shapes, min_dims="not an int"),
         e(xps.array_shapes, max_dims="not an int"),
         e(xps.from_dtype, dtype=1),
+        e(xps.from_dtype, dtype=None),
         e(xps.from_dtype, dtype=xp.int8, min_value="not an int"),
         e(xps.from_dtype, dtype=xp.int8, max_value="not an int"),
         e(xps.from_dtype, dtype=xp.float32, min_value="not a float"),


### PR DESCRIPTION
Fixes `None` being inferred as `xp.float64` for these methods when using a NumPy strategies namespace. This happens as a result of `numpy.array_api.float64` aliasing to `np.dtype('float64')`, which awkwardly has equality with `None`. This is actually *meant* to be deprecated behaviour—see numpy/numpy#18434.
