### PR TITLE
Break between pprinting `DataFrame`s in failing examples

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch clarifies our pretty-printing of DataFrames (:issue:`3114`).

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -837,14 +837,16 @@ def _counter_pprint(obj, p, cycle):
             p.pretty(dict(obj))
 
 
+def _repr_dataframe(obj, p, cycle):  # pragma: no cover
+    with p.indent(4):
+        p.break_()
+        _repr_pprint(obj, p, cycle)
+    p.break_()
+
+
 for_type_by_name("collections", "defaultdict", _defaultdict_pprint)
 for_type_by_name("collections", "OrderedDict", _ordereddict_pprint)
 for_type_by_name("ordereddict", "OrderedDict", _ordereddict_pprint)
 for_type_by_name("collections", "deque", _deque_pprint)
 for_type_by_name("collections", "Counter", _counter_pprint)
-for_type_by_name("counter", "Counter", _counter_pprint)
-
-for_type_by_name("_collections", "defaultdict", _defaultdict_pprint)
-for_type_by_name("_collections", "OrderedDict", _ordereddict_pprint)
-for_type_by_name("_collections", "deque", _deque_pprint)
-for_type_by_name("_collections", "Counter", _counter_pprint)
+for_type_by_name("pandas.core.frame", "DataFrame", _repr_dataframe)


### PR DESCRIPTION
Fixes #3114.  Testing this turns out to be a flaky PITA due to dependencies and versions, but using the example from that issue:

```
Falsifying example: test_always_increasing(
    df_a=
                    A
        2021-01-01  1
    , df_b=
                    A
        2021-01-01  0
        2021-01-02  0
    ,
)
```

(the annoying lack of a newline in `, df_b=` is not pandas-specific and surprisingly tricky, so we can revisit that later)