### PR TITLE
Issue 3384 warn when draw is not use in composite

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -132,7 +132,7 @@ their individual contributions.
 * `Richard Scholtens <https://github.com/richardscholtens>`_ (richardscholtens2@gmail.com)
 * `Robert Howlett <https://github.com/jebob>`_
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
-* `Rodrigo Girão Serrão <https://github.com/rodrigogiraoserrao>` _ (rodrigo@mathspp.com)
+* `Rodrigo Girão Serrão <https://github.com/rodrigogiraoserrao>`_ (rodrigo@mathspp.com)
 * `Rónán Carrigan <https://www.github.com/rcarriga>`_ (rcarriga@tcd.ie)
 * `Ruben Opdebeeck <https://github.com/ROpdebee>`_
 * `Ryan Soklaski <https://www.github.com/rsokl>`_ (rsoklaski@gmail.com)
@@ -152,7 +152,7 @@ their individual contributions.
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
 * `Tessa Bradbury <https://www.github.com/tessereth>`_
 * `Thea Koutsoukis <https://www.github.com/theakaterina>`_
-* `Thomas Ball <https://www.github.com/bomtall>` _ (bomtall1@hotmail.com)
+* `Thomas Ball <https://www.github.com/bomtall>`_ (bomtall1@hotmail.com)
 * `Thomas Grainge <https://www.github.com/tgrainge>`_
 * `Thomas Kluyver <https://www.github.com/takluyver>`_ (thomas@kluyver.me.uk)
 * `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,7 +63,7 @@ their individual contributions.
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
-* `Grzegorz Zieba <https://github.com/gzaxel>` _ (g.zieba@erax.pl)
+* `Grzegorz Zieba <https://github.com/gzaxel>`_ (g.zieba@erax.pl)
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Humberto Rocha <https://github.com/humrochagf>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,6 +63,7 @@ their individual contributions.
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
+* `Grzegorz Zieba <https://github.com/gzaxel>` _ (g.zieba@erax.pl)
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Humberto Rocha <https://github.com/humrochagf>`_
@@ -131,6 +132,7 @@ their individual contributions.
 * `Richard Scholtens <https://github.com/richardscholtens>`_ (richardscholtens2@gmail.com)
 * `Robert Howlett <https://github.com/jebob>`_
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
+* `Rodrigo Girão Serrão <https://github.com/rodrigogiraoserrao>` _ (rodrigo@mathspp.com)
 * `Rónán Carrigan <https://www.github.com/rcarriga>`_ (rcarriga@tcd.ie)
 * `Ruben Opdebeeck <https://github.com/ROpdebee>`_
 * `Ryan Soklaski <https://www.github.com/rsokl>`_ (rsoklaski@gmail.com)
@@ -150,9 +152,10 @@ their individual contributions.
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
 * `Tessa Bradbury <https://www.github.com/tessereth>`_
 * `Thea Koutsoukis <https://www.github.com/theakaterina>`_
+* `Thomas Ball <https://www.github.com/bomtall>` _ (bomtall1@hotmail.com)
 * `Thomas Grainge <https://www.github.com/tgrainge>`_
