### PR TITLE
Optional `pytest` and `better-exceptions` integration for `MultipleFailures`

### DIFF
--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -1,12 +1,13 @@
 [run]
 branch = True
 omit =
-    **/pytestplugin.py
-    **/scrutineer.py
+    **/extra/pytestplugin.py
     **/extra/array_api.py
     **/extra/cli.py
     **/extra/django/*.py
     **/extra/ghostwriter.py
+    **/internal/scrutineer.py
+    **/utils/terminal.py
 
 [report]
 exclude_lines =

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release teaches Hypothesis' multiple-error reporting to format tracebacks
+using :pypi:`pytest` or :pypi:`better-exceptions`, if they are installed and
+enabled (:issue:`3116`).

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -243,10 +243,15 @@ else:
         try:
             from rich.console import Console
             from rich.syntax import Syntax
+
+            from hypothesis.utils.terminal import guess_background_color
         except ImportError:
             print(code)
         else:
-            Console().print(
-                Syntax(code, lexer_name="python", background_color="default"),
-                soft_wrap=True,
+            code = Syntax(
+                code,
+                lexer_name="python",
+                background_color="default",
+                theme="default" if guess_background_color() == "light" else "monokai",
             )
+            Console().print(code, soft_wrap=True)

--- a/hypothesis-python/src/hypothesis/extra/pytestplugin.py
+++ b/hypothesis-python/src/hypothesis/extra/pytestplugin.py
@@ -21,6 +21,7 @@ import pytest
 from hypothesis import HealthCheck, Phase, Verbosity, core, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.detection import is_hypothesis_test
+from hypothesis.internal.escalation import current_pytest_item
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.statistics import collector, describe_statistics
@@ -217,7 +218,8 @@ else:
 
             with collector.with_value(note_statistics):
                 with with_reporter(store):
-                    yield
+                    with current_pytest_item.with_value(item):
+                        yield
             if store.results:
                 item.hypothesis_report_information = list(store.results)
 

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -28,6 +28,7 @@ from hypothesis.errors import (
     UnsatisfiedAssumption,
     _Trimmable,
 )
+from hypothesis.utils.dynamicvariables import DynamicVariable
 
 
 def belongs_to(package):
@@ -124,6 +125,15 @@ def get_interesting_origin(exception):
     )
 
 
+current_pytest_item = DynamicVariable(None)
+
+
 def format_exception(err, tb):
+    # Try using Pytest to match the currently configured traceback style
+    if current_pytest_item.value is not None and "_pytest._code" in sys.modules:
+        item = current_pytest_item.value
+        ExceptionInfo = sys.modules["_pytest._code"].ExceptionInfo
+        return str(item.repr_failure(ExceptionInfo((type(err), err, tb)))) + "\n"
+
     # If all else fails, use the standard-library formatting tools
     return "".join(traceback.format_exception(type(err), err, tb))

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -122,3 +122,8 @@ def get_interesting_origin(exception):
         # to support introspection when debugging, so we can use that unconditionally.
         get_interesting_origin(exception.__context__) if exception.__context__ else (),
     )
+
+
+def format_exception(err, tb):
+    # If all else fails, use the standard-library formatting tools
+    return "".join(traceback.format_exception(type(err), err, tb))

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -135,5 +135,11 @@ def format_exception(err, tb):
         ExceptionInfo = sys.modules["_pytest._code"].ExceptionInfo
         return str(item.repr_failure(ExceptionInfo((type(err), err, tb)))) + "\n"
 
+    # Or use better_exceptions, if that's installed and enabled
+    if "better_exceptions" in sys.modules:
+        better_exceptions = sys.modules["better_exceptions"]
+        if sys.excepthook is better_exceptions.excepthook:
+            return "".join(better_exceptions.format_exception(type(err), err, tb))
+
     # If all else fails, use the standard-library formatting tools
     return "".join(traceback.format_exception(type(err), err, tb))

--- a/hypothesis-python/src/hypothesis/utils/terminal.py
+++ b/hypothesis-python/src/hypothesis/utils/terminal.py
@@ -1,0 +1,38 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Most of this work is copyright (C) 2013-2021 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+import os
+
+
+def guess_background_color():
+    """Returns one of "dark", "light", or "unknown".
+
+    This is basically just guessing, but better than always guessing "dark"!
+    See also https://stackoverflow.com/questions/2507337/ and
+    https://unix.stackexchange.com/questions/245378/
+    """
+    # Guessing based on the $COLORFGBG environment variable
+    try:
+        fg, *_, bg = os.getenv("COLORFGBG").split(";")
+    except Exception:
+        pass
+    else:
+        # 0=black, 7=light-grey, 15=white ; we don't interpret other colors
+        if fg in ("7", "15") and bg == "0":
+            return "dark"
+        elif fg == "0" and bg in ("7", "15"):
+            return "light"
+    # TODO: Guessing based on the xterm control sequence
+    return "unknown"


### PR DESCRIPTION
We now respect the `pytest --tb={no,short,native,auto,long}` configuration; or if you aren't using `pytest` but do have [`better-exceptions`](https://github.com/Qix-/better-exceptions) active we'll use that.  Closes #3116.

As a bonus: tries to detect light-colored terminal backgrounds, and prints ghostwritten code with light-theme syntax highlighting.  This doesn't always work, but it's a lot better than the status quo of assuming a dark background and there's a clear place for future improvements.