### PR TITLE
Switch from `MultipleFailures` to PEP-654 `ExceptionGroup`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+Reporting of :obj:`multiple failing examples <hypothesis.settings.report_multiple_bugs>`
+now uses the :pep:`654` `ExceptionGroup <https://docs.python.org/3.11/library/exceptions.html#ExceptionGroup>`__ type, which is provided by the
+:pypi:`exceptiongroup` backport on Python 3.10 and earlier (:issue:`3175`).
+``hypothesis.errors.MultipleFailures`` is therefore deprecated.
+
+Failing examples and other reports are now stored as :pep:`678` exception notes, which
+ensures that they will always appear together with the traceback and other information
+about their respective error.

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -178,6 +178,13 @@ else:
                 pass
             core.global_force_seed = seed
 
+        core.pytest_shows_exceptiongroups = (
+            sys.version_info[:2] >= (3, 11)
+            ## See https://github.com/pytest-dev/pytest/issues/9159
+            # or pytest_version >= (7, 2)  # TODO: fill in correct version here
+            or config.getoption("tbstyle", "auto") == "native"
+        )
+
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(item):
         __tracebackhide__ = True

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -126,6 +126,7 @@ TestFunc = TypeVar("TestFunc", bound=Callable)
 
 
 running_under_pytest = False
+pytest_shows_exceptiongroups = True
 global_force_seed = None
 _hypothesis_global_random = None
 
@@ -436,7 +437,7 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs, original_s
                     err = new
 
                 yield (fragments_reported, err)
-                if state.settings.report_multiple_bugs:
+                if state.settings.report_multiple_bugs and pytest_shows_exceptiongroups:
                     continue
                 break
             finally:
@@ -840,7 +841,7 @@ class StateForActualGivenExecution:
 
         if not self.falsifying_examples:
             return
