### PR TITLE
Allow subnormal in complex_numbers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ their individual contributions.
 * `Eduardo Enriquez <https://www.github.com/eduzen>`_ (eduardo.a.enriquez@gmail.com)
 * `El Awbery <https://www.github.com/ElAwbery>`_
 * `Emmanuel Leblond <https://www.github.com/touilleMan>`_
+* `Evan Tey <https://github.com/evantey14>`_
 * `Felix Divo <https://www.github.com/felixdivo>`_
 * `Felix Grünewald <https://www.github.com/fgruen>`_
 * `Felix Sheldon <https://www.github.com/darkpaw>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,7 +51,7 @@ their individual contributions.
 * `Eduardo Enriquez <https://www.github.com/eduzen>`_ (eduardo.a.enriquez@gmail.com)
 * `El Awbery <https://www.github.com/ElAwbery>`_
 * `Emmanuel Leblond <https://www.github.com/touilleMan>`_
-* `Evan They <https://github.com/evantey14>`_
+* `Evan Tey <https://github.com/evantey14>`_
 * `Felix Divo <https://www.github.com/felixdivo>`_
 * `Felix Grünewald <https://www.github.com/fgruen>`_
 * `Felix Sheldon <https://www.github.com/darkpaw>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,7 +51,7 @@ their individual contributions.
 * `Eduardo Enriquez <https://www.github.com/eduzen>`_ (eduardo.a.enriquez@gmail.com)
 * `El Awbery <https://www.github.com/ElAwbery>`_
 * `Emmanuel Leblond <https://www.github.com/touilleMan>`_
