### PR TITLE
Handle unions of builtin generics

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes :issue:`3080`, where :func:`~hypothesis.strategies.from_type`
+failed on unions containing :pep:`585` builtin generic types (like ``list[int]``)
+in Python 3.9 and later.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -2249,7 +2249,7 @@ backport on PyPI.
 5.16.3 - 2020-06-21
 -------------------
 
-This patch precomputes some of the setup logic for our experimental
+This patch precomputes some of the setup logic for our
 :ref:`external fuzzer integration <fuzz_one_input>` and sets
 :obj:`deadline=None <hypothesis.settings.deadline>` in fuzzing mode,
 saving around 150us on each iteration.
@@ -3901,7 +3901,7 @@ some internal compatibility shims we use to support older Pythons.
 -------------------
 
 This release adds the :func:`hypothesis.target` function, which implements
-**experimental** support for :ref:`targeted property-based testing <targeted-search>`
+:ref:`targeted property-based testing <targeted-search>`
 (:issue:`1779`).
 
 By calling :func:`~hypothesis.target` in your test function, Hypothesis can

--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -413,8 +413,10 @@ high confidence in the system being tested than random PBT.
 (`Löscher and Sagonas <http://proper.softlab.ntua.gr/Publications.html>`__)
 
 This is not *always* a good idea - for example calculating the search metric
-might take time better spent running more uniformly-random test cases - but
-Hypothesis has **experimental** support for targeted PBT you may wish to try.
+might take time better spent running more uniformly-random test cases, or your
+target metric might accidentally lead Hypothesis *away* from bugs - but if
+there is a natural metric like "floating-point error", "load factor" or
+"queue length", we encourage you to experiment with targeted testing.
 
 .. autofunction:: hypothesis.target
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -941,8 +941,6 @@ class HypothesisHandle:
 
         Returns None if buffer invalid for the strategy, canonical pruned
         bytes if the buffer was valid, and leaves raised exceptions alone.
-
-        Note: this feature is experimental and may change or be removed.
         """
         # Note: most users, if they care about fuzzer performance, will access the
         # property and assign it to a local variable to move the attribute lookup

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -81,6 +81,7 @@ def type_sorting_key(t):
         raise InvalidArgument(f"thing={t} must be a type")  # pragma: no cover
     if t is None or t is type(None):  # noqa: E721
         return (-1, repr(t))
+    t = getattr(t, "__origin__", t)
     if not isinstance(t, type):  # pragma: no cover
         # Some generics in the typing module are not actually types in 3.7
         return (2, repr(t))

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -21,6 +21,8 @@ import pytest
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
 
+from tests.common.debug import find_any
+
 
 @pytest.mark.parametrize(
     "annotated_type,expected_strategy_repr",
@@ -85,3 +87,10 @@ def test_string_forward_ref_message():
     s = st.builds(User)
     with pytest.raises(InvalidArgument, match="`from __future__ import annotations`"):
         s.example()
+
+
+def test_issue_3080():
+    # Check for https://github.com/HypothesisWorks/hypothesis/issues/3080
+    s = st.from_type(typing.Union[list[int], int])
+    find_any(s, lambda x: isinstance(x, int))
+    find_any(s, lambda x: isinstance(x, list))


### PR DESCRIPTION
This turned out to be a much simpler fix that I feared.  Fixes #3080 for @SDesch.