### PR TITLE
Clean up `extra.array_api.ArrayStrategy`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch cleans up internal logic for :func:`xps.arrays()`. There is no
+user-visible change.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -266,28 +266,14 @@ class ArrayStrategy(st.SearchStrategy):
         self.array_size = math.prod(shape)
         self.builtin = find_castable_builtin_for_dtype(xp, dtype)
 
-    def set_value(self, result, i, val, strategy=None):
-        strategy = strategy or self.elements_strategy
-        try:
-            result[i] = val
-        except TypeError as e:
-            raise InvalidArgument(
-                f"Could not add generated array element {val!r} "
-                f"of dtype {type(val)} to array of dtype {result.dtype}."
-            ) from e
-        self.check_set_value(val, result[i], strategy)
-
     def check_set_value(self, val, val_0d, strategy):
-        if self.builtin is bool:
-            finite = True
-        else:
-            finite = self.xp.isfinite(val_0d)
+        finite = self.builtin is bool or self.xp.isfinite(val_0d)
         if finite and self.builtin(val_0d) != val:
             raise InvalidArgument(
                 f"Generated array element {val!r} from strategy {strategy} "
-                f"cannot be represented as dtype {self.dtype}. "
+                f"cannot be represented with dtype {self.dtype}. "
                 f"Array module {self.xp.__name__} instead "
-                f"represents the element as {val_0d!r}. "
+                f"represents the element as {val_0d}. "
                 "Consider using a more precise elements strategy, "
                 "for example passing the width argument to floats()."
             )
@@ -302,26 +288,32 @@ class ArrayStrategy(st.SearchStrategy):
             # elements strategy does not produce reusable values), so we must
             # generate a fully dense array with a freshly drawn value for each
             # entry.
-
-            # This could legitimately be a xp.empty, but the performance gains
-            # for that are likely marginal, so there's really not much point
-            # risking undefined behaviour shenanigans.
-            result = self.xp.zeros(self.array_size, dtype=self.dtype)
-
-            if self.unique:
-                seen = set()
-                elems = st.lists(
+            elems = data.draw(
+                st.lists(
                     self.elements_strategy,
                     min_size=self.array_size,
                     max_size=self.array_size,
-                    unique=True,
+                    unique=self.unique,
                 )
-                for i, v in enumerate(data.draw(elems)):
-                    self.set_value(result, i, v)
-            else:
-                for i in range(self.array_size):
-                    val = data.draw(self.elements_strategy)
-                    self.set_value(result, i, val)
+            )
+            try:
+                result = self.xp.asarray(elems, dtype=self.dtype)
+            except Exception as e:
+                if len(elems) <= 6:
+                    f_elems = str(elems)
+                else:
+                    f_elems = f"[{elems[0]}, {elems[1]}, ..., {elems[-2]}, {elems[-1]}]"
+                types = tuple({type(e) for e in elems})
+                f_types = f"type {types[0]}" if len(types) == 1 else f"types {types}"
+                raise InvalidArgument(
+                    f"Generated elements {f_elems} from strategy "
+                    f"{self.elements_strategy} could not be converted "
+                    f"to array of dtype {self.dtype}. "
+                    f"Consider if elements of {f_types} "
+                    f"are compatible with {self.dtype}."
+                ) from e
+            for i in range(self.array_size):
+                self.check_set_value(elems[i], result[i], self.elements_strategy)
         else:
             # We draw arrays as "sparse with an offset". We assume not every
             # element will be assigned and so first draw a single value from our
@@ -338,7 +330,7 @@ class ArrayStrategy(st.SearchStrategy):
                     f"with fill value {fill_val!r}"
                 ) from e
             sample = result[0]
