### PR TITLE
Fix issue 3384

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,6 +63,7 @@ their individual contributions.
 * `Graham Williamson <https://github.com/00willo>`_
 * `Grant David Bachman <https://github.com/grantbachman>`_ (grantbachman@gmail.com)
 * `Gregory Petrosyan <https://github.com/flyingmutant>`_
+* `Grzegorz Zieba <https://github.com/gzaxel>`_ (g.zieba@erax.pl)
 * `Grigorios Giannakopoulos <https://github.com/grigoriosgiann>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Humberto Rocha <https://github.com/humrochagf>`_
@@ -131,6 +132,7 @@ their individual contributions.
 * `Richard Scholtens <https://github.com/richardscholtens>`_ (richardscholtens2@gmail.com)
 * `Robert Howlett <https://github.com/jebob>`_
 * `Robert Knight <https://github.com/robertknight>`_ (robertknight@gmail.com)
+* `Rodrigo Girão Serrão <https://github.com/rodrigogiraoserrao>`_ (rodrigo@mathspp.com)
 * `Rónán Carrigan <https://www.github.com/rcarriga>`_ (rcarriga@tcd.ie)
 * `Ruben Opdebeeck <https://github.com/ROpdebee>`_
 * `Ryan Soklaski <https://www.github.com/rsokl>`_ (rsoklaski@gmail.com)
@@ -150,9 +152,10 @@ their individual contributions.
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (tariq@khokhar.net)
 * `Tessa Bradbury <https://www.github.com/tessereth>`_
 * `Thea Koutsoukis <https://www.github.com/theakaterina>`_
+* `Thomas Ball <https://www.github.com/bomtall>`_ (bomtall1@hotmail.com)
 * `Thomas Grainge <https://www.github.com/tgrainge>`_
-* `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Thomas Kluyver <https://www.github.com/takluyver>`_ (thomas@kluyver.me.uk)
+* `Tim Martin <https://www.github.com/timmartin>`_ (tim@asymptotic.co.uk)
 * `Tom McDermott <https://www.github.com/sponster-au>`_ (sponster@gmail.com)
 * `Tom Milligan <https://www.github.com/tommilligan>`_ (code@tommilligan.net)
 * `Tyler Gibbons <https://www.github.com/kavec>`_ (tyler.gibbons@flexport.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+Issue a deprecation warning if a function decorated with :func:`@composite <hypothesis.strategies.composite>`
+does not draw any values (:issue:`3384`).
+
+Thanks to Grzegorz Zieba, Rodrigo Girão, and Thomas Ball for working on this at the EuroPython sprints!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,8 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-Issue a deprecation warning if a function decorated with :func:`@composite <hypothesis.strategies.composite>`
+Issue a deprecation warning if a function decorated with
+:func:`@composite <hypothesis.strategies.composite>`
 does not draw any values (:issue:`3384`).
 
-Thanks to Grzegorz Zieba, Rodrigo Girão, and Thomas Ball for working on this at the EuroPython sprints!
+Thanks to Grzegorz Zieba, Rodrigo Girão, and Thomas Ball for
+working on this at the EuroPython sprints!

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -17,6 +17,7 @@ import inspect
 import os
 import re
 import sys
+import textwrap
 import types
 from functools import wraps
 from keyword import iskeyword
@@ -217,6 +218,21 @@ def ast_arguments_matches_signature(args, sig):
     if args.kwarg is not None:
         expected.append((args.kwarg.arg, inspect.Parameter.VAR_KEYWORD))
     return expected == [(p.name, p.kind) for p in sig.parameters.values()]
+
+
+def is_func_param_called_within(f, name):
+    """Is the given name referenced within f?"""
+    try:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(f)))
+    except Exception:
+        return True
+    else:
+        return any(
+            isinstance(node, ast.Name)
+            and node.id == name
+            and isinstance(node.ctx, ast.Load)
+            for node in ast.walk(tree)
+        )
 
 
 def extract_all_lambdas(tree, matching_signature):

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -220,19 +220,18 @@ def ast_arguments_matches_signature(args, sig):
     return expected == [(p.name, p.kind) for p in sig.parameters.values()]
 
 
-def is_func_param_called_within(f, name):
+def is_first_param_referenced_in_function(f, name):
     """Is the given name referenced within f?"""
     try:
         tree = ast.parse(textwrap.dedent(inspect.getsource(f)))
     except Exception:
