### PR TITLE
Generate non-UTF-8 unicode for Numpy arrays

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+This release allows :func:`~hypothesis.extra.numpy.from_dtype` to generate
+Unicode strings which cannot be encoded in UTF-8, but are valid in Numpy
+arrays (which use UTF-32).
+
+This logic will only be used with :pypi:`Numpy` >= 1.19, because earlier
+versions have `an issue <https://github.com/numpy/numpy/issues/15363>`__
+which led us to revert :ref:`Hypothesis 5.2 <v5.2.0>` last time!

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -63,6 +63,9 @@ __all__ = [
 
 TIME_RESOLUTIONS = tuple("Y  M  D  h  m  s  ms  us  ns  ps  fs  as".split())
 
+# See https://github.com/HypothesisWorks/hypothesis/pull/3394 and linked discussion.
+NP_FIXED_UNICODE = tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 19)
+
 
 @defines_strategy(force_reusable_values=True)
 def from_dtype(
@@ -157,6 +160,8 @@ def from_dtype(
     elif dtype.kind == "U":
         # Encoded in UTF-32 (four bytes/codepoint) and null-terminated
         max_size = (dtype.itemsize or 0) // 4 or None
+        if NP_FIXED_UNICODE and "alphabet" not in kwargs:
+            kwargs["alphabet"] = st.characters()
         result = st.text(**compat_kw("alphabet", "min_size", max_size=max_size)).filter(
             lambda b: b[-1:] != "\0"
         )

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -104,7 +104,7 @@ def test_can_unicode_strings_without_decode_error(arr):
     pass
 
 
-@pytest.mark.xfail(strict=False, reason="mitigation for issue above")
+@pytest.mark.skipif(not nps.NP_FIXED_UNICODE, reason="workaround for old bug")
 def test_unicode_string_dtypes_need_not_be_utf8():
     def cannot_encode(string):
         try:


### PR DESCRIPTION
This has been a saga:

- First implemented in https://github.com/HypothesisWorks/hypothesis/pull/2307/ (Jan 2020)
- Reverted in https://github.com/HypothesisWorks/hypothesis/pull/2329 because of https://github.com/numpy/numpy/issues/15363
- Retried in https://github.com/HypothesisWorks/hypothesis/pull/2455, abandoned due to more upstream errors

I retried again hoping that we could get everything working by the end of the Scipy sprints, but it turns out to *just work<sup>TM</sup>*; so here we go.  I've manually tested it on 1.19.0, 1.20.0, 1.21.0, 1.22.0, and in CI for the latest version of Numpy.