### PR TITLE
Quieter and prettier `functions()` strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release makes ``st.functions(pure=True)`` less noisy (:issue:`3253`),
+and generally improves pretty-printing of functions.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -82,7 +82,6 @@ from hypothesis.internal.escalation import (
 )
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.internal.reflection import (
-    arg_string,
     convert_positional_arguments,
     define_function_signature,
     function_digest,
@@ -91,6 +90,7 @@ from hypothesis.internal.reflection import (
     impersonate,
     is_mock,
     proxies,
+    repr_call,
 )
 from hypothesis.internal.scrutineer import Tracer, explanatory_lines
 from hypothesis.reporting import (
@@ -584,7 +584,7 @@ class StateForActualGivenExecution:
 
         data.is_find = self.is_find
 
-        text_repr = [None]
+        text_repr = None
         if self.settings.deadline is None:
             test = self.test
         else:
@@ -617,7 +617,8 @@ class StateForActualGivenExecution:
                         # Generate all arguments to the test function.
                         args, kwargs = data.draw(self.search_strategy)
                         if expected_failure is not None:
-                            text_repr[0] = arg_string(test, args, kwargs)
+                            nonlocal text_repr
+                            text_repr = repr_call(test, args, kwargs)
 
                         if print_example or current_verbosity() >= Verbosity.verbose:
                             output = StringIO()
@@ -682,9 +683,8 @@ class StateForActualGivenExecution:
             else:
                 report("Failed to reproduce exception. Expected: \n" + traceback)
             self.__flaky(
-                "Hypothesis %s(%s) produces unreliable results: Falsified"
+                f"Hypothesis {text_repr} produces unreliable results: Falsified"
                 " on the first call but did not on a subsequent one"
-                % (test.__name__, text_repr[0])
             )
         return result
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -431,7 +431,7 @@ def nicerepr(v):
         return re.sub(r"(\[)~([A-Z][a-z]*\])", r"\g<1>\g<2>", pretty(v))
 
 
-def arg_string(f, args, kwargs, reorder=True):
+def repr_call(f, args, kwargs, reorder=True):
     if reorder:
         args, kwargs = convert_positional_arguments(f, args, kwargs)
 
@@ -444,7 +444,10 @@ def arg_string(f, args, kwargs, reorder=True):
         for a in sorted(kwargs):
             bits.append(f"{a}={nicerepr(kwargs[a])}")
 
-    return ", ".join(bits)
+    rep = nicerepr(f)
+    if rep.startswith("lambda") and ":" in rep:
+        rep = f"({rep})"
+    return rep + "(" + ", ".join(bits) + ")"
 
 
 def check_valid_identifier(identifier):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -13,10 +13,10 @@ from typing import MutableMapping
 from weakref import WeakKeyDictionary
 
 from hypothesis.internal.reflection import (
-    arg_string,
     convert_keyword_arguments,
     convert_positional_arguments,
     get_pretty_function_description,
+    repr_call,
 )
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
@@ -147,11 +147,9 @@ class LazyStrategy(SearchStrategy):
                 for k, v in _kwargs.items()
                 if k not in sig.parameters or v is not sig.parameters[k].default
             }
-            self.__representation = "{}({}){}".format(
-                self.function.__name__,
-                arg_string(self.function, _args, kwargs_for_repr, reorder=False),
-                "".join(map(_repr_filter, self.__filters)),
-            )
+            self.__representation = repr_call(
+                self.function, _args, kwargs_for_repr, reorder=False
+            ) + "".join(map(_repr_filter, self.__filters))
         return self.__representation
 
     def do_draw(self, data):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -862,7 +862,7 @@ class FilteredStrategy(SearchStrategy):
             self._cached_repr = "{!r}{}".format(
                 self.filtered_strategy,
                 "".join(
-                    ".filter(%s)" % get_pretty_function_description(cond)
+                    f".filter({get_pretty_function_description(cond)})"
                     for cond in self.flat_conditions
                 ),
             )

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -718,11 +718,9 @@ def _repr_pprint(obj, p, cycle):
 
 def _function_pprint(obj, p, cycle):
     """Base pprint for all functions and builtin functions."""
-    name = _safe_getattr(obj, "__qualname__", obj.__name__)
-    mod = obj.__module__
-    if mod and mod not in ("__builtin__", "builtins", "exceptions"):
-        name = mod + "." + name
-    p.text(f"<function {name}>")
+    from hypothesis.internal.reflection import get_pretty_function_description
+
+    p.text(get_pretty_function_description(obj))
 
 
 def _exception_pprint(obj, p, cycle):

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -12,8 +12,9 @@ from inspect import getfullargspec
 
 import pytest
 
-from hypothesis import assume, given
+from hypothesis import Verbosity, assume, given, settings
 from hypothesis.errors import InvalidArgument, InvalidState
+from hypothesis.reporting import with_reporter
 from hypothesis.strategies import booleans, functions, integers
 
 
@@ -179,3 +180,23 @@ def test_functions_pure_two_functions_same_args_different_result(f1, f2, arg1, a
     r2 = f2(arg1, arg2)
     assume(r1 != r2)
     # If this is never true, the test will fail with Unsatisfiable
+
+
+@settings(verbosity=Verbosity.verbose)
+@given(functions(pure=False))
+def test_functions_note_all_calls_to_impure_functions(f):
+    ls = []
+    with with_reporter(ls.append):
+        f()
+        f()
+    assert len(ls) == 2
+
+
+@settings(verbosity=Verbosity.verbose)
+@given(functions(pure=True))
+def test_functions_note_only_first_to_pure_functions(f):
+    ls = []
+    with with_reporter(ls.append):
+        f()
+        f()
+    assert len(ls) == 1

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -338,8 +338,7 @@ def test_long_dict():
 
 
 def test_unbound_method():
-    output = pretty.pretty(MyObj.somemethod)
-    assert "MyObj.somemethod" in output
+    assert pretty.pretty(MyObj.somemethod) == "somemethod"
 
 
 class MetaClass(type):
@@ -597,11 +596,11 @@ def test_custom():
 
 
 def test_print_builtin_function():
-    assert pretty.pretty(abs) == "<function abs>"
+    assert pretty.pretty(abs) == "abs"
 
 
 def test_pretty_function():
-    assert "." in pretty.pretty(test_pretty_function)
+    assert pretty.pretty(test_pretty_function) == "test_pretty_function"
 
 
 def test_empty_printer():

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -21,7 +21,6 @@ from pytest import raises
 from hypothesis import given, strategies as st
 from hypothesis.internal import reflection
 from hypothesis.internal.reflection import (
-    arg_string,
     convert_keyword_arguments,
     convert_positional_arguments,
     define_function_signature,
@@ -29,6 +28,7 @@ from hypothesis.internal.reflection import (
     get_pretty_function_description,
     is_mock,
     proxies,
+    repr_call,
     required_args,
     source_exec_as_module,
 )
@@ -241,9 +241,10 @@ def test_arg_string_is_in_order():
     def foo(c, a, b, f, a1):
         pass
 
-    assert arg_string(foo, (1, 2, 3, 4, 5), {}) == "c=1, a=2, b=3, f=4, a1=5"
+    assert repr_call(foo, (1, 2, 3, 4, 5), {}) == "foo(c=1, a=2, b=3, f=4, a1=5)"
     assert (
-        arg_string(foo, (1, 2), {"b": 3, "f": 4, "a1": 5}) == "c=1, a=2, b=3, f=4, a1=5"
+        repr_call(foo, (1, 2), {"b": 3, "f": 4, "a1": 5})
+        == "foo(c=1, a=2, b=3, f=4, a1=5)"
     )
 
 
@@ -252,8 +253,8 @@ def test_varkwargs_are_sorted_and_after_real_kwargs():
         pass
 
     assert (
-        arg_string(foo, (), {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6})
-        == "d=4, e=5, f=6, a=1, b=2, c=3"
+        repr_call(foo, (), {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6})
+        == "foo(d=4, e=5, f=6, a=1, b=2, c=3)"
     )
 
 
@@ -261,21 +262,21 @@ def test_varargs_come_without_equals():
     def foo(a, *args):
         pass
 
-    assert arg_string(foo, (1, 2, 3, 4), {}) == "2, 3, 4, a=1"
+    assert repr_call(foo, (1, 2, 3, 4), {}) == "foo(2, 3, 4, a=1)"
 
 
 def test_can_mix_varargs_and_varkwargs():
     def foo(*args, **kwargs):
         pass
 
-    assert arg_string(foo, (1, 2, 3), {"c": 7}) == "1, 2, 3, c=7"
+    assert repr_call(foo, (1, 2, 3), {"c": 7}) == "foo(1, 2, 3, c=7)"
 
 
 def test_arg_string_does_not_include_unprovided_defaults():
     def foo(a, b, c=9, d=10):
         pass
 
-    assert arg_string(foo, (1,), {"b": 1, "d": 11}) == "a=1, b=1, d=11"
+    assert repr_call(foo, (1,), {"b": 1, "d": 11}) == "foo(a=1, b=1, d=11)"
 
 
 def universal_acceptor(*args, **kwargs):
@@ -531,8 +532,8 @@ def test_can_handle_unicode_repr():
     def foo(x):
         pass
 
-    assert arg_string(foo, [Snowman()], {}) == "x=☃"
-    assert arg_string(foo, [], {"x": Snowman()}) == "x=☃"
+    assert repr_call(foo, [Snowman()], {}) == "foo(x=☃)"
+    assert repr_call(foo, [], {"x": Snowman()}) == "foo(x=☃)"
 
 
 class NoRepr:
@@ -543,23 +544,23 @@ def test_can_handle_repr_on_type():
     def foo(x):
         pass
 
-    assert arg_string(foo, [Snowman], {}) == "x=Snowman"
-    assert arg_string(foo, [NoRepr], {}) == "x=NoRepr"
+    assert repr_call(foo, [Snowman], {}) == "foo(x=Snowman)"
+    assert repr_call(foo, [NoRepr], {}) == "foo(x=NoRepr)"
 
 
 def test_can_handle_repr_of_none():
     def foo(x):
         pass
 
-    assert arg_string(foo, [None], {}) == "x=None"
-    assert arg_string(foo, [], {"x": None}) == "x=None"
+    assert repr_call(foo, [None], {}) == "foo(x=None)"
+    assert repr_call(foo, [], {"x": None}) == "foo(x=None)"
 
 
 def test_kwargs_appear_in_arg_string():
     def varargs(*args, **kwargs):
         pass
 
-    assert "x=1" in arg_string(varargs, (), {"x": 1})
+    assert "x=1" in repr_call(varargs, (), {"x": 1})
 
 
 def test_is_mock_with_negative_cases():


### PR DESCRIPTION
Fixes #3253.

This includes some other function-related cleanup related to helper functions - mostly replacing the `arg_string` helper with a `repr_call` helper, since that's what we always use it for.  The new helper also knows to wrap lambdas in parens to make the call syntax valid.