### PR TITLE
Add annotations for @proxies reflection util

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves annotations on some of Hypothesis' internal functions, in order to 
+deobfuscate the signatures of some strategies. In particular, strategies shared between 
+:ref:`hypothesis.extra.numpy <hypothesis-numpy>` and 
+:ref:`the hypothesis.extra.array_api extra <array-api>` will benefit from this patch.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -570,7 +570,7 @@ def impersonate(target):
     return accept
 
 
-def proxies(target):
+def proxies(target: C) -> Callable[[Callable], C]:
     replace_sig = define_function_signature(
         target.__name__.replace("<lambda>", "_lambda_"),
         target.__doc__,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -22,10 +22,7 @@ from hypothesis.internal.floats import float_to_int
 from hypothesis.internal.reflection import proxies
 
 if TYPE_CHECKING:
-    from hypothesis.strategies._internal.strategies import (
-        SearchStrategy,
-        T,
-    )  # noqa: F401
+    from hypothesis.strategies._internal.strategies import SearchStrategy, T
 
 _strategies: Dict[str, Callable[..., "SearchStrategy"]] = {}
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -15,16 +15,21 @@
 
 import threading
 from inspect import signature
-from typing import TYPE_CHECKING, Callable, Dict
+from typing import TYPE_CHECKING, Callable, Dict, TypeVar
 
 from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.floats import float_to_int
 from hypothesis.internal.reflection import proxies
 
 if TYPE_CHECKING:
-    from hypothesis.strategies._internal.strategies import SearchStrategy, T
+    from hypothesis.strategies._internal.strategies import (
+        SearchStrategy,
+        T,
+    )  # noqa: F401
 
 _strategies: Dict[str, Callable[..., "SearchStrategy"]] = {}
+
+C = TypeVar("C", bound=Callable)
 
 
 class FloatKey:
@@ -63,7 +68,7 @@ def clear_cache() -> None:
     cache.clear()
 
 
-def cacheable(fn: "T") -> "T":
+def cacheable(fn: C) -> C:
     from hypothesis.strategies._internal.strategies import SearchStrategy
 
     @proxies(fn)


### PR DESCRIPTION
The use of @proxies to help "share" strategies between `hypothesis.extra.numpy` and `hypothesis.extra.array_api` left some strategies with obfuscated signatures.

E.g. in VSCode:

![image](https://user-images.githubusercontent.com/29104956/144717040-6390b1df-0156-4be7-bf7d-7e4d6082c780.png)

This patch provides annotations for `@proxies` and thus remedies this:

![image](https://user-images.githubusercontent.com/29104956/144717074-ec0838bd-87ab-4e97-851f-c0fb20a88464.png)
