### PR TITLE
Add `sphinx-codeautolink` for hyperlinks in code samples

### DIFF
--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "hoverxref.extension",
+    "sphinx_codeautolink",
     "sphinx_selective_exclude.eager_only",
 ]
 
@@ -93,6 +94,13 @@ intersphinx_mapping = {
 }
 
 autodoc_mock_imports = ["numpy", "pandas", "redis"]
+
+codeautolink_autodoc_inject = False
+codeautolink_global_preface = """
+from hypothesis import *
+import hypothesis.strategies as st
+from hypothesis.strategies import *
+"""
 
 # This config value must be a dictionary of external sites, mapping unique
 # short alias names to a base URL and a prefix.

--- a/hypothesis-python/docs/reproducing.rst
+++ b/hypothesis-python/docs/reproducing.rst
@@ -140,7 +140,7 @@ as follows:
     ...     pass
     ...
     Falsifying example: test(f=nan)
-    <BLANKLINE>
+
     You can reproduce this example by temporarily adding @reproduce_failure(..., b'AAAA//AAAAAAAAEA') as a decorator on your test case
 
 Adding the suggested decorator to the test should reproduce the failure (as

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -156,8 +156,12 @@ def divide(a: int, b: int) -> float:
         ),
         pytest.param(
             ("magic_builtins", ghostwriter.magic(builtins)),
-            # Signature of builtins.compile() changed in 3.8 and we use that version.
-            marks=[pytest.mark.skipif(sys.version_info[:2] <= (3, 7), reason="")],
+            marks=[
+                pytest.mark.skipif(
+                    sys.version_info[:2] not in [(3, 8), (3, 9)],
+                    reason="compile arg new in 3.8, aiter and anext new in 3.10",
+                )
+            ],
         ),
     ],
     ids=lambda x: x[0],
@@ -174,6 +178,6 @@ def test_ghostwriter_on_hypothesis(update_recorded_outputs):
     expected = get_recorded("hypothesis_module_magic", actual * update_recorded_outputs)
     # The py36 typing module has some different handling of generics (SearchStrategy)
     # and contents (collections.abc vs typing), but we can still check the code works.
-    if sys.version_info[:2] > (3, 6):
+    if (3, 6) < sys.version_info[:2] < (3, 10):
         assert actual == expected
     exec(expected, {"not_set": not_set})

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -21,6 +21,7 @@ requests
 restructuredtext-lint
 shed
 sphinx
+sphinx-codeautolink
 sphinx-hoverxref
 sphinx-rtd-theme
 sphinx-selective-exclude

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -23,6 +23,8 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 bandit==1.7.0
     # via flake8-bandit
+beautifulsoup4==4.10.0
+    # via sphinx-codeautolink
 black==21.9b0
     # via
     #   blacken-docs
@@ -254,10 +256,15 @@ snowballstemmer==2.1.0
     #   sphinx
 sortedcontainers==2.4.0
     # via hypothesis (hypothesis-python/setup.py)
+soupsieve==2.2.1
+    # via beautifulsoup4
 sphinx==4.2.0
     # via
     #   -r requirements/tools.in
+    #   sphinx-codeautolink
     #   sphinx-rtd-theme
+sphinx-codeautolink==0.3.0
+    # via -r requirements/tools.in
 sphinx-hoverxref==0.7b1
     # via -r requirements/tools.in
 sphinx-rtd-theme==1.0.0

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -364,7 +364,7 @@ PY36 = "3.6.15"
 PY37 = "3.7.12"
 PY38 = PYMAIN = "3.8.12"  # Sync PYMAIN minor version with GH Actions main.yml
 PY39 = "3.9.7"
-PY310 = "3.10-dev"
+PY310 = "3.10.0"
 PYPY36 = "pypy3.6-7.3.3"
 PYPY37 = "pypy3.7-7.3.5"
 


### PR DESCRIPTION
See https://github.com/felix-hilden/sphinx-codeautolink/discussions/29 ; once we get a release with these features (tonight?) I'll update the requirements file with a proper pin and we can merge!

Online preview docs here: https://hypothesis--3112.org.readthedocs.build/en/3112/details.html

(todo: also `import hypothesis.strategies as st`)