### PR TITLE
Fix pytest>=7.0.0 deprecation warnigs

### DIFF
--- a/hypothesis-python/tests/cover/test_mock.py
+++ b/hypothesis-python/tests/cover/test_mock.py
@@ -14,7 +14,10 @@
 import math
 from unittest import mock
 
-from _pytest.config import Config
+try:
+    from pytest import Config
+except ImportError:  # pytest<7.0.0
+    from _pytest.config import Config
 
 from hypothesis import given, strategies as st
 


### PR DESCRIPTION
As discussed in #3222, this fixes the relevant deprecations.

The logic in `escalation.py` is quite convoluted, but I do not know if anyone is using `_pytest` without importing `pytest`, so to be super safe, I except both `AttributeError` and `KeyError`.

Cheers,
Libor