### PR TITLE
Support PEP-604 `int | str` syntax for union types

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Fixed :func:`~hypothesis.strategies.from_type` support for
+:pep:`604` union types, like ``int | None`` (:issue:`3255`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1025,7 +1025,7 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
                 return as_strategy(types._global_type_lookup[thing], thing)
             return from_type(thing.__supertype__)
         # Unions are not instances of `type` - but we still want to resolve them!
-        if getattr(thing, "__origin__", None) is typing.Union:
+        if types.is_a_union(thing):
             args = sorted(thing.__args__, key=types.type_sorting_key)
             return one_of([from_type(t) for t in args])
     if not types.is_a_type(thing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -740,6 +740,10 @@ class RandomSeeder:
 
 class RandomModule(SearchStrategy):
     def do_draw(self, data):
+        # It would be unsafe to do run this method more than once per test case,
+        # because cleanup() runs tasks in FIFO order (at time of writing!).
+        # Fortunately, the random_module() strategy wraps us in shared(), so
+        # it's cached for all but the first of any number of calls.
         seed = data.draw(integers(0, 2**32 - 1))
         seed_all, restore_all = get_seeder_and_restorer(seed)
         seed_all()

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -31,6 +31,8 @@ if sys.version_info < (3, 8):
     collect_ignore_glob.append("cover/*py38*")
 if sys.version_info < (3, 9):
     collect_ignore_glob.append("cover/*py39*")
+if sys.version_info < (3, 10):
+    collect_ignore_glob.append("cover/*py310*")
 
 if sys.version_info >= (3, 11):
     collect_ignore_glob.append("cover/test_asyncio.py")  # @asyncio.coroutine removed

--- a/hypothesis-python/tests/cover/test_lookup_py310.py
+++ b/hypothesis-python/tests/cover/test_lookup_py310.py
@@ -1,0 +1,19 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from hypothesis import strategies as st
+
+from tests.common.debug import find_any
+
+
+def test_native_unions():
+    s = st.from_type(int | list[str])
+    find_any(s, lambda x: isinstance(x, int))
+    find_any(s, lambda x: isinstance(x, list))


### PR DESCRIPTION
Fixes #3255.