### PR TITLE
Reference timezone strategies from datetimes docstring

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ their individual contributions.
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
+* `George Macon <https://www.github.com/gmacon>`_
 * `Glenn Lehman <https://www.github.com/glnnlhmn>`_
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+Mention :func:`hypothesis.strategies.timezones`
+in the documentation of :func:`hypothesis.strategies.datetimes` for completeness.
+
+Thanks to George Macon for this addition.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -186,9 +186,14 @@ def datetimes(
 
     ``timezones`` must be a strategy that generates either ``None``, for naive
     datetimes, or :class:`~python:datetime.tzinfo` objects for 'aware' datetimes.
-    You can construct your own, though we recommend using the :pypi:`dateutil
-    <python-dateutil>` package and :func:`hypothesis.extra.dateutil.timezones`
-    strategy, and also provide :func:`hypothesis.extra.pytz.timezones`.
+    You can construct your own, though we recommend using one of these built-in
+    strategies:
+
+    * with Python 3.9 or newer or :pypi:`backports.zoneinfo`:
+      :func:`hypothesis.strategies.timezones`;
+    * with :pypi:`dateutil <python-dateutil>`:
+      :func:`hypothesis.extra.dateutil.timezones`; or
+    * with :pypi:`pytz`: :func:`hypothesis.extra.pytz.timezones`.
 
     You may pass ``allow_imaginary=False`` to filter out "imaginary" datetimes
     which did not (or will not) occur due to daylight savings, leap seconds,


### PR DESCRIPTION
It took me an inordinate amount of time to realize that [`strategies.timezones`](https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.timezones) exists, so I thought it would be helpful to mention it in the [`strategies.datetimes`](https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.datetimes) documentation next to the other timezone strategies.