### PR TITLE
Distinguish negative and signaling NaNs in our pretty-printer

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+Did you know that of the 2\ :superscript:`64` possible floating-point numbers,
+2\ :superscript:`53` of them are ``nan`` - and Python prints them all the same way?
+
+While nans *usually* have all zeros in the sign bit and mantissa, this
+`isn't always true <https://wingolog.org/archives/2011/05/18/value-representation-in-javascript-implementations>`__,
+and :wikipedia:`'signaling' nans might trap or error <https://en.wikipedia.org/wiki/NaN#Signaling_NaN>`.
+To help distinguish such errors in e.g. CI logs, Hypothesis now prints ``-nan`` for
+negative nans, and adds a comment like ``# Saw 3 signaling NaNs`` if applicable.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -34,7 +34,7 @@ like ``s.map(lambda x: x)`` and ``lists().filter(len)`` more efficient
 6.24.6 - 2021-11-18
 -------------------
 
-This patch makes :func:`hypothesis.strategies.floats` generate
+This patch makes :func:`~hypothesis.strategies.floats` generate
 :wikipedia:`"subnormal" floating point numbers <Subnormal_number>`
 more often, as these rare values can have strange interactions with
 `unsafe compiler optimisations like -ffast-math
@@ -47,7 +47,7 @@ more often, as these rare values can have strange interactions with
 6.24.5 - 2021-11-16
 -------------------
 
-This patch fixes a rare internal error in the :func:`hypothesis.strategies.datetimes`
+This patch fixes a rare internal error in the :func:`~hypothesis.strategies.datetimes`
 strategy, where the implementation of ``allow_imaginary=False`` crashed when checking
 a time during the skipped hour of a DST transition *if* the DST offset is negative -
 only true of ``Europe/Dublin``, who we presume have their reasons - and the ``tzinfo``

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -147,6 +147,9 @@ def integers(
     return IntegersStrategy(min_value, max_value)
 
 
+SIGNALING_NAN = int_to_float(0x7FF8_0000_0000_0001)  # nonzero mantissa
+assert math.isnan(SIGNALING_NAN) and math.copysign(1, SIGNALING_NAN) == 1
+
 NASTY_FLOATS = sorted(
     [
         0.0,
@@ -170,7 +173,8 @@ NASTY_FLOATS = sorted(
     ]
     + [2.0 ** -n for n in (24, 14, 149, 126)]  # minimum (sub)normals for float16,32
     + [float_info.min / n for n in (2, 10, 1000, 100_000)]  # subnormal in float64
-    + [math.inf, math.nan] * 5,
+    + [math.inf, math.nan] * 5
+    + [SIGNALING_NAN],
     key=flt.float_to_lex,
 )
 NASTY_FLOATS = list(map(float, NASTY_FLOATS))

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -20,9 +20,6 @@ to provide their own pretty print callbacks.
 This module is based on ruby's `prettyprint.rb` library by `Tanaka Akira`.
 Example Usage
 -------------
-To directly print the representation of an object use `pprint`::
-    from pretty import pprint
-    pprint(complex_object)
 To get a string of the output use `pretty`::
     from pretty import pretty
     string = pretty(complex_object)
@@ -73,7 +70,6 @@ Inheritance diagram:
 import datetime
 import platform
 import re
-import sys
 import types
 from collections import deque
 from contextlib import contextmanager
@@ -81,7 +77,6 @@ from io import StringIO
 
 __all__ = [
     "pretty",
-    "pprint",
     "PrettyPrinter",
     "RepresentationPrinter",
     "for_type_by_name",
@@ -118,19 +113,6 @@ def pretty(
     printer.pretty(obj)
     printer.flush()
     return stream.getvalue()
-
-
-def pprint(
-    obj, verbose=False, max_width=79, newline="\n", max_seq_length=MAX_SEQ_LENGTH
-):
-    """Like `pretty` but print to stdout."""
-    printer = RepresentationPrinter(
-        sys.stdout, verbose, max_width, newline, max_seq_length=max_seq_length
-    )
-    printer.pretty(obj)
-    printer.flush()
-    sys.stdout.write(newline)
-    sys.stdout.flush()
 
 
 class _PrettyPrinterBase:

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -61,8 +61,6 @@ import pytest
 from hypothesis.internal.compat import PYPY
 from hypothesis.vendor import pretty
 
-from tests.common.utils import capture_out
-
 
 class MyList:
     def __init__(self, content):
@@ -544,13 +542,6 @@ def test_cyclic_set():
     x = set()
     x.add(HashItAnyway(x))
     assert pretty.pretty(x) == "{{...}}"
-
-
-def test_pprint():
-    t = {"hi": 1}
-    with capture_out() as o:
-        pretty.pprint(t)
-    assert o.getvalue().strip() == pretty.pretty(t)
 
 
 class BigList(list):

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -59,6 +59,7 @@ from io import StringIO
 import pytest
 
 from hypothesis.internal.compat import PYPY
+from hypothesis.strategies._internal.numbers import SIGNALING_NAN
 from hypothesis.vendor import pretty
 
 
@@ -622,3 +623,17 @@ def test_empty_printer():
 
 def test_breakable_at_group_boundary():
     assert "\n" in pretty.pretty([[], "000000"], max_width=5)
+
+
+@pytest.mark.parametrize(
+    "obj, rep",
+    [
+        (float("nan"), "nan"),
+        (-float("nan"), "-nan"),
+        (SIGNALING_NAN, "nan  # Saw 1 signaling NaN"),
+        (-SIGNALING_NAN, "-nan  # Saw 1 signaling NaN"),
+        ((SIGNALING_NAN, SIGNALING_NAN), "(nan, nan)  # Saw 2 signaling NaNs"),
+    ],
+)
+def test_nan_reprs(obj, rep):
+    assert pretty.pretty(obj) == rep

--- a/hypothesis-python/tests/nocover/test_floating.py
+++ b/hypothesis-python/tests/nocover/test_floating.py
@@ -21,9 +21,10 @@ import sys
 import pytest
 
 from hypothesis import HealthCheck, assume, given, settings
-from hypothesis.internal.floats import next_down
+from hypothesis.internal.floats import float_to_int, next_down
 from hypothesis.strategies import data, floats, lists
 
+from tests.common.debug import find_any
 from tests.common.utils import fails
 
 TRY_HARDER = settings(
@@ -161,3 +162,16 @@ def test_floats_are_in_range(x, y, data):
 
     t = data.draw(floats(x, y))
     assert x <= t <= y
+
+
+@pytest.mark.parametrize("neg", [False, True])
+@pytest.mark.parametrize("snan", [False, True])
+def test_can_find_negative_and_signaling_nans(neg, snan):
+    find_any(
+        floats().filter(math.isnan),
+        lambda x: (
+            snan is (float_to_int(abs(x)) != float_to_int(float("nan")))
+            and neg is (math.copysign(1, x) == -1)
+        ),
+        settings=TRY_HARDER,
+    )


### PR DESCRIPTION
"Trap on snan" bit me a while ago, and this notation would have really helped to clarify what was going on in CI logs (though it generally doesn't affect e.g. numpy array elements).  It also boosts the probability of getting the canonical `snan` with only the last mantissa bit set, since snan is otherwise very very much rarer than standard nan.

After this patch, we have the property that *either* floats bitwise-roundtrip from their pretty reprs (new for `-nan`), *or* we have a comment to note that we printed however many signaling NaNs.