### PR TITLE
Setting for shrinker deadline

### DIFF
--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -156,7 +156,7 @@ class settings(metaclass=settingsMeta):
         suppress_health_check: Collection["HealthCheck"] = not_set,  # type: ignore
         deadline: Union[int, float, datetime.timedelta, None] = not_set,  # type: ignore
         print_blob: bool = not_set,  # type: ignore
-        max_shrink_seconds: float = not_set,  # type:ignore
+        max_shrink_seconds: int = not_set,  # type:ignore
     ) -> None:
         if parent is not None:
             check_type(settings, parent, "parent")

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -156,6 +156,7 @@ class settings(metaclass=settingsMeta):
         suppress_health_check: Collection["HealthCheck"] = not_set,  # type: ignore
         deadline: Union[int, float, datetime.timedelta, None] = not_set,  # type: ignore
         print_blob: bool = not_set,  # type: ignore
+        max_shrink_seconds: float = not_set,  # type:ignore
     ) -> None:
         if parent is not None:
             check_type(settings, parent, "parent")
@@ -661,6 +662,13 @@ If set to ``True``, Hypothesis will print code for failing examples that can be 
 :func:`@reproduce_failure <hypothesis.reproduce_failure>` to reproduce the failing example.
 The default is ``True`` if the ``CI`` or ``TF_BUILD`` env vars are set, ``False`` otherwise.
 """,
+)
+
+settings._define_setting(
+    "max_shrink_seconds",
+    default=300,
+    validator=int,
+    description="""The maximum time given to the shrinker to work.""",
 )
 
 settings.lock_further_definitions()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -914,7 +914,9 @@ class ConjectureRunner:
         # a warning.   Many CI systems will kill a build after around ten minutes with
         # no output, and appearing to hang isn't great for interactive use either -
         # showing partially-shrunk examples is better than quitting with no examples!
-        self.finish_shrinking_deadline = time.perf_counter() + 300
+        self.finish_shrinking_deadline = (
+            time.perf_counter() + self.settings.max_shrink_seconds
+        )
 
         for prev_data in sorted(
             self.interesting_examples.values(), key=lambda d: sort_key(d.buffer)


### PR DESCRIPTION
Currently the shrinker gives up after 5 minutes (#3243 ), and this number is hardcoded.
`max_shrink_seconds` setting

#3243 states that you don't want to expose that as a user setting, contra this PR. Is it because it encourages complacency in the runtime of strategies?

Testing: I found `tests/conjecture/test_engine.py::test_exit_because_shrink_phase_timeout`, but couldn't figure out how to make it check that the deadline is responsive to the setting. Maybe making `f` stateful and it needs to be called N times before it marks the data as interesting?

Enhancements: I've thrown together a minimal change for my own use, but I can make this setting a `timedelta` similar to `deadline` if the PR is wanted.