### PR TITLE
Fix pytest workaround for `ExceptionGroup` display

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes our workaround for `a pytest bug where the inner exceptions in
+an ExceptionGroup are not displayed <https://github.com/pytest-dev/pytest/issues/9159>`__
+(:issue:`3430`).

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -178,13 +178,6 @@ else:
                 pass
             core.global_force_seed = seed
 
-        core.pytest_shows_exceptiongroups = (
-            sys.version_info[:2] >= (3, 11)
-            ## See https://github.com/pytest-dev/pytest/issues/9159
-            # or pytest_version >= (7, 2)  # TODO: fill in correct version here
-            or config.getoption("tbstyle", "auto") == "native"
-        )
-
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(item):
         __tracebackhide__ = True
@@ -195,6 +188,11 @@ else:
         from hypothesis import core
         from hypothesis.internal.detection import is_hypothesis_test
 
+        ## See https://github.com/pytest-dev/pytest/issues/9159
+        # TODO: add `pytest_version >= (7, 2) or` once the issue above is fixed.
+        core.pytest_shows_exceptiongroups = (
+            item.config.getoption("tbstyle", "auto") == "native"
+        )
         core.running_under_pytest = True
 
         if not is_hypothesis_test(item.obj):

--- a/hypothesis-python/tests/pytest/test_reporting.py
+++ b/hypothesis-python/tests/pytest/test_reporting.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import pytest
+
 pytest_plugins = "pytester"
 
 
@@ -33,3 +35,24 @@ def test_runs_reporting_hook(testdir):
     assert "Captured stdout call" not in out
     assert "Falsifying example" in out
     assert result.ret != 0
+
+
+TEST_EXCEPTIONGROUP = """
+from hypothesis import given, strategies as st
+
+@given(x=st.booleans())
+def test_fuzz_sorted(x):
+    raise ValueError if x else TypeError
+"""
+
+
+@pytest.mark.parametrize("tb", ["auto", "long", "short", "native"])
+def test_no_missing_reports(testdir, tb):
+    script = testdir.makepyfile(TEST_EXCEPTIONGROUP)
+    result = testdir.runpytest(script, f"--tb={tb}")
+    out = "\n".join(result.stdout.lines)
+    # If the False case is missing, that means we're not printing exception info.
+    # See https://github.com/HypothesisWorks/hypothesis/issues/3430  With --tb=native,
+    # we should show the full ExceptionGroup with *both* errors.
+    assert "x=False" in out
+    assert "x=True" in out or tb != "native"


### PR DESCRIPTION
Fixes #3430, and adds a test to ensure it can't reoccur.