### PR TITLE
Use `ParamSpec` to precisely annotate `@st.composite` and `st.functions()`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ their individual contributions.
 * `Felix Sheldon <https://www.github.com/darkpaw>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
+* `Gabe Joseph <https://github.com/gjoseph92>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
 * `George Macon <https://www.github.com/gmacon>`_
 * `Glenn Lehman <https://www.github.com/glnnlhmn>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,4 +3,5 @@ RELEASE_TYPE: minor
 This release uses :pep:`612` :obj:`python:typing.ParamSpec` (or the
 :pypi:`typing_extensions` backport) to express the first-argument-removing
 behaviour of :func:`@st.composite <hypothesis.strategies.composite>`
+and signature-preservation of :func:`~hypothesis.strategies.functions`
 to IDEs, editor plugins, and static type checkers such as :pypi:`mypy`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release uses :pep:`612` :obj:`python:typing.ParamSpec` (or the
+:pypi:`typing_extensions` backport) to express the first-argument-removing
+behaviour of :func:`@st.composite <hypothesis.strategies.composite>`
+to IDEs, editor plugins, and static type checkers such as :pypi:`mypy`.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -148,19 +148,19 @@ class settings(metaclass=settingsMeta):
         # The intended use is "like **kwargs, but more tractable for tooling".
         max_examples: int = not_set,  # type: ignore
         derandomize: bool = not_set,  # type: ignore
-        database: Union[None, "ExampleDatabase"] = not_set,  # type: ignore
+        database: Optional["ExampleDatabase"] = not_set,  # type: ignore
         verbosity: "Verbosity" = not_set,  # type: ignore
         phases: Collection["Phase"] = not_set,  # type: ignore
         stateful_step_count: int = not_set,  # type: ignore
         report_multiple_bugs: bool = not_set,  # type: ignore
         suppress_health_check: Collection["HealthCheck"] = not_set,  # type: ignore
-        deadline: Union[None, int, float, datetime.timedelta] = not_set,  # type: ignore
+        deadline: Union[int, float, datetime.timedelta, None] = not_set,  # type: ignore
         print_blob: bool = not_set,  # type: ignore
     ) -> None:
         if parent is not None:
             check_type(settings, parent, "parent")
         if derandomize not in (not_set, False):
-            if database not in (not_set, None):
+            if database not in (not_set, None):  # type: ignore
                 raise InvalidArgument(
                     "derandomize=True implies database=None, so passing "
                     f"database={database!r} too is invalid."

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1001,7 +1001,7 @@ def fullargspec_to_signature(
 def given(
     *_given_arguments: Union[SearchStrategy[Any], InferType],
 ) -> Callable[
-    [Callable[..., Union[None, Coroutine[Any, Any, None]]]], Callable[..., None]
+    [Callable[..., Optional[Coroutine[Any, Any, None]]]], Callable[..., None]
 ]:  # pragma: no cover
     ...
 
@@ -1010,7 +1010,7 @@ def given(
 def given(
     **_given_kwargs: Union[SearchStrategy[Any], InferType],
 ) -> Callable[
-    [Callable[..., Union[None, Coroutine[Any, Any, None]]]], Callable[..., None]
+    [Callable[..., Optional[Coroutine[Any, Any, None]]]], Callable[..., None]
 ]:  # pragma: no cover
     ...
 
@@ -1019,7 +1019,7 @@ def given(
     *_given_arguments: Union[SearchStrategy[Any], InferType],
     **_given_kwargs: Union[SearchStrategy[Any], InferType],
 ) -> Callable[
-    [Callable[..., Union[None, Coroutine[Any, Any, None]]]], Callable[..., None]
+    [Callable[..., Optional[Coroutine[Any, Any, None]]]], Callable[..., None]
 ]:
     """A decorator for turning a test function that accepts arguments into a
     randomized test.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -27,19 +27,19 @@ PYPY = platform.python_implementation() == "PyPy"
 WINDOWS = platform.system() == "Windows"
 
 
-def escape_unicode_characters(s):
+def escape_unicode_characters(s: str) -> str:
     return codecs.encode(s, "unicode_escape").decode("ascii")
 
 
-def int_from_bytes(data):
+def int_from_bytes(data: typing.Union[bytes, bytearray]) -> int:
     return int.from_bytes(data, "big")
 
 
-def int_to_bytes(i, size):
+def int_to_bytes(i: int, size: int) -> bytes:
     return i.to_bytes(size, "big")
 
 
-def int_to_byte(i):
+def int_to_byte(i: int) -> bytes:
     return bytes([i])
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -148,7 +148,7 @@ class TreeNode:
         self.n: "Optional[int]" = None
 
     @property
-    def exhausted(self):
+    def exhausted(self) -> bool:
         return self.live_child_count == 0
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from typing_extensions import dataclass_transform
 
     from hypothesis.strategies import SearchStrategy
+    from hypothesis.strategies._internal.strategies import Ex
 else:
 
     def dataclass_transform():
@@ -816,7 +817,7 @@ class ConjectureData:
         self.max_length = max_length
         self.is_find = False
         self.overdraw = 0
-        self.__prefix = prefix
+        self.__prefix = bytes(prefix)
         self.__random = random
 
         assert random is not None or max_length <= len(prefix)
@@ -907,7 +908,7 @@ class ConjectureData:
             value = repr(value)
         self.output += value
 
-    def draw(self, strategy: "SearchStrategy[Any]", label: Optional[int] = None) -> Any:
+    def draw(self, strategy: "SearchStrategy[Ex]", label: Optional[int] = None) -> "Ex":
         if self.is_find and not strategy.supports_find:
             raise InvalidArgument(
                 f"Cannot use strategy {strategy!r} within a call to find "

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -61,7 +61,7 @@ class ConstructivePredicate(NamedTuple):
     predicate: Optional[Predicate]
 
     @classmethod
-    def unchanged(cls, predicate):
+    def unchanged(cls, predicate: Predicate) -> "ConstructivePredicate":
         return cls({}, predicate)
 
 

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -11,7 +11,7 @@
 import math
 import struct
 from sys import float_info
-from typing import Callable, Optional
+from typing import Callable, Optional, SupportsFloat
 
 # Format codes for (int, float) sized types, used for byte-wise casts.
 # See https://docs.python.org/3/library/struct.html#format-characters
@@ -36,17 +36,13 @@ def float_of(x, width):
         return reinterpret_bits(float(x), "!e", "!e")
 
 
-def sign(x):
+def is_negative(x: SupportsFloat) -> bool:
     try:
-        return math.copysign(1.0, x)
+        return math.copysign(1.0, x) < 0
     except TypeError:
         raise TypeError(
             f"Expected float but got {x!r} of type {type(x).__name__}"
         ) from None
-
-
-def is_negative(x):
-    return sign(x) < 0
 
 
 def count_between_floats(x, y, width=64):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -889,7 +889,7 @@ def builds(
             "target to construct."
         )
 
-    if infer in args:
+    if infer in args:  # type: ignore  # we only annotated the allowed types
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument(
             "... was passed as a positional argument to "
@@ -1396,9 +1396,9 @@ def decimals(
     special: List[Decimal] = []
     if allow_nan or (allow_nan is None and (None in (min_value, max_value))):
         special.extend(map(Decimal, ("NaN", "-NaN", "sNaN", "-sNaN")))
-    if allow_infinity or (allow_infinity is max_value is None):
+    if allow_infinity or (allow_infinity is None and max_value is None):
         special.append(Decimal("Infinity"))
-    if allow_infinity or (allow_infinity is min_value is None):
+    if allow_infinity or (allow_infinity is None and min_value is None):
         special.append(Decimal("-Infinity"))
     return strat | (sampled_from(special) if special else nothing())
 

--- a/hypothesis-python/tests/cover/test_internal_helpers.py
+++ b/hypothesis-python/tests/cover/test_internal_helpers.py
@@ -10,11 +10,11 @@
 
 import pytest
 
-from hypothesis.internal.floats import sign
+from hypothesis.internal.floats import is_negative
 
 
-def test_sign_gives_good_type_error():
+def test_is_negative_gives_good_type_error():
     x = "foo"
     with pytest.raises(TypeError) as e:
-        sign(x)
+        is_negative(x)
     assert repr(x) in e.value.args[0]

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -107,8 +107,6 @@ def any_call_of_method(draw, method):
         a, b = sorted((a, b))
         if draw(st.booleans()):
             draw(st.floats(a, b))
-        else:
-            pass
         kwargs = {"low": a, "high": b, "mode": None}
     elif method == "uniform":
         a = normalize_zero(draw(st.floats(allow_infinity=False, allow_nan=False)))

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -27,7 +27,7 @@ def test_saves_incremental_steps_in_database():
     database = InMemoryExampleDatabase()
     find(
         st.binary(min_size=10),
-        lambda x: has_a_non_zero_byte(x),
+        has_a_non_zero_byte,
         settings=settings(database=database),
         database_key=key,
     )

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,7 @@ no_implicit_reexport = True
 follow_imports = silent
 ignore_missing_imports = True
 
+strict_equality = True
 warn_no_return = True
 warn_unused_ignores = True
 warn_unused_configs = True

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -176,6 +176,27 @@ def test_composite_type_tracing(tmpdir):
     assert got == "def (x: int) -> SearchStrategy[int]"
 
 
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("", "def ()"),
+        ("like=f", "def (x: int) -> int"),
+        ("returns=booleans()", "def () -> bool"),
+        ("like=f, returns=booleans()", "def (x: int) -> bool"),
+    ],
+)
+def test_functions_type_tracing(tmpdir, source, expected):
+    f = tmpdir.join("check_mypy_on_st_composite.py")
+    f.write(
+        "from hypothesis.strategies import booleans, functions\n"
+        "def f(x: int) -> int: return x\n"
+        f"g = functions({source}).example()\n"
+        "reveal_type(g)\n"
+    )
+    got = get_mypy_analysed_type(str(f.realpath()), ...)
+    assert got == expected, (got, expected)
+
+
 def test_settings_preserves_type(tmpdir):
     f = tmpdir.join("check_mypy_on_settings.py")
     f.write(
@@ -438,7 +459,7 @@ def test_pos_only_args(tmpdir):
 
             st.tuples(a1=st.integers())
             st.tuples(a1=st.integers(), a2=st.integers())
-            
+
             st.one_of(a1=st.integers())
             st.one_of(a1=st.integers(), a2=st.integers())
             """


### PR DESCRIPTION
Being a follow-up to https://github.com/HypothesisWorks/hypothesis/pull/3219, now that [Mypy support for `Concatenate`](https://mypy-lang.blogspot.com/2022/04/mypy-0950-released.html) has been out for long enough for most users to pick up - since 0.950, April 2022.

(We explictly *don't* promise any degree of compatibility with anything but a best-effort attempt to support the latest state of the static-type-checking ecosystem, but giving people more than a few days to update like this seems reasonable to me.  The whole *point* of this is to provide a better user experience, after all!)