### PR TITLE
Update setup.cfg to use license_files

### DIFF
--- a/hypothesis-python/setup.cfg
+++ b/hypothesis-python/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
 # This includes the license file in the wheel.
-license_file = LICENSE.txt
+license_files = LICENSE.txt


### PR DESCRIPTION
Fix the following setuptools deprecation warning:

> The license_file parameter is deprecated, use license_files instead.

-----

Should I be creating `RELEASE.rst` if I don't think this change deserves a release of its own?