### PR TITLE
Document `st.timezones()` windows-only dependency on `tzdata`, bump min version

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch documents :func:`~hypothesis.strategies.timezones`
+`Windows-only requirement <https://docs.python.org/3/library/zoneinfo.html#data-sources>`__
+for the :pypi:`tzdata` package, and ensures that
+``pip install hypothesis[zoneinfo]`` will install the latest version.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -71,7 +71,7 @@ extras = {
     # zoneinfo is an odd one: every dependency is conditional, because they're
     # only necessary on old versions of Python or Windows systems.
     "zoneinfo": [
-        "tzdata>=2020.4 ; sys_platform == 'win32'",
+        "tzdata>=2021.5 ; sys_platform == 'win32'",
         "backports.zoneinfo>=0.2.1 ; python_version<'3.9'",
         "importlib_resources>=3.3.0 ; python_version<'3.7'",
     ],

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -369,7 +369,6 @@ def mutually_broadcastable_shapes(
     * ``base_shape`` is the shape against which all generated shapes can broadcast.
       The default shape is empty, which corresponds to a scalar and thus does
       not constrain broadcasting at all.
-    * ``shape`` is a tuple of integers.
     * ``min_dims`` is the smallest length that the generated shape can possess.
     * ``max_dims`` is the largest length that the generated shape can possess,
       defaulting to ``max(len(shape), min_dims) + 2``.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -396,6 +396,9 @@ def timezone_keys(
         to install the :pypi:`backports.zoneinfo` module on earlier versions, and
         the :pypi:`importlib_resources` backport on Python 3.6.
 
+        `On Windows, you will also need to install the tzdata package
+        <https://docs.python.org/3/library/zoneinfo.html#data-sources>`__.
+
         ``pip install hypothesis[zoneinfo]`` will install these conditional
         dependencies if and only if they are needed.
 
@@ -453,6 +456,9 @@ def timezones(*, no_cache: bool = False) -> SearchStrategy["zoneinfo.ZoneInfo"]:
         The :mod:`python:zoneinfo` module is new in Python 3.9, so you will need
         to install the :pypi:`backports.zoneinfo` module on earlier versions, and
         the :pypi:`importlib_resources` backport on Python 3.6.
+
+        `On Windows, you will also need to install the tzdata package
+        <https://docs.python.org/3/library/zoneinfo.html#data-sources>`__.
 
         ``pip install hypothesis[zoneinfo]`` will install these conditional
         dependencies if and only if they are needed.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -98,7 +98,10 @@ def datetime_does_not_exist(value):
         # 9999, so it should be a very small fraction of possible values.
         return True
 
-    if value.tzinfo.utcoffset != roundtrip.tzinfo.utcoffset:
+    if (
+        value.tzinfo is not roundtrip.tzinfo
+        and value.utcoffset() != roundtrip.utcoffset()
+    ):
         # This only ever occurs during imaginary (i.e. nonexistent) datetimes,
         # and only for pytz timezones which do not follow PEP-495 semantics.
         # (may exclude a few other edge cases, but you should use zoneinfo anyway)

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -20,6 +20,8 @@ from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as nps
 
+from tests.common.utils import checks_deprecated_behaviour
+
 
 def e(a, **kwargs):
     kw = ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
@@ -267,8 +269,6 @@ def e(a, **kwargs):
         e(nps.basic_indices, shape=(0, 0), max_dims=-1),
         e(nps.basic_indices, shape=(0, 0), max_dims=1.0),
         e(nps.basic_indices, shape=(0, 0), min_dims=2, max_dims=1),
-        e(nps.basic_indices, shape=(0, 0), min_dims=50),
-        e(nps.basic_indices, shape=(0, 0), max_dims=50),
         e(nps.basic_indices, shape=(3, 3, 3), max_dims="not an int"),
         e(nps.integer_array_indices, shape=()),
         e(nps.integer_array_indices, shape=(2, 0)),
@@ -278,5 +278,18 @@ def e(a, **kwargs):
     ],
 )
 def test_raise_invalid_argument(function, kwargs):
+    with pytest.raises(InvalidArgument):
+        function(**kwargs).example()
+
+
+@pytest.mark.parametrize(
+    ("function", "kwargs"),
+    [
+        e(nps.basic_indices, shape=(0, 0), min_dims=50),
+        e(nps.basic_indices, shape=(0, 0), max_dims=50),
+    ],
+)
+@checks_deprecated_behaviour
+def test_raise_invalid_argument_deprecated(function, kwargs):
     with pytest.raises(InvalidArgument):
         function(**kwargs).example()

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -318,6 +318,13 @@ def update_vendored_files():
     if fname.read_bytes().splitlines()[1:] != new.splitlines()[1:]:
         fname.write_bytes(new)
 
+    # Always require the latest version of the tzdata package
+    tz_url = "https://pypi.org/pypi/tzdata/json"
+    tzdata_version = requests.get(tz_url).json()["info"]["version"]
+    setup = pathlib.Path(hp.BASE_DIR, "setup.py")
+    new = re.sub(r"tzdata>=(.+?) ", f"tzdata>={tzdata_version} ", setup.read_text())
+    setup.write_text(new)
+
 
 def has_diff(file_or_directory):
     diff = ["git", "diff", "--no-patch", "--exit-code", "--", file_or_directory]


### PR DESCRIPTION
Closes #3167.

I also made our weekly update PR bump the minimum required version of `tzdata`: while we usually want to permit working with older versions of our dependencies, the TZ database is an exception and should always be as kept up-to-date as possible.