### PR TITLE
Treat `SystemExit` and `GeneratorExit` as normal test failures

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+This release follows :pypi:`pytest` in considering :class:`SystemExit` and
+:class:`GeneratorExit` exceptions to be test failures, meaning that we will
+shink to minimal examples and check for flakiness even though they subclass
+:class:`BaseException` directly (:issue:`2223`).
+
+:class:`KeyboardInterrupt` continues to interrupt everything, and will be
+re-raised immediately.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -121,7 +121,7 @@ class settingsMeta(type):
                 "settings with settings.load_profile, or use @settings(...) "
                 "to decorate your test instead."
             )
-        return type.__setattr__(cls, name, value)
+        return super().__setattr__(name, value)
 
 
 class settings(metaclass=settingsMeta):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -493,7 +493,11 @@ def failure_exceptions_to_catch():
     This is intended to cover most common test runners; if you would
     like another to be added please open an issue or pull request.
     """
-    exceptions = [Exception]
+    # While SystemExit and GeneratorExit are instances of BaseException, we also
+    # expect them to be deterministic - unlike KeyboardInterrupt - and so we treat
+    # them as standard exceptions, check for flakiness, etc.
+    # See https://github.com/HypothesisWorks/hypothesis/issues/2223 for details.
+    exceptions = [Exception, SystemExit, GeneratorExit]
     if "_pytest" in sys.modules:  # pragma: no branch
         exceptions.append(sys.modules["_pytest"].outcomes.Failed)
     return tuple(exceptions)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -226,7 +226,7 @@ def decode_failure(blob):
 class WithRunner(MappedSearchStrategy):
     def __init__(self, base, runner):
         assert runner is not None
-        MappedSearchStrategy.__init__(self, base)
+        super().__init__(base)
         self.runner = runner
 
     def do_draw(self, data):

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -503,7 +503,7 @@ class MutuallyBroadcastableShapesStrategy(st.SearchStrategy):
         min_side=1,
         max_side=None,
     ):
-        st.SearchStrategy.__init__(self)
+        super().__init__()
         self.base_shape = base_shape
         self.side_strat = st.integers(min_side, max_side)
         self.num_shapes = num_shapes

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -389,7 +389,7 @@ class LearnedDFA(DFA):
     distinguished by a membership test and a set of experiments."""
 
     def __init__(self, lstar):
-        DFA.__init__(self)
+        super().__init__()
         self.__lstar = lstar
         self.__generation = lstar.generation
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -233,7 +233,7 @@ class StateMachineMeta(type):
                     "on the {cls} class."
                 ).format(cls=cls.__name__, value=value)
             )
-        return type.__setattr__(cls, name, value)
+        return super().__setattr__(name, value)
 
 
 class RuleBasedStateMachine(metaclass=StateMachineMeta):
@@ -883,7 +883,7 @@ LOOP_LABEL = cu.calc_label_from_name("RuleStrategy loop iteration")
 
 class RuleStrategy(SearchStrategy):
     def __init__(self, machine):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.machine = machine
         self.rules = list(machine.rules())
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -38,7 +38,7 @@ class TupleStrategy(SearchStrategy):
     strategies for each of their elements."""
 
     def __init__(self, strategies):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.element_strategies = tuple(strategies)
 
     def do_validate(self):
@@ -136,7 +136,7 @@ class ListStrategy(SearchStrategy):
     allowed lengths, and generates lists with the correct size and contents."""
 
     def __init__(self, elements, min_size=0, max_size=float("inf")):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.min_size = min_size or 0
         self.max_size = max_size if max_size is not None else float("inf")
         assert 0 <= self.min_size <= self.max_size

--- a/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
@@ -24,7 +24,7 @@ class DeferredStrategy(SearchStrategy):
     """A strategy which may be used before it is fully defined."""
 
     def __init__(self, definition):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.__wrapped_strategy = None
         self.__in_repr = False
         self.__definition = definition

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -76,7 +76,7 @@ class LazyStrategy(SearchStrategy):
     """
 
     def __init__(self, function, args, kwargs, filters=(), *, force_repr=None):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.__wrapped_strategy = None
         self.__representation = force_repr
         self.function = function

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -181,7 +181,7 @@ class FloatStrategy(SearchStrategy):
     """Generic superclass for strategies which produce floats."""
 
     def __init__(self, allow_infinity, allow_nan, width):
-        SearchStrategy.__init__(self)
+        super().__init__()
         assert isinstance(allow_infinity, bool)
         assert isinstance(allow_nan, bool)
         assert width in (16, 32, 64)
@@ -239,7 +239,7 @@ class FixedBoundedFloatStrategy(SearchStrategy):
     """
 
     def __init__(self, lower_bound, upper_bound, width):
-        SearchStrategy.__init__(self)
+        super().__init__()
         assert isinstance(lower_bound, float)
         assert isinstance(upper_bound, float)
         assert 0 <= lower_bound < upper_bound

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -190,7 +190,7 @@ class ArtificialRandom(HypothesisRandom):
     VERSION = 10 ** 6
 
     def __init__(self, note_method_calls, data):
-        HypothesisRandom.__init__(self, note_method_calls=note_method_calls)
+        super().__init__(note_method_calls=note_method_calls)
         self.__data = data
         self.__state = RandomState()
 
