### PR TITLE
Explicit error if `@pytest.fixture()` is applied after `@given()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release makes it an explicit error to apply
+:func:`@pytest.fixture <pytest:pytest.fixture>` to a function which has
+already been decorated with :func:`@given() <hypothesis.given>`.  Previously,
+``pytest`` would convert your test to a fixture, and then never run it.

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -175,3 +175,19 @@ def test_override_fixture(event_loop, x):
 def test_given_plus_overridden_fixture(testdir):
     script = testdir.makepyfile(TESTSCRIPT_OVERRIDE_FIXTURE)
     testdir.runpytest(script, "-Werror").assert_outcomes(passed=1, failed=0)
+
+
+TESTSCRIPT_FIXTURE_THEN_GIVEN = """
+import pytest
+from hypothesis import given, strategies as st
+
+@given(x=st.integers())
+@pytest.fixture()
+def test(x):
+    pass
+"""
+
+
+def test_given_fails_if_already_decorated_with_fixture(testdir):
+    script = testdir.makepyfile(TESTSCRIPT_FIXTURE_THEN_GIVEN)
+    testdir.runpytest(script).assert_outcomes(failed=1)

--- a/hypothesis-python/tests/pytest/test_fixtures.py
+++ b/hypothesis-python/tests/pytest/test_fixtures.py
@@ -191,3 +191,22 @@ def test(x):
 def test_given_fails_if_already_decorated_with_fixture(testdir):
     script = testdir.makepyfile(TESTSCRIPT_FIXTURE_THEN_GIVEN)
     testdir.runpytest(script).assert_outcomes(failed=1)
+
+
+TESTSCRIPT_GIVEN_THEN_FIXTURE = """
+import pytest
+from hypothesis import given, strategies as st
+
+@pytest.fixture()
+@given(x=st.integers())
+def test(x):
+    pass
+"""
+
+
+def test_fixture_errors_if_already_decorated_with_given(testdir):
+    script = testdir.makepyfile(TESTSCRIPT_GIVEN_THEN_FIXTURE)
+    if int(pytest.__version__.split(".")[0]) > 5:
+        testdir.runpytest(script).assert_outcomes(errors=1)
+    else:
+        testdir.runpytest(script).assert_outcomes(error=1)


### PR DESCRIPTION
We would already fail the test nicely if you applied `@given()` to a fixture, but the reverse was not true - and in that case `pytest` would cheerfully never notify you that you had an unused fixture which looked *an awful lot like a test*.  Since [I observed this in practice lately](https://github.com/zenml-io/zenml/blob/905a60ea90a3279a019dd298114ce4b1f7a9fcc9/tests/unit/io/test_fileio.py#L150-L152), it's now an explicit error.