### PR TITLE
change requirement file type

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,6 +54,7 @@ their individual contributions.
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
+* `Glenn Lehman <https://www.github.com/glnnlhmn>`_
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,8 +53,8 @@ make changes and install the changed version) you can do this with:
 
 .. code:: bash
 
-  pip install -r requirements/test.txt
-  pip install -r requirements/tools.txt
+  pip install -r requirements/test.in
+  pip install -r requirements/tools.in
   pip install -e hypothesis-python/
 
   # You don't need to run the tests, but here's the command:


### PR DESCRIPTION
When testing the setup for contributors, the file extensions needed to be changed from _.txt_ to _.in_. File extensions have been updated, and the installation procedures tested satisfactorily. 