### PR TITLE
Improve pytest error tracebacks and fix weakref error in `event()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+:func:`hypothesis.event` now works for hashable objects which do not
+support weakrefs, such as integers and tuples.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1067,10 +1067,13 @@ class ConjectureRunner:
             return event
         try:
             return self.events_to_strings[event]
-        except KeyError:
+        except (KeyError, TypeError):
             pass
         result = str(event)
-        self.events_to_strings[event] = result
+        try:
+            self.events_to_strings[event] = result
+        except TypeError:
+            pass
         return result
 
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1587,3 +1587,8 @@ def test_can_be_set_to_ignore_limits():
             runner.cached_test_function([c])
 
         assert runner.tree.is_exhausted
+
+
+def test_can_convert_non_weakref_types_to_event_strings():
+    runner = ConjectureRunner(lambda data: None)
+    runner.event_to_string(())

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -254,3 +254,8 @@ def test_statistics_with_events_and_target():
     stats = describe_statistics(call_for_statistics(test))
     assert "- Events:" in stats
     assert "- Highest target score: " in stats
+
+
+@given(st.booleans())
+def test_event_with_non_weakrefable_keys(b):
+    event((b,))

--- a/hypothesis-python/tests/pytest/test_checks.py
+++ b/hypothesis-python/tests/pytest/test_checks.py
@@ -33,4 +33,6 @@ def test_repro_without_given_fails():
 
 def test_decorators_without_given_should_fail(testdir):
     script = testdir.makepyfile(TEST_DECORATORS_ALONE)
-    testdir.runpytest(script).assert_outcomes(failed=4)
+    result = testdir.runpytest(script)
+    result.assert_outcomes(failed=4)
+    assert "pytest_runtest_call" not in "\n".join(result.outlines)


### PR DESCRIPTION
Inspired by https://stackoverflow.com/q/72843753 and the extremely verbose traceback shown in https://stackoverflow.com/q/72792829.