### PR TITLE
`get_type_hints()` support for `partial()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch teaches our enhanced :func:`~typing.get_type_hints` function to
+'see through' :obj:`~functools.partial` application, allowing inference
+from type hints to work in a few more cases which aren't (yet!) supported
+by the standard-library version.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -13,6 +13,7 @@ import inspect
 import platform
 import sys
 import typing
+from functools import partial
 from typing import Any, ForwardRef, Tuple
 
 try:
@@ -119,6 +120,14 @@ def get_type_hints(thing):
     Never errors: instead of raising TypeError for uninspectable objects, or
     NameError for unresolvable forward references, just return an empty dict.
     """
+    if isinstance(thing, partial):
+        from hypothesis.internal.reflection import get_signature
+
+        bound = set(get_signature(thing.func).parameters).difference(
+            get_signature(thing).parameters
+        )
+        return {k: v for k, v in get_type_hints(thing.func).items() if k not in bound}
+
     kwargs = {} if sys.version_info[:2] < (3, 9) else {"include_extras": True}
 
     try:

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -24,7 +24,7 @@ from io import StringIO
 from keyword import iskeyword
 from tokenize import COMMENT, detect_encoding, generate_tokens, untokenize
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import _patch as PatchType
 
 from hypothesis.internal.compat import PYPY, is_typed_named_tuple, update_code_location
@@ -127,7 +127,7 @@ def check_signature(sig: inspect.Signature) -> None:
             )
 
 
-def get_signature(target, *, follow_wrapped=True):
+def get_signature(target: Any, *, follow_wrapped: bool = True) -> inspect.Signature:
     # Special case for use of `@unittest.mock.patch` decorator, mimicking the
     # behaviour of getfullargspec instead of reporting unusable arguments.
     patches = getattr(target, "patchings", None)


### PR DESCRIPTION
Closes #3478.