### PR TITLE
Biases IntegersStrategy to sample extreme values more often

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch forces :func:`~hypothesis.strategies.integers` to spend more time sampling near its maximum bound (:issue:`2942`).
+
+Thanks to Sam Clamons at the SciPy Sprints!


### PR DESCRIPTION
IntegersStrategy now samples each finite endpoint 2% of the time, and one away from each finite endpoint 1% of the time. 

This change is implemented in IntegersStrategy. Therefore other strategies that rely on integer generation (like st.characters) should not be affected. 