### PR TITLE
ensure warnings point to non-hypothesis code (fixes #3403)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ their individual contributions.
 * `Ivan Tham <https://github.com/pickfire>`_
 * `Jack Massey <https://github.com/massey101>`_
 * `Jakub Nabaglo <https://github.com/nbgl>`_ (j@nab.gl)
+* `James Lamb <https://github.com/jameslamb>`_
 * `Jenny Rouleau <https://github.com/jennyrou>`_
 * `Jeremy Thurgood <https://github.com/jerith>`_
 * `J.J. Green <http://soliton.vm.bytemark.co.uk/pub/jjg/>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch ensures that the warning for non-interactive ``.example()``
+points to your code instead of Hypothesis internals (:issue:`3403`).
+
+Thanks to @jameslamb for this fix.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -288,6 +288,7 @@ class SearchStrategy(Generic[Ex]):
                 "it performs better, saves and replays failures to avoid flakiness, "
                 "and reports minimal examples. (strategy: %r)" % (self,),
                 NonInteractiveExampleWarning,
+                stacklevel=2,
             )
 
         context = _current_build_context.value


### PR DESCRIPTION
Fixes #3403.

This PR proposes changes to achieve the following behavior:

> wherever user code leads `hypothesis` to raise a warning, that warning should point back to a file and line number in the user's code, instead of in `hypothesis`'s internals.

### How I tested this

Creating a test script which causes most of the warnings mentioned in https://github.com/HypothesisWorks/hypothesis/issues/3403#issuecomment-1186549745 to be raised.

<details><summary>test_warnings.py (click me)</summary>

The warning from `database._db_for_path()` is only raised when you try to point the example database at a path with limited permissions, so I created one like this:

```shell
# mkdir -p /tmp/some-nonsense
# chmod 'a=r' /tmp/some-nonsense/
```

Then put the following in a file `test_warnings.py`

```python
from hypothesis import given, example, strategies as st
from hypothesis.configuration import set_hypothesis_home_dir
from hypothesis.extra.array_api import make_strategies_namespace

# mkdir -p /tmp/some-nonsense
# chmod 'a=r' /tmp/some-nonsense/
set_hypothesis_home_dir("/tmp/some-nonsense")

# array_api.py ("Could not determine whether module math is an Array API library")
# array_api.py ("Array module numpy does not have the following dtypes in its namespace")
import numpy as xp

del xp.int8
del xp.int16
xps = make_strategies_namespace(xp)


@given(xps.arrays(xps.integer_dtypes(), xps.array_shapes()))
def test_array_api_warnings(arr):
    assert arr.shape

# strategies.py
def test_search_strategy_warnings():
    st.integers().example()
    st.characters().example()


# strings.py
# database.py
@given(st.text().filter(str.lower))
@example("a")
def test_string_strategy_warnings(x):
    pass
```

</details>

Then ran that script like this:

```shell
pytest -Wdefault ./test_warnings.py
```

On latest `master` (https://github.com/HypothesisWorks/hypothesis/commit/f3bd54aa00b2882dfff1b3ea78c56ce4f43c7be6), those warnings point to `hypothesis`.

<img width="952" alt="Screen Shot 2022-07-17 at 11 06 08 AM" src="https://user-images.githubusercontent.com/7608904/179410662-d109fd84-b73b-4acc-92da-71f30933abe3.png">

On this branch, they point to the line in my test code that set `hypothesis` down the code path that resulted in each warning.

<img width="908" alt="Screen Shot 2022-07-17 at 11 04 14 AM" src="https://user-images.githubusercontent.com/7608904/179409977-0ce5b198-72e2-4004-a7b8-88aaeaa65741.png">

### Notes for Reviewers

~I chose `stacklevel=2` for this warning because `SearchStrategy.example()` is in `hypothesis`'s public API, and I assumed that it would be called directly from user code.~

~If there are other uses of that method internal to `hypothesis` (which was a bit hard for me to figure out with just `git grep`), then those uses would result in warning text that points to `hypothesis`  code.~

I decided instead to propose adding a utility function to inspect the current state of the stack to find how far up the first non-`hypothesis` call is.

I did my best to follow the instructions at https://github.com/HypothesisWorks/hypothesis/blob/master/guides/documentation.rst#changelog-entries and https://github.com/HypothesisWorks/hypothesis/blob/master/CONTRIBUTING.rst.

@Zac-HD ~I wanted to break the cases in #3403 into multiple small PRs, but now that I understand that every commit in this project becomes a release, I'm not sure if that's what you'd prefer. Happy to include the other cases here if you'd prefer, so that they're all together in one coherent patch release.~ We talked about this in person, I'll batch the other changes in here.

Thanks very much for your time and consideration!