### PR TITLE
Clean-up and slightly optimise `extra.array_api.ArrayStrategy`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch makes :func:`~xps.arrays()` from the
+:ref:`Array API extra <array-api>` slightly faster by not repeating internal
+checks done on generated elements.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -265,32 +265,22 @@ class ArrayStrategy(st.SearchStrategy):
         self.unique = unique
         self.array_size = math.prod(shape)
         self.builtin = find_castable_builtin_for_dtype(xp, dtype)
-
-    def set_value(self, result, i, val, strategy=None):
-        strategy = strategy or self.elements_strategy
-        try:
-            result[i] = val
-        except TypeError as e:
-            raise InvalidArgument(
-                f"Could not add generated array element {val!r} "
-                f"of dtype {type(val)} to array of dtype {result.dtype}."
-            ) from e
-        self.check_set_value(val, result[i], strategy)
+        self.check_hist = set()
 
     def check_set_value(self, val, val_0d, strategy):
-        if self.builtin is bool:
-            finite = True
-        else:
-            finite = self.xp.isfinite(val_0d)
+        if val in self.check_hist:
+            return
+        finite = self.builtin is bool or self.xp.isfinite(val_0d)
         if finite and self.builtin(val_0d) != val:
             raise InvalidArgument(
                 f"Generated array element {val!r} from strategy {strategy} "
-                f"cannot be represented as dtype {self.dtype}. "
+                f"cannot be represented with dtype {self.dtype}. "
                 f"Array module {self.xp.__name__} instead "
-                f"represents the element as {val_0d!r}. "
+                f"represents the element as {val_0d}. "
                 "Consider using a more precise elements strategy, "
                 "for example passing the width argument to floats()."
             )
+        self.check_hist.add(val)
 
     def do_draw(self, data):
         if 0 in self.shape:
@@ -302,26 +292,32 @@ class ArrayStrategy(st.SearchStrategy):
             # elements strategy does not produce reusable values), so we must
             # generate a fully dense array with a freshly drawn value for each
             # entry.
-
-            # This could legitimately be a xp.empty, but the performance gains
-            # for that are likely marginal, so there's really not much point
-            # risking undefined behaviour shenanigans.
-            result = self.xp.zeros(self.array_size, dtype=self.dtype)
-
-            if self.unique:
-                seen = set()
-                elems = st.lists(
+            elems = data.draw(
+                st.lists(
                     self.elements_strategy,
                     min_size=self.array_size,
                     max_size=self.array_size,
-                    unique=True,
+                    unique=self.unique,
                 )
-                for i, v in enumerate(data.draw(elems)):
-                    self.set_value(result, i, v)
-            else:
-                for i in range(self.array_size):
-                    val = data.draw(self.elements_strategy)
-                    self.set_value(result, i, val)
+            )
+            try:
+                result = self.xp.asarray(elems, dtype=self.dtype)
+            except Exception as e:
+                if len(elems) <= 6:
+                    f_elems = str(elems)
+                else:
+                    f_elems = f"[{elems[0]}, {elems[1]}, ..., {elems[-2]}, {elems[-1]}]"
+                types = tuple({type(e) for e in elems})
+                f_types = f"type {types[0]}" if len(types) == 1 else f"types {types}"
+                raise InvalidArgument(
+                    f"Generated elements {f_elems} from strategy "
+                    f"{self.elements_strategy} could not be converted "
+                    f"to array of dtype {self.dtype}. "
+                    f"Consider if elements of {f_types} "
+                    f"are compatible with {self.dtype}."
+                ) from e
+            for i in range(self.array_size):
+                self.check_set_value(elems[i], result[i], self.elements_strategy)
         else:
             # We draw arrays as "sparse with an offset". We assume not every
             # element will be assigned and so first draw a single value from our
@@ -338,7 +334,7 @@ class ArrayStrategy(st.SearchStrategy):
                     f"with fill value {fill_val!r}"
                 ) from e
             sample = result[0]
