### PR TITLE
fix(provisional): traversable.read_text error handling

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -104,6 +104,7 @@ their individual contributions.
 * `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (maxim.kulkin@gmail.com)
 * `Michel Alexandre Salim <https://github.com/michel-slm>`_ (michel@michel-slm.name)
 * `mulkieran <https://www.github.com/mulkieran>`_
+* `Munir Abdinur <https://www.github.com/mabdinur>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Nick Anyos <https://www.github.com/NickAnyos>`_
 * `Nikita Sobolev <https://github.com/sobolevn>`_ (mail@sobolevn.me)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+This release catches a ValueError when `importlib.abc.Traversable.read_text` attempts to read a DegenerateFile in python 3.10. To avoid raising this error we should fallback to using `importlib.resources.read_text`.
+
+Note: `importlib.resources.read_text` is deprecated in python 3.10 and this error will resurface when python 3.8 support is dropped.
+
+Thanks to Munir Abdinur for this contribution.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,8 @@
 RELEASE_TYPE: patch
-This release catches a ValueError when `importlib.abc.Traversable.read_text` attempts to read a DegenerateFile in python 3.10. To avoid raising this error we should fallback to using `importlib.resources.read_text`.
 
-Note: `importlib.resources.read_text` is deprecated in python 3.10 and this error will resurface when python 3.8 support is dropped.
+This patch fixes :issue:`3314`, where Hypothesis would raise an internal
+error from :func:`~hypothesis.provisional.domains` or (only on Windows)
+from :func:`~hypothesis.strategies.timezones` in some rare circumstances
+where the installation was subtly broken.
 
 Thanks to Munir Abdinur for this contribution.

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -24,9 +24,8 @@ Hypothesis 6.x
 6.45.1 - 2022-04-27
 -------------------
 
-This release fixes deprecation warnings about ``sre_compile`` / ``sre_parse`` imports and ``importlib.resources`` usage when running Hypothesis on Python 3.11.
-
-It also ensures that Hypothesis' test suite runs with warnings turned into errors, so that such issues will be discovered earlier in the future. This uncovered a couple of formerly hidden minor issues with the testsuite, which are now fixed as well.
+This release fixes deprecation warnings about ``sre_compile`` and ``sre_parse``
+imports and ``importlib.resources`` usage when running Hypothesis on Python 3.11.
 
 Thanks to Florian Bruhin for this contribution.
 
@@ -49,11 +48,11 @@ expand dimensions via indexing (`data-apis/array-api#408
 6.44.0 - 2022-04-21
 -------------------
 
-This release adds the option to pass strategies for generating names for:
-    * :class:`pandas.Index` created via :func:`~hypothesis.extra.pandas.indexes`
-    * :class:`pandas.Series` created via :func:`~hypothesis.extra.pandas.series`
+This release adds a ``names`` argument to :func:`~hypothesis.extra.pandas.indexes`
+and :func:`~hypothesis.extra.pandas.series`, so that you can create Pandas
+objects with specific or varied names.
 
-Hacked together by Sam Watts :)
+Contributed by Sam Watts.
 
 .. _v6.43.3:
 

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -41,8 +41,7 @@ if setuptools_version < (36, 2):
     )
 
 
-# Assignment to placate pyflakes. The actual version is from the exec that
-# follows.
+# Assignment to placate pyflakes. The actual version is from the exec that follows.
 __version__ = None
 
 with open(local_file("src/hypothesis/version.py")) as o:

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -35,7 +35,7 @@ FRAGMENT_SAFE_CHARACTERS = URL_SAFE_CHARACTERS | {"?", "/"}
 try:  # pragma: no cover
     traversable = resources.files("hypothesis.vendor") / "tlds-alpha-by-domain.txt"
     _tlds = traversable.read_text().splitlines()
-except AttributeError:  # .files() was added in Python 3.9
+except (AttributeError, ValueError):  # .files() was added in Python 3.9
     _tlds = resources.read_text(
         "hypothesis.vendor", "tlds-alpha-by-domain.txt"
     ).splitlines()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -351,7 +351,7 @@ def _valid_key_cacheable(tzpath, key):
             try:
                 traversable = resources.files(package) / resource_name
                 return traversable.exists()
-            except AttributeError:
+            except (AttributeError, ValueError):
                 # .files() was added in Python 3.9
                 return resources.is_resource(package, resource_name)
         except ModuleNotFoundError:


### PR DESCRIPTION
`traversable.read_text` raises a ValueError in python 3.10

Sample Error with `hypothesis==6.45.1`: 

```
tests/tracer/test_http.py:3: in <module>
    from hypothesis.provisional import urls
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
.riot/venv_py3103_mock_pytest700_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
.riot/venv_py3103_mock_pytest700_pytest-mock_coverage_pytest-cov_opentracing_hypothesis/lib/python3.10/site-packages/hypothesis/provisional.py:37: in <module>
    _tlds = traversable.read_text().splitlines()
../.pyenv/versions/3.10.3/lib/python3.10/importlib/abc.py:378: in read_text
    with self.open(encoding=encoding) as strm:
../.pyenv/versions/3.10.3/lib/python3.10/importlib/_adapters.py:54: in open
    raise ValueError()
E   ValueError
```