### PR TITLE
Remove dead code

### DIFF
--- a/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
@@ -76,8 +76,6 @@ off the higher powers of 2 in the fraction first.
 
 MAX_EXPONENT = 0x7FF
 
-SPECIAL_EXPONENTS = (0, MAX_EXPONENT)
-
 BIAS = 1023
 MAX_POSITIVE_EXPONENT = MAX_EXPONENT - 1 - BIAS
 


### PR DESCRIPTION
While studying the float machinery (I'm trying to make floats shrink in a similar fashion in Elm's test library), I figured out that the constant `SPECIAL_EXPONENTS` is not used anywhere. It can probably be removed. Only the `MAX_EXPONENT` seems to be special anyways (kept at the end of the new exponents ordering).