### PR TITLE
fix docstring typo

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1673,7 +1673,7 @@ def uuids(
     to :class:`~python:uuid.UUID` and only UUIDs of that version will
     be generated.
 
-    If ``allow_nil` is True, generate the nil UUID much more often.
+    If ``allow_nil`` is True, generate the nil UUID much more often.
     Otherwise, all returned values from this will be unique, so e.g. if you do
     ``lists(uuids())`` the resulting list will never contain duplicates.
 


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/pull/3323#issuecomment-1129575500

> If we really want to avoid making a release just for that typo-fix, I can always cherry-pick it onto something else before I merge that.

That works for me 👍🏼

> I think maybe we just need to remove the `python:` (or whichever project) prefix in these? Just reproducing with sphinx-build in nitpicky mode would be a great start.

Looks like those are Python specific cross references ([doc](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#python-roles)) which I think should be `py:` for the Python domain ([doc](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#the-python-domain))?

Also, there’s a bunch of [pygrep-hooks](https://github.com/pre-commit/pygrep-hooks) for [pre-commit](http://pre-commit.com/) that might be useful here?