### PR TITLE
Adding type check and provide numpy strategy for NDArray

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adding support to `NDArray <https://numpy.org/devdocs/reference/typing.html#numpy.typing.NDArray>`_ from `numpy.typing <https://numpy.org/devdocs/reference/typing.html>`_ in :func:`~hypothesis.strategies.from_type` (:issue:`3150`)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: minor
 
-Adding support to `NDArray <https://numpy.org/devdocs/reference/typing.html#numpy.typing.NDArray>`_ from `numpy.typing <https://numpy.org/devdocs/reference/typing.html>`_ in :func:`~hypothesis.strategies.from_type` (:issue:`3150`)
+:func:`~hypothesis.strategies.from_type` now supports :obj:`numpy.typing.NDArray` (:issue:`3150`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -713,6 +713,7 @@ def resolve_Type(thing):
 def resolve_List(thing):
     return st.lists(st.from_type(thing.__args__[0]))
 
+
 try:
     import numpy.typing as npt
 
@@ -729,6 +730,7 @@ try:
 
 except ImportError:
     pass
+
 
 def _can_hash(val):
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -256,17 +256,11 @@ def is_a_union(thing):
     )
 
 
-try:
-    import numpy as np
-except ImportError:
-
-    def is_np_type(thing):
+def is_np_type(thing):
+    np = sys.modules.get("numpy")
+    if np is None:
         return False