-            self.check_set_value(fill_val, sample, strategy=self.fill)
+            self.check_set_value(fill_val, sample, self.fill)
             if self.unique and not self.xp.all(self.xp.isnan(result)):
                 raise InvalidArgument(
                     f"Array module {self.xp.__name__} did not recognise fill "
@@ -371,7 +367,14 @@ class ArrayStrategy(st.SearchStrategy):
                         continue
                     else:
                         seen.add(val)
-                self.set_value(result, i, val)
+                try:
+                    result[i] = val
+                except Exception as e:
+                    raise InvalidArgument(
+                        f"Could not add generated array element {val!r} "
+                        f"of type {type(val)} to array of dtype {result.dtype}."
+                    ) from e
+                self.check_set_value(val, result[i], self.elements_strategy)
                 assigned.add(i)
 
         result = self.xp.reshape(result, self.shape)
@@ -459,8 +462,9 @@ def _arrays(
     hundreds or more elements, having a fill value is essential if you want
     your tests to run in reasonable time.
     """
-
-    check_xp_attributes(xp, ["zeros", "full", "all", "isnan", "isfinite", "reshape"])
+    check_xp_attributes(
+        xp, ["asarray", "zeros", "full", "all", "isnan", "isfinite", "reshape"]
+    )
 
     if isinstance(dtype, st.SearchStrategy):
         return dtype.flatmap(

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -276,7 +276,7 @@ class ArrayStrategy(st.SearchStrategy):
         self.builtin = find_castable_builtin_for_dtype(xp, dtype)
 
     def check_set_value(self, val, val_0d, strategy):
-        if val in self.check_hist[self.dtype]:
+        if val in ArrayStrategy.check_hist[self.dtype]:
             return
         finite = self.builtin is bool or self.xp.isfinite(val_0d)
         if finite and self.builtin(val_0d) != val:
@@ -288,7 +288,7 @@ class ArrayStrategy(st.SearchStrategy):
                 "Consider using a more precise elements strategy, "
                 "for example passing the width argument to floats()."
             )
-        self.check_hist[self.dtype].add(val)
+        ArrayStrategy.check_hist[self.dtype].add(val)
 
     def do_draw(self, data):
         if 0 in self.shape:
@@ -297,8 +297,8 @@ class ArrayStrategy(st.SearchStrategy):
         # We reset a dtype's cache when it reaches a certain size to prevent
         # unbounded memory usage. The limit 75_000 is under a set's reallocation
         # size of 78_642, but is other chosen as an arbitrarily large number.
-        if len(self.check_hist[self.dtype]) >= 75_000:
-            self.check_hist[self.dtype] = set()
+        if len(ArrayStrategy.check_hist[self.dtype]) >= 75_000:
+            ArrayStrategy.check_hist[self.dtype] = set()
 
         if self.fill.is_empty:
             # We have no fill value (either because the user explicitly

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -294,9 +294,10 @@ class ArrayStrategy(st.SearchStrategy):
         if 0 in self.shape:
             return self.xp.zeros(self.shape, dtype=self.dtype)
 
-        # We reset check_hist when it reaches an arbitrarily large size to
-        # prevent unbounded memory usage.
-        if len(self.check_hist[self.dtype]) >= 100_000:
+        # We reset a dtype's cache when it reaches a certain size to prevent
+        # unbounded memory usage. The limit 75_000 is under a set's reallocation
+        # size of 78_642, but is other chosen as an arbitrarily large number.
+        if len(self.check_hist[self.dtype]) >= 75_000:
             self.check_hist[self.dtype] = set()
 
         if self.fill.is_empty:

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -317,7 +317,9 @@ class ArrayStrategy(st.SearchStrategy):
                     f_elems = str(elems)
                 else:
                     f_elems = f"[{elems[0]}, {elems[1]}, ..., {elems[-2]}, {elems[-1]}]"
-                types = tuple({type(e) for e in elems})
+                types = tuple(
+                    sorted({type(e) for e in elems}, key=lambda t: t.__name__)
+                )
                 f_types = f"type {types[0]}" if len(types) == 1 else f"types {types}"
                 raise InvalidArgument(
                     f"Generated elements {f_elems} from strategy "

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -133,7 +133,7 @@ def find_castable_builtin_for_dtype(
     # None equals NumPy's xp.float64 object, so we specifically skip it here to
     # ensure that InvalidArgument is still raised. xp.float64 is in fact an
     # alias of np.dtype('float64'), and its equality with None is meant to be
-    # deprecated at some point - see https://github.com/numpy/numpy/issues/18434.
+    # deprecated at some point. See https://github.com/numpy/numpy/issues/18434
     if dtype is not None and dtype in float_dtypes:
         return float
 

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -201,7 +201,7 @@ def count_unique(x):
     # TODO: The Array API makes boolean indexing optional, so in the future this
     # will need to be reworked if we want to test libraries other than NumPy.
     # If not possible, errors should be caught and the test skipped.
-    # See https://github.com/data-apis/array-api/issues/249.
+    # See https://github.com/data-apis/array-api/issues/249
     filtered_x = x[~nan_index]
     unique_x = xp.unique(filtered_x)
     n_unique += unique_x.size

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -570,17 +570,17 @@ def test_check_hist_resets_when_too_large(fresh_arrays, data):
     """Strategy resets its cache of checked values once it gets too large.
 
     At the start of a draw, xps.arrays() should check the size of the cache.
-    If it contains 100_000 or more values, it should be completely reset.
+    If it contains 75_000 or more values, it should be completely reset.
     """
-    # Our elements/fill strategy generates values >=100_000  so that it won't
+    # Our elements/fill strategy generates values >=75_000  so that it won't
     # collide with our mocked cached values later.
-    strat = fresh_arrays(dtype=xp.uint64, shape=5, elements={"min_value": 100_000})
-    # We inject the mocked cache containing all positive integers below 100_000.
-    strat.check_hist[xp.uint64] = set(range(99_999))
+    strat = fresh_arrays(dtype=xp.uint64, shape=5, elements={"min_value": 75_000})
+    # We inject the mocked cache containing all positive integers below 75_000.
+    strat.check_hist[xp.uint64] = set(range(74_999))
     # We then call the strategy's do_draw() method.
     data.draw(strat)
     # The cache should *not* reset here, as the check is done at the start of a draw.
-    assert len(strat.check_hist[xp.uint64]) >= 100_000
+    assert len(strat.check_hist[xp.uint64]) >= 75_000
     # But another call of do_draw() should reset the cache.
     data.draw(strat)
     assert 1 <= len(strat.check_hist[xp.uint64]) <= 5

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -201,6 +201,7 @@ def count_unique(x):
     # TODO: The Array API makes boolean indexing optional, so in the future this
     # will need to be reworked if we want to test libraries other than NumPy.
     # If not possible, errors should be caught and the test skipped.
+    # See https://github.com/data-apis/array-api/issues/249.
     filtered_x = x[~nan_index]
     unique_x = xp.unique(filtered_x)
     n_unique += unique_x.size


### PR DESCRIPTION
Following up from #3065 where I [mentioned](https://github.com/HypothesisWorks/hypothesis/pull/3065#issuecomment-914232284) cleaning some internal logic up (no public API changes). Personally I find it easier to follow now, although if folk disagree then that'd be good to know!

I also thought to not repeat `check_set_value()`'s logic on values that have already been seen, as I think we can be pretty assured that values will be deterministically promoted once assigned into an array. With `numpy.array_api` this gives a ~15% performance boost locally when I compared and averaged the results of typical `xps.arrays()` runs using this [scrappy script](https://gist.github.com/honno/151a572757a3a3d892b0be25eb12efa4)... note I'm generally new to benchmarking and Hypothesis is obviously a tricky beast here, so I might need to revisit this.