### PR TITLE
Private internal patch to help downstream jsonschema regex support

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds a temporary hook for a downstream tool,
+which is not part of the public API.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
@@ -213,7 +213,7 @@ def base_regex_strategy(regex, parsed=None):
     )
 
 
-def regex_strategy(regex, fullmatch):
+def regex_strategy(regex, fullmatch, *, _temp_jsonschema_hack_no_end_newline=False):
     if not hasattr(regex, "pattern"):
         regex = re.compile(regex)
 
@@ -254,6 +254,15 @@ def regex_strategy(regex, fullmatch):
                 )
             else:
                 right_pad = st.one_of(empty, newline)
+
+            # This will be removed when a regex-syntax-translation library exists.
+            # It's a pretty nasty hack, but means that we can match the semantics
+            # of JSONschema's compatible subset of ECMA regex, which is important
+            # for hypothesis-jsonschema and Schemathesis. See e.g.
+            # https://github.com/schemathesis/schemathesis/issues/1241
+            if _temp_jsonschema_hack_no_end_newline:
+                right_pad = empty
+
     if parsed[0][0] == sre.AT:
         if parsed[0][1] == sre.AT_BEGINNING_STRING:
             left_pad = empty

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -25,6 +25,7 @@ from hypothesis.strategies._internal.regex import (
     UNICODE_SPACE_CHARS,
     UNICODE_WORD_CATEGORIES,
     base_regex_strategy,
+    regex_strategy,
 )
 
 from tests.common.debug import assert_all_examples, assert_no_examples, find_any
@@ -461,4 +462,13 @@ def test_sets_allow_multichar_output_in_ignorecase_mode():
     find_any(
         st.from_regex(re.compile("[\u0130_]", re.IGNORECASE)),
         lambda s: len(s) > 1,
+    )
+
+
+def test_internals_can_disable_newline_from_dollar_for_jsonschema():
+    pattern = "^abc$"
+    find_any(st.from_regex(pattern), lambda s: s == "abc\n")
+    assert_all_examples(
+        regex_strategy(pattern, False, _temp_jsonschema_hack_no_end_newline=True),
+        lambda s: s == "abc",
     )


### PR DESCRIPTION
Python allows a trailing newline for `...$` regex, but jsonschema doesn't - and that's the only blocker for [perfect compatibility with the recommended jsonschema regex syntax](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html), which is a problem in practice (see e.g. https://github.com/schemathesis/schemathesis/issues/1241 and https://github.com/schemathesis/schemathesis/issues/1350).

I'm hardly *delighted* to carry such a patch in Hypothesis, but it's clearly the best place to solve this problem for many end-users downstream.  We already have similar patches to handle e.g. library-specific `Skip` exceptions, `numpy.random`, and a few other things, and as private internals this can be cleanly and immediately removed if a better solution becomes possible.