### PR TITLE
Fix rare type hints issue

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare bug where we could incorrectly treat
+:obj:`~python:inspect.Parameter.empty` as a type annotation,
+if the callable had an explicitly assigned ``__signature__``.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -91,7 +91,11 @@ def get_type_hints(thing):
 
             vkinds = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
             for p in inspect.signature(thing).parameters.values():
-                if p.kind not in vkinds and is_a_type(p.annotation):
+                if (
+                    p.kind not in vkinds
+                    and is_a_type(p.annotation)
+                    and p.annotation is not p.empty
+                ):
                     if p.default is None:
                         hints[p.name] = typing.Optional[p.annotation]
                     else:

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -10,6 +10,7 @@
 
 import abc
 import enum
+from inspect import Parameter as P, Signature
 from typing import Callable, Dict, Generic, List, Sequence, TypeVar, Union
 
 import pytest
@@ -20,6 +21,7 @@ from hypothesis.errors import (
     InvalidArgument,
     ResolutionFailed,
 )
+from hypothesis.internal.compat import get_type_hints
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal import types
 from hypothesis.strategies._internal.core import _from_type
@@ -416,3 +418,11 @@ def _pos_and_kwd_only(x: int, *, y: str):
 def test_infer_all(func):
     # tests @given(...) against various signatures
     settings(max_examples=1)(given(...))(func)()
+
+
+def test_does_not_add_param_empty_to_type_hints():
+    def f(x):
+        pass
+
+    f.__signature__ = Signature([P("y", P.KEYWORD_ONLY)], return_annotation=None)
+    assert get_type_hints(f) == {}


### PR DESCRIPTION
I noticed this via the ghostwriter when playing around with the recent keyword-related issues.  Intending to merge pretty quickly, but might be of interest to @sobolevn too.