### PR TITLE
Use weak references in `register_*` functions so that garbage collection still works

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch changes the backing datastructures of :func:`~hypothesis.register_random`
+and a few internal caches to use :class:`weakref.WeakKeyDictionary`.  This reduces
+memory usage and may improve performance when registered :class:`~random.Random`
+instances are only used for a subset of your tests (:issue:`3131`).

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -16,10 +16,16 @@
 import contextlib
 import random
 import sys
+from itertools import count
+from weakref import WeakValueDictionary
 
 from hypothesis.errors import InvalidArgument
 
-RANDOMS_TO_MANAGE: list = [random]
+# This is effectively a WeakSet, which allows us to associate the saved states
+# with their respective Random instances even as new ones are registered and old
+# ones go out of scope and get garbage collected.  Keys are ascending integers.
+_RKEY = count()
+RANDOMS_TO_MANAGE: WeakValueDictionary = WeakValueDictionary({next(_RKEY): random})
 
 
 class NumpyRandomWrapper:
@@ -32,6 +38,9 @@ class NumpyRandomWrapper:
         self.seed = numpy.random.seed
         self.getstate = numpy.random.get_state
         self.setstate = numpy.random.set_state
+
+
+NP_RANDOM = None
 
 
 def register_random(r: random.Random) -> None:
@@ -49,8 +58,8 @@ def register_random(r: random.Random) -> None:
     """
     if not (hasattr(r, "seed") and hasattr(r, "getstate") and hasattr(r, "setstate")):
         raise InvalidArgument(f"r={r!r} does not have all the required methods")
-    if r not in RANDOMS_TO_MANAGE:
-        RANDOMS_TO_MANAGE.append(r)
+    if r not in RANDOMS_TO_MANAGE.values():
+        RANDOMS_TO_MANAGE[next(_RKEY)] = r
 
 
 def get_seeder_and_restorer(seed=0):
@@ -64,24 +73,26 @@ def get_seeder_and_restorer(seed=0):
     using the global random state.  See e.g. #1709.
     """
     assert isinstance(seed, int) and 0 <= seed < 2 ** 32
-    states: list = []
+    states: dict = {}
 
-    if "numpy" in sys.modules and not any(
-        isinstance(x, NumpyRandomWrapper) for x in RANDOMS_TO_MANAGE
-    ):
-        RANDOMS_TO_MANAGE.append(NumpyRandomWrapper())
+    if "numpy" in sys.modules:
+        global NP_RANDOM
+        if NP_RANDOM is None:
+            # Protect this from garbage-collection by adding it to global scope
+            NP_RANDOM = RANDOMS_TO_MANAGE[next(_RKEY)] = NumpyRandomWrapper()
 
     def seed_all():
         assert not states
-        for r in RANDOMS_TO_MANAGE:
-            states.append(r.getstate())
+        for k, r in RANDOMS_TO_MANAGE.items():
+            states[k] = r.getstate()
             r.seed(seed)
 
     def restore_all():
-        assert len(states) == len(RANDOMS_TO_MANAGE)
-        for r, state in zip(RANDOMS_TO_MANAGE, states):
-            r.setstate(state)
-        del states[:]
+        for k, state in states.items():
+            r = RANDOMS_TO_MANAGE.get(k)
+            if r is not None:  # i.e., hasn't been garbage-collected
+                r.setstate(state)
+        states.clear()
 
     return seed_all, restore_all
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -14,7 +14,8 @@
 # END HEADER
 
 from inspect import getfullargspec
-from typing import Dict
+from typing import MutableMapping
+from weakref import WeakKeyDictionary
 
 from hypothesis.internal.reflection import (
     arg_string,
@@ -24,7 +25,7 @@ from hypothesis.internal.reflection import (
 )
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
-unwrap_cache: Dict[SearchStrategy, SearchStrategy] = {}
+unwrap_cache: MutableMapping[SearchStrategy, SearchStrategy] = WeakKeyDictionary()
 unwrap_depth = 0
 
 


### PR DESCRIPTION
See #3131; this is a nice performance optimization for anyone registering lots of transient `Random` instances.

I experimented with using the same technique under `register_type_strategy()` etc., but there are so many can't-be-weak caches, closures, and references involved in strategy internals that there's no practical way to make it happen without serious performance degradation.

The exception to *that* is `unwrap_cache`, where if the outer strategy is dropped we certainly don't need to remember what it wrapped; it's a small but cheap memory-use reduction.