### PR TITLE
Fix regression in `@proxies`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes a regression where the bound inner function
+(``your_test.hypothesis.inner_test``) would be invoked with positional
+arguments rather than passing them by name, which broke
+:pypi:`pytest-asyncio` (:issue:`3245`).

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -84,7 +84,7 @@ def function_digest(function):
     return hasher.digest()
 
 
-def get_signature(target):
+def get_signature(target, *, follow_wrapped=True):
     # Special case for use of `@unittest.mock.patch` decorator, mimicking the
     # behaviour of getfullargspec instead of reporting unusable arguments.
     patches = getattr(target, "patchings", None)
@@ -119,7 +119,7 @@ def get_signature(target):
             return sig.replace(
                 parameters=[v for k, v in sig.parameters.items() if k != "self"]
             )
-    return inspect.signature(target)
+    return inspect.signature(target, follow_wrapped=follow_wrapped)
 
 
 def arg_is_required(param):
@@ -605,7 +605,7 @@ def define_function_signature_from_signature(name, docstring, signature):
     ]
 
     def accept(f):
-        fsig = inspect.signature(f)
+        fsig = inspect.signature(f, follow_wrapped=False)
         must_pass_as_kwargs = []
         invocation_parts = []
         for p in pos_args:
@@ -687,7 +687,7 @@ def proxies(target: "T") -> Callable[[Callable], "T"]:
     replace_sig = define_function_signature_from_signature(
         target.__name__.replace("<lambda>", "_lambda_"),  # type: ignore
         target.__doc__,
-        get_signature(target),
+        get_signature(target, follow_wrapped=False),
     )
 
     def accept(proxy):

--- a/hypothesis-python/tests/nocover/test_modify_inner_test.py
+++ b/hypothesis-python/tests/nocover/test_modify_inner_test.py
@@ -91,3 +91,14 @@ def test_inner_is_original_even_when_invalid():
         invalid_test()
 
     assert invalid_test.hypothesis.inner_test == original
+
+
+def test_invokes_inner_function_with_args_by_name():
+    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/3245
+    @given(st.integers())
+    def test(x):
+        pass
+
+    f = test.hypothesis.inner_test
+    test.hypothesis.inner_test = wraps(f)(lambda **kw: f(**kw))
+    test()


### PR DESCRIPTION
Closes #3245.

@rsokl correctly called this one as the change to `follow_wrapped`; after digging in I think we actually don't want `@proxies` to follow wrappers so the patch is simple.  Unfortunately GH Actions seem to be degraded at the moment, so I can't merge and release it tonight... we'll shoot for 36 hours instead I guess.