-        return True
-    else:
-        return any(
-            isinstance(node, ast.Name)
-            and node.id == name
-            and isinstance(node.ctx, ast.Load)
-            for node in ast.walk(tree)
-        )
+        return True  # Assume it's OK unless we know otherwise
+    return any(
+        isinstance(node, ast.Name)
+        and node.id == name
+        and isinstance(node.ctx, ast.Load)
+        for node in ast.walk(tree)
+    )
 
 
 def extract_all_lambdas(tree, matching_signature):

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -220,12 +220,13 @@ def ast_arguments_matches_signature(args, sig):
     return expected == [(p.name, p.kind) for p in sig.parameters.values()]
 
 
-def is_first_param_referenced_in_function(f, name):
+def is_first_param_referenced_in_function(f):
     """Is the given name referenced within f?"""
     try:
         tree = ast.parse(textwrap.dedent(inspect.getsource(f)))
     except Exception:
         return True  # Assume it's OK unless we know otherwise
+    name = list(get_signature(f).parameters)[0]
     return any(
         isinstance(node, ast.Name)
         and node.id == name

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -60,7 +60,7 @@ from hypothesis.internal.reflection import (
     define_function_signature,
     get_pretty_function_description,
     get_signature,
-    is_func_param_called_within,
+    is_first_param_referenced_in_function,
     nicerepr,
     required_args,
 )
@@ -1533,7 +1533,7 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
-    if not is_func_param_called_within(f, params[0].name):
+    if not is_first_param_referenced_in_function(f, params[0].name):
         note_deprecation(
             "There is no reason to use @st.composite on a function which "
             + "does not call the provided draw() function internally.",

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -44,6 +44,7 @@ from uuid import UUID
 
 import attr
 
+from hypothesis._settings import note_deprecation
 from hypothesis.control import cleanup, note
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.internal.cathetus import cathetus
@@ -59,6 +60,7 @@ from hypothesis.internal.reflection import (
     define_function_signature,
     get_pretty_function_description,
     get_signature,
+    is_func_param_called_within,
     nicerepr,
     required_args,
 )
@@ -1531,6 +1533,13 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
+    if not is_func_param_called_within(f, params[0].name):
+        note_deprecation(
+            "There is no reason to use @st.composite on a function which "
+            + "does not call the provided draw() function internally.",
+            since="RELEASEDAY",
+            has_codemod=False,
+        )
     if params[0].kind.name != "VAR_POSITIONAL":
         params = params[1:]
     newsig = sig.replace(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1533,7 +1533,7 @@ def _composite(f):
         )
     if params[0].default is not sig.empty:
         raise InvalidArgument("A default value for initial argument will never be used")
-    if not is_first_param_referenced_in_function(f, params[0].name):
+    if not is_first_param_referenced_in_function(f):
         note_deprecation(
             "There is no reason to use @st.composite on a function which "
             + "does not call the provided draw() function internally.",

--- a/hypothesis-python/tests/cover/test_annotations.py
+++ b/hypothesis-python/tests/cover/test_annotations.py
@@ -83,8 +83,8 @@ def test_converter_notices_missing_kwonly_args():
         assert convert_positional_arguments(f, (), {})
 
 
-def pointless_composite(draw: None, strat: bool, nothing: list) -> int:
-    return 3
+def to_wrap_with_composite(draw: None, strat: bool, nothing: list) -> int:
+    return draw(st.none())
 
 
 def return_annot() -> int:
@@ -96,7 +96,7 @@ def first_annot(draw: None):
 
 
 def test_composite_edits_annotations():
-    sig_comp = signature(st.composite(pointless_composite))
+    sig_comp = signature(st.composite(to_wrap_with_composite))
     assert sig_comp.return_annotation == st.SearchStrategy[int]
     assert sig_comp.parameters["nothing"].annotation is not P.empty
     assert "draw" not in sig_comp.parameters
@@ -104,7 +104,7 @@ def test_composite_edits_annotations():
 
 @pytest.mark.parametrize("nargs", [1, 2, 3])
 def test_given_edits_annotations(nargs):
-    sig_given = signature(given(*(nargs * [st.none()]))(pointless_composite))
+    sig_given = signature(given(*(nargs * [st.none()]))(to_wrap_with_composite))
     assert sig_given.return_annotation is None
     assert len(sig_given.parameters) == 3 - nargs
     assert all(p.annotation is not P.empty for p in sig_given.parameters.values())

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -11,7 +11,7 @@
 import pytest
 
 from hypothesis import assume, given, strategies as st
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
 
 from tests.common.debug import minimal
 from tests.common.utils import flaky
@@ -75,6 +75,14 @@ def test_errors_given_kwargs_only():
             pass
 
 
+def test_warning_given_no_drawfn_call():
+    with pytest.raises(HypothesisDeprecationWarning):
+
+        @st.composite
+        def foo(_):
+            return "bar"
+
+
 def test_can_use_pure_args():
     @st.composite
     def stuff(*args):
@@ -122,6 +130,7 @@ def test_does_not_change_arguments(data, ls):
     # regression test for issue #1017 or other argument mutation
     @st.composite
     def strat(draw, arg):
+        draw(st.none())
         return arg
 
     ex = data.draw(strat(ls))

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -76,7 +76,7 @@ def test_errors_given_kwargs_only():
 
 
 def test_warning_given_no_drawfn_call():
-    with pytest.raises(HypothesisDeprecationWarning):
+    with pytest.warns(HypothesisDeprecationWarning):
 
         @st.composite
         def foo(_):

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -27,7 +27,7 @@ from hypothesis.internal.reflection import (
     function_digest,
     get_pretty_function_description,
     get_signature,
-    is_func_param_called_within,
+    is_first_param_referenced_in_function,
     is_mock,
     proxies,
     repr_call,
@@ -629,7 +629,7 @@ def test_param_is_called_within_func():
     def f(any_name):
         any_name()
 
-    assert is_func_param_called_within(f, "any_name")
+    assert is_first_param_referenced_in_function(f, "any_name")
 
 
 def test_param_is_called_within_subfunc():
@@ -637,17 +637,17 @@ def test_param_is_called_within_subfunc():
         def f2():
             any_name()
 
-    assert is_func_param_called_within(f, "any_name")
+    assert is_first_param_referenced_in_function(f, "any_name")
 
 
 def test_param_is_not_called_within_func():
     def f(any_name):
         pass
 
-    assert not is_func_param_called_within(f, "any_name")
+    assert not is_first_param_referenced_in_function(f, "any_name")
 
 
 def test_param_called_within_defaults_on_error():
     # Create a function object for which we cannot retrieve the source.
     f = compile("lambda: ...", "_.py", "eval")
-    assert is_func_param_called_within(f, "any_name")
+    assert is_first_param_referenced_in_function(f, "any_name")

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -27,6 +27,7 @@ from hypothesis.internal.reflection import (
     function_digest,
     get_pretty_function_description,
     get_signature,
+    is_func_param_called_within,
     is_mock,
     proxies,
     repr_call,
@@ -622,3 +623,31 @@ def test_error_on_keyword_parameter_name():
 
     with pytest.raises(ValueError, match="SyntaxError because `from` is a keyword"):
         get_signature(f)
+
+
+def test_param_is_called_within_func():
+    def f(any_name):
+        any_name()
+
+    assert is_func_param_called_within(f, "any_name")
+
+
+def test_param_is_called_within_subfunc():
+    def f(any_name):
+        def f2():
+            any_name()
+
+    assert is_func_param_called_within(f, "any_name")
+
+
+def test_param_is_not_called_within_func():
+    def f(any_name):
+        pass
+
+    assert not is_func_param_called_within(f, "any_name")
+
+
+def test_param_called_within_defaults_on_error():
+    # Create a function object for which we cannot retrieve the source.
+    f = compile("lambda: ...", "_.py", "eval")
+    assert is_func_param_called_within(f, "any_name")

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -629,7 +629,7 @@ def test_param_is_called_within_func():
     def f(any_name):
         any_name()
 
-    assert is_first_param_referenced_in_function(f, "any_name")
+    assert is_first_param_referenced_in_function(f)
 
 
 def test_param_is_called_within_subfunc():
@@ -637,17 +637,17 @@ def test_param_is_called_within_subfunc():
         def f2():
             any_name()
 
-    assert is_first_param_referenced_in_function(f, "any_name")
+    assert is_first_param_referenced_in_function(f)
 
 
 def test_param_is_not_called_within_func():
     def f(any_name):
         pass
 
-    assert not is_first_param_referenced_in_function(f, "any_name")
+    assert not is_first_param_referenced_in_function(f)
 
 
 def test_param_called_within_defaults_on_error():
     # Create a function object for which we cannot retrieve the source.
     f = compile("lambda: ...", "_.py", "eval")
-    assert is_first_param_referenced_in_function(f, "any_name")
+    assert is_first_param_referenced_in_function(f)

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -152,6 +152,7 @@ def test_draw_time_percentage(draw_delay, test_delay):
     def s(draw):
         if draw_delay:
             time.sleep(0.05)
+        draw(st.integers())
 
     @given(s())
     def test(_):

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -34,6 +34,9 @@ def test_exception_propagates_fine_from_strategy(e):
     @composite
     def interrupt_eventually(draw):
         raise e
+        # this line will not be executed, but must be here
+        # to pass draw function static reference check
+        return draw(st.none())
 
     @given(interrupt_eventually())
     def test_do_nothing(x):
@@ -69,13 +72,14 @@ def test_baseexception_no_rerun_no_flaky(e):
     "e", [KeyboardInterrupt, SystemExit, GeneratorExit, ValueError]
 )
 def test_baseexception_in_strategy_no_rerun_no_flaky(e):
-    runs = [0]
+    runs = 0
     interrupt = 3
 
     @composite
     def interrupt_eventually(draw):
-        runs[0] += 1
-        if runs[0] == interrupt:
+        nonlocal runs
+        runs += 1
+        if runs == interrupt:
             raise e
         return draw(integers())
 
@@ -87,7 +91,7 @@ def test_baseexception_in_strategy_no_rerun_no_flaky(e):
         with pytest.raises(e):
             test_do_nothing()
 
-        assert runs[0] == interrupt
+        assert runs == interrupt
 
     else:
         # Now SystemExit and GeneratorExit are caught like other exceptions
@@ -101,6 +105,9 @@ from hypothesis import given, note, strategies as st
 @st.composite
 def things(draw):
     raise {exception}
+    # this line will not be executed, but must be here 
+    # to pass draw function static reference check
+    return draw(st.none())
 
 
 @given(st.data(), st.integers())

--- a/hypothesis-python/tests/nocover/test_labels.py
+++ b/hypothesis-python/tests/nocover/test_labels.py
@@ -22,12 +22,12 @@ def test_labels_are_distinct():
 
 @st.composite
 def foo(draw):
-    pass
+    return draw(st.none())
 
 
 @st.composite
 def bar(draw):
-    pass
+    return draw(st.none())
 
 
 def test_different_composites_have_different_labels():

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -108,10 +108,10 @@ def test_healthcheck_traceback_is_hidden(testdir):
 
 
 COMPOSITE_IS_NOT_A_TEST = """
-from hypothesis.strategies import composite
+from hypothesis.strategies import composite, none
 @composite
 def test_data_factory(draw):
-    pass
+    return draw(none())
 """
 
 

--- a/hypothesis-python/tests/pytest/test_checks.py
+++ b/hypothesis-python/tests/pytest/test_checks.py
@@ -10,12 +10,12 @@
 
 TEST_DECORATORS_ALONE = """
 import hypothesis
-from hypothesis.strategies import composite
+from hypothesis.strategies import composite, none
 
 @composite
 def test_composite_is_not_a_test(draw):
     # This strategy will be instantiated, but no draws == no calls.
-    assert False
+    return draw(none())
 
 @hypothesis.seed(0)
 def test_seed_without_given_fails():

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -10,19 +10,16 @@
 
 import collections
 import sys
-from typing import Callable, Dict, List, Union
+from typing import Callable, DefaultDict, Dict, List, NewType, Type, Union
 
 import pytest
 from typing_extensions import (
     Annotated,
     Concatenate,
-    DefaultDict,
     Literal,
-    NewType,
     NotRequired,
     ParamSpec,
     Required,
-    Type,
     TypedDict,
     TypeGuard,
 )


### PR DESCRIPTION
Work by @bomtall, @gzaxel, and me, to issue a deprecation warning when people misuse `st.composite` in a function that does not use the first argument `draw`. This closes #3384.

The original (messy) history and discussion can be found in #3405.