### PR TITLE
Add failing test to check what CI jobs run numpy tests

### DIFF
--- a/hypothesis-python/tests/numpy/test_fill_values.py
+++ b/hypothesis-python/tests/numpy/test_fill_values.py
@@ -54,3 +54,7 @@ def test_minimizes_to_fill():
 )
 def test_fills_everything(x):
     assert x.all()
+
+
+def test_should_fail():
+    assert False


### PR DESCRIPTION
I think numpy tests are only running against `check-py38`.