### PR TITLE
Distinguish multiple `ExceptionGroup`s by their inner exceptions 

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+When distinguishing multiple errors, Hypothesis now looks at the inner
+exceptions of :pep:`654` ``ExceptionGroup``\ s.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -74,9 +74,9 @@ from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
+    InterestingOrigin,
     escalate_hypothesis_internal_error,
     format_exception,
-    get_interesting_origin,
     get_trimmed_traceback,
 )
 from hypothesis.internal.healthcheck import fail_health_check
@@ -742,7 +742,7 @@ class StateForActualGivenExecution:
 
                 self.failed_normally = True
 
-                interesting_origin = get_interesting_origin(e)
+                interesting_origin = InterestingOrigin.from_exception(e)
                 if trace:  # pragma: no cover
                     # Trace collection is explicitly disabled under coverage.
                     self.explain_traces[interesting_origin].add(trace)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -74,9 +74,9 @@ from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
-    InterestingOrigin,
     escalate_hypothesis_internal_error,
     format_exception,
+    get_interesting_origin,
     get_trimmed_traceback,
 )
 from hypothesis.internal.healthcheck import fail_health_check
@@ -742,7 +742,7 @@ class StateForActualGivenExecution:
 
                 self.failed_normally = True
 
-                interesting_origin = InterestingOrigin.from_exception(e)
+                interesting_origin = get_interesting_origin(e)
                 if trace:  # pragma: no cover
                     # Trace collection is explicitly disabled under coverage.
                     self.explain_traces[interesting_origin].add(trace)

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -14,6 +14,14 @@ import platform
 import sys
 import typing
 
+try:
+    BaseExceptionGroup = BaseExceptionGroup
+except NameError:  # pragma: no cover
+    try:
+        from exceptiongroup import BaseExceptionGroup
+    except ImportError:
+        BaseExceptionGroup = ()  # valid in isinstance and except clauses!
+
 PYPY = platform.python_implementation() == "PyPy"
 WINDOWS = platform.system() == "Windows"
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -18,7 +18,7 @@ try:
     BaseExceptionGroup = BaseExceptionGroup
 except NameError:  # pragma: no cover
     try:
-        from exceptiongroup import BaseExceptionGroup
+        from exceptiongroup import BaseExceptionGroup as BaseExceptionGroup  # for mypy
     except ImportError:
         BaseExceptionGroup = ()  # valid in isinstance and except clauses!
 


### PR DESCRIPTION
As discussed in https://github.com/HypothesisWorks/hypothesis/pull/3191#issuecomment-992533311; this is the part that has nothing at all to do with `__note__` and the draft PEP-678.