### PR TITLE
Faster, safer kwonly-arg codemods

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch makes the :command:`hypothesis codemod`
+:ref:`command <hypothesis-cli>` somewhat faster.

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -27,6 +27,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as npst
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.coverage import check, check_function
+from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.internal.validation import (
     check_type,
     check_valid_interval,
@@ -322,7 +323,7 @@ class column:
 
     name = attr.ib(default=None)
     elements = attr.ib(default=None)
-    dtype = attr.ib(default=None)
+    dtype = attr.ib(default=None, repr=get_pretty_function_description)
     fill = attr.ib(default=None)
     unique = attr.ib(default=False)
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -25,7 +25,6 @@ import inspect
 from copy import copy
 from functools import lru_cache
 from io import StringIO
-from operator import attrgetter
 from typing import (
     Any,
     Callable,
@@ -53,7 +52,12 @@ from hypothesis.core import TestFunc, given
 from hypothesis.errors import InvalidArgument, InvalidDefinition
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.healthcheck import fail_health_check
-from hypothesis.internal.reflection import function_digest, nicerepr, proxies
+from hypothesis.internal.reflection import (
+    function_digest,
+    get_pretty_function_description,
+    nicerepr,
+    proxies,
+)
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import current_verbosity, report
 from hypothesis.strategies._internal.featureflags import FeatureStrategy
@@ -405,7 +409,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
 @attr.s()
 class Rule:
     targets = attr.ib()
-    function = attr.ib(repr=attrgetter("__qualname__"))
+    function = attr.ib(repr=get_pretty_function_description)
     arguments = attr.ib()
     preconditions = attr.ib()
     bundles = attr.ib(init=False)
@@ -823,7 +827,7 @@ def precondition(precond: Callable[[Any], bool]) -> Callable[[TestFunc], TestFun
 
 @attr.s()
 class Invariant:
-    function = attr.ib()
+    function = attr.ib(repr=get_pretty_function_description)
     preconditions = attr.ib()
     check_during_init = attr.ib()
 

--- a/hypothesis-python/tests/codemods/test_codemods.py
+++ b/hypothesis-python/tests/codemods/test_codemods.py
@@ -118,3 +118,13 @@ class TestFixPositionalKeywonlyArgs(CodemodTest):
             target(**kwargs)
         """
         self.assertCodemod(before=before, after=before)
+
+    def test_noop_with_too_many_arguments_passed(self) -> None:
+        # If there are too many arguments, we should leave this alone to raise
+        # TypeError on older versions instead of deleting the additional args.
+        before = """
+            import hypothesis.strategies as st
+
+            st.sets(st.integers(), 0, 1, True)
+        """
+        self.assertCodemod(before=before, after=before)


### PR DESCRIPTION
This is a prerequisite for handling `allow_subnormal` properly in #3156.

(plus some repr fixes for #3144)