### PR TITLE
Declare support for Python 3.9 and 3.10

### DIFF
--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -121,6 +121,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Education :: Testing",


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955