### PR TITLE
Add pypy39 to CI; add tests so we notice new releases in future

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           - check-py38
           - check-pypy38
           - check-py39
+          - check-pypy39
           - check-py310
           # - check-py310-pyjion  # see notes in tox.ini
           - check-py311

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ if [ -n "${GITHUB_ACTIONS-}" ] || [ -n "${CODESPACES-}" ] ; then
     PYTHON=$(command -v python)
 else
     # Otherwise, we install it from scratch
-    # NOTE: tooling keeps this version in sync with PYMAIN in tooling
+    # NOTE: tooling keeps this version in sync with ci_version in tooling
     "$SCRIPTS/ensure-python.sh" 3.8.13
     PYTHON=$(pythonloc 3.8.13)/bin/python
 fi

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -28,7 +28,7 @@ deps =
     -r../requirements/test.txt
     # We'd like to pin this, but pip-compile has to run under Python 3.10 (+)
     # to do so and that's painful because other tools aren't compatible yet.
-    # If it's mid-2022, try again, starting by updating PYMAIN to 3.10
+    # If it's mid-2022, try again, starting by updating ci_version to 3.10
     pyjion
 commands =
     # TODO: restore `-n auto` https://github.com/tonybaloney/Pyjion/issues/456

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,py37,38,py38,39,310,311}-{brief,prettyquick,full,custom}
+envlist = py{37,py37,38,py38,39,py39,310,311}-{brief,prettyquick,full,custom}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -387,6 +387,7 @@ PYTHONS = {
     "3.11": "3.11-dev",
     "pypy3.7": "pypy3.7-7.3.9",
     "pypy3.8": "pypy3.8-7.3.9",
+    "pypy3.9": "pypy3.9-7.3.9",
 }
 ci_version = "3.8"  # Keep this in sync with GH Actions main.yml
 

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -14,7 +14,6 @@ import re
 import subprocess
 import sys
 from glob import glob
-from urllib.parse import urlparse
 
 import requests
 from coverage.config import CoverageConfig
@@ -262,7 +261,7 @@ def compile_requirements(upgrade=False):
 
 
 def update_python_versions():
-    install.ensure_python(PYMAIN)  # ensures pyenv is installed and up to date
+    install.ensure_python(PYTHONS[ci_version])
     cmd = "~/.cache/hypothesis-build-runtimes/pyenv/bin/pyenv install --list"
     result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE).stdout.decode()
     # pyenv reports available versions in chronological order, so we keep the newest
@@ -270,24 +269,25 @@ def update_python_versions():
     stable = re.compile(r".*3\.\d+.\d+$")
     best = {}
     for line in map(str.strip, result.splitlines()):
-        if m := re.match(r"(?:pypy)?3\.(?:[6-9]|\d\d)", line):
+        if m := re.match(r"(?:pypy)?3\.(?:[789]|\d\d)", line):
             key = m.group()
             if stable.match(line) or not stable.match(best.get(key, line)):
                 best[key] = line
-    print(best)
-    thisfile = pathlib.Path(__file__)
-    before = after = thisfile.read_text()
-    for key, version in best.items():
-        var = key.upper().replace(".", "")
-        after = re.sub(rf'({var} = .*?"){key}[^"]+', rf"\g<1>{version}", after)
-    if before != after:
-        thisfile.write_text(after)
 
-    # Automatically sync PYMAIN with the version in build.sh
+    if best == PYTHONS:
+        return
+
+    # Write the new mapping back to this file
+    thisfile = pathlib.Path(__file__)
+    before = thisfile.read_text()
+    after = re.sub(r"\nPYTHONS = \{[^{}]+\}", f"\nPYTHONS = {best}", before)
+    thisfile.write_text(after)
+    pip_tool("shed", str(thisfile))
+
+    # Automatically sync ci_version with the version in build.sh
     build_sh = pathlib.Path(tools.ROOT) / "build.sh"
     sh_before = build_sh.read_text()
-    new_pymain = re.search(r'PYMAIN = "(3\.\d\d?\.\d\d?)"', after).group(1)
-    sh_after = re.sub(r"3\.\d\d?\.\d\d?", new_pymain, sh_before)
+    sh_after = re.sub(r"3\.\d\d?\.\d\d?", best[ci_version], sh_before)
     if sh_before != sh_after:
         build_sh.unlink()  # so bash doesn't reload a modified file
         build_sh.write_text(sh_after)
@@ -299,7 +299,7 @@ def update_vendored_files():
 
     # Turns out that as well as adding new gTLDs, IANA can *terminate* old ones
     url = "http://data.iana.org/TLD/tlds-alpha-by-domain.txt"
-    fname = vendor / urlparse(url).path.split("/")[-1]
+    fname = vendor / url.split("/")[-1]
     new = requests.get(url).content
     # If only the timestamp in the header comment has changed, skip the update.
     if fname.read_bytes().splitlines()[1:] != new.splitlines()[1:]:
@@ -376,28 +376,19 @@ def run_tox(task, version, *args):
     pip_tool("tox", "-e", task, *args, env=env, cwd=hp.HYPOTHESIS_PYTHON)
 
 
