### PR TITLE
ParamSpec for `@st.composite` annotations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,6 +52,7 @@ their individual contributions.
 * `Felix Sheldon <https://www.github.com/darkpaw>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
+* `Gabe Joseph <https://github.com/gjoseph92>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release uses :pep:`612` :obj:`python:typing.ParamSpec` (or the
+:pypi:`typing_extensions` backport) to express the first-argument-removing
+behaviour of :func:`@st.composite <hypothesis.strategies.composite>`
+to IDEs, editor plugins, and static type checkers such as :pypi:`mypy`.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -111,6 +111,14 @@ try:
 except ImportError:  # < py3.8
     Protocol = object  # type: ignore[assignment]
 
+try:
+    from typing import Concatenate, ParamSpec
+except ImportError:
+    try:
+        from typing_extensions import Concatenate, ParamSpec
+    except ImportError:
+        ParamSpec = None
+
 UniqueBy = Union[Callable[[Ex], Hashable], Tuple[Callable[[Ex], Hashable], ...]]
 
 
@@ -1494,6 +1502,16 @@ def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:
     if special_method is not None:
         return special_method(accept)
     return accept
+
+
+if typing.TYPE_CHECKING or ParamSpec is not None:
+    P = ParamSpec("P")
+    _composite = composite
+
+    def composite(
+        f: Callable[Concatenate[DrawFn, P], Ex]
+    ) -> Callable[P, SearchStrategy[Ex]]:
+        return _composite(f)
 
 
 @defines_strategy(force_reusable_values=True)

--- a/whole-repo-tests/test_type_hints.py
+++ b/whole-repo-tests/test_type_hints.py
@@ -142,6 +142,19 @@ def test_drawfn_type_tracing(tmpdir):
     assert got == "str"
 
 
+def test_composite_type_tracing(tmpdir):
+    f = tmpdir.join("check_mypy_on_st_composite.py")
+    f.write(
+        "from hypothesis.strategies import composite, DrawFn\n"
+        "@composite\n"
+        "def comp(draw: DrawFn, x: int) -> int:\n"
+        "    return x\n"
+        "reveal_type(comp)\n"
+    )
+    got = get_mypy_analysed_type(str(f.realpath()), ...)
+    assert got == "def (x: int) -> int"
+
+
 def test_settings_preserves_type(tmpdir):
     f = tmpdir.join("check_mypy_on_settings.py")
     f.write(


### PR DESCRIPTION
MVP version of #3212; `st.functions()` is going to be harder thanks to longstanding `mypy` issues.