### PR TITLE
Improve error messages for Pandas when `dtype=object` is omitted

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release fixes :issue:`3133` and :issue:`3144`, where attempting
+to generate Pandas series of lists or sets would fail with confusing
+errors if you did not specify ``dtype=object``.

--- a/hypothesis-python/tests/pandas/test_argument_validation.py
+++ b/hypothesis-python/tests/pandas/test_argument_validation.py
@@ -16,6 +16,7 @@ from hypothesis import given, strategies as st
 from hypothesis.extra import pandas as pdst
 
 from tests.common.arguments import argument_validation_test, e
+from tests.common.utils import checks_deprecated_behaviour
 
 BAD_ARGS = [
     e(pdst.data_frames),
@@ -91,3 +92,8 @@ def test_timestamp_as_datetime_bounds(dt):
     assert isinstance(dt, datetime)
     assert lo <= dt <= hi
     assert not isinstance(dt, pd.Timestamp)
+
+
+@checks_deprecated_behaviour
+def test_confusing_object_dtype_aliases():
+    pdst.series(elements=st.tuples(st.integers()), dtype=tuple).example()


### PR DESCRIPTION
Closes #3133 and closes #3144.  In both cases it's either impossible or too-magical to actually support what they're trying to do, but we can give detailed and helpful error messages 😁 