### PR TITLE
Add new `--errors-equivalent` Ghostwriter

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+:doc:`The Ghostwriter <ghostwriter>` can now write tests which check that
+two or more functions are equivalent on valid inputs, *or* raise the same
+type of exception for invalid inputs (:issue:`3267`).

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -182,8 +182,18 @@ else:
         flag_value="equivalent",
         help="very useful when optimising or refactoring code",
     )
-    @click.option("--idempotent", "writer", flag_value="idempotent")
-    @click.option("--binary-op", "writer", flag_value="binary_operation")
+    @click.option(
+        "--idempotent",
+        "writer",
+        flag_value="idempotent",
+        help="check that f(x) == f(f(x))",
+    )
+    @click.option(
+        "--binary-op",
+        "writer",
+        flag_value="binary_operation",
+        help="associativity, commutativity, identity element",
+    )
     # Note: we deliberately omit a --ufunc flag, because the magic()
     # detection of ufuncs is both precise and complete.
     @click.option(

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -183,6 +183,12 @@ else:
         help="very useful when optimising or refactoring code",
     )
     @click.option(
+        "--errors-equivalent",
+        "writer",
+        flag_value="errors-equivalent",
+        help="--equivalent, but also allows consistent errors",
+    )
+    @click.option(
         "--idempotent",
         "writer",
         flag_value="idempotent",
@@ -228,14 +234,18 @@ else:
         # NOTE: if you want to call this function from Python, look instead at the
         # ``hypothesis.extra.ghostwriter`` module.  Click-decorated functions have
         # a different calling convention, and raise SystemExit instead of returning.
+        kwargs = {"except_": except_ or (), "style": style}
         if writer is None:
             writer = "magic"
         elif writer == "idempotent" and len(func) > 1:
             raise click.UsageError("Test functions for idempotence one at a time.")
         elif writer == "roundtrip" and len(func) == 1:
             writer = "idempotent"
-        elif writer == "equivalent" and len(func) == 1:
+        elif "equivalent" in writer and len(func) == 1:
             writer = "fuzz"
+        if writer == "errors-equivalent":
+            writer = "equivalent"
+            kwargs["allow_same_errors"] = True
 
         try:
             from hypothesis.extra import ghostwriter
@@ -243,7 +253,7 @@ else:
             sys.stderr.write(MESSAGE.format("black"))
             sys.exit(1)
 
-        code = getattr(ghostwriter, writer)(*func, except_=except_ or (), style=style)
+        code = getattr(ghostwriter, writer)(*func, **kwargs)
         try:
             from rich.console import Console
             from rich.syntax import Syntax

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -42,8 +42,8 @@ generally do their best to write you a useful test.  You can also use
     Options:
       --roundtrip                start by testing write/read or encode/decode!
       --equivalent               very useful when optimising or refactoring code
-      --idempotent
-      --binary-op
+      --idempotent               check that f(x) == f(f(x))
+      --binary-op                associativity, commutativity, identity element
       --style [pytest|unittest]  pytest-style function, or unittest-style method?
       -e, --except OBJ_NAME      dotted name of exception(s) to ignore
       -h, --help                 Show this message and exit.

--- a/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_1error.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_1error.txt
@@ -1,0 +1,28 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import pytest
+from hypothesis import given, reject, strategies as st, target
+
+
+@given(
+    iterable=st.one_of(st.iterables(st.integers()), st.iterables(st.text())),
+    key=st.none(),
+    reverse=st.booleans(),
+)
+def test_equivalent_sorted_sorted(iterable, key, reverse):
+    try:
+        result_0_sorted = sorted(iterable, key=key, reverse=reverse)
+        exc_type = None
+        target(1, label="input was valid")
+    except ValueError:
+        reject()
+    except Exception as exc:
+        exc_type = type(exc)
+
+    if exc_type:
+        with pytest.raises(exc_type):
+            sorted(iterable, key=key, reverse=reverse)
+    else:
+        result_1_sorted = sorted(iterable, key=key, reverse=reverse)
+        assert result_0_sorted == result_1_sorted, (result_0_sorted, result_1_sorted)

--- a/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_2error_unittest.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_2error_unittest.txt
@@ -1,0 +1,29 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import unittest
+from hypothesis import given, reject, strategies as st, target
+
+
+class TestEquivalentSortedSorted(unittest.TestCase):
+    @given(
+        iterable=st.one_of(st.iterables(st.integers()), st.iterables(st.text())),
+        key=st.none(),
+        reverse=st.booleans(),
+    )
+    def test_equivalent_sorted_sorted(self, iterable, key, reverse):
+        try:
+            result_0_sorted = sorted(iterable, key=key, reverse=reverse)
+            exc_type = None
+            target(1, label="input was valid")
+        except (TypeError, ValueError):
+            reject()
+        except Exception as exc:
+            exc_type = type(exc)
+
+        if exc_type:
+            with self.assertRaises(exc_type):
+                sorted(iterable, key=key, reverse=reverse)
+        else:
+            result_1_sorted = sorted(iterable, key=key, reverse=reverse)
+            self.assertEqual(result_0_sorted, result_1_sorted)

--- a/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_simple.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_simple.txt
@@ -1,0 +1,26 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import pytest
+from hypothesis import given, strategies as st, target
+
+
+@given(
+    iterable=st.one_of(st.iterables(st.integers()), st.iterables(st.text())),
+    key=st.none(),
+    reverse=st.booleans(),
+)
+def test_equivalent_sorted_sorted(iterable, key, reverse):
+    try:
+        result_0_sorted = sorted(iterable, key=key, reverse=reverse)
+        exc_type = None
+        target(1, label="input was valid")
+    except Exception as exc:
+        exc_type = type(exc)
+
+    if exc_type:
+        with pytest.raises(exc_type):
+            sorted(iterable, key=key, reverse=reverse)
+    else:
+        result_1_sorted = sorted(iterable, key=key, reverse=reverse)
+        assert result_0_sorted == result_1_sorted, (result_0_sorted, result_1_sorted)

--- a/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_threefuncs.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/sorted_self_error_equivalent_threefuncs.txt
@@ -1,0 +1,33 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import pytest
+from hypothesis import given, strategies as st, target
+
+
+@given(
+    iterable=st.one_of(st.iterables(st.integers()), st.iterables(st.text())),
+    key=st.none(),
+    reverse=st.booleans(),
+)
+def test_equivalent_sorted_sorted_sorted(iterable, key, reverse):
+    try:
+        result_0_sorted = sorted(iterable, key=key, reverse=reverse)
+        exc_type = None
+        target(1, label="input was valid")
+    except Exception as exc:
+        exc_type = type(exc)
+
+    if exc_type:
+        with pytest.raises(exc_type):
+            sorted(iterable, key=key, reverse=reverse)
+    else:
+        result_1_sorted = sorted(iterable, key=key, reverse=reverse)
+        assert result_0_sorted == result_1_sorted, (result_0_sorted, result_1_sorted)
+
+    if exc_type:
+        with pytest.raises(exc_type):
+            sorted(iterable, key=key, reverse=reverse)
+    else:
+        result_2_sorted = sorted(iterable, key=key, reverse=reverse)
+        assert result_0_sorted == result_2_sorted, (result_0_sorted, result_2_sorted)

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -149,6 +149,33 @@ def divide(a: int, b: int) -> float:
                 style="unittest",
             ),
         ),
