### PR TITLE
Turn warnings into errors for tests

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+This release fixes deprecation warnings about ``sre_compile`` / ``sre_parse`` imports and ``importlib.resources`` usage when running Hypothesis on Python 3.11.
+
+It also ensures that Hypothesis' test suite runs with warnings turned into errors, so that such issues will be discovered earlier in the future. This uncovered a couple of formerly hidden minor issues with the testsuite, which are now fixed as well.
+
+Thanks to Florian Bruhin for this contribution.

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -69,7 +69,10 @@ $PYTEST tests/nocover/
 
 # Run some tests without docstrings or assertions, to catch bugs
 # like issue #822 in one of the test decorators.  See also #1541.
-PYTHONOPTIMIZE=2 $PYTEST tests/cover/test_testdecorators.py
+PYTHONOPTIMIZE=2 $PYTEST \
+    -W'ignore:assertions not in test modules or plugins will be ignored because assert statements are not executed by the underlying Python interpreter:pytest.PytestConfigWarning' \
+    -W'ignore:Module already imported so cannot be rewritten:pytest.PytestAssertRewriteWarning' \
+    tests/cover/test_testdecorators.py
 
 if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then
   pip install .[django]

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -19,7 +19,7 @@ definitions it links to.  If not, report the bug!
 # https://tools.ietf.org/html/rfc3696
 
 import string
-from importlib.resources import read_text
+from importlib import resources
 
 from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument
@@ -32,7 +32,14 @@ FRAGMENT_SAFE_CHARACTERS = URL_SAFE_CHARACTERS | {"?", "/"}
 
 # This file is sourced from http://data.iana.org/TLD/tlds-alpha-by-domain.txt
 # The file contains additional information about the date that it was last updated.
-_tlds = read_text("hypothesis.vendor", "tlds-alpha-by-domain.txt").splitlines()
+try:  # pragma: no cover
+    traversable = resources.files("hypothesis.vendor") / "tlds-alpha-by-domain.txt"
+    _tlds = traversable.read_text().splitlines()
+except AttributeError:  # .files() was added in Python 3.9
+    _tlds = resources.read_text(
+        "hypothesis.vendor", "tlds-alpha-by-domain.txt"
+    ).splitlines()
+
 assert _tlds[0].startswith("#")
 TOP_LEVEL_DOMAINS = ["COM"] + sorted(_tlds[1:], key=len)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -12,7 +12,7 @@ import datetime as dt
 import os.path
 from calendar import monthrange
 from functools import lru_cache
-from importlib.resources import is_resource
+from importlib import resources
 from typing import Optional
 
 from hypothesis.errors import InvalidArgument
@@ -348,7 +348,12 @@ def _valid_key_cacheable(tzpath, key):
         *package_loc, resource_name = key.split("/")
         package = "tzdata.zoneinfo." + ".".join(package_loc)
         try:
-            return is_resource(package, resource_name)
+            try:
+                traversable = resources.files(package) / resource_name
+                return traversable.exists()
+            except AttributeError:
+                # .files() was added in Python 3.9
+                return resources.is_resource(package, resource_name)
         except ModuleNotFoundError:
             return False
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/regex.py
@@ -10,8 +10,13 @@
 
 import operator
 import re
-import sre_constants as sre
-import sre_parse
+
+try:  # pragma: no cover
+    import re._constants as sre
+    import re._parser as sre_parse
+except ImportError:  # Python < 3.11
+    import sre_constants as sre  # type: ignore
+    import sre_parse  # type: ignore
 
 from hypothesis import reject, strategies as st
 from hypothesis.internal.charmap import as_general_categories, categories

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -469,7 +469,7 @@ def test_show_changed():
 
 
 def test_note_deprecation_checks_date():
-    with pytest.warns(None) as rec:
+    with pytest.warns(HypothesisDeprecationWarning) as rec:
         note_deprecation("This is bad", since="RELEASEDAY", has_codemod=False)
     assert len(rec) == 1
     with pytest.raises(AssertionError):

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -10,7 +10,7 @@
 
 import threading
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
 
 from tests.common.debug import find_any, minimal
 from tests.common.utils import flaky
@@ -128,11 +128,15 @@ def test_can_form_sets_of_recursive_data():
 
 
 def test_drawing_from_recursive_strategy_is_thread_safe():
-    shared_strategy = st.recursive(st.integers(), lambda s: st.lists(s, max_size=3))
+    shared_strategy = st.recursive(
+        st.integers(), lambda s: st.lists(s, max_size=2), max_leaves=20
+    )
 
     errors = []
 
-    @settings(database=None)
+    @settings(
+        database=None, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+    )
     @given(data=st.data())
     def test(data):
         try:

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,15 @@ xfail_strict = True
 filterwarnings =
     error
     ignore::hypothesis.errors.NonInteractiveExampleWarning
+    # https://github.com/pandas-dev/pandas/issues/41199
+    default:Creating a LegacyVersion has been deprecated and will be removed in the next major release:DeprecationWarning
+    default:distutils Version classes are deprecated\. Use packaging\.version instead:DeprecationWarning
+    # https://github.com/pandas-dev/pandas/issues/32056 (?)
+    default:numpy\.ufunc size changed, may indicate binary incompatibility\. Expected 216 from C header, got 232 from PyObject:RuntimeWarning
+    # https://github.com/lark-parser/lark/pull/1140
+    default:module 'sre_constants' is deprecated:DeprecationWarning
+    default:module 'sre_parse' is deprecated:DeprecationWarning
+    # https://github.com/pandas-dev/pandas/issues/34848
+    default:`np\.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning
+    default:`np\.complex` is a deprecated alias for the builtin `complex`:DeprecationWarning
+    default:`np\.object` is a deprecated alias for the builtin `object`:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@
 addopts=--strict-markers --tb=native -p pytester --runpytest=subprocess --durations=20 -rfEX
 xfail_strict = True
 filterwarnings =
+    error
     ignore::hypothesis.errors.NonInteractiveExampleWarning

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -36,9 +36,6 @@ def get_mypy_output(fname, *extra_args):
         encoding="utf-8",
         capture_output=True,
         text=True,
-        # We set the MYPYPATH explicitly, because PEP561 discovery wasn't
-        # working in CI as of mypy==0.730 - hopefully a temporary workaround.
-        env=dict(os.environ, MYPYPATH=PYTHON_SRC),
     ).stdout
 
 

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import os
 import subprocess
 import textwrap
 

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -31,15 +31,15 @@ def test_mypy_passes_on_hypothesis_strict():
 
 
 def get_mypy_output(fname, *extra_args):
-    return subprocess.Popen(
+    return subprocess.run(
         [tool_path("mypy"), *extra_args, fname],
-        stdout=subprocess.PIPE,
         encoding="utf-8",
-        universal_newlines=True,
+        capture_output=True,
+        text=True,
         # We set the MYPYPATH explicitly, because PEP561 discovery wasn't
         # working in CI as of mypy==0.730 - hopefully a temporary workaround.
         env=dict(os.environ, MYPYPATH=PYTHON_SRC),
-    ).stdout.read()
+    ).stdout
 
 
 def get_mypy_analysed_type(fname, val):


### PR DESCRIPTION
This would uncover various issues which otherwise pass ~silently on CI:

- #3309
- Using [deprecated](https://docs.pytest.org/en/7.1.x/deprecations.html#using-pytest-warns-none) `pytest.warns(None)`

Submitting this so that I can see a full CI run to check if there's anything else I didn't see locally. Would be happy to fix the two issues above. Should such a fix be in separate PRs, or should I add them here?