-* `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Thomas Kluyver <https://www.github.com/takluyver>`_ (thomas@kluyver.me.uk)
+* `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Tom McDermott <https://www.github.com/sponster-au>`_ (sponster@gmail.com)
 * `Tom Milligan <https://www.github.com/tommilligan>`_ (code@tommilligan.net)
 * `Tyler Gibbons <https://www.github.com/kavec>`_ (tyler.gibbons@flexport.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,6 @@
 RELEASE_TYPE: patch
 
-Issue a deprecation warning if a function decorated with `st.composite` does not reference its first argument (which is typically `draw`).
+Issue a deprecation warning if a function decorated with :func:`@composite <hypothesis.strategies.composite>`
+does not draw any values (:issue:`3384`).
 
-A couple of tests triggered this warning, so we also fix those tests.
+Thanks to Grzegorz Zieba, Rodrigo Girão, and Thomas Ball for working on this at the EuroPython sprints!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Issue a deprecation warning if a function decorated with `st.composite` does not reference its first argument (which is typically `draw`).
+
+A couple of tests triggered this warning, so we also fix those tests.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -224,13 +224,14 @@ def is_func_param_called_within(f, name):
     """Is the given name referenced within f?"""
     try:
         tree = ast.parse(textwrap.dedent(inspect.getsource(f)))
-    except (OSError, ValueError):
+    except Exception:
         return True
     else:
         return any(
-            isinstance(node, ast.Name)
-            and node.id == name
-            and isinstance(node.ctx, ast.Load)
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == name
+            and isinstance(node.func.ctx, ast.Load)
             for node in ast.walk(tree)
         )
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -244,7 +244,7 @@ class _NameUsageNodeVisitor(ast.NodeVisitor):
             self.found = True
 
 
-def check_if_param_name_called(f, name):
+def is_func_param_called_within(f, name):
     """Is the given name referenced within f?"""
     return _NameUsageNodeVisitor(f, name).check()
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -220,7 +220,7 @@ def ast_arguments_matches_signature(args, sig):
     return expected == [(p.name, p.kind) for p in sig.parameters.values()]
 
 
-class NameUsageNodeVisitor(ast.NodeVisitor):
+class _NameUsageNodeVisitor(ast.NodeVisitor):
     """Node visitor to check if a name is used inside an AST."""
 
     def __init__(self, f, name):
@@ -247,7 +247,7 @@ class NameUsageNodeVisitor(ast.NodeVisitor):
 
 def check_if_param_name_called(f, name):
     """Is the given name referenced within f?"""
-    return NameUsageNodeVisitor(f, name).check()
+    return _NameUsageNodeVisitor(f, name).check()
 
 
 def extract_all_lambdas(tree, matching_signature):

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -228,7 +228,9 @@ def is_func_param_called_within(f, name):
         return True
     else:
         return any(
-            isinstance(node, ast.Name) and node.id == name and isinstance(node.ctx, ast.Load)
+            isinstance(node, ast.Name)
+            and node.id == name
+            and isinstance(node.ctx, ast.Load)
             for node in ast.walk(tree)
         )
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -228,10 +228,9 @@ def is_func_param_called_within(f, name):
         return True
     else:
         return any(
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == name
-            and isinstance(node.func.ctx, ast.Load)
+            isinstance(node, ast.Name)
+            and node.id == name
+            and isinstance(node.ctx, ast.Load)
             for node in ast.walk(tree)
         )
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -237,7 +237,6 @@ class _NameUsageNodeVisitor(ast.NodeVisitor):
     def generic_visit(self, node):
         if self.found:
             return self.found
-        print(node)
         return super().generic_visit(node)
 
     def visit_Name(self, node):

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -224,11 +224,17 @@ class _NameUsageNodeVisitor(ast.NodeVisitor):
     """Node visitor to check if a name is used inside an AST."""
 
     def __init__(self, f, name):
-        # Remove indentation the function source might have to allow ast to parse it.
-        source = textwrap.dedent(inspect.getsource(f))
-        self.tree = ast.parse(source)
         self.name = name
-        self.found = False
+
+        # Getting the source might fail if we are in the REPL and parsing might fail
+        # in other edge cases.
+        try:
+            tree = ast.parse(textwrap.dedent(inspect.getsource(f)))
+        except (OSError, ValueError):
+            self.found = True
+        else:
+            self.found = False
+            self.tree = tree
 
     def check(self):
         self.visit(self.tree)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1531,6 +1531,10 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
+
+    if check_if_param_name_called(f, params[0]):
+        raise(DeprecationWarning)
+
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -62,7 +62,6 @@ from hypothesis.internal.reflection import (
     get_signature,
     nicerepr,
     required_args,
-    
 )
 from hypothesis.internal.validation import (
     check_type,
@@ -1533,10 +1532,8 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
-
     if not is_func_param_called_within(f, params[0].name):
         raise DeprecationWarning("First parameter should be referenced within")
-
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1535,8 +1535,8 @@ def _composite(f):
         raise InvalidArgument("A default value for initial argument will never be used")
     if not is_func_param_called_within(f, params[0].name):
         return note_deprecation(
-            "There is no reason to use @st.composite on a function which " +
-            "does not call the provided draw() function internally.",
+            "There is no reason to use @st.composite on a function which "
+            + "does not call the provided draw() function internally.",
             since="RELEASEDAY",
             has_codemod=False,
         )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1535,7 +1535,7 @@ def _composite(f):
         raise InvalidArgument("A default value for initial argument will never be used")
     if params[0].kind.name != "VAR_POSITIONAL":
         if not is_func_param_called_within(f, params[0].name):
-            return note_deprecation(
+            note_deprecation(
                 "There is no reason to use @st.composite on a function which "
                 + "does not call the provided draw() function internally.",
                 since="RELEASEDAY",

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -56,7 +56,7 @@ from hypothesis.internal.conjecture.utils import (
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.reflection import (
-    check_if_param_name_called,
+    is_func_param_called_within,
     define_function_signature,
     get_pretty_function_description,
     get_signature,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1533,14 +1533,13 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
-    if params[0].kind.name != "VAR_POSITIONAL":
-        if not is_func_param_called_within(f, params[0].name):
-            note_deprecation(
-                "There is no reason to use @st.composite on a function which "
-                + "does not call the provided draw() function internally.",
-                since="RELEASEDAY",
-                has_codemod=False,
-            )
+    if not is_func_param_called_within(f, params[0].name):
+        note_deprecation(
+            "There is no reason to use @st.composite on a function which "
+            + "does not call the provided draw() function internally.",
+            since="RELEASEDAY",
+            has_codemod=False,
+        )
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -107,6 +107,7 @@ from hypothesis.strategies._internal.strings import (
 )
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 from hypothesis.utils.conventions import infer, not_set
+from hypothesis._settings import note_deprecation
 
 if sys.version_info >= (3, 10):  # pragma: no cover
     from types import EllipsisType as InferType
@@ -1533,7 +1534,8 @@ def _composite(f):
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
     if not is_func_param_called_within(f, params[0].name):
-        raise DeprecationWarning("First parameter should be referenced within")
+        #raise DeprecationWarning("First parameter should be referenced within")
+        return note_deprecation("First parameter should be referenced within", since="2022-07-16", has_codemod=False)
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -44,6 +44,7 @@ from uuid import UUID
 
 import attr
 
+from hypothesis._settings import note_deprecation
 from hypothesis.control import cleanup, note
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.cathetus import cathetus
@@ -107,7 +108,6 @@ from hypothesis.strategies._internal.strings import (
 )
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 from hypothesis.utils.conventions import infer, not_set
-from hypothesis._settings import note_deprecation
 
 if sys.version_info >= (3, 10):  # pragma: no cover
     from types import EllipsisType as InferType
@@ -1534,8 +1534,12 @@ def _composite(f):
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
     if not is_func_param_called_within(f, params[0].name):
-        #raise DeprecationWarning("First parameter should be referenced within")
-        return note_deprecation("First parameter should be referenced within", since="2022-07-16", has_codemod=False)
+        # raise DeprecationWarning("First parameter should be referenced within")
+        return note_deprecation(
+            "First parameter should be referenced within",
+            since="2022-07-16",
+            has_codemod=False,
+        )
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1534,8 +1534,8 @@ def _composite(f):
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
 
-    if not check_if_param_name_called(f, params[0]):
-        raise(DeprecationWarning)
+    if not is_func_param_called_within(f, params[0].name):
+        raise DeprecationWarning("First parameter should be referenced within")
 
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -56,10 +56,10 @@ from hypothesis.internal.conjecture.utils import (
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.reflection import (
-    is_func_param_called_within,
     define_function_signature,
     get_pretty_function_description,
     get_signature,
+    is_func_param_called_within,
     nicerepr,
     required_args,
 )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1534,10 +1534,10 @@ def _composite(f):
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
     if not is_func_param_called_within(f, params[0].name):
-        # raise DeprecationWarning("First parameter should be referenced within")
         return note_deprecation(
-            "First parameter should be referenced within",
-            since="2022-07-16",
+            "There is no reason to use @st.composite on a function which " +
+            "does not call the provided draw() function internally.",
+            since="RELEASEDAY",
             has_codemod=False,
         )
     if params[0].kind.name != "VAR_POSITIONAL":

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -56,11 +56,13 @@ from hypothesis.internal.conjecture.utils import (
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.reflection import (
+    check_if_param_name_called,
     define_function_signature,
     get_pretty_function_description,
     get_signature,
     nicerepr,
     required_args,
+    
 )
 from hypothesis.internal.validation import (
     check_type,
@@ -1532,7 +1534,7 @@ def _composite(f):
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
 
-    if check_if_param_name_called(f, params[0]):
+    if not check_if_param_name_called(f, params[0]):
         raise(DeprecationWarning)
 
     if params[0].kind.name != "VAR_POSITIONAL":

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1533,13 +1533,14 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
-    if not is_func_param_called_within(f, params[0].name):
-        return note_deprecation(
-            "There is no reason to use @st.composite on a function which "
-            + "does not call the provided draw() function internally.",
-            since="RELEASEDAY",
-            has_codemod=False,
-        )
+    if params[0].kind.name != "VAR_POSITIONAL":
+        if not is_func_param_called_within(f, params[0].name):
+            return note_deprecation(
+                "There is no reason to use @st.composite on a function which "
+                + "does not call the provided draw() function internally.",
+                since="RELEASEDAY",
+                has_codemod=False,
+            )
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -101,6 +101,7 @@ def test_composite_edits_annotations():
     assert sig_comp.parameters["nothing"].annotation is not P.empty
     assert "draw" not in sig_comp.parameters
 
+
 @pytest.mark.parametrize("nargs", [1, 2, 3])
 def test_given_edits_annotations(nargs):
     sig_given = signature(given(*(nargs * [st.none()]))(pointless_composite))

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -83,8 +83,8 @@ def test_converter_notices_missing_kwonly_args():
         assert convert_positional_arguments(f, (), {})
 
 
-def pointless_composite(draw: None, strat: bool, nothing: list) -> int:
-    return draw(st.integers())
+def to_wrap_with_composite(draw: None, strat: bool, nothing: list) -> int:
+    return draw(st.none())
 
 
 def return_annot() -> int:
@@ -96,7 +96,7 @@ def first_annot(draw: None):
 
 
 def test_composite_edits_annotations():
-    sig_comp = signature(st.composite(pointless_composite))
+    sig_comp = signature(st.composite(to_wrap_with_composite))
     assert sig_comp.return_annotation == st.SearchStrategy[int]
     assert sig_comp.parameters["nothing"].annotation is not P.empty
     assert "draw" not in sig_comp.parameters
@@ -104,7 +104,7 @@ def test_composite_edits_annotations():
 
 @pytest.mark.parametrize("nargs", [1, 2, 3])
 def test_given_edits_annotations(nargs):
-    sig_given = signature(given(*(nargs * [st.none()]))(pointless_composite))
+    sig_given = signature(given(*(nargs * [st.none()]))(to_wrap_with_composite))
     assert sig_given.return_annotation is None
     assert len(sig_given.parameters) == 3 - nargs
     assert all(p.annotation is not P.empty for p in sig_given.parameters.values())

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -84,7 +84,7 @@ def test_converter_notices_missing_kwonly_args():
 
 
 def pointless_composite(draw: None, strat: bool, nothing: list) -> int:
-    return 3
+    return draw(st.integers())
 
 
 def return_annot() -> int:
@@ -100,7 +100,6 @@ def test_composite_edits_annotations():
     assert sig_comp.return_annotation == st.SearchStrategy[int]
     assert sig_comp.parameters["nothing"].annotation is not P.empty
     assert "draw" not in sig_comp.parameters
-
 
 @pytest.mark.parametrize("nargs", [1, 2, 3])
 def test_given_edits_annotations(nargs):

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -14,7 +14,7 @@ from hypothesis import assume, given, strategies as st
 from hypothesis.errors import InvalidArgument
 
 from tests.common.debug import minimal
-from tests.common.utils import fails, flaky
+from tests.common.utils import flaky
 
 
 @st.composite

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -14,7 +14,7 @@ from hypothesis import assume, given, strategies as st
 from hypothesis.errors import InvalidArgument
 
 from tests.common.debug import minimal
-from tests.common.utils import flaky
+from tests.common.utils import fails, flaky
 
 
 @st.composite
@@ -73,6 +73,15 @@ def test_errors_given_kwargs_only():
         @st.composite
         def foo(**kwargs):
             pass
+
+
+@pytest.mark.xfail
+def test_warning_given_no_drawfn_call():
+    with pytest.raises(DeprecationWarning):
+
+        @st.composite
+        def foo(_):
+            return "bar"
 
 
 def test_can_use_pure_args():

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -128,8 +128,9 @@ class MyList(list):
 @given(st.data(), st.lists(st.integers()).map(MyList))
 def test_does_not_change_arguments(data, ls):
     # regression test for issue #1017 or other argument mutation
-    def strat(arg):
-        return st.just(arg)
+    @st.composite
+    def strat(draw):
+        return draw(st.none())
 
     ex = data.draw(strat(ls))
     assert ex is ls

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -75,7 +75,6 @@ def test_errors_given_kwargs_only():
             pass
 
 
-
 def test_warning_given_no_drawfn_call():
     with pytest.raises(HypothesisDeprecationWarning):
 

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -129,8 +129,9 @@ class MyList(list):
 def test_does_not_change_arguments(data, ls):
     # regression test for issue #1017 or other argument mutation
     @st.composite
-    def strat(draw):
-        return draw(st.none())
+    def strat(draw, arg):
+        draw(st.none())
+        return arg
 
     ex = data.draw(strat(ls))
     assert ex is ls

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -75,7 +75,7 @@ def test_errors_given_kwargs_only():
             pass
 
 
-def test_warning_given_no_drawfn_call():
+def test_warning_given_no_drawfn_call_within():
     with pytest.raises(DeprecationWarning):
 
         @st.composite

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -11,7 +11,7 @@
 import pytest
 
 from hypothesis import assume, given, strategies as st
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
 
 from tests.common.debug import minimal
 from tests.common.utils import flaky
@@ -75,8 +75,9 @@ def test_errors_given_kwargs_only():
             pass
 
 
-def test_warning_given_no_drawfn_call_within():
-    with pytest.raises(DeprecationWarning):
+
+def test_warning_given_no_drawfn_call():
+    with pytest.raises(HypothesisDeprecationWarning):
 
         @st.composite
         def foo(_):

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -83,12 +83,12 @@ def test_warning_given_no_drawfn_call():
             return "bar"
 
 
-def test_cannot_use_pure_args():
-    with pytest.raises(HypothesisDeprecationWarning):
+def test_can_use_pure_args():
+    @st.composite
+    def stuff(*args):
+        return args[0](st.sampled_from(args[1:]))
 
-        @st.composite
-        def stuff(*args):
-            return args[0](st.sampled_from(args[1:]))
+    assert minimal(stuff(1, 2, 3, 4, 5), lambda x: True) == 1
 
 
 def test_composite_of_lists():

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -75,7 +75,6 @@ def test_errors_given_kwargs_only():
             pass
 
 
-@pytest.mark.xfail
 def test_warning_given_no_drawfn_call():
     with pytest.raises(DeprecationWarning):
 
@@ -129,9 +128,8 @@ class MyList(list):
 @given(st.data(), st.lists(st.integers()).map(MyList))
 def test_does_not_change_arguments(data, ls):
     # regression test for issue #1017 or other argument mutation
-    @st.composite
-    def strat(draw, arg):
-        return arg
+    def strat(arg):
+        return st.just(arg)
 
     ex = data.draw(strat(ls))
     assert ex is ls

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -83,14 +83,6 @@ def test_warning_given_no_drawfn_call():
             return "bar"
 
 
-def test_can_use_pure_args():
-    @st.composite
-    def stuff(*args):
-        return args[0](st.sampled_from(args[1:]))
-
-    assert minimal(stuff(1, 2, 3, 4, 5), lambda x: True) == 1
-
-
 def test_composite_of_lists():
     @st.composite
     def f(draw):

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -83,6 +83,14 @@ def test_warning_given_no_drawfn_call():
             return "bar"
 
 
+def test_cannot_use_pure_args():
+    with pytest.raises(HypothesisDeprecationWarning):
+
+        @st.composite
+        def stuff(*args):
+            return args[0](st.sampled_from(args[1:]))
+
+
 def test_composite_of_lists():
     @st.composite
     def f(draw):

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -632,14 +632,6 @@ def test_param_is_called_within_func():
     assert is_func_param_called_within(f, "any_name")
 
 
-def test_param_is_called_within_func_after_assignment():
-    def f(any_name):
-        new_name = any_name
-        new_name()
-
-    assert is_func_param_called_within(f, "any_name")
-
-
 def test_param_is_called_within_subfunc():
     def f(any_name):
         def f2():

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -16,6 +16,9 @@ from inspect import Parameter, Signature, signature
 from unittest.mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
 import pytest
+from pytest import raises
+
+from hypothesis import given, strategies as st
 from hypothesis.internal import reflection
 from hypothesis.internal.reflection import (
     convert_keyword_arguments,
@@ -31,10 +34,6 @@ from hypothesis.internal.reflection import (
     required_args,
     source_exec_as_module,
 )
-from pytest import raises
-
-from hypothesis import given
-from hypothesis import strategies as st
 
 
 def do_conversion_test(f, args, kwargs):

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -653,3 +653,9 @@ def test_param_is_not_called_within_func():
         pass
 
     assert not is_func_param_called_within(f, "any_name")
+
+
+def test_param_called_within_defaults_on_error():
+    # Create a function object for which we cannot retrieve the source.
+    f = compile("lambda: ...", "_.py", "eval")
+    assert is_func_param_called_within(f, "any_name")

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -629,7 +629,7 @@ def test_param_is_called_within_func():
     def f(any_name):
         any_name()
 
-    assert is_func_param_called_within(f, "any_name") is True
+    assert is_func_param_called_within(f, "any_name")
 
 
 def test_param_is_called_within_func_after_assignment():
@@ -637,7 +637,7 @@ def test_param_is_called_within_func_after_assignment():
         new_name = any_name
         new_name()
 
-    assert is_func_param_called_within(f, "any_name") is True
+    assert is_func_param_called_within(f, "any_name")
 
 
 def test_param_is_called_within_subfunc():
@@ -645,11 +645,11 @@ def test_param_is_called_within_subfunc():
         def f2():
             any_name()
 
-    assert is_func_param_called_within(f, "any_name") is True
+    assert is_func_param_called_within(f, "any_name")
 
 
 def test_param_is_not_called_within_func():
     def f(any_name):
         pass
 
-    assert is_func_param_called_within(f, "any_name") is False
+    assert not is_func_param_called_within(f, "any_name")

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -152,6 +152,7 @@ def test_draw_time_percentage(draw_delay, test_delay):
     def s(draw):
         if draw_delay:
             time.sleep(0.05)
+        draw(st.integers())
 
     @given(s())
     def test(_):

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -12,7 +12,7 @@ import pytest
 
 from hypothesis import given
 from hypothesis.errors import Flaky
-from hypothesis.strategies import composite, integers
+from hypothesis.strategies import composite, integers, none
 
 
 @pytest.mark.parametrize(
@@ -36,7 +36,7 @@ def test_exception_propagates_fine_from_strategy(e):
         raise e
         # this line will not be executed, but must be here
         # to pass draw function static reference check
-        return draw(st.integers())
+        return draw(st.none())
 
     @given(interrupt_eventually())
     def test_do_nothing(x):
@@ -80,7 +80,7 @@ def test_baseexception_in_strategy_no_rerun_no_flaky(e):
         runs[0] += 1
         if runs[0] == interrupt:
             raise e
-        return draw(integers())
+        return draw(none())
 
     @given(interrupt_eventually())
     def test_do_nothing(x):
@@ -106,7 +106,7 @@ def things(draw):
     raise {exception}
     # this line will not be executed, but must be here 
     # to pass draw function static reference check
-    return draw(st.integers())
+    return draw(st.none())
 
 
 @given(st.data(), st.integers())

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -12,7 +12,7 @@ import pytest
 
 from hypothesis import given
 from hypothesis.errors import Flaky
-from hypothesis.strategies import composite, integers, none
+from hypothesis.strategies import composite, integers
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -34,8 +34,8 @@ def test_exception_propagates_fine_from_strategy(e):
     @composite
     def interrupt_eventually(draw):
         raise e
-        # this line will not be executed, but must be here 
-        # to pass draw funcition static reference check
+        # this line will not be executed, but must be here
+        # to pass draw function static reference check
         return draw(st.integers())
 
     @given(interrupt_eventually())
@@ -105,7 +105,7 @@ from hypothesis import given, note, strategies as st
 def things(draw):
     raise {exception}
     # this line will not be executed, but must be here 
-    # to pass draw funcition static reference check
+    # to pass draw function static reference check
     return draw(st.integers())
 
 

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -34,6 +34,9 @@ def test_exception_propagates_fine_from_strategy(e):
     @composite
     def interrupt_eventually(draw):
         raise e
+        # this line will not be executed, but must be here 
+        # to pass draw funcition static reference check
+        return draw(st.integers())
 
     @given(interrupt_eventually())
     def test_do_nothing(x):
@@ -101,6 +104,9 @@ from hypothesis import given, note, strategies as st
 @st.composite
 def things(draw):
     raise {exception}
+    # this line will not be executed, but must be here 
+    # to pass draw funcition static reference check
+    return draw(st.integers())
 
 
 @given(st.data(), st.integers())

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -72,15 +72,16 @@ def test_baseexception_no_rerun_no_flaky(e):
     "e", [KeyboardInterrupt, SystemExit, GeneratorExit, ValueError]
 )
 def test_baseexception_in_strategy_no_rerun_no_flaky(e):
-    runs = [0]
+    runs = 0
     interrupt = 3
 
     @composite
     def interrupt_eventually(draw):
-        runs[0] += 1
-        if runs[0] == interrupt:
+        nonlocal runs
+        runs += 1
+        if runs == interrupt:
             raise e
-        return draw(none())
+        return draw(integers())
 
     @given(interrupt_eventually())
     def test_do_nothing(x):
@@ -90,7 +91,7 @@ def test_baseexception_in_strategy_no_rerun_no_flaky(e):
         with pytest.raises(e):
             test_do_nothing()
 
-        assert runs[0] == interrupt
+        assert runs == interrupt
 
     else:
         # Now SystemExit and GeneratorExit are caught like other exceptions

--- a/hypothesis-python/tests/nocover/test_labels.py
+++ b/hypothesis-python/tests/nocover/test_labels.py
@@ -22,12 +22,12 @@ def test_labels_are_distinct():
 
 @st.composite
 def foo(draw):
-    return draw(st.integers())
+    return draw(st.none())
 
 
 @st.composite
 def bar(draw):
-    return draw(st.integers())
+    return draw(st.none())
 
 
 def test_different_composites_have_different_labels():

--- a/hypothesis-python/tests/nocover/test_labels.py
+++ b/hypothesis-python/tests/nocover/test_labels.py
@@ -22,12 +22,12 @@ def test_labels_are_distinct():
 
 @st.composite
 def foo(draw):
-    pass
+    return draw(st.integers())
 
 
 @st.composite
 def bar(draw):
-    pass
+    return draw(st.integers())
 
 
 def test_different_composites_have_different_labels():

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -108,10 +108,10 @@ def test_healthcheck_traceback_is_hidden(testdir):
 
 
 COMPOSITE_IS_NOT_A_TEST = """
-from hypothesis.strategies import composite
+from hypothesis.strategies import composite, integers
 @composite
 def test_data_factory(draw):
-    pass
+    return draw(integers())
 """
 
 

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -108,10 +108,10 @@ def test_healthcheck_traceback_is_hidden(testdir):
 
 
 COMPOSITE_IS_NOT_A_TEST = """
-from hypothesis.strategies import composite, integers
+from hypothesis.strategies import composite, none
 @composite
 def test_data_factory(draw):
-    return draw(integers())
+    return draw(none())
 """
 
 

--- a/hypothesis-python/tests/pytest/test_checks.py
+++ b/hypothesis-python/tests/pytest/test_checks.py
@@ -10,12 +10,12 @@
 
 TEST_DECORATORS_ALONE = """
 import hypothesis
-from hypothesis.strategies import composite
+from hypothesis.strategies import composite, none
 
 @composite
 def test_composite_is_not_a_test(draw):
     # This strategy will be instantiated, but no draws == no calls.
-    assert draw
+    return draw(none())
 
 @hypothesis.seed(0)
 def test_seed_without_given_fails():

--- a/hypothesis-python/tests/pytest/test_checks.py
+++ b/hypothesis-python/tests/pytest/test_checks.py
@@ -15,7 +15,7 @@ from hypothesis.strategies import composite
 @composite
 def test_composite_is_not_a_test(draw):
     # This strategy will be instantiated, but no draws == no calls.
-    assert False
+    assert draw
 
 @hypothesis.seed(0)
 def test_seed_without_given_fails():

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -10,19 +10,16 @@
 
 import collections
 import sys
-from typing import Callable, Dict, List, Union
+from typing import Callable, DefaultDict, Dict, List, NewType, Type, Union
 
 import pytest
 from typing_extensions import (
     Annotated,
     Concatenate,
-    DefaultDict,
     Literal,
-    NewType,
     NotRequired,
     ParamSpec,
     Required,
-    Type,
     TypedDict,
     TypeGuard,
 )


### PR DESCRIPTION
This will fix #3384

We had to change tests for composite that did not reference draw
