### PR TITLE
Remove sorting of dictionaries in pretty.printer. #3370

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,7 @@ their individual contributions.
 * `Chase Garner <https://www.github.com/chasegarner>`_ (chase@garner.red)
 * `Cheuk Ting Ho <https://github.com/Cheukting>`_
 * `Chris Down  <https://chrisdown.name>`_
+* `Chris van Dronkelaar <https://github.com/Chrisvandr>`_
 * `Christopher Martin <https://www.github.com/chris-martin>`_ (ch.martin@gmail.com)
 * `Claudio Jolowicz <https://github.com/cjolowicz>`_
 * `Conrad Ho <https://www.github.com/conradho>`_ (conrad.alwin.ho@gmail.com)
@@ -126,6 +127,7 @@ their individual contributions.
 * `Pierre-Jean Campigotto <https://github.com/PJCampi>`_
 * `Przemek Konopko <https://github.com/soutys>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (richard@tartarus.org)
+* `Richard Scholtens <https://github.com/richardscholtens>`_ (richardscholtens2@gmail.com)
 * `Robert Howlett <https://github.com/jebob>`_
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
 * `Rónán Carrigan <https://www.github.com/rcarriga>`_ (rcarriga@tcd.ie)
@@ -138,6 +140,7 @@ their individual contributions.
 * `Sangarshanan <https://www.github.com/sangarshanan>`_ (sangarshanan1998@gmail.com)
 * `Sanyam Khurana <https://github.com/CuriousLearner>`_
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (s.shanabrook@gmail.com)
+* `Sebastiaan Zeeff <https://github.com/SebastiaanZ>`_ (sebastiaan.zeeff@ordina.nl)
 * `Shlok Gandhi <https://github.com/shlok57>`_ (shlok.gandhi@gmail.com)
 * `Sogata Ray <https://github.com/rayardinanda>`_ (rayardinanda@gmail.com)
 * `Stuart Cook <https://www.github.com/Zalathar>`_
@@ -155,6 +158,7 @@ their individual contributions.
 * `Tyler Nickerson <https://www.github.com/nmbrgts>`_
 * `Vidya Rani <https://www.github.com/vidyarani-dg>`_ (vidyarani.d.g@gmail.com)
 * `Vincent Michel <https://www.github.com/vxgmichel>`_ (vxgmichel@gmail.com)
+* `Viorel Pluta <https://github.com/viopl>`_ (viopluta@gmail.com)
 * `Vytautas Strimaitis <https://www.github.com/vstrimaitis>`_
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+
+Order of dictionaries is now enforced in Python 3.7 and higher. This means that the original order of dictionaries matters for falsifying examples.
+
+This PR closes #3370.
+
+This PR was kindly supported by Ordina Pythoneers.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,8 +1,6 @@
 RELEASE_TYPE: patch
 
-
-Order of dictionaries is now enforced in Python 3.7 and higher. This means that the original order of dictionaries matters for falsifying examples.
-
-This PR closes #3370.
-
-This PR was kindly supported by Ordina Pythoneers.
+Our pretty-printer no longer sorts dictionary keys, since iteration order is
+stable in Python 3.7+ and this can affect reproducing examples (:issue:`3370`).
+This PR was kindly supported by `Ordina Pythoneers
+<https://www.ordina.nl/vakgebieden/python/>`__.

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -603,16 +603,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
         if cycle:
             return p.text("{...}")
         p.begin_group(1, start)
-        keys = obj.keys()
-        # if dict isn't large enough to be truncated, sort keys before
-        # displaying
-        if not (p.max_seq_length and len(obj) >= p.max_seq_length):
-            try:
-                keys = sorted(keys)
-            except Exception:
-                # Sometimes the keys don't sort.
-                pass
-        for idx, key in p._enumerate(keys):
+        for idx, key in p._enumerate(obj):
             if idx:
                 p.text(",")
                 p.breakable()

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -134,6 +134,7 @@ def test_list():
 def test_dict():
     assert pretty.pretty({}) == "{}"
     assert pretty.pretty({1: 1}) == "{1: 1}"
+    assert pretty.pretty({1: 1, 0: 0}) == "{1: 1, 0: 0}"
 
 
 def test_tuple():


### PR DESCRIPTION
Order of dictionaries is now enforced in Python 3.7 and higher. This means that the original order of dictionaries matters for falsifying examples.

This PR closes #3370. 

This PR was kindly supported by [Ordina Pythoneers](https://www.ordina.nl/vakgebieden/python/).