### PR TITLE
strategies.uuids can generate nil uuids

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -131,6 +131,7 @@ their individual contributions.
 * `Sangarshanan <https://www.github.com/sangarshanan>`_ (sangarshanan1998@gmail.com)
 * `Sanyam Khurana <https://github.com/CuriousLearner>`_
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (s.shanabrook@gmail.com)
+* `Shlok Gandhi <https://github.com/shlok57>`_ (shlok.gandhi@gmail.com)
 * `Stuart Cook <https://www.github.com/Zalathar>`_
 * `SuperStormer <https://github.com/SuperStormer>`_
 * `Sushobhit <https://github.com/sushobhit27>`_ (sushobhitsolanki@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,4 @@
 RELEASE_TYPE: minor
 
-This release updates :func:`hypothesis.strategies.uuids` by introducing an
-``allow_nil`` argument, defaulting to ``False``. If ``allow_nil=True``, 
-nil UUID would be generated more often
+This release adds an ``allow_nil`` argument to :func:`~hypothesis.strategies.uuids`,
+which you can use to... generate the nil UUID.  Thanks to Shlok Gandhi for the patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release updates :func:`hypothesis.strategies.uuids` by introducing an
+``allow_nil`` argument, defaulting to ``False``. If ``allow_nil=True``, 
+nil UUID would be generated more often

--- a/hypothesis-python/src/hypothesis/strategies/__init__.py
+++ b/hypothesis-python/src/hypothesis/strategies/__init__.py
@@ -121,6 +121,9 @@ def _check_exports(_public):
 
     # Verify that all exported strategy functions were registered with
     # @declares_strategy.
+
+    existing_strategies = set(_strategies) - {"_maybe_nil_uuids"}
+
     exported_strategies = set(__all__) - {
         "DataObject",
         "DrawFn",
@@ -128,9 +131,9 @@ def _check_exports(_public):
         "composite",
         "register_type_strategy",
     }
-    assert set(_strategies) == exported_strategies, (
-        set(_strategies) - exported_strategies,
-        exported_strategies - set(_strategies),
+    assert existing_strategies == exported_strategies, (
+        existing_strategies - exported_strategies,
+        exported_strategies - existing_strategies,
     )
 
 

--- a/hypothesis-python/tests/cover/test_uuids.py
+++ b/hypothesis-python/tests/cover/test_uuids.py
@@ -30,3 +30,5 @@ def test_can_only_allow_nil_uuid_with_none_version():
     st.uuids(version=None, allow_nil=True).example()
     with pytest.raises(InvalidArgument):
         st.uuids(version=4, allow_nil=True).example()
+    with pytest.raises(InvalidArgument):
+        st.uuids(version=None, allow_nil="not a bool").example()

--- a/hypothesis-python/tests/cover/test_uuids.py
+++ b/hypothesis-python/tests/cover/test_uuids.py
@@ -1,0 +1,32 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import uuid
+
+import pytest
+
+from hypothesis import strategies as st
+from hypothesis.errors import InvalidArgument
+
+from tests.common.debug import assert_no_examples, find_any
+
+
+def test_no_nil_uuid_by_default():
+    assert_no_examples(st.uuids(), lambda x: x == uuid.UUID(int=0))
+
+
+def test_can_generate_nil_uuid():
+    find_any(st.uuids(allow_nil=True), lambda x: x == uuid.UUID(int=0))
+
+
+def test_can_only_allow_nil_uuid_with_none_version():
+    st.uuids(version=None, allow_nil=True).example()
+    with pytest.raises(InvalidArgument):
+        st.uuids(version=4, allow_nil=True).example()

--- a/hypothesis-python/tests/nocover/test_uuids.py
+++ b/hypothesis-python/tests/nocover/test_uuids.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-
 import pytest
 
 from hypothesis import given, strategies as st

--- a/hypothesis-python/tests/nocover/test_uuids.py
+++ b/hypothesis-python/tests/nocover/test_uuids.py
@@ -8,14 +8,12 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import uuid
 
 import pytest
 
 from hypothesis import given, strategies as st
-from hypothesis.errors import InvalidArgument
 
-from tests.common.debug import assert_no_examples, minimal
+from tests.common.debug import minimal
 
 
 @given(st.lists(st.uuids()))
@@ -35,17 +33,3 @@ def test_can_generate_specified_version(version):
         assert version == uuid.version
 
     inner()
-
-
-def test_no_nil_uuid():
-    assert_no_examples(st.uuids(), lambda x: x == uuid.UUID(int=0))
-
-
-def test_nil_uuid():
-    st.uuids(allow_nil=True), lambda x: x == uuid.UUID(int=0)
-
-
-def test_can_only_allow_nil_uuid_with_none_version():
-    st.uuids(version=None, allow_nil=True).example()
-    with pytest.raises(InvalidArgument):
-        st.uuids(version=4, allow_nil=True).example()

--- a/hypothesis-python/tests/nocover/test_uuids.py
+++ b/hypothesis-python/tests/nocover/test_uuids.py
@@ -8,11 +8,14 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import uuid
+
 import pytest
 
 from hypothesis import given, strategies as st
+from hypothesis.errors import InvalidArgument
 
-from tests.common.debug import minimal
+from tests.common.debug import assert_no_examples, minimal
 
 
 @given(st.lists(st.uuids()))
@@ -32,3 +35,17 @@ def test_can_generate_specified_version(version):
         assert version == uuid.version
 
     inner()
+
+
+def test_no_nil_uuid():
+    assert_no_examples(st.uuids(), lambda x: x == uuid.UUID(int=0))
+
+
+def test_nil_uuid():
+    st.uuids(allow_nil=True), lambda x: x == uuid.UUID(int=0)
+
+
+def test_can_only_allow_nil_uuid_with_none_version():
+    st.uuids(version=None, allow_nil=True).example()
+    with pytest.raises(InvalidArgument):
+        st.uuids(version=4, allow_nil=True).example()

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -12,7 +12,7 @@ backports-zoneinfo==0.2.1
     # via -r requirements/coverage.in
 black==22.3.0
     # via -r requirements/coverage.in
-click==8.1.2
+click==8.1.3
     # via
     #   -r requirements/coverage.in
     #   black

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.0
+asgiref==3.5.1
     # via django
 astor==0.8.1
     # via flake8-simplify
@@ -39,7 +39,7 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via
     #   black
     #   pip-tools
@@ -51,7 +51,7 @@ commonmark==0.9.1
     # via rich
 coverage==6.3.2
     # via -r requirements/tools.in
-cryptography==36.0.2
+cryptography==37.0.1
     # via secretstorage
 decorator==5.1.1
     # via ipython
@@ -93,7 +93,7 @@ flake8-2020==1.6.1
     # via -r requirements/tools.in
 flake8-bandit==3.0.0
     # via -r requirements/tools.in
-flake8-bugbear==22.3.23
+flake8-bugbear==22.4.25
     # via -r requirements/tools.in
 flake8-builtins==1.5.3
     # via -r requirements/tools.in
@@ -140,7 +140,7 @@ importlib-metadata==4.11.3
     #   twine
 iniconfig==1.1.1
     # via pytest
-ipython==8.2.0
+ipython==8.3.0
     # via -r requirements/tools.in
 isort==5.10.1
     # via shed
@@ -150,7 +150,7 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
 keyring==23.5.0
     # via twine
@@ -166,7 +166,7 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.6.1
     # via flake8
-mypy==0.942
+mypy==0.950
     # via -r requirements/tools.in
 mypy-extensions==0.4.3
     # via
@@ -226,7 +226,7 @@ pyflakes==2.4.0
     # via
     #   autoflake
     #   flake8
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   ipython
     #   readme-renderer
@@ -234,7 +234,7 @@ pygments==2.11.2
     #   sphinx
 pyparsing==3.0.8
     # via packaging
-pyright==1.1.239
+pyright==1.1.242
     # via -r requirements/tools.in
 pytest==7.1.2
     # via -r requirements/tools.in
@@ -262,7 +262,7 @@ restructuredtext-lint==1.4.0
     # via -r requirements/tools.in
 rfc3986==2.0.0
     # via twine
-rich==12.2.0
+rich==12.3.0
     # via twine
 secretstorage==3.3.2
     # via keyring
@@ -340,9 +340,9 @@ types-click==7.1.8
     # via -r requirements/tools.in
 types-pkg-resources==0.1.3
     # via -r requirements/tools.in
-types-pytz==2021.3.6
+types-pytz==2021.3.7
     # via -r requirements/tools.in
-types-redis==4.1.22
+types-redis==4.2.0
     # via -r requirements/tools.in
 typing-extensions==4.2.0
     # via

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -39,7 +39,10 @@ def get_mypy_output(fname, *extra_args):
 
 
 def get_mypy_analysed_type(fname, val):
-    out = get_mypy_output(fname)
+    out = get_mypy_output(fname).rstrip()
+    msg = "Success: no issues found in 1 source file"
+    if out.endswith(msg):
+        out = out[: len(msg)]
     assert len(out.splitlines()) == 1
     # See https://mypy.readthedocs.io/en/latest/common_issues.html#reveal-type
     # The shell output for `reveal_type([1, 2, 3])` looks like a literal:

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -42,7 +42,7 @@ def get_mypy_analysed_type(fname, val):
     out = get_mypy_output(fname).rstrip()
     msg = "Success: no issues found in 1 source file"
     if out.endswith(msg):
-        out = out[: len(msg)]
+        out = out[: -len(msg)]
     assert len(out.splitlines()) == 1
     # See https://mypy.readthedocs.io/en/latest/common_issues.html#reveal-type
     # The shell output for `reveal_type([1, 2, 3])` looks like a literal:


### PR DESCRIPTION
Fixes #3263

Allow `strategies.uuids` can generate nil uuids

- Contributed as a part of PyConUS2022 mentored sprint