### PR TITLE
Use `signature` so that we support positional-only arguments

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release improves Hypothesis' handling of positional-only arguments,
+which are now allowed :func:`@st.composite <hypothesis.strategies.composite>`
+strategies.
+
+On Python 3.8 and later, the first arguments to :func:`~hypothesis.strategies.builds`
+and :func:`~hypothesis.extra.django.from_model` are now natively positional-only.
+In cases which were already errors, the ``TypeError`` from incorrect usage will
+therefore be raises immediately when the function is called, rather than when
+the strategy object is used.

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -22,6 +22,7 @@ from django.db import IntegrityError, models as dm
 from hypothesis import reject, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django._fields import from_field
+from hypothesis.internal.reflection import define_function_signature_from_signature
 from hypothesis.strategies._internal.utils import defines_strategy
 from hypothesis.utils.conventions import InferType, infer
 
@@ -129,7 +130,11 @@ if sys.version_info[:2] >= (3, 8):  # pragma: no branch
     sig = signature(from_model)
     params = list(sig.parameters.values())
     params[0] = params[0].replace(kind=Parameter.POSITIONAL_ONLY)
-    from_model.__signature__ = sig.replace(parameters=params)
+    from_model = define_function_signature_from_signature(
+        name=from_model.__name__,
+        docstring=from_model.__doc__,
+        signature=sig.replace(parameters=params),
+    )(from_model)
 
 
 @st.composite

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -29,7 +29,7 @@ infeasible.  We may also be quite aggressive in bumping the minimum version of
 Lark, unless someone volunteers to either fund or do the maintenance.
 """
 
-from inspect import getfullargspec
+from inspect import signature
 from typing import Dict, Optional
 
 import attr
@@ -90,7 +90,7 @@ class LarkStrategy(st.SearchStrategy):
         # This is a total hack, but working around the changes is a nicer user
         # experience than breaking for anyone who doesn't instantly update their
         # installation of Lark alongside Hypothesis.
-        compile_args = getfullargspec(grammar.grammar.compile).args
+        compile_args = signature(grammar.grammar.compile).parameters
         if "terminals_to_keep" in compile_args:
             terminals, rules, ignore_names = grammar.grammar.compile(start, ())
         elif "start" in compile_args:  # pragma: no cover

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import enum
-import inspect
 import math
 import operator
 import random
@@ -57,7 +56,6 @@ from hypothesis.internal.conjecture.utils import (
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.reflection import (
-    define_function_signature,
     define_function_signature_from_signature,
     get_pretty_function_description,
     nicerepr,
@@ -845,7 +843,7 @@ def builds(
     the callable.
     """
     if not callable_and_args:
-        raise InvalidArgument(
+        raise InvalidArgument(  # pragma: no cover
             "builds() must be passed a callable as the first positional "
             "argument, but no positional arguments were given."
         )
@@ -900,17 +898,21 @@ if sys.version_info[:2] >= (3, 8):  # pragma: no branch
     # matches the semantics of the function.  Great for documentation!
     sig = signature(builds)
     args, kwargs = sig.parameters.values()
-    builds.__signature__ = sig.replace(
-        parameters=[
-            Parameter(
-                name="target",
-                kind=Parameter.POSITIONAL_ONLY,
-                annotation=Callable[..., Ex],
-            ),
-            args.replace(name="args", annotation=SearchStrategy[Any]),
-            kwargs,
-        ]
-    )
+    builds = define_function_signature_from_signature(
+        name=builds.__name__,
+        docstring=builds.__doc__,
+        signature=sig.replace(
+            parameters=[
+                Parameter(
+                    name="target",
+                    kind=Parameter.POSITIONAL_ONLY,
+                    annotation=Callable[..., Ex],
+                ),
+                args.replace(name="args", annotation=SearchStrategy[Any]),
+                kwargs,
+            ]
+        ),
+    )(builds)
 
 
 @cacheable

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -17,7 +17,7 @@ import attr
 
 from hypothesis.control import should_note
 from hypothesis.internal.conjecture import utils as cu
-from hypothesis.internal.reflection import define_function_signature
+from hypothesis.internal.reflection import define_function_signature_from_signature
 from hypothesis.reporting import report
 from hypothesis.strategies._internal.core import (
     binary,
@@ -133,11 +133,11 @@ def define_copy_method(name):
         self._hypothesis_log_random(name, kwargs, result)
         return result
 
-    spec = inspect.getfullargspec(STUBS.get(name, target))
+    spec = inspect.signature(STUBS.get(name, target))
 
-    result = define_function_signature(target.__name__, target.__doc__, spec)(
-        implementation
-    )
+    result = define_function_signature_from_signature(
+        target.__name__, target.__doc__, spec
+    )(implementation)
 
     result.__module__ = __name__
     result.__qualname__ = "HypothesisRandom." + result.__name__

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -103,7 +103,7 @@ def first_annot(draw: None):
 
 def test_composite_edits_annotations():
     spec_comp = getfullargspec(st.composite(pointless_composite))
-    assert spec_comp.annotations["return"] == int
+    assert spec_comp.annotations["return"] == st.SearchStrategy[int]
     assert "nothing" in spec_comp.annotations
     assert "draw" not in spec_comp.annotations
 

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -293,13 +293,13 @@ def test_build_class_with_target_kwarg():
 
 
 def test_builds_raises_with_no_target():
-    with pytest.raises(InvalidArgument):
+    with pytest.raises(TypeError):
         ds.builds().example()
 
 
 @pytest.mark.parametrize("non_callable", [1, "abc", ds.integers()])
 def test_builds_raises_if_non_callable_as_target_kwarg(non_callable):
-    with pytest.raises(InvalidArgument):
+    with pytest.raises(TypeError):
         ds.builds(target=non_callable).example()
 
 

--- a/hypothesis-python/tests/cover/test_posonly_args_py38.py
+++ b/hypothesis-python/tests/cover/test_posonly_args_py38.py
@@ -27,3 +27,8 @@ def test_composite_with_posonly_args(data, min_value):
 def test_preserves_signature():
     with pytest.raises(TypeError):
         strat(x=1)
+
+
+def test_builds_real_pos_only():
+    with pytest.raises(TypeError):
+        st.builds()  # requires a target!

--- a/hypothesis-python/tests/cover/test_posonly_args_py38.py
+++ b/hypothesis-python/tests/cover/test_posonly_args_py38.py
@@ -1,0 +1,29 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from hypothesis import given, strategies as st
+
+
+@st.composite
+def strat(draw, x=0, /):
+    return draw(st.integers(min_value=x))
+
+
+@given(st.data(), st.integers())
+def test_composite_with_posonly_args(data, min_value):
+    v = data.draw(strat(min_value))
+    assert min_value <= v
+
+
+def test_preserves_signature():
+    with pytest.raises(TypeError):
+        strat(x=1)

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime as dt
+import sys
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -192,6 +193,11 @@ class TestPosOnlyArg(TestCase):
         pass
 
     def test_from_model_argspec(self):
-        self.assertRaises(TypeError, from_model().example)
-        self.assertRaises(TypeError, from_model(Car, None).example)
-        self.assertRaises(TypeError, from_model(model=Customer).example)
+        if sys.version_info[:2] <= (3, 7):
+            self.assertRaises(TypeError, from_model().example)
+            self.assertRaises(TypeError, from_model(Car, None).example)
+            self.assertRaises(TypeError, from_model(model=Customer).example)
+        else:
+            self.assertRaises(TypeError, from_model)
+            self.assertRaises(TypeError, from_model, Car, None)
+            self.assertRaises(TypeError, from_model, model=Customer)


### PR DESCRIPTION
This patch addresses about two-thirds of #2706 - notably,

- `@st.composite` strategies may now use positional-only arguments, which were added in Python 3.8, and
- the first arguments to `st.builds()` and the Django extra's `from_model()` are now true positional-only arguments

This is basically just a nice cleanup to have; for API clarity I don't intend to support nontrivial signatures in `@given()`-wrapped tests.  That's also some scary core code, so I'm leaving the relevant no-user-impact refactoring in there for later.