-        elif not self.settings.report_multiple_bugs:
+        elif not (self.settings.report_multiple_bugs and pytest_shows_exceptiongroups):
             # Pretend that we only found one failure, by discarding the others.
             del self.falsifying_examples[:-1]
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -60,7 +60,6 @@ from hypothesis.errors import (
     HypothesisDeprecationWarning,
     HypothesisWarning,
     InvalidArgument,
-    MultipleFailures,
     NoSuchExample,
     StopTest,
     Unsatisfiable,
@@ -69,6 +68,7 @@ from hypothesis.errors import (
 from hypothesis.executors import default_new_style_executor, new_style_executor
 from hypothesis.internal.compat import (
     PYPY,
+    BaseExceptionGroup,
     bad_django_TestCase,
     get_type_hints,
     int_from_bytes,
@@ -575,7 +575,6 @@ class StateForActualGivenExecution:
         self.settings = settings
         self.last_exception = None
         self.falsifying_examples = ()
-        self.__was_flaky = False
         self.random = random
         self.__test_runtime = None
         self.ever_executed = False
@@ -710,11 +709,10 @@ class StateForActualGivenExecution:
                 )
             else:
                 report("Failed to reproduce exception. Expected: \n" + traceback)
-            self.__flaky(
-                f"Hypothesis {text_repr} produces unreliable results: Falsified"
-                " on the first call but did not on a subsequent one",
-                cause=exception,
-            )
+            raise Flaky(
+                f"Hypothesis {text_repr} produces unreliable results: "
+                "Falsified on the first call but did not on a subsequent one"
+            ) from exception
         return result
 
     def _execute_once_for_engine(self, data):
@@ -849,57 +847,50 @@ class StateForActualGivenExecution:
         # The engine found one or more failures, so we need to reproduce and
         # report them.
 
-        flaky = 0
+        errors_to_report = []
 
-        if runner.best_observed_targets:
-            for line in describe_targets(runner.best_observed_targets):
-                report(line)
-            report("")
+        report_lines = describe_targets(runner.best_observed_targets)
+        if report_lines:
+            report_lines.append("")
 
         explanations = explanatory_lines(self.explain_traces, self.settings)
         for falsifying_example in self.falsifying_examples:
             info = falsifying_example.extra_information
+            fragments = []
 
             ran_example = ConjectureData.for_buffer(falsifying_example.buffer)
-            self.__was_flaky = False
             assert info.__expected_exception is not None
             try:
-                self.execute_once(
-                    ran_example,
-                    print_example=not self.is_find,
-                    is_final=True,
-                    expected_failure=(
-                        info.__expected_exception,
-                        info.__expected_traceback,
-                    ),
-                )
+                with with_reporter(fragments.append):
+                    self.execute_once(
+                        ran_example,
+                        print_example=not self.is_find,
+                        is_final=True,
+                        expected_failure=(
+                            info.__expected_exception,
+                            info.__expected_traceback,
+                        ),
+                    )
             except (UnsatisfiedAssumption, StopTest) as e:
-                report(format_exception(e, e.__traceback__))
-                self.__flaky(
+                err = Flaky(
                     "Unreliable assumption: An example which satisfied "
                     "assumptions on the first run now fails it.",
-                    cause=e,
                 )
+                err.__cause__ = err.__context__ = e
+                errors_to_report.append((fragments, err))
             except BaseException as e:
                 # If we have anything for explain-mode, this is the time to report.
                 for line in explanations[falsifying_example.interesting_origin]:
-                    report(line)
-
-                if len(self.falsifying_examples) <= 1:
-                    # There is only one failure, so we can report it by raising
-                    # it directly.
-                    raise
-
-                # We are reporting multiple failures, so we need to manually
-                # print each exception's stack trace and information.
-                tb = get_trimmed_traceback()
-                report(format_exception(e, tb))
+                    fragments.append(line)
+                errors_to_report.append(
+                    (fragments, e.with_traceback(get_trimmed_traceback()))
+                )
 
             finally:
                 # Whether or not replay actually raised the exception again, we want
                 # to print the reproduce_failure decorator for the failing example.
                 if self.settings.print_blob:
-                    report(
+                    fragments.append(
                         "\nYou can reproduce this example by temporarily adding "
                         "@reproduce_failure(%r, %r) as a decorator on your test case"
                         % (__version__, encode_failure(falsifying_example.buffer))
@@ -908,30 +899,38 @@ class StateForActualGivenExecution:
                 # hold on to a reference to ``data`` know that it's now been
                 # finished and they can't draw more data from it.
                 ran_example.freeze()
+        _raise_to_user(errors_to_report, self.settings, report_lines)
 
-            if self.__was_flaky:
-                flaky += 1
 
-        # If we only have one example then we should have raised an error or
-        # flaky prior to this point.
-        assert len(self.falsifying_examples) > 1
+def add_note(exc, note):
+    try:
+        exc.add_note(note)
+    except AttributeError:
+        if not hasattr(exc, "__notes__"):
+            exc.__notes__ = []
+        exc.__notes__.append(note)
 
-        if flaky > 0:
-            raise Flaky(
-                f"Hypothesis found {len(self.falsifying_examples)} distinct failures, "
-                f"but {flaky} of them exhibited some sort of flaky behaviour."
-            )
-        else:
-            raise MultipleFailures(
-                f"Hypothesis found {len(self.falsifying_examples)} distinct failures."
-            )
 
-    def __flaky(self, message, *, cause):
-        if len(self.falsifying_examples) <= 1:
-            raise Flaky(message) from cause
-        else:
-            self.__was_flaky = True
-            report("Flaky example! " + message)
+def _raise_to_user(errors_to_report, settings, target_lines, trailer=""):
+    """Helper function for attaching notes and grouping multiple errors."""
+    if settings.verbosity >= Verbosity.normal:
+        for fragments, err in errors_to_report:
+            for note in fragments:
+                add_note(err, note)
+
+    if len(errors_to_report) == 1:
+        _, the_error_hypothesis_found = errors_to_report[0]
+    else:
+        assert errors_to_report
+        the_error_hypothesis_found = BaseExceptionGroup(
+            f"Hypothesis found {len(errors_to_report)} distinct failures{trailer}.",
+            [e for _, e in errors_to_report],
+        )
+
+    if settings.verbosity >= Verbosity.normal:
+        for line in target_lines:
+            add_note(the_error_hypothesis_found, line)
+    raise the_error_hypothesis_found
 
 
 @contextlib.contextmanager
@@ -1189,23 +1188,11 @@ def given(
                     state, wrapped_test, arguments, kwargs, original_sig
                 )
             )
-            with local_settings(state.settings):
-                if len(errors) > 1:
-                    # If we're not going to report multiple bugs, we would have
-                    # stopped running explicit examples at the first failure.
-                    assert state.settings.report_multiple_bugs
-                    for fragments, err in errors:
-                        for f in fragments:
-                            report(f)
-                        report(format_exception(err, err.__traceback__))
-                    raise MultipleFailures(
-                        f"Hypothesis found {len(errors)} failures in explicit examples."
-                    )
-                elif errors:
-                    fragments, the_error_hypothesis_found = errors[0]
-                    for f in fragments:
-                        report(f)
-                    raise the_error_hypothesis_found
+            if errors:
+                # If we're not going to report multiple bugs, we would have
+                # stopped running explicit examples at the first failure.
+                assert len(errors) == 1 or state.settings.report_multiple_bugs
+                _raise_to_user(errors, state.settings, [], " in explicit examples")
 
             # If there were any explicit examples, they all ran successfully.
             # The next step is to use the Conjecture engine to run the test on
@@ -1236,7 +1223,7 @@ def given(
                     state.run_engine()
             except BaseException as e:
                 # The exception caught here should either be an actual test
-                # failure (or MultipleFailures), or some kind of fatal error
+                # failure (or BaseExceptionGroup), or some kind of fatal error
                 # that caused the engine to stop.
 
                 generated_seed = wrapped_test._hypothesis_internal_use_generated_seed
@@ -1262,7 +1249,9 @@ def given(
                     # which will actually appear in tracebacks is as clear as
                     # possible - "raise the_error_hypothesis_found".
                     the_error_hypothesis_found = e.with_traceback(
-                        get_trimmed_traceback()
+                        None
+                        if isinstance(e, BaseExceptionGroup)
+                        else get_trimmed_traceback()
                     )
                     raise the_error_hypothesis_found
 

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -124,9 +124,18 @@ class Frozen(HypothesisException):
     after freeze() has been called."""
 
 
-class MultipleFailures(_Trimmable):
-    """Indicates that Hypothesis found more than one distinct bug when testing
-    your code."""
+def __getattr__(name):
+    if name == "MultipleFailures":
+        from hypothesis._settings import note_deprecation
+        from hypothesis.internal.compat import BaseExceptionGroup
+
+        note_deprecation(
+            "MultipleFailures is deprecated; use the builtin `BaseExceptionGroup` type "
+            "instead, or `exceptiongroup.BaseExceptionGroup` before Python 3.11",
+            since="RELEASEDAY",
+            has_codemod=False,  # This would be a great PR though!
+        )
+        return BaseExceptionGroup
 
 
 class DeadlineExceeded(_Trimmable):

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -86,7 +86,7 @@ def get_trimmed_traceback(exception=None):
     else:
         tb = exception.__traceback__
     # Avoid trimming the traceback if we're in verbose mode, or the error
-    # was raised inside Hypothesis (and is not a MultipleFailures)
+    # was raised inside Hypothesis
     if hypothesis.settings.default.verbosity >= hypothesis.Verbosity.debug or (
         is_hypothesis_file(traceback.extract_tb(tb)[-1][0])
         and not isinstance(exception, _Trimmable)

--- a/hypothesis-python/src/hypothesis/reporting.py
+++ b/hypothesis-python/src/hypothesis/reporting.py
@@ -15,10 +15,6 @@ from hypothesis.internal.compat import escape_unicode_characters
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
 
-def silent(value):
-    pass
-
-
 def default(value):
     try:
         print(value)

--- a/hypothesis-python/tests/cover/test_arbitrary_data.py
+++ b/hypothesis-python/tests/cover/test_arbitrary_data.py
@@ -11,10 +11,8 @@
 import pytest
 from pytest import raises
 
-from hypothesis import find, given, reporting, strategies as st
+from hypothesis import find, given, strategies as st
 from hypothesis.errors import InvalidArgument
-
-from tests.common.utils import capture_out
 
 
 @given(st.integers(), st.data())
@@ -32,13 +30,10 @@ def test_prints_on_failure():
         if y in x:
             raise ValueError()
 
-    with raises(ValueError):
-        with capture_out() as out:
-            with reporting.with_reporter(reporting.default):
-                test()
-    result = out.getvalue()
-    assert "Draw 1: [0, 0]" in result
-    assert "Draw 2: 0" in result
+    with raises(ValueError) as err:
+        test()
+    assert "Draw 1: [0, 0]" in err.value.__notes__
+    assert "Draw 2: 0" in err.value.__notes__
 
 
 def test_prints_labels_if_given_on_failure():
@@ -50,13 +45,10 @@ def test_prints_labels_if_given_on_failure():
         x.remove(y)
         assert y not in x
 
-    with raises(AssertionError):
-        with capture_out() as out:
-            with reporting.with_reporter(reporting.default):
-                test()
-    result = out.getvalue()
-    assert "Draw 1 (Some numbers): [0, 0]" in result
-    assert "Draw 2 (A number): 0" in result
+    with raises(AssertionError) as err:
+        test()
+    assert "Draw 1 (Some numbers): [0, 0]" in err.value.__notes__
+    assert "Draw 2 (A number): 0" in err.value.__notes__
 
 
 def test_given_twice_is_same():
@@ -66,13 +58,10 @@ def test_given_twice_is_same():
         data2.draw(st.integers())
         raise ValueError()
 
-    with raises(ValueError):
-        with capture_out() as out:
-            with reporting.with_reporter(reporting.default):
-                test()
-    result = out.getvalue()
-    assert "Draw 1: 0" in result
-    assert "Draw 2: 0" in result
+    with raises(ValueError) as err:
+        test()
+    assert "Draw 1: 0" in err.value.__notes__
+    assert "Draw 2: 0" in err.value.__notes__
 
 
 def test_errors_when_used_in_find():

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -15,7 +15,7 @@ import pytest
 from hypothesis import given, settings, strategies as st
 from hypothesis.errors import DeadlineExceeded, Flaky, InvalidArgument
 
-from tests.common.utils import assert_falsifying_output, capture_out, fails_with
+from tests.common.utils import assert_falsifying_output, fails_with
 
 
 def test_raises_deadline_on_slow_test():
@@ -109,11 +109,10 @@ def test_gives_a_deadline_specific_flaky_error_message():
             once[0] = False
             time.sleep(0.2)
 
-    with capture_out() as o:
-        with pytest.raises(Flaky):
-            slow_once()
-    assert "Unreliable test timing" in o.getvalue()
-    assert "took 2" in o.getvalue()
+    with pytest.raises(Flaky) as err:
+        slow_once()
+    assert "Unreliable test timing" in "\n".join(err.value.__notes__)
+    assert "took 2" in "\n".join(err.value.__notes__)
 
 
 @pytest.mark.parametrize("slow_strategy", [False, True])

--- a/hypothesis-python/tests/cover/test_error_in_draw.py
+++ b/hypothesis-python/tests/cover/test_error_in_draw.py
@@ -12,8 +12,6 @@ import pytest
 
 from hypothesis import given, strategies as st
 
-from tests.common.utils import capture_out
-
 
 def test_error_is_in_finally():
     @given(st.data())
@@ -23,8 +21,7 @@ def test_error_is_in_finally():
         finally:
             raise ValueError()
 
-    with capture_out() as o:
-        with pytest.raises(ValueError):
-            test()
+    with pytest.raises(ValueError) as err:
+        test()
 
-    assert "[0, 1, -1]" in o.getvalue()
+    assert "[0, 1, -1]" in "\n".join(err.value.__notes__)

--- a/hypothesis-python/tests/cover/test_escalation.py
+++ b/hypothesis-python/tests/cover/test_escalation.py
@@ -13,7 +13,9 @@ import os
 import pytest
 
 import hypothesis
+from hypothesis import errors
 from hypothesis.internal import escalation as esc
+from hypothesis.internal.compat import BaseExceptionGroup
 
 
 def test_does_not_escalate_errors_in_non_hypothesis_file():
@@ -62,3 +64,9 @@ def test_is_hypothesis_file_not_confused_by_prefix(monkeypatch):
 @pytest.mark.parametrize("fname", ["", "<ipython-input-18-f7c304bea5eb>"])
 def test_is_hypothesis_file_does_not_error_on_invalid_paths_issue_2319(fname):
     assert not esc.is_hypothesis_file(fname)
+
+
+def test_multiplefailures_deprecation():
+    with pytest.warns(errors.HypothesisDeprecationWarning):
+        exc = errors.MultipleFailures
+    assert exc is BaseExceptionGroup

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -13,13 +13,11 @@ import random
 
 import pytest
 
-from hypothesis import core, find, given, register_random, reporting, strategies as st
+from hypothesis import core, find, given, register_random, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import entropy
 from hypothesis.internal.compat import PYPY
 from hypothesis.internal.entropy import deterministic_PRNG
-
-from tests.common.utils import capture_out
 
 
 def gc_on_pypy():
@@ -32,16 +30,13 @@ def gc_on_pypy():
 
 
 def test_can_seed_random():
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with pytest.raises(AssertionError):
+    @given(st.random_module())
+    def test(r):
+        raise AssertionError
 
-                @given(st.random_module())
-                def test(r):
-                    raise AssertionError
-
-                test()
-    assert "RandomSeeder(0)" in out.getvalue()
+    with pytest.raises(AssertionError) as err:
+        test()
+    assert "RandomSeeder(0)" in "\n".join(err.value.__notes__)
 
 
 @given(st.random_module(), st.random_module())

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -16,7 +16,7 @@ from copy import copy
 import pytest
 
 from hypothesis import assume, given, strategies as st
-from hypothesis.errors import MultipleFailures
+from hypothesis.internal.compat import ExceptionGroup
 from hypothesis.strategies._internal.random import (
     RANDOM_METHODS,
     HypothesisRandom,
@@ -26,7 +26,6 @@ from hypothesis.strategies._internal.random import (
 )
 
 from tests.common.debug import find_any
-from tests.common.utils import capture_out
 
 
 def test_implements_all_random_methods():
@@ -242,10 +241,9 @@ def test_outputs_random_calls(use_true_random):
         rnd.uniform(0.1, 0.5)
         raise AssertionError
 
-    with capture_out() as out:
-        with pytest.raises(AssertionError):
-            test()
-    assert ".uniform(0.1, 0.5)" in out.getvalue()
+    with pytest.raises(AssertionError) as err:
+        test()
+    assert ".uniform(0.1, 0.5)" in "\n".join(err.value.__notes__)
 
 
 @pytest.mark.skipif(
@@ -259,10 +257,9 @@ def test_converts_kwargs_correctly_in_output(use_true_random):
         rnd.choices([1, 2, 3, 4], k=2)
         raise AssertionError
 
-    with capture_out() as out:
-        with pytest.raises(AssertionError):
-            test()
-    assert ".choices([1, 2, 3, 4], k=2)" in out.getvalue()
+    with pytest.raises(AssertionError) as err:
+        test()
+    assert ".choices([1, 2, 3, 4], k=2)" in "\n".join(err.value.__notes__)
 
 
 @given(st.randoms(use_true_random=False))
@@ -298,7 +295,7 @@ def test_triangular_modes():
         assert x < 0.5
         assert x > 0.5
 
-    with pytest.raises(MultipleFailures):
+    with pytest.raises(ExceptionGroup):
         test()
 
 

--- a/hypothesis-python/tests/cover/test_reporting.py
+++ b/hypothesis-python/tests/cover/test_reporting.py
@@ -21,18 +21,6 @@ from hypothesis.strategies import integers
 from tests.common.utils import capture_out
 
 
-def test_can_suppress_output():
-    @given(integers())
-    def test_int(x):
-        raise AssertionError
-
-    with capture_out() as o:
-        with reporting.with_reporter(reporting.silent):
-            with pytest.raises(AssertionError):
-                test_int()
-    assert "Falsifying example" not in o.getvalue()
-
-
 def test_can_print_bytes():
     with capture_out() as o:
         with reporting.with_reporter(reporting.default):

--- a/hypothesis-python/tests/cover/test_reporting.py
+++ b/hypothesis-python/tests/cover/test_reporting.py
@@ -45,11 +45,9 @@ def test_prints_output_by_default():
     def test_int(x):
         raise AssertionError
 
-    with capture_out() as o:
-        with reporting.with_reporter(reporting.default):
-            with pytest.raises(AssertionError):
-                test_int()
-    assert "Falsifying example" in o.getvalue()
+    with pytest.raises(AssertionError) as err:
+        test_int()
+    assert "Falsifying example" in "\n".join(err.value.__notes__)
 
 
 def test_does_not_print_debug_in_verbose():

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -128,13 +128,13 @@ def test_prints_reproduction_if_requested():
             failing_example[0] = i
         assert i not in failing_example
 
-    with capture_out() as o:
-        with pytest.raises(AssertionError):
-            test()
-    assert "@reproduce_failure" in o.getvalue()
+    with pytest.raises(AssertionError) as err:
+        test()
+    notes = "\n".join(err.value.__notes__)
+    assert "@reproduce_failure" in notes
 
     exp = re.compile(r"reproduce_failure\(([^)]+)\)", re.MULTILINE)
-    extract = exp.search(o.getvalue())
+    extract = exp.search(notes)
     reproduction = eval(extract.group(0))
     test = reproduction(test)
 

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -406,13 +406,12 @@ def test_when_set_to_no_simplifies_runs_failing_example_twice():
             failing.append(x)
             raise AssertionError
 
-    with raises(AssertionError):
-        with capture_out() as out:
-            foo()
+    with raises(AssertionError) as err:
+        foo()
     assert len(failing) == 2
     assert len(set(failing)) == 1
-    assert "Falsifying example" in out.getvalue()
-    assert "Lo" in out.getvalue()
+    assert "Falsifying example" in "\n".join(err.value.__notes__)
+    assert "Lo" in err.value.__notes__
 
 
 @given(integers().filter(lambda x: x % 4 == 0))
@@ -466,12 +465,9 @@ def test_prints_notes_once_on_failure():
         if sum(xs) <= 100:
             raise ValueError()
 
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with raises(ValueError):
-                test()
-    lines = out.getvalue().strip().splitlines()
-    assert lines.count("Hi there") == 1
+    with raises(ValueError) as err:
+        test()
+    assert err.value.__notes__.count("Hi there") == 1
 
 
 @given(lists(integers(), max_size=0))

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -37,8 +37,9 @@ import attr
 import click
 import pytest
 
-from hypothesis.errors import InvalidArgument, MultipleFailures, Unsatisfiable
+from hypothesis.errors import InvalidArgument, Unsatisfiable
 from hypothesis.extra import cli, ghostwriter
+from hypothesis.internal.compat import BaseExceptionGroup
 from hypothesis.strategies import builds, from_type, just, lists
 from hypothesis.strategies._internal.lazy import LazyStrategy
 
@@ -336,7 +337,7 @@ def test_run_ghostwriter_roundtrip():
     )
     try:
         get_test_function(source_code)()
-    except (AssertionError, ValueError, MultipleFailures):
+    except (AssertionError, ValueError, BaseExceptionGroup):
         pass
 
     # Finally, restricting ourselves to finite floats makes the test pass!

--- a/hypothesis-python/tests/nocover/test_interesting_origin.py
+++ b/hypothesis-python/tests/nocover/test_interesting_origin.py
@@ -11,7 +11,7 @@
 import pytest
 
 from hypothesis import given, settings, strategies as st
-from hypothesis.errors import MultipleFailures
+from hypothesis.internal.compat import ExceptionGroup
 
 from tests.common.utils import flaky
 
@@ -58,5 +58,5 @@ def test_can_generate_specified_version(function):
         # Indirection to fix https://github.com/HypothesisWorks/hypothesis/issues/2888
         return function(x, y)
 
-    with pytest.raises(MultipleFailures):
+    with pytest.raises(ExceptionGroup):
         test_fn()

--- a/hypothesis-python/tests/nocover/test_scrutineer.py
+++ b/hypothesis-python/tests/nocover/test_scrutineer.py
@@ -59,7 +59,10 @@ def get_reports(file_contents, *, testdir):
         for i, line in enumerate(file_contents.splitlines())
         if line.endswith(BUG_MARKER)
     }
-    expected = ["\n".join(r) for k, r in make_report(explanations).items()]
+    expected = [
+        ("\n".join(r), "\n    | ".join(r))  # single, ExceptionGroup
+        for r in make_report(explanations).values()
+    ]
     return pytest_stdout, expected
 
 
@@ -67,8 +70,8 @@ def get_reports(file_contents, *, testdir):
 def test_explanations(code, testdir):
     pytest_stdout, expected = get_reports(PRELUDE + code, testdir=testdir)
     assert len(expected) == code.count(BUG_MARKER)
-    for report in expected:
-        assert report in pytest_stdout
+    for single, group in expected:
+        assert single in pytest_stdout or group in pytest_stdout
 
 
 @pytest.mark.parametrize("code", FRAGMENTS)

--- a/hypothesis-python/tests/nocover/test_stateful.py
+++ b/hypothesis-python/tests/nocover/test_stateful.py
@@ -11,13 +11,10 @@
 from collections import namedtuple
 
 import pytest
-from pytest import raises
 
 from hypothesis import settings as Settings
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, precondition, rule
 from hypothesis.strategies import booleans, integers, lists
-
-from tests.common.utils import capture_out
 
 Leaf = namedtuple("Leaf", ("label",))
 Split = namedtuple("Split", ("left", "right"))
@@ -183,13 +180,9 @@ with_cheap_bad_machines = pytest.mark.parametrize(
 def test_bad_machines_fail(machine):
     test_class = machine.TestCase
     try:
-        with capture_out() as o:
-            with raises(AssertionError):
-                test_class().runTest()
-    except Exception:
-        print(o.getvalue())
-        raise
-    v = o.getvalue()
-    print(v)
-    steps = [l for l in v.splitlines() if "Step " in l or "state." in l]
+        test_class().runTest()
+        raise RuntimeError("Expected an assertion error")
+    except AssertionError as err:
+        notes = err.__notes__
+    steps = [l for l in notes if "Step " in l or "state." in l]
     assert 1 <= len(steps) <= 50

--- a/hypothesis-python/tests/nocover/test_targeting.py
+++ b/hypothesis-python/tests/nocover/test_targeting.py
@@ -34,7 +34,6 @@ def test_reports_target_results(testdir, multiple):
     assert "Falsifying example" in out
     assert "x=101" in out
     assert out.count("Highest target score") == 1
-    assert out.index("Highest target score") < out.index("Falsifying example")
     assert result.ret != 0
 
 

--- a/hypothesis-python/tests/pytest/test_skipping.py
+++ b/hypothesis-python/tests/pytest/test_skipping.py
@@ -23,7 +23,7 @@ def test_to_be_skipped(xs):
     if xs == 0:
         pytest.skip()
     # But the pytest 3.0 internals don't have such an exception, so we keep
-    # going and raise a MultipleFailures error.  Ah well.
+    # going and raise a BaseExceptionGroup error.  Ah well.
     else:
         assert xs == 0
 """


### PR DESCRIPTION
Using the new features from PEP-654 and PEP-678, exception groups and enriching exceptions with notes.

Draft because I'm not quite done updating tests yet - and will want to do some further manual confirmation that the output *looks* good too - but this will close #3175 when merged.

- [x] Experiment with ExceptionGroup
- [x] Write PEP-678 so we can attach notes (failing examples, etc) to each exception
- [x] Core implementation work (this PR)
- [x] https://github.com/agronholm/exceptiongroup/pull/8 (`traceback.format_exception_only()`) makes Pytest show PEP-678 notes
- [x] `BuildContext.close()` could raise `ExceptionGroup` for failed cleanup tasks instead of just printing tracebacks
  - [x] check for other loops with a try/except in them.
- [x] We have some tests which check that stdout *doesn't* contain some value; inspect each usage of `capsys`, or `capture_out()` to ensure that they're still correct with use of notes.
- [ ] Pytest does not show `ExceptionGroup.exceptions` (i.e. the actual errors!) unless you use `--tb=native` https://github.com/pytest-dev/pytest/issues/9159
  - [x] Disable the `report_multiple_bugs` reporting when running on old pytest without `--tb=native`
- [ ] (nice-to-have) `rich.traceback` support https://github.com/Textualize/rich/issues/2238

