### PR TITLE
Handle TypedDict classes with PEP-655 (Not)Required keys

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch by Cheuk Ting Ho added handling of annotation of `Required` and `NotRequired` in `TypedDict` (See PEP-655: https://peps.python.org/pep-0655/) (:issue:`3339`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch by Cheuk Ting Ho added handling of annotation of `Required` and `NotRequired` in `TypedDict` (See PEP-655: https://peps.python.org/pep-0655/) (:issue:`3339`).
+This patch by Cheuk Ting Ho added handling of annotation of `Required` and `NotRequired` in `TypedDict` in :func:`~hypothesis.strategies.from_type` (See PEP-655: https://peps.python.org/pep-0655/) (:issue:`3339`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-This patch by Cheuk Ting Ho adds support for :pep:`655` `Required` and `NotRequired` as attributes of
+This patch by Cheuk Ting Ho adds support for :pep:`655` ``Required`` and ``NotRequired`` as attributes of
 :class:`~python:typing.TypedDict` in :func:`~hypothesis.strategies.from_type` (:issue:`3339`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,4 @@
 RELEASE_TYPE: patch
 
-This patch by Cheuk Ting Ho adds support for :pep:`655` :class:`~python:typing.Required` and 
-:class:`~python:typing.NotRequired` as attributes of :class:`~python:typing.TypedDict` in
-:func:`~hypothesis.strategies.from_type` (:issue:`3339`).
+This patch by Cheuk Ting Ho adds support for :pep:`655` `Required` and `NotRequired` as attributes of
+:class:`~python:typing.TypedDict` in :func:`~hypothesis.strategies.from_type` (:issue:`3339`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1098,8 +1098,6 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
                         f"`{k}: {v.__name__}` is not a valid type annotation"
                     ) from None
             anns[k] = from_type(v)
-
-        # anns = {k: from_type(v) for k, v in get_type_hints(thing).items()}
         if (
             (not anns)
             and thing.__annotations__

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1082,11 +1082,11 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         # The __optional_keys__ attribute may or may not be present, but if there's no
         # way to tell and we just have to assume that everything is required.
         # See https://github.com/python/cpython/pull/17214 for details.
-        optional = getattr(thing, "__optional_keys__", ())
+        optional = set(getattr(thing, "__optional_keys__", ()))
         anns = {}
         for k, v in get_type_hints(thing).items():
             if hasattr(v, "__origin__") and v.__origin__ in types.NotRequiredTypes:
-                optional = optional.union({k})
+                optional.add(k)
                 anns.update({k: from_type(v.__args__[0])})
             elif hasattr(v, "__origin__") and v.__origin__ in types.RequiredTypes:
                 anns.update({k: from_type(v.__args__[0])})

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -120,34 +120,6 @@ except ImportError:  # < py3.8
     Protocol = object  # type: ignore[assignment]
 
 
-try:
-    import typing_extensions
-except ImportError:
-    typing_extensions = None  # type: ignore
-
-
-RequiredTypes: tuple = ()
-try:
-    RequiredTypes += (typing.Required,)
-except AttributeError:  # pragma: no cover
-    pass  # Is missing for `python<3.11`
-try:
-    RequiredTypes += (typing_extensions.Required,)
-except AttributeError:  # pragma: no cover
-    pass  # `typing_extensions` might not be installed
-
-
-NotRequiredTypes: tuple = ()
-try:
-    NotRequiredTypes += (typing.NotRequired,)
-except AttributeError:  # pragma: no cover
-    pass  # Is missing for `python<3.11`
-try:
-    NotRequiredTypes += (typing_extensions.NotRequired,)
-except AttributeError:  # pragma: no cover
-    pass  # `typing_extensions` might not be installed
-
-
 @cacheable
 @defines_strategy()
 def booleans() -> SearchStrategy[bool]:
@@ -1113,10 +1085,10 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
         optional = getattr(thing, "__optional_keys__", ())
         anns = {}
         for k, v in get_type_hints(thing).items():
-            if hasattr(v, "__origin__") and v.__origin__ in NotRequiredTypes:
+            if hasattr(v, "__origin__") and v.__origin__ in types.NotRequiredTypes:
                 optional = optional.union({k})
                 anns.update({k: from_type(v.__args__[0])})
-            elif hasattr(v, "__origin__") and v.__origin__ in RequiredTypes:
+            elif hasattr(v, "__origin__") and v.__origin__ in types.RequiredTypes:
                 anns.update({k: from_type(v.__args__[0])})
             else:
                 anns.update({k: from_type(v)})

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1094,7 +1094,9 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
                 try:
                     v = v.__args__[0]
                 except IndexError:
-                    raise InvalidArgument(f"`{k}: {v.__name__}` is not a valid type annotation") from None
+                    raise InvalidArgument(
+                        f"`{k}: {v.__name__}` is not a valid type annotation"
+                    ) from None
             anns[k] = from_type(v)
 
         # anns = {k: from_type(v) for k, v in get_type_hints(thing).items()}

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -121,6 +121,28 @@ except AttributeError:  # pragma: no cover
     pass  # `typing_extensions` might not be installed
 
 
+RequiredTypes: tuple = ()
+try:
+    RequiredTypes += (typing.Required,)
+except AttributeError:  # pragma: no cover
+    pass  # Is missing for `python<3.11`
+try:
+    RequiredTypes += (typing_extensions.Required,)
+except AttributeError:  # pragma: no cover
+    pass  # `typing_extensions` might not be installed
+
+
+NotRequiredTypes: tuple = ()
+try:
+    NotRequiredTypes += (typing.NotRequired,)
+except AttributeError:  # pragma: no cover
+    pass  # Is missing for `python<3.11`
+try:
+    NotRequiredTypes += (typing_extensions.NotRequired,)
+except AttributeError:  # pragma: no cover
+    pass  # `typing_extensions` might not be installed
+
+
 # We use this variable to be sure that we are working with a type from `typing`:
 typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -123,7 +123,7 @@ except AttributeError:  # pragma: no cover
 
 RequiredTypes: tuple = ()
 try:
-    RequiredTypes += (typing.Required,)
+    RequiredTypes += (typing.Required,)  # type: ignore
 except AttributeError:  # pragma: no cover
     pass  # Is missing for `python<3.11`
 try:
@@ -134,7 +134,7 @@ except AttributeError:  # pragma: no cover
 
 NotRequiredTypes: tuple = ()
 try:
-    NotRequiredTypes += (typing.NotRequired,)
+    NotRequiredTypes += (typing.NotRequired,)  # type: ignore
 except AttributeError:  # pragma: no cover
     pass  # Is missing for `python<3.11`
 try:

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -32,7 +32,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal.types import NON_RUNTIME_TYPES
 
-from tests.common.debug import find_any
+from tests.common.debug import find_any, assert_all_examples
 
 # See also nocover/test_type_lookp.py
 

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -32,7 +32,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal.types import NON_RUNTIME_TYPES
 
-from tests.common.debug import find_any, assert_all_examples
+from tests.common.debug import assert_all_examples, find_any
 
 # See also nocover/test_type_lookp.py
 
@@ -276,3 +276,15 @@ class Novel(Book):
 )
 def test_required_and_not_required_keys(check, condition):
     check(from_type(Novel), condition)
+
+
+def test_typeddict_error_msg():
+    with pytest.raises(TypeError, match="is not valid as type argument"):
+
+        class Foo(TypedDict):
+            attr: Required
+
+    with pytest.raises(TypeError, match="is not valid as type argument"):
+
+        class Bar(TypedDict):
+            attr: NotRequired

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -32,6 +32,8 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal.types import NON_RUNTIME_TYPES
 
+from tests.common.debug import find_any
+
 # See also nocover/test_type_lookp.py
 
 
@@ -232,3 +234,56 @@ def test_typeddict_required(value):
     assert isinstance(value["title"], str)
     if "year" in value:
         assert isinstance(value["year"], int)
+
+
+class Story(TypedDict, total=True):
+    author: str
+
+
+class Book(Story, total=False):
+    pages: int
+
+
+class Novel(Book):
+    genre: Required[str]
+    rating: NotRequired[str]
+
+
+def test_author_and_genre_only():
+    find_any(
+        from_type(Novel),
+        lambda novel: "author" in novel
+        and "genre" in novel
+        and "pages" not in novel
+        and "rating" not in novel,
+    )
+
+
+def test_author_and_genre_and_pages_only():
+    find_any(
+        from_type(Novel),
+        lambda novel: "author" in novel
+        and "genre" in novel
+        and "pages" in novel
+        and "rating" not in novel,
+    )
+
+
+def test_author_and_genre_and_rating_only():
+    find_any(
+        from_type(Novel),
+        lambda novel: "author" in novel
+        and "genre" in novel
+        and "pages" not in novel
+        and "rating" in novel,
+    )
+
+
+def test_novel_all_in():
+    find_any(
+        from_type(Novel),
+        lambda novel: "author" in novel
+        and "genre" in novel
+        and "pages" in novel
+        and "rating" in novel,
+    )

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -19,7 +19,9 @@ from typing_extensions import (
     DefaultDict,
     Literal,
     NewType,
+    NotRequired,
     ParamSpec,
+    Required,
     Type,
     TypedDict,
     TypeGuard,
@@ -202,3 +204,31 @@ def test_callable_return_typegard_type():
 
     with pytest.raises(InvalidArgument, match="Cannot register generic type"):
         st.register_type_strategy(Callable[[], TypeGuard[int]], st.none())
+
+
+class Movie(TypedDict):  # implicitly total=True
+    title: str
+    year: NotRequired[int]
+
+
+@given(from_type(Movie))
+def test_typeddict_not_required(value):
+    assert type(value) == dict
+    assert set(value).issubset({"title", "year"})
+    assert isinstance(value["title"], str)
+    if "year" in value:
+        assert isinstance(value["year"], int)
+
+
+class OtherMovie(TypedDict, total=False):
+    title: Required[str]
+    year: int
+
+
+@given(from_type(OtherMovie))
+def test_typeddict_required(value):
+    assert type(value) == dict
+    assert set(value).issubset({"title", "year"})
+    assert isinstance(value["title"], str)
+    if "year" in value:
+        assert isinstance(value["year"], int)

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -222,6 +222,10 @@ def test_typeddict_not_required(value):
         assert isinstance(value["year"], int)
 
 
+def test_typeddict_not_required_can_skip():
+    find_any(from_type(Movie), lambda movie: "year" not in movie)
+
+
 class OtherMovie(TypedDict, total=False):
     title: Required[str]
     year: int
@@ -234,6 +238,10 @@ def test_typeddict_required(value):
     assert isinstance(value["title"], str)
     if "year" in value:
         assert isinstance(value["year"], int)
+
+
+def test_typeddict_required_must_have():
+    assert_all_examples(from_type(OtherMovie), lambda movie: "title" in movie)
 
 
 class Story(TypedDict, total=True):

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -249,41 +249,30 @@ class Novel(Book):
     rating: NotRequired[str]
 
 
-def test_author_and_genre_only():
-    find_any(
-        from_type(Novel),
-        lambda novel: "author" in novel
-        and "genre" in novel
-        and "pages" not in novel
-        and "rating" not in novel,
-    )
-
-
-def test_author_and_genre_and_pages_only():
-    find_any(
-        from_type(Novel),
-        lambda novel: "author" in novel
-        and "genre" in novel
-        and "pages" in novel
-        and "rating" not in novel,
-    )
-
-
-def test_author_and_genre_and_rating_only():
-    find_any(
-        from_type(Novel),
-        lambda novel: "author" in novel
-        and "genre" in novel
-        and "pages" not in novel
-        and "rating" in novel,
-    )
-
-
-def test_novel_all_in():
-    find_any(
-        from_type(Novel),
-        lambda novel: "author" in novel
-        and "genre" in novel
-        and "pages" in novel
-        and "rating" in novel,
-    )
+@pytest.mark.parametrize(
+    "check,condition",
+    [
+        pytest.param(
+            assert_all_examples,
+            lambda novel: "author" in novel,
+            id="author-is-required",
+        ),
+        pytest.param(
+            assert_all_examples, lambda novel: "genre" in novel, id="genre-is-required"
+        ),
+        pytest.param(
+            find_any, lambda novel: "pages" in novel, id="pages-may-be-present"
+        ),
+        pytest.param(
+            find_any, lambda novel: "pages" not in novel, id="pages-may-be-absent"
+        ),
+        pytest.param(
+            find_any, lambda novel: "rating" in novel, id="rating-may-be-present"
+        ),
+        pytest.param(
+            find_any, lambda novel: "rating" not in novel, id="rating-may-be-absent"
+        ),
+    ],
+)
+def test_required_and_not_required_keys(check, condition):
+    check(from_type(Novel), condition)


### PR DESCRIPTION
Added handling of annotation of `Required` and `NotRequired` in `TypedDict` in `from_typed`.

Closes #3339 