### PR TITLE
Fix exp. lineno in test_healthcheck_traceback_is_hidden on PyPy3.8

### DIFF
--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -17,7 +17,7 @@ import sys
 
 import pytest
 
-from hypothesis.internal.compat import WINDOWS, escape_unicode_characters
+from hypothesis.internal.compat import PYPY, WINDOWS, escape_unicode_characters
 
 pytest_plugins = "pytester"
 
@@ -106,7 +106,7 @@ def test_healthcheck_traceback_is_hidden(testdir):
     timeout_token = ": FailedHealthCheck"
     def_line = get_line_num(def_token, result)
     timeout_line = get_line_num(timeout_token, result)
-    expected = 6 if sys.version_info[:2] < (3, 8) else 7
+    expected = 6 if sys.version_info[:2] < (3, 8) or PYPY else 7
     assert timeout_line - def_line == expected
 
 


### PR DESCRIPTION
tests/pytest/test_capture.py::test_healthcheck_traceback_is_hidden
assumes that the line number will be higher on Python 3.8+.  However,
PyPy3.8 seems to yield the same line number as older versions of CPython
(and PyPy).  Update the test to expect the old line number on PyPy.

Fixes #3119