### PR TITLE
Annotate decorators with `ParamSpec`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
-This preserves the type annotations of functions passed to :func:`hypothesis.strategies.composite`, :func:`hypothesis.strategies.functions`, and :func:`hypothesis.given` by using :obj:`python:typing.ParamSpec`.
+This preserves the type annotations of functions passed to :func:`hypothesis.strategies.composite` and :func:`hypothesis.strategies.functions` by using :obj:`python:typing.ParamSpec`.
 
 This improves the ability of static type-checkers to check test code that uses Hypothesis, and improves auto-completion in IDEs.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This preserves the type annotations of functions passed to :func:`hypothesis.strategies.composite`, :func:`hypothesis.strategies.functions`, and :func:`hypothesis.given` by using :obj:`python:typing.ParamSpec`.
+
+This improves the ability of static type-checkers to check test code that uses Hypothesis, and improves auto-completion in IDEs.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -37,6 +37,7 @@ from typing import (
 from unittest import TestCase
 
 import attr
+from typing_extensions import ParamSpec
 
 from hypothesis import strategies as st
 from hypothesis._settings import (
@@ -948,12 +949,13 @@ class HypothesisHandle:
             return self.__cached_target
 
 
+P = ParamSpec("P")
+
+
 def given(
     *_given_arguments: Union[SearchStrategy, InferType],
     **_given_kwargs: Union[SearchStrategy, InferType],
-) -> Callable[
-    [Callable[..., Union[None, Coroutine[Any, Any, None]]]], Callable[..., None]
-]:
+) -> Callable[[Callable[P, Union[None, Coroutine[Any, Any, None]]]], Callable[P, None]]:
     """A decorator for turning a test function that accepts arguments into a
     randomized test.
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -37,7 +37,6 @@ from typing import (
 from unittest import TestCase
 
 import attr
-from typing_extensions import ParamSpec
 
 from hypothesis import strategies as st
 from hypothesis._settings import (
@@ -949,13 +948,10 @@ class HypothesisHandle:
             return self.__cached_target
 
 
-P = ParamSpec("P")
-
-
 def given(
     *_given_arguments: Union[SearchStrategy, InferType],
     **_given_kwargs: Union[SearchStrategy, InferType],
-) -> Callable[[Callable[P, Union[None, Coroutine[Any, Any, None]]]], Callable[P, None]]:
+) -> Callable[[Callable[..., Union[None, Coroutine[Any, Any, None]]]], Callable[..., None]]:
     """A decorator for turning a test function that accepts arguments into a
     randomized test.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1854,13 +1854,16 @@ def emails() -> SearchStrategy[str]:
 
 
 P = ParamSpec("P")
+T = TypeVar("T")
+
+
 @defines_strategy()
 def functions(
     *,
-    like: Callable[P, Any] = lambda: None,
-    returns: Optional[SearchStrategy[Any]] = None,
+    like: Callable[P, T] = lambda: None,
+    returns: Optional[SearchStrategy[T]] = None,
     pure: bool = False,
-) -> SearchStrategy[Callable[P, Any]]:
+) -> SearchStrategy[Callable[P, T]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737
     """functions(*, like=lambda: None, returns=none(), pure=False)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -43,7 +43,7 @@ from typing import (
 from uuid import UUID
 
 import attr
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import Concatenate
 
 from hypothesis.control import cleanup, note
 from hypothesis.errors import InvalidArgument, ResolutionFailed
@@ -95,6 +95,7 @@ from hypothesis.strategies._internal.recursive import RecursiveStrategy
 from hypothesis.strategies._internal.shared import SharedStrategy
 from hypothesis.strategies._internal.strategies import (
     Ex,
+    P,
     SampledFromStrategy,
     T,
     one_of,
@@ -1451,9 +1452,6 @@ class DrawFn(Protocol):
         raise NotImplementedError
 
 
-P = ParamSpec("P")
-
-
 @cacheable
 def composite(
     f: Callable[Concatenate[DrawFn, P], Ex]
@@ -1851,10 +1849,6 @@ def emails() -> SearchStrategy[str]:
     return builds("{}@{}".format, local_part, domains()).filter(
         lambda addr: len(addr) <= 254
     )
-
-
-P = ParamSpec("P")
-T = TypeVar("T")
 
 
 @defines_strategy()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1854,10 +1854,10 @@ def emails() -> SearchStrategy[str]:
 @defines_strategy()
 def functions(
     *,
-    like: Callable[P, T] = lambda: None,
-    returns: Optional[SearchStrategy[T]] = None,
+    like: Callable[P, Any] = lambda: None,
+    returns: Optional[SearchStrategy[Any]] = None,
     pure: bool = False,
-) -> SearchStrategy[Callable[P, T]]:
+) -> SearchStrategy[Callable[P, Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737
     """functions(*, like=lambda: None, returns=none(), pure=False)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -43,6 +43,7 @@ from typing import (
 from uuid import UUID
 
 import attr
+from typing_extensions import Concatenate, ParamSpec
 
 from hypothesis.control import cleanup, note
 from hypothesis.errors import InvalidArgument, ResolutionFailed
@@ -1450,8 +1451,13 @@ class DrawFn(Protocol):
         raise NotImplementedError
 
 
+P = ParamSpec("P")
+
+
 @cacheable
-def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
+def composite(
+    f: Callable[Concatenate[DrawFn, P], Ex]
+) -> Callable[P, SearchStrategy[Ex]]:
     """Defines a strategy that is built out of potentially arbitrarily many
     other strategies.
 
@@ -1847,13 +1853,14 @@ def emails() -> SearchStrategy[str]:
     )
 
 
+P = ParamSpec("P")
 @defines_strategy()
 def functions(
     *,
-    like: Callable[..., Any] = lambda: None,
+    like: Callable[P, Any] = lambda: None,
     returns: Optional[SearchStrategy[Any]] = None,
     pure: bool = False,
-) -> SearchStrategy[Callable[..., Any]]:
+) -> SearchStrategy[Callable[P, Any]]:
     # The proper type signature of `functions()` would have T instead of Any, but mypy
     # disallows default args for generics: https://github.com/python/mypy/issues/3737
     """functions(*, like=lambda: None, returns=none(), pure=False)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -24,6 +24,8 @@ from typing import (
     overload,
 )
 
+from typing_extensions import ParamSpec
+
 from hypothesis._settings import HealthCheck, Phase, Verbosity, settings
 from hypothesis.control import _current_build_context, assume
 from hypothesis.errors import (
@@ -54,6 +56,7 @@ T = TypeVar("T")
 T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 T5 = TypeVar("T5")
+P = ParamSpec("P")
 
 calculating = UniqueIdentifier("calculating")
 

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -181,20 +181,6 @@ def test_settings_preserves_type(tmpdir):
     assert got == "def (x: int) -> int"
 
 
-def test_given_preserves_type(tmpdir):
-    f = tmpdir.join("check_mypy_on_given.py")
-    f.write(
-        "from hypothesis import given\n"
-        "from hypothesis.strategies import integers\n"
-        "@given(integers())\n"
-        "def f(x: int) -> int:\n"
-        "    return x\n"
-        "reveal_type(f)\n"
-    )
-    got = get_mypy_analysed_type(str(f.realpath()), ...)
-    assert got == "def (x: int) -> int"
-
-
 def test_stateful_bundle_generic_type(tmpdir):
     f = tmpdir.join("check_mypy_on_stateful_bundle.py")
     f.write(

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -142,11 +142,51 @@ def test_drawfn_type_tracing(tmpdir):
     assert got == "str"
 
 
+def test_composite_type_tracing(tmpdir):
+    f = tmpdir.join("check_mypy_on_st_composite.py")
+    f.write(
+        "from hypothesis.strategies import composite, DrawFn\n"
+        "@composite"
+        "def comp(draw: DrawFn, x: int) -> int:\n"
+        "    return x\n"
+        "reveal_type(comp)"
+    )
+    got = get_mypy_analysed_type(str(f.realpath()), ...)
+    assert got == "def (x: int) -> int"
+
+
+def test_functions_type_tracing(tmpdir):
+    f = tmpdir.join("check_mypy_on_st_functions.py")
+    f.write(
+        "from hypothesis.strategies import functions\n"
+        "def like(x: int, y: str) -> str:"
+        "    return str(x) + y"
+        "st = functions(like)"
+        "reveal_type(st)"
+    )
+    got = get_mypy_analysed_type(str(f.realpath()), ...)
+    assert got == "SearchStrategy[Callable[[int, str], str]]"
+
+
 def test_settings_preserves_type(tmpdir):
     f = tmpdir.join("check_mypy_on_settings.py")
     f.write(
         "from hypothesis import settings\n"
         "@settings(max_examples=10)\n"
+        "def f(x: int) -> int:\n"
+        "    return x\n"
+        "reveal_type(f)\n"
+    )
+    got = get_mypy_analysed_type(str(f.realpath()), ...)
+    assert got == "def (x: int) -> int"
+
+
+def test_given_preserves_type(tmpdir):
+    f = tmpdir.join("check_mypy_on_given.py")
+    f.write(
+        "from hypothesis import given\n"
+        "from hypothesis.strategies import integers\n"
+        "@given(integers())\n"
         "def f(x: int) -> int:\n"
         "    return x\n"
         "reveal_type(f)\n"

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -146,10 +146,10 @@ def test_composite_type_tracing(tmpdir):
     f = tmpdir.join("check_mypy_on_st_composite.py")
     f.write(
         "from hypothesis.strategies import composite, DrawFn\n"
-        "@composite"
+        "@composite\n"
         "def comp(draw: DrawFn, x: int) -> int:\n"
         "    return x\n"
-        "reveal_type(comp)"
+        "reveal_type(comp)\n"
     )
     got = get_mypy_analysed_type(str(f.realpath()), ...)
     assert got == "def (x: int) -> int"
@@ -159,10 +159,10 @@ def test_functions_type_tracing(tmpdir):
     f = tmpdir.join("check_mypy_on_st_functions.py")
     f.write(
         "from hypothesis.strategies import functions\n"
-        "def like(x: int, y: str) -> str:"
-        "    return str(x) + y"
-        "st = functions(like)"
-        "reveal_type(st)"
+        "def like(x: int, y: str) -> str:\n"
+        "    return str(x) + y\n"
+        "st = functions(like)\n"
+        "reveal_type(st)\n"
     )
     got = get_mypy_analysed_type(str(f.realpath()), ...)
     assert got == "SearchStrategy[Callable[[int, str], str]]"


### PR DESCRIPTION
This uses `typing.ParamSpec` on `composite` and `functions`. This should allow type-checkers and IDEs to infer the signatures of functions returned by these decorators. For `composite` and `functions`, I find this especially helpful.