### PR TITLE
Use xfail strict mode

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare internal error in the :func:`hypothesis.strategies.datetimes`
+strategy, where the implementation of ``allow_imaginary=False`` crashed when checking
+a time during the skipped hour of a DST transition *if* the DST offset is negative -
+only true of ``Europe/Dublin``, who we presume have their reasons - and the ``tzinfo``
+object is a :pypi:`pytz` timezone (which predates :pep:`495`).

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -17,6 +17,7 @@ import contextlib
 import random
 import sys
 
+import hypothesis.core
 from hypothesis.errors import InvalidArgument
 
 RANDOMS_TO_MANAGE: list = [random]
@@ -95,6 +96,10 @@ def deterministic_PRNG(seed=0):
     bad idea in principle, and breaks all kinds of independence assumptions
     in practice.
     """
+    if hypothesis.core._hypothesis_global_random is None:  # pragma: no cover
+        hypothesis.core._hypothesis_global_random = random.Random()
+        register_random(hypothesis.core._hypothesis_global_random)
+
     seed_all, restore_all = get_seeder_and_restorer(seed)
     seed_all()
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -97,6 +97,13 @@ def datetime_does_not_exist(value):
         # meaningless before ~1900 and subject to a lot of change by
         # 9999, so it should be a very small fraction of possible values.
         return True
+
+    if value.tzinfo.utcoffset != roundtrip.tzinfo.utcoffset:
+        # This only ever occurs during imaginary (i.e. nonexistent) datetimes,
+        # and only for pytz timezones which do not follow PEP-495 semantics.
+        # (may exclude a few other edge cases, but you should use zoneinfo anyway)
+        return True
+
     assert value.tzinfo is roundtrip.tzinfo, "so only the naive portions are compared"
     return value != roundtrip
 
@@ -196,9 +203,6 @@ def datetimes(
     which did not (or will not) occur due to daylight savings, leap seconds,
     timezone and calendar adjustments, etc.  Imaginary datetimes are allowed
     by default, because malformed timestamps are a common source of bugs.
-    Note that because :pypi:`pytz` predates :pep:`495`, this does not work
-    correctly with timezones that use a negative DST offset (such as
-    ``"Europe/Dublin"``).
 
     Examples from this strategy shrink towards midnight on January 1st 2000,
     local time.

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -79,7 +79,7 @@ def test_non_interactive_example_emits_warning():
 def test_interactive_example_does_not_emit_warning():
     try:
         child = pexpect.spawn(f"{sys.executable} -Werror")
-        child.expect(">>> ", timeout=1)
+        child.expect(">>> ", timeout=10)
     except pexpect.exceptions.EOF:
         pytest.skip(
             "Unable to run python with -Werror.  This may be because you are "

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -32,6 +32,7 @@ import pytest
 from hypothesis import HealthCheck, assume, given, infer, settings, strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.compat import PYPY, get_type_hints, typing_root_type
+from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types
 
@@ -53,7 +54,6 @@ generics = sorted(
     ),
     key=str,
 )
-xfail_on_39 = () if sys.version_info[:2] < (3, 9) else pytest.mark.xfail
 
 
 @pytest.mark.parametrize("typ", generics, ids=repr)
@@ -263,7 +263,7 @@ def if_available(name):
 @pytest.mark.parametrize(
     "typ",
     [
-        pytest.param(typing.Sequence, marks=xfail_on_39),
+        typing.Sequence,
         typing.Container,
         typing.Mapping,
         typing.Reversible,
@@ -275,6 +275,7 @@ def if_available(name):
         typing.SupportsRound,
         if_available("SupportsIndex"),
     ],
+    ids=get_pretty_function_description,
 )
 def test_resolves_weird_types(typ):
     from_type(typ).example()

--- a/hypothesis-python/tests/cover/test_lookup_py37.py
+++ b/hypothesis-python/tests/cover/test_lookup_py37.py
@@ -34,7 +34,7 @@ from hypothesis import assume, given, infer
 
 if sys.version_info < (3, 9):
     pytestmark = pytest.mark.xfail(
-        raises=Exception, strict=True, reason="Requires Python 3.9 (PEP 585) or later."
+        raises=Exception, reason="Requires Python 3.9 (PEP 585) or later."
     )
 
 

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -14,11 +14,13 @@
 # END HEADER
 
 import dataclasses
+import sys
 import typing
 
 import pytest
 
 from hypothesis import given, strategies as st
+from hypothesis.errors import Unsatisfiable
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import from_type
 
@@ -77,7 +79,15 @@ def test_typeddict_with_optional(value):
         assert isinstance(value["b"], bool)
 
 
-@pytest.mark.xfail
+if sys.version_info[:2] < (3, 9):
+    xfail_on_38 = pytest.mark.xfail(raises=Unsatisfiable)
+else:
+
+    def xfail_on_38(f):
+        return f
+
+
+@xfail_on_38
 def test_simple_optional_key_is_optional():
     # Optional keys are not currently supported, as PEP-589 leaves no traces
     # at runtime.  See https://github.com/python/cpython/pull/17214
@@ -110,7 +120,7 @@ def test_typeddict_with_nested_value(value):
     assert isinstance(value["inner"]["a"], int)
 
 
-@pytest.mark.xfail
+@xfail_on_38
 def test_layered_optional_key_is_optional():
     # Optional keys are not currently supported, as PEP-589 leaves no traces
     # at runtime.  See https://github.com/python/cpython/pull/17214

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 
 # -rfEX :: Print a summary of failures, errors, and xpasses (xfails that pass).
 addopts=--strict-markers --tb=native -p pytester --runpytest=subprocess --durations=20 -rfEX
+xfail_strict = True
 filterwarnings =
     ignore::hypothesis.errors.NonInteractiveExampleWarning


### PR DESCRIPTION
Thanks to Paul for [reminding me that `xpass` is a pass by default](https://blog.ganssle.io/articles/2021/11/pytest-xfail.html); this PR enables strict mode so that we notice when xfail-decorated tests are not in fact failing.  I expect this to turn up a few more cases where we expect failure *if* some condition holds; in those cases we should use conditional xfails for clarity.