### PR TITLE
docs: fix simple typo, organisating -> organising

### DIFF
--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -142,7 +142,7 @@ class LStar:
 
         # When we're trying to figure out what state a string leads to we will
         # end up searching to find a suitable candidate. By putting states in
-        # a self-organisating list we ideally minimise the number of lookups.
+        # a self-organising list we ideally minimise the number of lookups.
         self.__self_organising_states = SelfOrganisingList(self.__states)
 
         self.start = 0


### PR DESCRIPTION
There is a small typo in hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py.

Should read `organising` rather than `organisating`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md