### PR TITLE
Seed off a single `Random` instance, not global state

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch gives Hypothesis it's own internal :class:`~random.Random` instance,
+ensuring that test suites which reset the global random state don't induce
+weird correlations between property-based tests (:issue:`2135`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -20,7 +20,6 @@ import contextlib
 import datetime
 import inspect
 import io
-import random as rnd_module
 import sys
 import time
 import traceback
@@ -120,6 +119,7 @@ TestFunc = TypeVar("TestFunc", bound=Callable)
 
 running_under_pytest = False
 global_force_seed = None
+_hypothesis_global_random = None
 
 
 @attr.s()
@@ -419,7 +419,10 @@ def get_random_for_wrapped_test(test, wrapped_test):
     elif global_force_seed is not None:
         return Random(global_force_seed)
     else:
-        seed = rnd_module.getrandbits(128)
+        global _hypothesis_global_random
+        if _hypothesis_global_random is None:
+            _hypothesis_global_random = Random()
+        seed = _hypothesis_global_random.getrandbits(128)
         wrapped_test._hypothesis_internal_use_generated_seed = seed
         return Random(seed)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
@@ -238,6 +238,7 @@ def normalize(
     required_successes=100,
     allowed_to_update=False,
     max_dfas=10,
+    random=None,
 ):
     """Attempt to ensure that this test function successfully normalizes - i.e.
     whenever it declares a test case to be interesting, we are able
@@ -267,6 +268,7 @@ def normalize(
         test_function,
         settings=settings(database=None, suppress_health_check=HealthCheck.all()),
         ignore_limits=True,
+        random=random,
     )
 
     seen = set()

--- a/hypothesis-python/tests/cover/test_fuzz_one_input.py
+++ b/hypothesis-python/tests/cover/test_fuzz_one_input.py
@@ -14,7 +14,6 @@
 # END HEADER
 
 import io
-import random
 from operator import attrgetter
 
 import pytest
@@ -23,6 +22,11 @@ from hypothesis import Phase, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.shrinker import sort_key
+
+try:
+    from random import randbytes
+except ImportError:  # New in Python 3.9
+    from secrets import token_bytes as randbytes
 
 
 @pytest.mark.parametrize(
@@ -53,7 +57,7 @@ def test_fuzz_one_input(buffer_type):
     # find a failing example.
     with pytest.raises(AssertionError):
         for _ in range(1000):
-            buf = bytes(random.getrandbits(8) for _ in range(1000))
+            buf = randbytes(1000)
             seeds.append(buf)
             test.hypothesis.fuzz_one_input(buffer_type(buf))
 
@@ -95,7 +99,7 @@ def test_fuzzing_unsatisfiable_test_always_returns_None():
         raise AssertionError("Unreachable because there are no valid examples")
 
     for _ in range(100):
-        buf = bytes(random.getrandbits(8) for _ in range(3))
+        buf = randbytes(3)
         ret = test.hypothesis.fuzz_one_input(buf)
         assert ret is None
 

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -17,7 +17,7 @@ import random
 
 import pytest
 
-from hypothesis import find, given, register_random, reporting, strategies as st
+from hypothesis import core, find, given, register_random, reporting, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import entropy
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -120,11 +120,14 @@ def test_given_does_not_pollute_state():
 
         test()
         state_a = random.getstate()
+        state_a2 = core._hypothesis_global_random.getstate()
 
         test()
         state_b = random.getstate()
+        state_b2 = core._hypothesis_global_random.getstate()
 
-        assert state_a != state_b
+        assert state_a == state_b
+        assert state_a2 != state_b2
 
 
 def test_find_does_not_pollute_state():
@@ -132,8 +135,11 @@ def test_find_does_not_pollute_state():
 
         find(st.random_module(), lambda r: True)
         state_a = random.getstate()
+        state_a2 = core._hypothesis_global_random.getstate()
 
         find(st.random_module(), lambda r: True)
         state_b = random.getstate()
+        state_b2 = core._hypothesis_global_random.getstate()
 
-        assert state_a != state_b
+        assert state_a == state_b
+        assert state_a2 != state_b2

--- a/hypothesis-python/tests/nocover/test_randomization.py
+++ b/hypothesis-python/tests/nocover/test_randomization.py
@@ -13,20 +13,18 @@
 #
 # END HEADER
 
-import random
-
 from pytest import raises
 
-from hypothesis import Verbosity, find, given, settings, strategies as st
+from hypothesis import Verbosity, core, find, given, settings, strategies as st
 
 from tests.common.utils import no_shrink
 
 
-def test_seeds_off_random():
+def test_seeds_off_internal_random():
     s = settings(phases=no_shrink, database=None)
-    r = random.getstate()
+    r = core._hypothesis_global_random.getstate()
     x = find(st.integers(), lambda x: True, settings=s)
-    random.setstate(r)
+    core._hypothesis_global_random.setstate(r)
     y = find(st.integers(), lambda x: True, settings=s)
     assert x == y
 

--- a/hypothesis-python/tests/quality/test_normalization.py
+++ b/hypothesis-python/tests/quality/test_normalization.py
@@ -14,6 +14,7 @@
 # END HEADER
 
 from itertools import islice
+from random import Random
 
 import pytest
 
@@ -56,10 +57,6 @@ def test_common_strategies_normalize_small_values(strategy, n, normalize_kwargs)
 
 @pytest.mark.parametrize("strategy", [st.emails(), st.complex_numbers()], ids=repr)
 def test_harder_strategies_normalize_to_minimal(strategy, normalize_kwargs):
-    import random
-
-    random.seed(0)
-
     def test_function(data):
         try:
             v = data.draw(strategy)
@@ -68,4 +65,4 @@ def test_harder_strategies_normalize_to_minimal(strategy, normalize_kwargs):
         data.output = repr(v)
         data.mark_interesting()
 
-    dfas.normalize(repr(strategy), test_function, **normalize_kwargs)
+    dfas.normalize(repr(strategy), test_function, random=Random(0), **normalize_kwargs)

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -13,8 +13,8 @@
 #
 # END HEADER
 
-import random
 from math import log
+from random import Random
 
 from hypothesis import (
     HealthCheck,
@@ -77,8 +77,6 @@ base_settings = settings(
 def test_avoids_zig_zag_trap(p):
     b, marker, lower_bound = p
 
-    random.seed(0)
-
     n_bits = 8 * (len(b) + 1)
 
     def test_function(data):
@@ -95,6 +93,7 @@ def test_avoids_zig_zag_trap(p):
         test_function,
         database_key=None,
         settings=settings(base_settings, phases=(Phase.generate, Phase.shrink)),
+        random=Random(0),
     )
 
     runner.cached_test_function(b + bytes([0]) + b + bytes([1]) + marker)


### PR DESCRIPTION
We're actually already great about passing around `Random` instances rather than using the global state, so this is a pretty small patch.  Closes #2135.