### PR TITLE
Traceback-trimming of contextlib under Python 3.11

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,6 +30,7 @@ their individual contributions.
 * `Charles O'Farrell <https://www.github.com/charleso>`_
 * `Charlie Tanksley <https://www.github.com/charlietanksley>`_
 * `Chase Garner <https://www.github.com/chasegarner>`_ (chase@garner.red)
+* `Cheuk Ting Ho <https://github.com/Cheukting>`_
 * `Chris Down  <https://chrisdown.name>`_
 * `Christopher Martin <https://www.github.com/chris-martin>`_ (ch.martin@gmail.com)
 * `Claudio Jolowicz <https://github.com/cjolowicz>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,1 @@
+RELEASE_TYPE: patch

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,1 +1,3 @@
 RELEASE_TYPE: patch
+
+This patch by Cheuk Ting Ho improves traceback trimming on Python 3.11 prereleases (:issue:`3298`).

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -59,6 +59,7 @@ FILE_CACHE: Dict[bytes, bool] = {}
 
 
 is_hypothesis_file = belongs_to(hypothesis)
+is_contextlib_file = belongs_to(contextlib)
 
 HYPOTHESIS_CONTROL_EXCEPTIONS = (DeadlineExceeded, StopTest, UnsatisfiedAssumption)
 
@@ -98,6 +99,11 @@ def get_trimmed_traceback(exception=None):
         # But our `@proxies` decorator overrides the source location,
         # so we check for an attribute it injects into the frame too.
         or tb.tb_frame.f_globals.get("__hypothesistracebackhide__") is True
+        # trim frames from contextlib in python 3.11
+        or (
+            sys.version_info[:2] == (3, 11)
+            and is_contextlib_file(getframeinfo(tb.tb_frame).filename)
+        )
     ):
         tb = tb.tb_next
     return tb

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -37,11 +37,6 @@ if sys.version_info < (3, 10):
 if sys.version_info >= (3, 11):
     collect_ignore_glob.append("cover/test_asyncio.py")  # @asyncio.coroutine removed
 
-    assert sys.version_info.releaselevel == "alpha"
-    # TODO: our traceback elision doesn't work with Python 3.11's nice new format yet
-    collect_ignore_glob.append("cover/test_traceback_elision.py")
-    collect_ignore_glob.append("pytest/test_capture.py")
-
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: pandas expects this marker to exist.")


### PR DESCRIPTION
Trimming contextlib traceback for Python 3.11

closes #3298 