### PR TITLE
Fix test_healthcheck_traceback_is_hidden for PyPy3.9

### DIFF
--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -101,7 +101,8 @@ def test_healthcheck_traceback_is_hidden(testdir):
     timeout_token = ": FailedHealthCheck"
     def_line = get_line_num(def_token, result)
     timeout_line = get_line_num(timeout_token, result)
-    expected = 6 if sys.version_info[:2] < (3, 8) or PYPY else 7
+    seven_min = (3, 9) if PYPY else (3, 8)
+    expected = 6 if sys.version_info[:2] < seven_min else 7
     assert timeout_line - def_line == expected
 
 


### PR DESCRIPTION
Yes, PyPy3.9 is coming and once again the expected line number
in test_healthcheck_traceback_is_hidden needs to be updated.  This time
PyPy3.9 aligns it with CPython 3.8, so we expect: 6 for CPython < 3.8
and PyPy < 3.9, and 7 for CPython >= 3.8 and PyPy >= 3.9.