### PR TITLE
Replace `MultipleFailures` with `ExceptionGroup` on Python 3.11+

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release converts our ``MultipleFailures`` reporting to use the new builtin
+``ExceptionGroup`` type on Python 3.11, which is currently in alpha (:issue:`3175`).

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -133,9 +133,20 @@ class Frozen(HypothesisException):
     after freeze() has been called."""
 
 
-class MultipleFailures(_Trimmable):
-    """Indicates that Hypothesis found more than one distinct bug when testing
-    your code."""
+try:
+    MultipleFailures = ExceptionGroup  # type: ignore
+except NameError:  # pragma: no branch
+
+    class MultipleFailures(_Trimmable):  # type: ignore
+        """Indicates that Hypothesis found more than one distinct bug when testing
+        your code.
+
+        In Python 3.11+, this is an alias for the builtin ExceptionGroup type.
+        """
+
+        def __init__(self, message, exceptions):
+            super().__init__(message)
+            self.exceptions = tuple(exceptions)
 
 
 class DeadlineExceeded(_Trimmable):


### PR DESCRIPTION
> [PEP 654](https://www.python.org/dev/peps/pep-0654/) introduces a new `ExceptionGroup` type, which is designed to replace Trio's `MultiError` and our very own `MultipleFailures` types.  There's also neat new `except*` syntax for handling them, but that's not our problem.  Based on [our conversation](https://discuss.python.org/t/accepting-pep-654-exception-groups-and-except/10813/9), @iritkatriel also [added `BaseException.__note__`](https://github.com/python/cpython/pull/29880) so that we can attach our `Failing example:` strings (etc) to the exception objects, instead of printing them by hand.

Closes #3175, related to https://github.com/HypothesisWorks/hypothesis/issues/2192#issuecomment-554807528.

<details>
<summary>Example outputs on Python 3.9.8 and 3.11.0a3</summary>

```python
from hypothesis import given, strategies as st, target

@given(st.integers())
def test(x):
    target(x)
    assert x < 0
    assert x > 0
```

Running ` pytest test.py` prints, for respectively Python 3.9.8 and 3.11.0a3:

```python-traceback
Traceback (most recent call last):
  File "test.py", line 4, in test
    def test(x):
  File "hypothesis/core.py", line 1202, in wrapped_test
    raise the_error_hypothesis_found
hypothesis.errors.MultipleFailures: Hypothesis found 2 distinct failures.
--------------------------------- Hypothesis ----------------------------------
Highest target score: 1  (label='')

Falsifying example: test(
    x=-1,
)
Traceback (most recent call last):
  File "test.py", line 7, in test
    assert x > 0
AssertionError: assert -1 > 0

Falsifying example: test(
    x=0,
)
Traceback (most recent call last):
  File "test.py", line 6, in test
    assert x < 0
AssertionError: assert 0 < 0

```
```python-traceback
_______________________________________________ test _______________________________________________
  + Exception Group Traceback (most recent call last):
  |   File "test.py", line 4, in test
  |     def test(x):
  |
  |   File "hypothesis/core.py", line 1202, in wrapped_test
  |     raise the_error_hypothesis_found
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | ExceptionGroup: Hypothesis found 2 distinct failures.
  |
  | Highest target score: 1  (label='')
  |
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "test.py", line 7, in test
    |     assert x > 0
    |     ^^^^^^^^^^^^
    | AssertionError: assert -1 > 0
    |
    | Falsifying example: test(
    |     x=-1,
    | )
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "test.py", line 6, in test
    |     assert x < 0
    |     ^^^^^^^^^^^^
    | AssertionError: assert 0 < 0
    |
    | Falsifying example: test(
    |     x=0,
    | )
    +------------------------------------
```

</details>

So use of the new `__note__` approach does change the relative order of traceback and other information, but I don't think that's a big deal - we can reverse our own printing for consistency if it's important, because there are clear upstream reasons to display the `__note__` in relation to the exception object rather than the traceback.

I'm ambivalent about using `__note__` for singular errors, but if we want to that's left for future work in order to keep this diff small.