-# See update_python_versions() above
-# When adding or removing a version, also update the env lists in tox.ini and
-# workflows/main.yml, the `Programming Language ::` declaration(s) in setup.py,
-# and the corresponding @python_tests function below.
-PY37 = "3.7.13"
-PY38 = PYMAIN = "3.8.13"  # Sync PYMAIN minor version with GH Actions main.yml
-PY39 = "3.9.12"
-PY310 = "3.10.4"
-PY311 = "3.11-dev"
-PYPY37 = "pypy3.7-7.3.9"
-PYPY38 = "pypy3.8-7.3.9"
-
-
-# ALIASES are the executable names for each Python version
-ALIASES = {}
-for name, value in list(globals().items()):
-    if name.startswith("PYPY"):
-        ALIASES[value] = "pypy3"
-    elif name.startswith("PY"):
-        major, minor, patch = value.replace("-dev", ".").split(".")
-        ALIASES[value] = f"python{major}.{minor}"
-
+# update_python_versions(), above, keeps the contents of this dict up to date.
+# When a version is added or removed, manually update the env lists in tox.ini and
+# workflows/main.yml, and the `Programming Language ::` specifiers in setup.py
+PYTHONS = {
+    "3.7": "3.7.13",
+    "3.8": "3.8.13",
+    "3.9": "3.9.12",
+    "3.10": "3.10.4",
+    "3.11": "3.11-dev",
+    "pypy3.7": "pypy3.7-7.3.9",
+    "pypy3.8": "pypy3.8-7.3.9",
+}
+ci_version = "3.8"  # Keep this in sync with GH Actions main.yml
 
 python_tests = task(
     if_changed=(
@@ -409,44 +400,23 @@ python_tests = task(
 )
 
 
-@python_tests
-def check_py37():
-    run_tox("py37-full", PY37)
-
-
-@python_tests
-def check_py38():
-    run_tox("py38-full", PY38)
-
-
-@python_tests
-def check_py39():
-    run_tox("py39-full", PY39)
-
-
-@python_tests
-def check_py310():
-    run_tox("py310-full", PY310)
-
-
-@python_tests
-def check_py311():
-    run_tox("py311-full", PY311)
+# ALIASES are the executable names for each Python version
+ALIASES = {}
+for key, version in PYTHONS.items():
+    if key.startswith("pypy"):
+        ALIASES[version] = "pypy3"
+        name = key.replace(".", "")
+    else:
+        ALIASES[version] = f"python{key}"
+        name = f"py3{key[2:]}"
+    TASKS[f"check-{name}"] = python_tests(
+        lambda n=f"{name}-full", v=version: run_tox(n, v)
+    )
 
 
 @python_tests
 def check_py310_pyjion():
-    run_tox("py310-pyjion", PY310)
-
-
-@python_tests
-def check_pypy37():
-    run_tox("pypy3-full", PYPY37)
-
-
-@python_tests
-def check_pypy38():
-    run_tox("pypy3-full", PYPY38)
+    run_tox("py310-pyjion", PYTHONS["3.10"])
 
 
 @task()
@@ -458,7 +428,7 @@ def tox(*args):
 
 
 def standard_tox_task(name):
-    TASKS["check-" + name] = python_tests(lambda: run_tox(name, PYMAIN))
+    TASKS["check-" + name] = python_tests(lambda: run_tox(name, PYTHONS[ci_version]))
 
 
 standard_tox_task("nose")
@@ -477,12 +447,12 @@ standard_tox_task("conjecture-coverage")
 
 @task()
 def check_quality():
-    run_tox("quality", PYMAIN)
+    run_tox("quality", PYTHONS[ci_version])
 
 
 @task(if_changed=(hp.PYTHON_SRC, os.path.join(hp.HYPOTHESIS_PYTHON, "examples")))
 def check_examples3():
-    run_tox("examples3", PYMAIN)
+    run_tox("examples3", PYTHONS[ci_version])
 
 
 @task()

--- a/whole-repo-tests/test_ci_config.py
+++ b/whole-repo-tests/test_ci_config.py
@@ -1,0 +1,27 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from pathlib import Path
+
+import pytest
+
+from hypothesistooling.__main__ import PYTHONS
+
+ci_checks = tuple(
+    line.strip()
+    for line in Path(".github/workflows/main.yml").read_text().splitlines()
+    if "- check-py" in line
+)
+
+
+@pytest.mark.parametrize("version", sorted(PYTHONS))
+def test_python_versions_are_tested_in_ci(version):
+    slug = version.replace("pypy", "py").replace(".", "")
+    assert f"- check-py{slug}" in ci_checks, f"Add {version} to main.yml and tox.ini"


### PR DESCRIPTION
Most of this PR is the tooling changes, which will automatically update most of our CI config as new Python versions are released, and then fail CI as a reminder to do the last few fiddly manual bits too.  I think this is a good balance between automation and brittleness.

Oh, and adds pypy39 to our CI, since that's been released now 🥳 