### PR TITLE
Fix over-constrained singleton patterns from mutually broadcastable shapes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug in :func:`~hypothesis.extra.numpy.mutually_broadcastable_shapes`,
+which restricted the patterns of singleton dimensions that could be generated for
+dimensions that extended beyond ``base_shape`` (:issue:`3170`).

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -589,13 +589,14 @@ class MutuallyBroadcastableShapesStrategy(st.SearchStrategy):
                 # only a singleton is valid in alignment with the base-dim
                 dim_side = 1
 
+            allowed_sides = sorted([1, dim_side])  # shrink to 0 when available
             for shape_id, shape in enumerate(shapes):
                 # Populating this dimension-size for each shape, either
                 # the drawn size is used or, if permitted, a singleton
                 # dimension.
-                if dim_count <= len(base_shape) and self.size_one_allowed:
+                if dim <= len(result_shape) and self.size_one_allowed:
                     # aligned: shrink towards size 1
-                    side = data.draw(st.sampled_from([1, dim_side]))
+                    side = data.draw(st.sampled_from(allowed_sides))
                 else:
                     side = dim_side
 

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -388,7 +388,7 @@ def _arrays(
     dtype: Union[DataType, str, st.SearchStrategy[DataType], st.SearchStrategy[str]],
     shape: Union[int, Shape, st.SearchStrategy[Shape]],
     *,
-    elements: Optional[st.SearchStrategy] = None,
+    elements: Optional[Union[Mapping[str, Any], st.SearchStrategy]] = None,
     fill: Optional[st.SearchStrategy[Any]] = None,
     unique: bool = False,
 ) -> st.SearchStrategy:
@@ -779,7 +779,7 @@ def make_strategies_namespace(xp: Any) -> SimpleNamespace:
         ],
         shape: Union[int, Shape, st.SearchStrategy[Shape]],
         *,
-        elements: Optional[st.SearchStrategy] = None,
+        elements: Optional[Union[Mapping[str, Any], st.SearchStrategy]] = None,
         fill: Optional[st.SearchStrategy[Any]] = None,
         unique: bool = False,
     ) -> st.SearchStrategy:

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -81,7 +81,7 @@ def next_up(value, width=64):
 
     From https://stackoverflow.com/a/10426033, with thanks to Mark Dickinson.
     """
-    assert isinstance(value, float)
+    assert isinstance(value, float), f"{value!r} of type {type(value)}"
     if math.isnan(value) or (math.isinf(value) and value > 0):
         return value
     if value == 0.0 and is_negative(value):

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -258,7 +258,7 @@ def test_may_fill_unique_arrays_with_nan():
         xps.arrays(
             dtype=xp.float32,
             shape=10,
-            elements=st.floats(allow_nan=False),
+            elements={"allow_nan": False},
             unique=True,
             fill=st.just(xp.nan),
         ),
@@ -271,7 +271,7 @@ def test_may_fill_unique_arrays_with_nan():
     xps.arrays(
         dtype=xp.float32,
         shape=10,
-        elements=st.floats(allow_nan=False),
+        elements={"allow_nan": False},
         unique=True,
         fill=st.just(0.0),
     )
@@ -350,7 +350,7 @@ def test_floats_can_be_constrained_excluding_endpoints(x):
 @given(
     xps.arrays(
         dtype=xp.float32,
-        elements=st.floats(allow_nan=False, width=32),
+        elements={"allow_nan": False},
         shape=10,
         unique=True,
         fill=st.just(xp.nan),

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -403,7 +403,6 @@ def test_efficiently_generate_unique_arrays_using_all_elements(x):
 
 
 @needs_xp_unique_values
-@assumes_distinct_nans
 @given(st.data(), st.integers(-100, 100), st.integers(1, 100))
 def test_array_element_rewriting(data, start, size):
     """Unique strategy generates arrays with expected elements."""
@@ -416,7 +415,7 @@ def test_array_element_rewriting(data, start, size):
         )
     )
     x_set_expect = xp.linspace(start, start + size - 1, size, dtype=xp.int64)
-    x_set = xp.sort(xp.unique(x))
+    x_set = xp.sort(xp.unique_values(x))
     assert xp.all(x_set == x_set_expect)
 
 


### PR DESCRIPTION
Addresses an issue pointed out in #3170 regarding the quality of shapes generated by `hypothesis.extra.numpy.mutually_broadcastable_shapes`

There was a bug, which prevented the strategy from generating singleton dimensions paired against non-singleton dimensions, across shapes, unless those dimensions were aligned with the provided base-shape. 