### PR TITLE
Allow for min_value, max_value on binary strategy

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -682,6 +682,8 @@ def binary(
     *,
     min_size: int = 0,
     max_size: Optional[int] = None,
+    min_value: int = 0,
+    max_value: int = 255,
 ) -> SearchStrategy[bytes]:
     """Generates :class:`python:bytes`.
 
@@ -695,7 +697,9 @@ def binary(
     if min_size == max_size:
         return FixedSizeBytes(min_size)
     return lists(
-        integers(min_value=0, max_value=255), min_size=min_size, max_size=max_size
+        integers(min_value=min_value, max_value=max_value),
+        min_size=min_size,
+        max_size=max_size,
     ).map(bytes)
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -689,6 +689,9 @@ def binary(
 
     The generated :class:`python:bytes` will have a length of at least ``min_size``
     and at most ``max_size``.  If ``max_size`` is None there is no upper limit.
+    
+    To control the byte range specify a lower and upper range using ``min_value``
+    and ``max_value``.  The default range is from 0 to 255.
 
     Examples from this strategy shrink towards smaller strings and lower byte
     values.


### PR DESCRIPTION
This extends binary strategy with two new arguments using the previous range - but allowing for adjustment.  This helps test binary data that would otherwise be encodable when attempting to raise issues with an encoder.

For instance:

```python
>>> str(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', encoding='ascii')
'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'

>>> str(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80', encoding='ascii')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0x80 in position 9: ordinal not in range(128)
```