### PR TITLE
Correctly retrieve forward referenced annotations from typed dictionaries

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,6 +78,7 @@ their individual contributions.
 * `jwg4 <https://www.github.com/jwg4>`_
 * `Kai Chen <https://www.github.com/kx-chen>`_ (kaichen120@gmail.com)
 * `Karthikeyan Singaravelan <https://www.github.com/tirkarthi>`_ (tir.karthi@gmail.com)
+* `Katelyn Gigante <https://github.com/silasary>`_
 * `Katrina Durance <https://github.com/kdurance>`_
 * `kbara <https://www.github.com/kbara>`_
 * `Kristian Glass <https://www.github.com/doismellburning>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.strategies.from_type` on a :class:`~python:typing.TypedDict`
+with complex annotations, defined in a file using ``from __future__ import annotations``.
+Thanks to Katelyn Gigante for identifying and fixing this bug!

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1076,7 +1076,7 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         # way to tell and we just have to assume that everything is required.
         # See https://github.com/python/cpython/pull/17214 for details.
         optional = getattr(thing, "__optional_keys__", ())
-        anns = {k: from_type(v) for k, v in thing.__annotations__.items()}
+        anns = {k: from_type(v) for k, v in get_type_hints(thing).items()}
         return fixed_dictionaries(  # type: ignore
             mapping={k: v for k, v in anns.items() if k not in optional},
             optional={k: v for k, v in anns.items() if k in optional},

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1077,6 +1077,12 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         # See https://github.com/python/cpython/pull/17214 for details.
         optional = getattr(thing, "__optional_keys__", ())
         anns = {k: from_type(v) for k, v in get_type_hints(thing).items()}
+        if (
+            (not anns)
+            and thing.__annotations__
+            and ".<locals>." in getattr(thing, "__qualname__", "")
+        ):
+            raise InvalidArgument("Failed to retrieve type annotations for local type")
         return fixed_dictionaries(  # type: ignore
             mapping={k: v for k, v in anns.items() if k not in optional},
             optional={k: v for k, v in anns.items() if k in optional},

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -713,6 +713,11 @@ def test_generic_collections_only_use_hashable_elements(typ, data):
     data.draw(from_type(typ))
 
 
+@given(st.sets(st.integers() | st.binary(), min_size=2))
+def test_no_byteswarning(_):
+    pass
+
+
 def test_hashable_type_unhashable_value():
     # Decimal("snan") is not hashable; we should be able to generate it.
     # See https://github.com/HypothesisWorks/hypothesis/issues/2320

--- a/hypothesis-python/tests/nocover/test_type_lookup_future_annotations.py
+++ b/hypothesis-python/tests/nocover/test_type_lookup_future_annotations.py
@@ -1,0 +1,33 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from __future__ import annotations
+
+from typing import TypedDict, Union
+
+from hypothesis import given, strategies as st
+
+
+@given(st.data())
+def test_complex_forward_ref_in_typed_dict(data):
+    alias = Union[int, bool]
+
+    class A(TypedDict):
+        a: int
+
+    class B(TypedDict):
+        a: A
+        b: alias
+
+    b_strategy = st.from_type(B)
+    d = data.draw(b_strategy)
+    assert isinstance(d["a"], dict)
+    assert isinstance(d["a"]["a"], int)
+    assert isinstance(d["b"], (int, bool))


### PR DESCRIPTION
When resolving a TypedDict in a file with `from __future__ import annotations`, we were using `thing.__annotations__`, which would return unresolved ForwardRefs.  
For simple examples, this could be handled by later code that resolves ForwardRefs of builtins.  But it would fail the moment a complex annotation was provided.

This PR switches to using [typing.get_type_hints](https://docs.python.org/3/library/typing.html#typing.get_type_hints) which evalutates the forward references for us, returning the actual type.