+        (
+            "sorted_self_error_equivalent_simple",
+            ghostwriter.equivalent(sorted, sorted, allow_same_errors=True),
+        ),
+        (
+            "sorted_self_error_equivalent_threefuncs",
+            ghostwriter.equivalent(sorted, sorted, sorted, allow_same_errors=True),
+        ),
+        (
+            "sorted_self_error_equivalent_1error",
+            ghostwriter.equivalent(
+                sorted,
+                sorted,
+                allow_same_errors=True,
+                except_=ValueError,
+            ),
+        ),
+        (
+            "sorted_self_error_equivalent_2error_unittest",
+            ghostwriter.equivalent(
+                sorted,
+                sorted,
+                allow_same_errors=True,
+                except_=(TypeError, ValueError),
+                style="unittest",
+            ),
+        ),
         pytest.param(
             ("magic_builtins", ghostwriter.magic(builtins)),
             marks=[


### PR DESCRIPTION
The idea is that this is useful for cases where you (or your students, or your code synthesis tool, or whatever) are trying to replicate the behaviour of an existing function - it's actually fine to test with over-broad strategies and get an error, so long as you get *the same error from both*.  Also uses `target()` so that we aim to spend at least half our time on valid inputs, if we've seen any.

It's a large diff, but most of that is just reference-output files for the tests!  Closes #3267.