### PR TITLE
add annotations to @proxies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves annotations on some of Hypothesis' internal functions, in order to 
+deobfuscate the signatures of some strategies. In particular, strategies shared between 
+:ref:`hypothesis.extra.numpy <hypothesis-numpy>` and 
+:ref:`the hypothesis.extra.array_api extra <array-api>` will benefit from this patch.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -26,12 +26,14 @@ import types
 from functools import wraps
 from tokenize import detect_encoding
 from types import ModuleType
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable
 
 from hypothesis.internal.compat import is_typed_named_tuple, update_code_location
 from hypothesis.vendor.pretty import pretty
 
-C = TypeVar("C", bound=Callable)
+if TYPE_CHECKING:
+    from hypothesis.strategies._internal.strategies import T
+
 READTHEDOCS = os.environ.get("READTHEDOCS", None) == "True"
 
 
@@ -570,9 +572,9 @@ def impersonate(target):
     return accept
 
 
-def proxies(target):
+def proxies(target: "T") -> Callable[[Callable], "T"]:
     replace_sig = define_function_signature(
-        target.__name__.replace("<lambda>", "_lambda_"),
+        target.__name__.replace("<lambda>", "_lambda_"),  # type: ignore
         target.__doc__,
         getfullargspec_except_self(target),
     )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -85,7 +85,7 @@ def cacheable(fn: "T") -> "T":
                 cache[cache_key] = result
             return result
 
-    cached_strategy.__clear_cache = clear_cache
+    cached_strategy.__clear_cache = clear_cache  # type: ignore
     return cached_strategy
 
 


### PR DESCRIPTION
The use of @proxies to help "share" strategies between `hypothesis.extra.numpy` and `hypothesis.extra.array_api` left some strategies with obfuscated signatures.

E.g. in VSCode:

![image](https://user-images.githubusercontent.com/29104956/144717040-6390b1df-0156-4be7-bf7d-7e4d6082c780.png)

This patch provides annotations for `@proxies` and thus remedies this:

![image](https://user-images.githubusercontent.com/29104956/144717074-ec0838bd-87ab-4e97-851f-c0fb20a88464.png)