-
-else:
-
-    def is_np_type(thing):
-        return isinstance(thing, (np.ndarray, np.generic))
+    return isinstance(thing, (np.ndarray, np.generic))
 
 
 def is_a_type(thing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -259,7 +259,10 @@ def is_a_union(thing):
 try:
     import numpy.typing as npt
 except ImportError:
-    pass
+
+    def is_np_type(thing):
+        return False
+
 else:
 
     def is_np_type(thing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -719,6 +719,9 @@ try:
     from numpy._typing._generic_alias import ScalarType
 
     from hypothesis.extra.numpy import array_shapes, arrays, scalar_dtypes
+except ImportError:
+    pass
+else:
 
     @register(npt.NDArray)
     def resolve_ndarray(thing):
@@ -727,9 +730,6 @@ try:
             return arrays(scalar_dtypes(), array_shapes(max_dims=2))
         else:
             return arrays(st.from_type(array_type), array_shapes(max_dims=2))
-
-except ImportError:
-    pass
 
 
 def _can_hash(val):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -713,6 +713,22 @@ def resolve_Type(thing):
 def resolve_List(thing):
     return st.lists(st.from_type(thing.__args__[0]))
 
+try:
+    import numpy.typing as npt
+
+    from numpy._typing._generic_alias import ScalarType
+    from hypothesis.extra.numpy import array_shapes, arrays, scalar_dtypes
+
+    @register(npt.NDArray)
+    def resolve_ndarray(thing):
+        array_type = thing.__args__[1].__args__[0]
+        if array_type == ScalarType:
+            return arrays(scalar_dtypes(), array_shapes(max_dims=2))
+        else:
+            return arrays(st.from_type(array_type), array_shapes(max_dims=2))
+
+except ImportError:
+    pass
 
 def _can_hash(val):
     try:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -257,7 +257,7 @@ def is_a_union(thing):
 
 
 try:
-    import numpy.typing as npt
+    import numpy as np
 except ImportError:
 
     def is_np_type(thing):
@@ -266,7 +266,7 @@ except ImportError:
 else:
 
     def is_np_type(thing):
-        return issubclass(thing, (npt.ArrayLike, npt.DTypeLike))
+        return isinstance(thing, (np.ndarray, np.generic))
 
 
 def is_a_type(thing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -256,9 +256,24 @@ def is_a_union(thing):
     )
 
 
+try:
+    import numpy.typing as npt
+except ImportError:
+    pass
+else:
+
+    def is_np_type(thing):
+        return issubclass(thing, (npt.ArrayLike, npt.DTypeLike))
+
+
 def is_a_type(thing):
     """Return True if thing is a type or a generic type like thing."""
-    return isinstance(thing, type) or is_generic_type(thing) or is_a_new_type(thing)
+    return (
+        isinstance(thing, type)
+        or is_generic_type(thing)
+        or is_a_new_type(thing)
+        or is_np_type(thing)
+    )
 
 
 def is_typing_literal(thing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -716,8 +716,8 @@ def resolve_List(thing):
 
 try:
     import numpy.typing as npt
-
     from numpy._typing._generic_alias import ScalarType
+
     from hypothesis.extra.numpy import array_shapes, arrays, scalar_dtypes
 
     @register(npt.NDArray)

--- a/hypothesis-python/tests/numpy/test_type_lookup.py
+++ b/hypothesis-python/tests/numpy/test_type_lookup.py
@@ -17,10 +17,13 @@ import numpy as np
 
 from tests.common.debug import assert_all_examples
 
+
 def test_from_numpy_ndarray_any_type():
-    assert_all_examples(st.from_type(NDArray), lambda obj: isinstance(obj,np.ndarray))
+    assert_all_examples(st.from_type(NDArray), lambda obj: isinstance(obj, np.ndarray))
+
 
 def test_from_numpy_ndarray_specific_type():
     def check_dtype(obj):
         return obj.dtype == np.float64
+
     assert_all_examples(st.from_type(NDArray[np.float64]), check_dtype)

--- a/hypothesis-python/tests/numpy/test_type_lookup.py
+++ b/hypothesis-python/tests/numpy/test_type_lookup.py
@@ -1,0 +1,26 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from hypothesis import given, strategies as st
+
+from numpy.typing import NDArray
+import numpy as np
+
+from tests.common.debug import assert_all_examples
+
+def test_from_numpy_ndarray_any_type():
+    assert_all_examples(st.from_type(NDArray), lambda obj: isinstance(obj,np.ndarray))
+
+def test_from_numpy_ndarray_specific_type():
+    def check_dtype(obj):
+        return obj.dtype == np.float64
+    assert_all_examples(st.from_type(NDArray[np.float64]), check_dtype)

--- a/hypothesis-python/tests/numpy/test_type_lookup.py
+++ b/hypothesis-python/tests/numpy/test_type_lookup.py
@@ -8,12 +8,10 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
-
-from hypothesis import given, strategies as st
-
-from numpy.typing import NDArray
 import numpy as np
+from numpy.typing import NDArray
+
+from hypothesis import strategies as st
 
 from tests.common.debug import assert_all_examples
 

--- a/hypothesis-python/tests/numpy/test_type_lookup.py
+++ b/hypothesis-python/tests/numpy/test_type_lookup.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import numpy as np
+import pytest
 from numpy.typing import NDArray
 
 from hypothesis import strategies as st
@@ -20,8 +21,18 @@ def test_from_numpy_ndarray_any_type():
     assert_all_examples(st.from_type(NDArray), lambda obj: isinstance(obj, np.ndarray))
 
 
-def test_from_numpy_ndarray_specific_type():
-    def check_dtype(obj):
-        return obj.dtype == np.float64
-
-    assert_all_examples(st.from_type(NDArray[np.float64]), check_dtype)
+@pytest.mark.parametrize(
+    "test_nptype",
+    [
+        np.float64,
+        np.int32,
+        np.uint64,
+        np.int16,
+        np.uint8,
+        np.complex128,
+    ],
+)
+def test_from_numpy_ndarray_specific_type(test_nptype):
+    assert_all_examples(
+        st.from_type(NDArray[test_nptype]), lambda obj: obj.dtype == test_nptype
+    )


### PR DESCRIPTION
An attempt to close #3150 

This PR

- [x] proved support in `from_type` for NDArrays in numpy.typing
- [ ] provide a typing define of Shape to use when registering for numpy strategies (not sure is that what you mean @Zac-HD )

Feel free to let me know where I should put the tests, I put them in a separate file for my sanity but happy to move it.