### PR TITLE
Use an SPDX identifier for the Python license

### DIFF
--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -96,7 +96,7 @@ setuptools.setup(
         "Documentation": "https://hypothesis.readthedocs.io",
         "Issues": "https://github.com/HypothesisWorks/hypothesis/issues",
     },
-    license="MPL v2",
+    license="MPL-2.0",
     description="A library for property-based testing",
     zip_safe=False,
     extras_require=extras,


### PR DESCRIPTION
Many automated tools expect the license attribute in setup.py to be an SPDX
compatible identifier (even though PEP 639 has not yet been adopted), so
they can identify the licenses in use by a project.