### PR TITLE
Fix `given(...)(lambda x: ...)()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixed an internal error when ``given()`` was passed a lambda.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -482,6 +482,8 @@ def accept({funcname}):
 def define_function_signature(name, docstring, argspec):
     """A decorator which sets the name, argspec and docstring of the function
     passed into it."""
+    if name == "<lambda>":
+        name = "_lambda_"
     check_valid_identifier(name)
     for a in argspec.args:
         check_valid_identifier(a)

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -477,3 +477,9 @@ def test_prints_notes_once_on_failure():
 @given(lists(integers(), max_size=0))
 def test_empty_lists(xs):
     assert xs == []
+
+
+def test_given_usable_inline_on_lambdas():
+    xs = []
+    given(booleans())(lambda x: xs.append(x))()
+    assert len(xs) == 2 and set(xs) == {False, True}


### PR DESCRIPTION
This is obviously a rather niche use, but supporting it makes sense under the simple model of "a decorator is just application of a higher order function".  And it used to work, before I did some signature-related refactoring a few months ago.