### PR TITLE
Re-enable tests on 3.11

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes a few cases where :func:`~hypothesis.strategies.from_type`
+would give a worse error message on Python 3.11.

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -94,7 +94,7 @@ def get_trimmed_traceback(exception=None):
         return tb
     while tb.tb_next is not None and (
         # If the frame is from one of our files, it's been added by Hypothesis.
-        is_hypothesis_file(getframeinfo(tb.tb_frame)[0])
+        is_hypothesis_file(getframeinfo(tb.tb_frame).filename)
         # But our `@proxies` decorator overrides the source location,
         # so we check for an attribute it injects into the frame too.
         or tb.tb_frame.f_globals.get("__hypothesistracebackhide__") is True

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -100,6 +100,7 @@ typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
 # that this value can't be reassigned.
 NON_RUNTIME_TYPES = frozenset(
     (
+        typing.Any,
         *ClassVarTypes,
         *TypeAliasTypes,
         *FinalTypes,

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -37,14 +37,6 @@ if sys.version_info < (3, 10):
 if sys.version_info >= (3, 11):
     collect_ignore_glob.append("cover/test_asyncio.py")  # @asyncio.coroutine removed
 
-    assert sys.version_info.releaselevel == "alpha"
-    # These seem to fail due to traceback rendering failures, TODO fix the tests
-    collect_ignore_glob.append("cover/test_traceback_elision.py")
-    collect_ignore_glob.append("pytest/test_capture.py")
-    # Changes to type-annotation inspection, TODO fix during the beta phase
-    collect_ignore_glob.append("cover/test_lookup.py")
-    collect_ignore_glob.append("cover/test_lookup_py37.py")
-
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: pandas expects this marker to exist.")

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -17,6 +17,7 @@ import inspect
 import io
 import re
 import string
+import sys
 import typing
 from inspect import signature
 from numbers import Real
@@ -770,7 +771,11 @@ def test_compat_get_type_hints_aware_of_None_default():
     find_any(strategy, lambda x: x.a is None)
     find_any(strategy, lambda x: x.a is not None)
 
-    assert typing.get_type_hints(constructor)["a"] == typing.Optional[str]
+    if sys.version_info[:2] >= (3, 11):
+        # https://docs.python.org/3.11/library/typing.html#typing.get_type_hints
+        assert typing.get_type_hints(constructor)["a"] == str
+    else:
+        assert typing.get_type_hints(constructor)["a"] == typing.Optional[str]
     assert inspect.signature(constructor).parameters["a"].annotation == str
 
 

--- a/hypothesis-python/tests/cover/test_lookup_py37.py
+++ b/hypothesis-python/tests/cover/test_lookup_py37.py
@@ -163,6 +163,10 @@ def test_resolving_standard_callable_ellipsis(x: collections.abc.Callable[..., E
     assert isinstance(x(1, 2, 3, a=4, b=5, c=6), Elem)
 
 
+@pytest.mark.skipif(
+    sys.version_info[:3] == (3, 11, 0),
+    reason="https://github.com/python/cpython/issues/91621",
+)
 @given(...)
 def test_resolving_standard_callable_no_args(x: collections.abc.Callable[[], Elem]):
     assert isinstance(x, collections.abc.Callable)


### PR DESCRIPTION
In earlier alphas, we just skipped over some failing tests so that we could test for other regressions.

Since I'm thinking about `ExceptionGroup` again, let's see if they've since been fixed...