-            self.check_set_value(fill_val, sample, strategy=self.fill)
+            self.check_set_value(fill_val, sample, self.fill)
             if self.unique and not self.xp.all(self.xp.isnan(result)):
                 raise InvalidArgument(
                     f"Array module {self.xp.__name__} did not recognise fill "
@@ -371,7 +363,14 @@ class ArrayStrategy(st.SearchStrategy):
                         continue
                     else:
                         seen.add(val)
-                self.set_value(result, i, val)
+                try:
+                    result[i] = val
+                except Exception as e:
+                    raise InvalidArgument(
+                        f"Could not add generated array element {val!r} "
+                        f"of type {type(val)} to array of dtype {result.dtype}."
+                    ) from e
+                self.check_set_value(val, result[i], self.elements_strategy)
                 assigned.add(i)
 
         result = self.xp.reshape(result, self.shape)
@@ -459,8 +458,9 @@ def _arrays(
     hundreds or more elements, having a fill value is essential if you want
     your tests to run in reasonable time.
     """
-
-    check_xp_attributes(xp, ["zeros", "full", "all", "isnan", "isfinite", "reshape"])
+    check_xp_attributes(
+        xp, ["asarray", "zeros", "full", "all", "isnan", "isfinite", "reshape"]
+    )
 
     if isinstance(dtype, st.SearchStrategy):
         return dtype.flatmap(

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -303,7 +303,9 @@ class ArrayStrategy(st.SearchStrategy):
                     f_elems = str(elems)
                 else:
                     f_elems = f"[{elems[0]}, {elems[1]}, ..., {elems[-2]}, {elems[-1]}]"
-                types = tuple({type(e) for e in elems})
+                types = tuple(
+                    sorted({type(e) for e in elems}, key=lambda t: t.__name__)
+                )
                 f_types = f"type {types[0]}" if len(types) == 1 else f"types {types}"
                 raise InvalidArgument(
                     f"Generated elements {f_elems} from strategy "

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -133,7 +133,7 @@ def find_castable_builtin_for_dtype(
     # None equals NumPy's xp.float64 object, so we specifically skip it here to
     # ensure that InvalidArgument is still raised. xp.float64 is in fact an
     # alias of np.dtype('float64'), and its equality with None is meant to be
-    # deprecated at some point - see https://github.com/numpy/numpy/issues/18434.
+    # deprecated at some point. See https://github.com/numpy/numpy/issues/18434
     if dtype is not None and dtype in float_dtypes:
         return float
 

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -126,6 +126,19 @@ def test_generate_arrays_from_unsigned_ints(x):
     assert_array_namespace(x)
 
 
+@given(
+    xps.arrays(
+        dtype=xp.uint8,
+        shape=(5, 5),
+        elements=xps.from_dtype(xp.uint8).map(lambda e: xp.asarray(e, dtype=xp.uint8)),
+    )
+)
+def test_generate_arrays_from_0d_arrays(x):
+    """Generate arrays from 0d array elements."""
+    assert x.shape == (5, 5)
+    assert_array_namespace(x)
+
+
 def test_minimize_arrays_with_default_dtype_shape_strategies():
     """Strategy with default scalar_dtypes and array_shapes strategies minimize
     to a boolean 1-dimensional array of size 1."""
@@ -229,19 +242,17 @@ def test_generate_unique_arrays(x):
     assert count_unique(x) == x.size
 
 
-def test_cannot_draw_unique_arrays_with_too_small_elements():
+@fails_with(InvalidArgument)
+@given(xps.arrays(xp.int8, 10, elements=st.integers(0, 5), unique=True))
+def test_cannot_draw_unique_arrays_with_too_small_elements(_):
     """Unique strategy with elements strategy range smaller than its size raises
     helpful error."""
-    strat = xps.arrays(xp.int8, 10, elements=st.integers(0, 5), unique=True)
-    with pytest.raises(InvalidArgument):
-        strat.example()
 
 
+@fails_with(InvalidArgument)
+@given(xps.arrays(xp.int8, 10, fill=st.just("not a castable value")))
 def test_cannot_fill_arrays_with_non_castable_value():
     """Strategy with fill not castable to dtype raises helpful error."""
-    strat = xps.arrays(xp.int8, 10, fill=st.just("not a castable value"))
-    with pytest.raises(InvalidArgument):
-        strat.example()
 
 
 @given(

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -201,6 +201,7 @@ def count_unique(x):
     # TODO: The Array API makes boolean indexing optional, so in the future this
     # will need to be reworked if we want to test libraries other than NumPy.
     # If not possible, errors should be caught and the test skipped.
+    # See https://github.com/data-apis/array-api/issues/249
     filtered_x = x[~nan_index]
     unique_x = xp.unique(filtered_x)
     n_unique += unique_x.size


### PR DESCRIPTION
Just the clean-up part of #3105 as well as the relevant review commits. I included a test for 0d arrays (already passes).

I imagine we want to just not allow multi-dimensional array elements? If that's the case, I'll note writing checks that rely on Array API behaviour (i.e. not just `numpy.array_api`) is pretty tricky (impossible?) to do efficiently... but relying on current behaviour leads to one or two obscure logical paths where we aren't raising `InvalidArgument`. Basically, I will need to think about it more, and it's something tricky enough that I don't think will be appropriate for this PR.