@@ -397,7 +397,7 @@ def convert_kwargs(name, kwargs):
 
 class TrueRandom(HypothesisRandom):
     def __init__(self, seed, note_method_calls):
-        HypothesisRandom.__init__(self, note_method_calls)
+        super().__init__(note_method_calls)
         self.__seed = seed
         self.__random = Random(seed)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -458,7 +458,7 @@ class SampledFromStrategy(SearchStrategy):
     """
 
     def __init__(self, elements, repr_=None, transformations=()):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.elements = cu.check_sample(elements, "sampled_from")
         assert self.elements
         self.repr_ = repr_
@@ -592,7 +592,7 @@ class OneOfStrategy(SearchStrategy):
     """
 
     def __init__(self, strategies):
-        SearchStrategy.__init__(self)
+        super().__init__()
         strategies = tuple(strategies)
         self.original_strategies = list(strategies)
         self.__element_strategies = None
@@ -778,7 +778,7 @@ class MappedSearchStrategy(SearchStrategy):
     """
 
     def __init__(self, strategy, pack=None):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.mapped_strategy = strategy
         if pack is not None:
             self.pack = pack

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -333,9 +333,7 @@ class RepresentationPrinter(PrettyPrinter):
         max_seq_length=MAX_SEQ_LENGTH,
     ):
 
-        PrettyPrinter.__init__(
-            self, output, max_width, newline, max_seq_length=max_seq_length
-        )
+        super().__init__(output, max_width, newline, max_seq_length=max_seq_length)
         self.verbose = verbose
         self.stack = []
         if singleton_pprinters is None:

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -28,7 +28,7 @@ POISON = "POISON"
 
 class Poisoned(SearchStrategy):
     def __init__(self, poison_chance):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.__poison_chance = poison_chance
         self.__ints = st.integers(0, 10)
 
@@ -41,7 +41,7 @@ class Poisoned(SearchStrategy):
 
 class LinearLists(SearchStrategy):
     def __init__(self, elements, size):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.__length = st.integers(0, size)
         self.__elements = elements
 
@@ -51,7 +51,7 @@ class LinearLists(SearchStrategy):
 
 class Matrices(SearchStrategy):
     def __init__(self, elements, size):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.__length = st.integers(0, ceil(size ** 0.5))
         self.__elements = elements
 

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -35,7 +35,7 @@ class PoisonedTree(SearchStrategy):
     """
 
     def __init__(self, p):
-        SearchStrategy.__init__(self)
+        super().__init__()
         self.__p = p
 
     def do_draw(self, data):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -33,7 +33,7 @@ pytest==6.2.5
     #   pytest-xdist
 pytest-forked==1.3.0
     # via pytest-xdist
-pytest-xdist==2.3.0
+pytest-xdist==2.4.0
     # via -r requirements/test.in
 sortedcontainers==2.4.0
     # via hypothesis (hypothesis-python/setup.py)

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -55,7 +55,7 @@ cryptography==3.4.8
     # via secretstorage
 decorator==5.1.0
     # via ipython
-distlib==0.3.2
+distlib==0.3.3
     # via virtualenv
 django==3.2.7
     # via -r requirements/tools.in
@@ -109,7 +109,7 @@ importlib-metadata==4.8.1
     #   twine
 iniconfig==1.1.1
     # via pytest
-ipython==7.27.0
+ipython==7.28.0
     # via -r requirements/tools.in
 isort==5.9.3
     # via shed
@@ -125,7 +125,7 @@ keyring==23.2.1
     # via twine
 lark-parser==0.12.0
     # via -r requirements/tools.in
-libcst==0.3.20
+libcst==0.3.21
     # via
     #   -r requirements/tools.in
     #   pybetter
@@ -161,11 +161,11 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/tools.in
 pkginfo==1.7.1
     # via twine
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   black
     #   virtualenv
@@ -213,7 +213,7 @@ pytz==2021.1
     # via
     #   babel
     #   django
-pyupgrade==2.26.0.post1
+pyupgrade==2.28.0
     # via shed
 pyyaml==5.4.1
     # via
@@ -221,7 +221,7 @@ pyyaml==5.4.1
     #   libcst
 readme-renderer==29.0
     # via twine
-regex==2021.8.28
+regex==2021.9.24
     # via black
 requests==2.26.0
     # via
@@ -295,7 +295,7 @@ tomli==1.2.1
     #   pep517
 tox==3.24.4
     # via -r requirements/tools.in
-tqdm==4.62.2
+tqdm==4.62.3
     # via twine
 traitlets==5.1.0
     # via
@@ -320,9 +320,9 @@ typing-extensions==3.10.0.2
     #   typing-inspect
 typing-inspect==0.7.1
     # via libcst
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests
-virtualenv==20.8.0
+virtualenv==20.8.1
     # via tox
 wcwidth==0.2.5
     # via prompt-toolkit


### PR DESCRIPTION
This matches the behaviour of `pytest`, and means we'll shrink to minimal examples, check for `Flaky` tests, etc.  This is *unlike* `KeyboardInterrupt` where we stop and reraise immediately, though it's possible that the surrounding context will treat them specially in some way.

Closes #2223, after a long wait!