-* `Evan Tey <https://github.com/evantey14>`_
+* `Evan They <https://github.com/evantey14>`_
 * `Felix Divo <https://www.github.com/felixdivo>`_
 * `Felix Grünewald <https://www.github.com/fgruen>`_
 * `Felix Sheldon <https://www.github.com/darkpaw>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,6 @@
 RELEASE_TYPE: minor
 
-This release adds the ``allow_subnormal`` argument to ``complex_numbers()`` by
-applying it to each the real and imaginary parts separately. Closes issue
-:issue:`3390`.
+This release adds the ``allow_subnormal`` argument to :func:`~hypothesis.strategies.complex_numbers` by
+applying it to each of the real and imaginary parts separately. Closes :issue:`3390`.
 
-Thanks to Evan They for this fix.
+Thanks to Evan Tey for this fix.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -4,4 +4,4 @@ This release adds the ``allow_subnormal`` argument to ``complex_numbers()`` by
 applying it to each the real and imaginary parts separately. Closes issue
 :issue:`3390`.
 
-Thanks to Evan Tey for this fix.
+Thanks to Evan They for this fix.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release adds the ``allow_subnormal`` argument to ``complex_numbers()`` by
+applying it to each the real and imaginary parts separately. Closes issue
+:issue:`3390`.
+
+Thanks to Evan Tey for this fix.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1595,6 +1595,7 @@ def complex_numbers(
     max_magnitude: Optional[Real] = None,
     allow_infinity: Optional[bool] = None,
     allow_nan: Optional[bool] = None,
+    allow_subnormal: bool = True,
 ) -> SearchStrategy[complex]:
     """Returns a strategy that generates complex numbers.
 
@@ -1606,6 +1607,9 @@ def complex_numbers(
     If ``min_magnitude`` is nonzero or ``max_magnitude`` is finite, it
     is an error to enable ``allow_nan``.  If ``max_magnitude`` is finite,
     it is an error to enable ``allow_infinity``.
+
+    ``allow_subnormal`` is applied to each part of the complex number
+    separately.
 
     The magnitude constraints are respected up to a relative error
     of (around) floating-point epsilon, due to implementation via
@@ -1639,7 +1643,11 @@ def complex_numbers(
             f"Cannot have allow_nan={allow_nan!r}, min_magnitude={min_magnitude!r} "
             f"max_magnitude={max_magnitude!r}"
         )
-    allow_kw = {"allow_nan": allow_nan, "allow_infinity": allow_infinity}
+    allow_kw = {
+        "allow_nan": allow_nan,
+        "allow_infinity": allow_infinity,
+        "allow_subnormal": None if allow_subnormal else allow_subnormal,
+    }
 
     if min_magnitude == 0 and max_magnitude is None:
         # In this simple but common case, there are no constraints on the

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1643,6 +1643,8 @@ def complex_numbers(
             f"Cannot have allow_nan={allow_nan!r}, min_magnitude={min_magnitude!r} "
             f"max_magnitude={max_magnitude!r}"
         )
+
+    check_type(bool, allow_subnormal, "allow_subnormal")
     allow_kw = {
         "allow_nan": allow_nan,
         "allow_infinity": allow_infinity,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1656,7 +1656,7 @@ def complex_numbers(
         # In this simple but common case, there are no constraints on the
         # magnitude and therefore no relationship between the real and
         # imaginary parts.
-        return builds(complex, floats(**allow_kw), floats(**allow_kw))
+        return builds(complex, floats(**allow_kw), floats(**allow_kw))  # type: ignore
 
     @composite
     def constrained_complex(draw):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1646,6 +1646,9 @@ def complex_numbers(
     allow_kw = {
         "allow_nan": allow_nan,
         "allow_infinity": allow_infinity,
+        # If we have a nonzero normal min_magnitude and draw a zero imaginary part,
+        # then allow_subnormal=True would be an error with the min_value to the floats()
+        # strategy for the real part.  We therefore replace True with None.
         "allow_subnormal": None if allow_subnormal else allow_subnormal,
     }
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1609,7 +1609,7 @@ def complex_numbers(
     it is an error to enable ``allow_infinity``.
 
     ``allow_subnormal`` is applied to each part of the complex number
-    separately.
+    separately, as for :func:`~hypothesis.strategies.floats`.
 
     The magnitude constraints are respected up to a relative error
     of (around) floating-point epsilon, due to implementation via

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -94,7 +94,7 @@ def test_minmax_magnitude_equal(data, mag):
 
 
 def _is_subnormal(x):
-    return -sys.float_info.min < x < sys.float_info.min
+    return 0 < abs(x) < sys.float_info.min
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -120,6 +120,7 @@ def test_allow_subnormal(allow_subnormal, min_magnitude, max_magnitude):
             strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag)
         )
 
+
 @pytest.mark.parametrize("allow_subnormal", [1, 0.0, "False"])
 def test_allow_subnormal_validation(allow_subnormal):
     with pytest.raises(InvalidArgument):

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -11,10 +11,13 @@
 import math
 import sys
 
+import pytest
+
 from hypothesis import given, reject, strategies as st
 from hypothesis.strategies import complex_numbers
+from hypothesis.errors import InvalidArgument
 
-from tests.common.debug import minimal
+from tests.common.debug import assert_no_examples, find_any, minimal
 
 
 def test_minimal():
@@ -89,3 +92,29 @@ def test_minmax_magnitude_equal(data, mag):
         assert math.isclose(abs(val), mag)
     except OverflowError:
         reject()
+
+
+def _is_subnormal(x):
+    return -sys.float_info.min < x < sys.float_info.min
+
+@pytest.mark.parametrize(
+    "allow_subnormal, min_magnitude, max_magnitude",
+    [
+        (True, 0, None),
+        (True, 1, None),
+        (False, 0, None),
+    ]
+)
+def test_allow_subnormal(allow_subnormal, min_magnitude, max_magnitude):
+    strat = complex_numbers(
+        min_magnitude=min_magnitude,
+        max_magnitude=max_magnitude,
+        allow_subnormal=allow_subnormal,
+    ).filter(
+        lambda x: x.real != 0 and x.imag != 0
+    )
+
+    if allow_subnormal:
+        find_any(strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag))
+    else:
+        assert_no_examples(strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag))

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -14,6 +14,7 @@ import sys
 import pytest
 
 from hypothesis import given, reject, strategies as st
+from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import complex_numbers
 
 from tests.common.debug import assert_no_examples, find_any, minimal
@@ -118,3 +119,8 @@ def test_allow_subnormal(allow_subnormal, min_magnitude, max_magnitude):
         assert_no_examples(
             strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag)
         )
+
+@pytest.mark.parametrize("allow_subnormal", [1, 0.0, "False"])
+def test_allow_subnormal_validation(allow_subnormal):
+    with pytest.raises(InvalidArgument):
+        complex_numbers(allow_subnormal=allow_subnormal).example()

--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -15,7 +15,6 @@ import pytest
 
 from hypothesis import given, reject, strategies as st
 from hypothesis.strategies import complex_numbers
-from hypothesis.errors import InvalidArgument
 
 from tests.common.debug import assert_no_examples, find_any, minimal
 
@@ -97,24 +96,25 @@ def test_minmax_magnitude_equal(data, mag):
 def _is_subnormal(x):
     return -sys.float_info.min < x < sys.float_info.min
 
+
 @pytest.mark.parametrize(
     "allow_subnormal, min_magnitude, max_magnitude",
     [
         (True, 0, None),
         (True, 1, None),
         (False, 0, None),
-    ]
+    ],
 )
 def test_allow_subnormal(allow_subnormal, min_magnitude, max_magnitude):
     strat = complex_numbers(
         min_magnitude=min_magnitude,
         max_magnitude=max_magnitude,
         allow_subnormal=allow_subnormal,
-    ).filter(
-        lambda x: x.real != 0 and x.imag != 0
-    )
+    ).filter(lambda x: x.real != 0 and x.imag != 0)
 
     if allow_subnormal:
         find_any(strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag))
     else:
-        assert_no_examples(strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag))
+        assert_no_examples(
+            strat, lambda x: _is_subnormal(x.real) or _is_subnormal(x.imag)
+        )

--- a/tooling/ignore-list.txt
+++ b/tooling/ignore-list.txt
@@ -5,4 +5,4 @@ nin
 strat
 tread
 rouge
-Tey
+tey

--- a/tooling/ignore-list.txt
+++ b/tooling/ignore-list.txt
@@ -5,3 +5,4 @@ nin
 strat
 tread
 rouge
+Tey


### PR DESCRIPTION
Fixes #3390.

Adds the `allow_subnormal` argument to `complex_numbers` by applying it to both the real and imaginary parts separately.