### PR TITLE
Prevent `xps.indices()` from generating indices that flat index arrays

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch updates :func:`xps.indices` so no flat indices are generated, i.e.
+generated indices will now always explicitly cover each axes of an array if no
+ellipsis is present. This is to be consistent with a specification change that
+dropped support for flat indexing
+(`#272 <https://github.com/data-apis/array-api/pull/272>`_).

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -685,7 +685,7 @@ class BasicIndexStrategy(st.SearchStrategy):
             while j < len(result) and result[j] == slice(None):
                 j += 1
             result[i:j] = [Ellipsis]
-        elif self.allow_fewer_indices_than_dims:
+        elif self.allow_fewer_indices_than_dims:  # pragma: no cover
             while result[-1:] == [slice(None, None)] and data.draw(st.integers(0, 7)):
                 result.pop()
         if len(result) == 1 and data.draw(st.booleans()):

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -731,13 +731,12 @@ def indices(
     )
     check_valid_dims(min_dims, "min_dims")
 
-    ndim = len(shape)
     if max_dims is None:
-        max_dims = min(ndim, NDIM_MAX)
+        max_dims = min(len(shape), NDIM_MAX)
     check_type(int, max_dims, "max_dims")
     assert isinstance(max_dims, int)
     check_argument(
-        max_dims <= ndim,
+        max_dims <= len(shape),
         f"max_dims={max_dims} is larger than len(shape)={len(shape)}, "
         "but it is impossible for an indexing operation to add dimensions.",
     )

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -750,7 +750,7 @@ def indices(
         max_dims=max_dims,
         allow_ellipsis=allow_ellipsis,
         allow_newaxis=False,
-        flat_index=False,
+        allow_fewer_indices_than_dims=False,
     )
 
 

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -719,10 +719,6 @@ def indices(
     """
     check_type(tuple, shape, "shape")
     check_argument(
-        len(shape) != 0,
-        "No valid indices for zero-dimensional arrays",
-    )
-    check_argument(
         all(isinstance(x, int) and x >= 0 for x in shape),
         f"shape={shape!r}, but all dimensions must be non-negative integers.",
     )

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -745,25 +745,14 @@ def indices(
 
     order_check("dims", 0, min_dims, max_dims)
 
-    def not_flat_index(idx):
-        """Check idx would not flat index an array
-
-        Libraries such as NumPy proper support indexing a single-axis of a
-        higher-dimensional array, but that is out-of-scope for the Array API.
-        """
-        _idx = idx if isinstance(idx, tuple) else (idx,)
-        if Ellipsis in _idx:
-            return True
-        else:
-            return len(_idx) == ndim
-
     return BasicIndexStrategy(
         shape,
         min_dims=min_dims,
         max_dims=max_dims,
         allow_ellipsis=allow_ellipsis,
         allow_newaxis=False,
-    ).filter(not_flat_index)
+        flat_index=False,
+    )
 
 
 def make_strategies_namespace(xp: Any) -> SimpleNamespace:

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -731,12 +731,13 @@ def indices(
     )
     check_valid_dims(min_dims, "min_dims")
 
+    ndim = len(shape)
     if max_dims is None:
-        max_dims = min(len(shape), NDIM_MAX)
+        max_dims = min(ndim, NDIM_MAX)
     check_type(int, max_dims, "max_dims")
     assert isinstance(max_dims, int)
     check_argument(
-        max_dims <= len(shape),
+        max_dims <= ndim,
         f"max_dims={max_dims} is larger than len(shape)={len(shape)}, "
         "but it is impossible for an indexing operation to add dimensions.",
     )
@@ -744,13 +745,25 @@ def indices(
 
     order_check("dims", 0, min_dims, max_dims)
 
+    def not_flat_index(idx):
+        """Check idx would not flat index an array
+
+        Libraries such as NumPy proper support indexing a single-axis of a
+        higher-dimensional array, but that is out-of-scope for the Array API.
+        """
+        _idx = idx if isinstance(idx, tuple) else (idx,)
+        if Ellipsis in _idx:
+            return True
+        else:
+            return len(_idx) == ndim
+
     return BasicIndexStrategy(
         shape,
         min_dims=min_dims,
         max_dims=max_dims,
         allow_ellipsis=allow_ellipsis,
         allow_newaxis=False,
-    )
+    ).filter(not_flat_index)
 
 
 def make_strategies_namespace(xp: Any) -> SimpleNamespace:

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -880,6 +880,7 @@ def basic_indices(
         max_dims=max_dims,
         allow_ellipsis=allow_ellipsis,
         allow_newaxis=allow_newaxis,
+        flat_index=True,
     )
 
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -880,7 +880,7 @@ def basic_indices(
         max_dims=max_dims,
         allow_ellipsis=allow_ellipsis,
         allow_newaxis=allow_newaxis,
-        flat_index=True,
+        allow_fewer_indices_than_dims=True,
     )
 
 

--- a/hypothesis-python/tests/array_api/test_argument_validation.py
+++ b/hypothesis-python/tests/array_api/test_argument_validation.py
@@ -207,7 +207,6 @@ def e(a, **kwargs):
         e(xps.indices, shape=(0, 0), max_dims=-1),
         e(xps.indices, shape=(0, 0), max_dims=1.0),
         e(xps.indices, shape=(0, 0), min_dims=2, max_dims=1),
-        e(xps.indices, shape=()),
         e(xps.indices, shape=5, min_dims=0),
         e(xps.indices, shape=(5,), min_dims=2),
         e(xps.indices, shape=(5,), max_dims=2),

--- a/hypothesis-python/tests/array_api/test_indices.py
+++ b/hypothesis-python/tests/array_api/test_indices.py
@@ -107,9 +107,7 @@ def test_generate_valid_indices(shape, allow_ellipsis, data):
     # Check index is composed of valid objects
     for i in _idx:
         assert isinstance(i, int) or isinstance(i, slice) or i == Ellipsis
-    # Check idx does not flat index. Libraries such as NumPy proper support
-    # indexing a single-axis of a higher-dimensional array, but that is
-    # out-of-scope for the Array API.
+    # Check idx does not flat index
     if Ellipsis in _idx:
         assert sum(i == Ellipsis for i in _idx) == 1
         assert len(_idx) <= len(shape) + 1  # Ellipsis can index 0 axes

--- a/hypothesis-python/tests/array_api/test_indices.py
+++ b/hypothesis-python/tests/array_api/test_indices.py
@@ -73,7 +73,7 @@ def test_indices_replaces_whole_axis_slices_with_ellipsis(idx):
 
 
 @given(xps.indices((3, 3, 3, 3, 3)))
-def test_effeciently_generate_indexers(_):
+def test_efficiently_generate_indexers(_):
     """Generation is not too slow."""
 
 
@@ -89,30 +89,30 @@ def test_generate_valid_indices(shape, allow_ellipsis, data):
     max_dims = data.draw(
         st.none() | st.integers(min_dims, len(shape)), label="max_dims"
     )
-    idx = data.draw(
+    indexer = data.draw(
         xps.indices(
             shape,
             min_dims=min_dims,
             max_dims=max_dims,
             allow_ellipsis=allow_ellipsis,
         ),
-        label="idx",
+        label="indexer",
     )
 
-    _idx = idx if isinstance(idx, tuple) else (idx,)
+    _indexer = indexer if isinstance(indexer, tuple) else (indexer,)
     # Check that disallowed things are indeed absent
     if not allow_ellipsis:
-        assert Ellipsis not in _idx
-    assert None not in _idx  # i.e. np.newaxis
+        assert Ellipsis not in _indexer
+    assert None not in _indexer  # i.e. np.newaxis
     # Check index is composed of valid objects
-    for i in _idx:
+    for i in _indexer:
         assert isinstance(i, int) or isinstance(i, slice) or i == Ellipsis
-    # Check idx does not flat index
-    if Ellipsis in _idx:
-        assert sum(i == Ellipsis for i in _idx) == 1
-        assert len(_idx) <= len(shape) + 1  # Ellipsis can index 0 axes
+    # Check indexer does not flat index
+    if Ellipsis in _indexer:
+        assert sum(i == Ellipsis for i in _indexer) == 1
+        assert len(_indexer) <= len(shape) + 1  # Ellipsis can index 0 axes
     else:
-        assert len(_idx) == len(shape)
+        assert len(_indexer) == len(shape)
 
     if 0 in shape:
         # If there's a zero in the shape, the array will have no elements.
@@ -125,4 +125,4 @@ def test_generate_valid_indices(shape, allow_ellipsis, data):
         # We can't cheat on this one, so just try another.
         assume(False)
     # Finally, check that we can use our indexer without error
-    array[idx]
+    array[indexer]

--- a/hypothesis-python/tests/array_api/test_indices.py
+++ b/hypothesis-python/tests/array_api/test_indices.py
@@ -32,17 +32,18 @@ def test_generate_indices_with_and_without_ellipsis():
     find_any(strat, lambda ix: Ellipsis not in ix)
 
 
-def test_generate_empty_tuple():
-    """Strategy generates empty tuples as indices."""
-    find_any(xps.indices(shape=(0, 0), allow_ellipsis=True), lambda ix: ix == ())
+@given(xps.indices(shape=(), allow_ellipsis=True))
+def test_generate_indices_for_0d_shape(idx):
+    """Strategy only generates empty tuples or Ellipsis as indices for an empty
+    shape."""
+    assert idx in [(), Ellipsis, (Ellipsis,)]
 
 
-def test_generate_non_tuples():
-    """Strategy generates non-tuples as indices."""
-    find_any(
-        xps.indices(shape=(0, 0), allow_ellipsis=True),
-        lambda ix: not isinstance(ix, tuple),
-    )
+def test_generate_tuples_and_non_tuples_for_1d_shape():
+    """Strategy can generate tuple and non-tuple indices with a 1-dimensional shape."""
+    strat = xps.indices(shape=(1,), allow_ellipsis=True)
+    find_any(strat, lambda ix: isinstance(ix, tuple))
+    find_any(strat, lambda ix: not isinstance(ix, tuple))
 
 
 def test_generate_long_ellipsis():
@@ -72,7 +73,7 @@ def test_indices_replaces_whole_axis_slices_with_ellipsis(idx):
 
 
 @given(xps.indices((3, 3, 3, 3, 3)))
-def test_indices_effeciently_generate_indexers(_):
+def test_effeciently_generate_indexers(_):
     """Generation is not too slow."""
 
 

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -1128,6 +1128,18 @@ def test_basic_indices_replaces_whole_axis_slices_with_ellipsis(idx):
     assert slice(None) not in idx
 
 
+def test_basic_indices_can_generate_indices_not_covering_all_dims():
+    # These "flat indices" are skippable in the underlying BasicIndexStrategy,
+    # so we ensure we're definitely generating them for nps.basic_indices().
+    find_any(
+        nps.basic_indices(shape=(3, 3, 3)),
+        lambda ix: (
+            (not isinstance(ix, tuple) and ix != Ellipsis)
+            or (isinstance(ix, tuple) and Ellipsis not in ix and len(ix) < 3)
+        ),
+    )
+
+
 @given(
     shape=nps.array_shapes(min_dims=0, max_side=4)
     | nps.array_shapes(min_dims=0, min_side=0, max_side=10),


### PR DESCRIPTION
Resolves #3166.

I opted to simply filter the base `extra._array_helpers.BasicIndexStrategy` used inside of `extra.array_api._indices()`, which seems to do the trick... I didn't want to play around the internals haha. Let me know if you'd like a solution that doesn't filter itself. I'm fairly happy with the testing situation for indices now at least. 