### PR TITLE
Refactor pretty-printer to unlock future upgrades

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch improves our pretty-printing of failing examples, including
+some refactoring to prepare for exciting future features.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
-from typing import NoReturn, Union
+from typing import NoReturn, Optional, Union
 
 from hypothesis import Verbosity, settings
 from hypothesis.errors import InvalidArgument, UnsatisfiedAssumption
@@ -51,7 +51,7 @@ def currently_in_test_context() -> bool:
     return _current_build_context.value is not None
 
 
-def current_build_context():
+def current_build_context() -> "Optional[BuildContext]":
     context = _current_build_context.value
     if context is None:
         raise InvalidArgument("No build context registered")

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -348,7 +348,7 @@ def is_invalid_test(test, original_sig, given_arguments, given_kwargs):
 
     if ... in given_arguments:
         return invalid(
-            "... was passed as a positional argument to @given,  but may only be "
+            "... was passed as a positional argument to @given, but may only be "
             "passed as a keyword argument or as the sole argument of @given"
         )
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1119,7 +1119,7 @@ def given(
                 for p in original_sig.parameters.values()
                 if p.kind is p.POSITIONAL_OR_KEYWORD
             ]
-            given_kwargs = dict(zip(posargs[::-1], given_arguments[::-1]))
+            given_kwargs = dict(list(zip(posargs[::-1], given_arguments[::-1]))[::-1])
         # These have been converted, so delete them to prevent accidental use.
         del given_arguments
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -717,28 +717,13 @@ class StateForActualGivenExecution:
 
                             if self.print_given_args:
                                 printer.text(" ")
-                                printer.text(test.__name__)
-                                with printer.group(indent=4, open="(", close=""):
-                                    printer.break_()
-                                    for v in args:
-                                        printer.pretty(v)
-                                        # We add a comma unconditionally because
-                                        # generated arguments will always be kwargs,
-                                        # so there will always be more to come.
-                                        printer.text(",")
-                                        printer.breakable()
-
-                                    for i, (k, v) in enumerate(kwargs.items()):
-                                        printer.text(k)
-                                        printer.text("=")
-                                        printer.pretty(v)
-                                        printer.text(",")
-                                        if i + 1 < len(kwargs):
-                                            printer.breakable()
-                                printer.break_()
-                                printer.text(")")
-                            printer.flush()
-                            report(output.getvalue())
+                                printer.repr_call(
+                                    test.__name__,
+                                    args,
+                                    kwargs,
+                                    force_split=True,
+                                )
+                            report(printer.getvalue())
                         return test(*args, **kwargs)
 
         # Run the test function once, via the executor hook.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -443,6 +443,7 @@ def nicerepr(v):
 
 
 def repr_call(f, args, kwargs, reorder=True):
+    # Note: for multi-line pretty-printing, see RepresentationPrinter.repr_call()
     if reorder:
         args, kwargs = convert_positional_arguments(f, args, kwargs)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -116,6 +116,7 @@ from hypothesis.strategies._internal.strings import (
 )
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 from hypothesis.utils.conventions import not_set
+from hypothesis.vendor.pretty import RepresentationPrinter
 
 if sys.version_info >= (3, 10):
     from types import EllipsisType as EllipsisType
@@ -1834,10 +1835,11 @@ class DataObject:
         check_strategy(strategy, "strategy")
         result = self.conjecture_data.draw(strategy)
         self.count += 1
-        if label is not None:
-            note(f"Draw {self.count} ({label}): {result!r}")
-        else:
-            note(f"Draw {self.count}: {result!r}")
+        printer = RepresentationPrinter()
+        printer.text(f"Draw {self.count}")
+        printer.text(": " if label is None else f" ({label}): ")
+        printer.pretty(result)
+        note(printer.getvalue())
         return result
 
 

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -63,7 +63,6 @@ Inheritance diagram:
 """
 
 import datetime
-import platform
 import re
 import struct
 import types
@@ -74,16 +73,11 @@ from math import copysign, isnan
 
 __all__ = [
     "pretty",
-    "PrettyPrinter",
     "RepresentationPrinter",
-    "for_type_by_name",
 ]
 
 
-MAX_SEQ_LENGTH = 1000
 _re_pattern_type = type(re.compile(""))
-
-PYPY = platform.python_implementation() == "PyPy"
 
 
 def _safe_getattr(obj, attr, default=None):
@@ -99,56 +93,28 @@ def _safe_getattr(obj, attr, default=None):
         return default
 
 
-def pretty(
-    obj, verbose=False, max_width=79, newline="\n", max_seq_length=MAX_SEQ_LENGTH
-):
+def pretty(obj):
     """Pretty print the object's representation."""
-    stream = StringIO()
-    printer = RepresentationPrinter(
-        stream, verbose, max_width, newline, max_seq_length=max_seq_length
-    )
+    printer = RepresentationPrinter()
     printer.pretty(obj)
-    printer.flush()
-    return stream.getvalue()
+    return printer.getvalue()
 
 
-class _PrettyPrinterBase:
-    @contextmanager
-    def indent(self, indent):
-        """`with`-statement support for indenting/dedenting."""
-        self.indentation += indent
-        try:
-            yield
-        finally:
-            self.indentation -= indent
+class RepresentationPrinter:
+    """Special pretty printer that has a `pretty` method that calls the pretty
+    printer for a python object.
 
-    @contextmanager
-    def group(self, indent=0, open="", close=""):
-        """Like begin_group / end_group but for the with statement."""
-        self.begin_group(indent, open)
-        try:
-            yield
-        finally:
-            self.end_group(indent, close)
-
-
-class PrettyPrinter(_PrettyPrinterBase):
-    """Baseclass for the `RepresentationPrinter` prettyprinter that is used to
-    generate pretty reprs of objects.
-
-    Contrary to the `RepresentationPrinter` this printer knows nothing
-    about the default pprinters or the `_repr_pretty_` callback method.
+    This class stores processing data on `self` so you must *never* use
+    this class in a threaded environment.  Always lock it or
+    reinstantiate it.
 
     """
 
-    def __init__(
-        self, output, max_width=79, newline="\n", max_seq_length=MAX_SEQ_LENGTH
-    ):
+    def __init__(self, output=None):
         self.broken = False
-        self.output = output
-        self.max_width = max_width
-        self.newline = newline
-        self.max_seq_length = max_seq_length
+        self.output = StringIO() if output is None else output
+        self.max_width = 79
+        self.max_seq_length = 1000
         self.output_width = 0
         self.buffer_width = 0
         self.buffer = deque()
@@ -159,6 +125,59 @@ class PrettyPrinter(_PrettyPrinterBase):
         self.indentation = 0
 
         self.snans = 0
+
+        self.stack = []
+        self.singleton_pprinters = _singleton_pprinters.copy()
+        self.type_pprinters = _type_pprinters.copy()
+        self.deferred_pprinters = _deferred_type_pprinters.copy()
+
+    def pretty(self, obj):
+        """Pretty print the given object."""
+        obj_id = id(obj)
+        cycle = obj_id in self.stack
+        self.stack.append(obj_id)
+        try:
+            with self.group():
+                obj_class = _safe_getattr(obj, "__class__", None) or type(obj)
+                # First try to find registered singleton printers for the type.
+                try:
+                    printer = self.singleton_pprinters[obj_id]
+                except (TypeError, KeyError):
+                    pass
+                else:
+                    return printer(obj, self, cycle)
+                # Next walk the mro and check for either:
+                #   1) a registered printer
+                #   2) a _repr_pretty_ method
+                for cls in obj_class.__mro__:
+                    if cls in self.type_pprinters:
+                        # printer registered in self.type_pprinters
+                        return self.type_pprinters[cls](obj, self, cycle)
+                    else:
+                        # Check if the given class is specified in the deferred type
+                        # registry; move it to the regular type registry if so.
+                        key = (
+                            _safe_getattr(cls, "__module__", None),
+                            _safe_getattr(cls, "__name__", None),
+                        )
+                        if key in self.deferred_pprinters:
+                            # Move the printer over to the regular registry.
+                            printer = self.deferred_pprinters.pop(key)
+                            self.type_pprinters[cls] = printer
+                            return printer(obj, self, cycle)
+                        else:
+                            # Finally look for special method names.
+                            # Some objects automatically create any requested
+                            # attribute. Try to ignore most of them by checking for
+                            # callability.
+                            if "_repr_pretty_" in cls.__dict__:
+                                meth = cls._repr_pretty_
+                                if callable(meth):
+                                    return meth(obj, self, cycle)
+                # A user-provided repr. Find newlines and replace them with p.break_()
+                return _repr_pprint(obj, self, cycle)
+        finally:
+            self.stack.pop()
 
     def _break_outer_groups(self):
         while self.max_width < self.output_width + self.buffer_width:
@@ -201,8 +220,7 @@ class PrettyPrinter(_PrettyPrinterBase):
         group = self.group_stack[-1]
         if group.want_break:
             self.flush()
-            self.output.write(self.newline)
-            self.output.write(" " * self.indentation)
+            self.output.write("\n" + " " * self.indentation)
             self.output_width = self.indentation
             self.buffer_width = 0
         else:
@@ -214,24 +232,28 @@ class PrettyPrinter(_PrettyPrinterBase):
         """Explicitly insert a newline into the output, maintaining correct
         indentation."""
         self.flush()
-        self.output.write(self.newline)
-        self.output.write(" " * self.indentation)
+        self.output.write("\n" + " " * self.indentation)
         self.output_width = self.indentation
         self.buffer_width = 0
 
-    def begin_group(self, indent=0, open=""):
-        """
-        Begin a group.  If you want support for python < 2.5 which doesn't has
-        the with statement this is the preferred way:
-            p.begin_group(1, '{')
-            ...
-            p.end_group(1, '}')
-        The python 2.5 expression would be this:
+    @contextmanager
+    def indent(self, indent):
+        """`with`-statement support for indenting/dedenting."""
+        self.indentation += indent
+        try:
+            yield
+        finally:
+            self.indentation -= indent
+
+    @contextmanager
+    def group(self, indent=0, open="", close=""):
+        """Context manager for an indented group.
+
             with p.group(1, '{', '}'):
-                ...
-        The first parameter specifies the indentation for the next line (
-        usually the width of the opening text), the second the opening text.
-        All parameters are optional.
+
+        The first parameter specifies the indentation for the next line
+        (usually the width of the opening text), the second and third the
+        opening and closing delimiters.
         """
         if open:
             self.text(open)
@@ -239,6 +261,15 @@ class PrettyPrinter(_PrettyPrinterBase):
         self.group_stack.append(group)
         self.group_queue.enq(group)
         self.indentation += indent
+        try:
+            yield
+        finally:
+            self.indentation -= indent
+            group = self.group_stack.pop()
+            if not group.breakables:
+                self.group_queue.remove(group)
+            if close:
+                self.text(close)
 
     def _enumerate(self, seq):
         """Like enumerate, but with an upper limit on the number of items."""
@@ -249,19 +280,6 @@ class PrettyPrinter(_PrettyPrinterBase):
                 self.text("...")
                 return
             yield idx, x
-
-    def end_group(self, dedent=0, close=""):
-        """End a group.
-
-        See `begin_group` for more details.
-
-        """
-        self.indentation -= dedent
-        group = self.group_stack.pop()
-        if not group.breakables:
-            self.group_queue.remove(group)
-        if close:
-            self.text(close)
 
     def flush(self):
         """Flush data that is left in the buffer."""
@@ -276,121 +294,10 @@ class PrettyPrinter(_PrettyPrinterBase):
         self.buffer.clear()
         self.buffer_width = 0
 
-
-def _get_mro(obj_class):
-    """Get a reasonable method resolution order of a class and its superclasses
-    for both old-style and new-style classes."""
-    if not hasattr(obj_class, "__mro__"):  # pragma: no cover
-        # Old-style class. Mix in object to make a fake new-style class.
-        try:
-            obj_class = type(obj_class.__name__, (obj_class, object), {})
-        except TypeError:
-            # Old-style extension type that does not descend from object.
-            # FIXME: try to construct a more thorough MRO.
-            mro = [obj_class]
-        else:
-            mro = obj_class.__mro__[1:-1]
-    else:
-        mro = obj_class.__mro__
-    return mro
-
-
-class RepresentationPrinter(PrettyPrinter):
-    """Special pretty printer that has a `pretty` method that calls the pretty
-    printer for a python object.
-
-    This class stores processing data on `self` so you must *never* use
-    this class in a threaded environment.  Always lock it or
-    reinstanciate it. Instances also have a verbose flag callbacks can
-    access to control their output.  For example the default instance
-    repr prints all attributes and methods that are not prefixed by an
-    underscore if the printer is in verbose mode.
-
-    """
-
-    def __init__(
-        self,
-        output,
-        verbose=False,
-        max_width=79,
-        newline="\n",
-        singleton_pprinters=None,
-        type_pprinters=None,
-        deferred_pprinters=None,
-        max_seq_length=MAX_SEQ_LENGTH,
-    ):
-
-        super().__init__(output, max_width, newline, max_seq_length=max_seq_length)
-        self.verbose = verbose
-        self.stack = []
-        if singleton_pprinters is None:
-            singleton_pprinters = _singleton_pprinters.copy()
-        self.singleton_pprinters = singleton_pprinters
-        if type_pprinters is None:
-            type_pprinters = _type_pprinters.copy()
-        self.type_pprinters = type_pprinters
-        if deferred_pprinters is None:
-            deferred_pprinters = _deferred_type_pprinters.copy()
-        self.deferred_pprinters = deferred_pprinters
-
-    def pretty(self, obj):
-        """Pretty print the given object."""
-        obj_id = id(obj)
-        cycle = obj_id in self.stack
-        self.stack.append(obj_id)
-        self.begin_group()
-        try:
-            obj_class = _safe_getattr(obj, "__class__", None) or type(obj)
-            # First try to find registered singleton printers for the type.
-            try:
-                printer = self.singleton_pprinters[obj_id]
-            except (TypeError, KeyError):
-                pass
-            else:
-                return printer(obj, self, cycle)
-            # Next walk the mro and check for either:
-            #   1) a registered printer
-            #   2) a _repr_pretty_ method
-            for cls in _get_mro(obj_class):
-                if cls in self.type_pprinters:
-                    # printer registered in self.type_pprinters
-                    return self.type_pprinters[cls](obj, self, cycle)
-                else:
-                    # deferred printer
-                    printer = self._in_deferred_types(cls)
-                    if printer is not None:
-                        return printer(obj, self, cycle)
-                    else:
-                        # Finally look for special method names.
-                        # Some objects automatically create any requested
-                        # attribute. Try to ignore most of them by checking for
-                        # callability.
-                        if "_repr_pretty_" in cls.__dict__:
-                            meth = cls._repr_pretty_
-                            if callable(meth):
-                                return meth(obj, self, cycle)
-            return _default_pprint(obj, self, cycle)
-        finally:
-            self.end_group()
-            self.stack.pop()
-
-    def _in_deferred_types(self, cls):
-        """Check if the given class is specified in the deferred type registry.
-
-        Returns the printer from the registry if it exists, and None if
-        the class is not in the registry. Successful matches will be
-        moved to the regular type registry for future use.
-
-        """
-        mod = _safe_getattr(cls, "__module__", None)
-        name = _safe_getattr(cls, "__name__", None)
-        key = (mod, name)
-        printer = None
-        if key in self.deferred_pprinters:
-            # Move the printer over to the regular registry.
-            printer = self.deferred_pprinters.pop(key)
-            self.type_pprinters[cls] = printer
-        return printer
+    def getvalue(self):
+        assert isinstance(self.output, StringIO)
+        self.flush()
+        return self.output.getvalue()
 
 
 class Printable:
@@ -425,8 +332,7 @@ class Breakable(Printable):
     def output(self, stream, output_width):
         self.group.breakables.popleft()
         if self.group.want_break:
-            stream.write(self.pretty.newline)
-            stream.write(" " * self.indentation)
+            stream.write("\n" + " " * self.indentation)
             return self.indentation
         if not self.group.breakables:
             self.pretty.group_queue.remove(self.group)
@@ -471,46 +377,6 @@ class GroupQueue:
             pass
 
 
-def _default_pprint(obj, p, cycle):
-    """The default print function.
-
-    Used if an object does not provide one and it's none of the builtin
-    objects.
-
-    """
-    klass = _safe_getattr(obj, "__class__", None) or type(obj)
-    if _safe_getattr(klass, "__repr__", None) is not object.__repr__:
-        # A user-provided repr. Find newlines and replace them with p.break_()
-        _repr_pprint(obj, p, cycle)
-        return
-    p.begin_group(1, "<")
-    p.pretty(klass)
-    p.text(f" at 0x{id(obj):x}")
-    if cycle:
-        p.text(" ...")
-    elif p.verbose:
-        first = True
-        for key in dir(obj):
-            if not key.startswith("_"):
-                try:
-                    value = getattr(obj, key)
-                except AttributeError:
-                    continue
-                if isinstance(value, types.MethodType):
-                    continue
-                if not first:
-                    p.text(",")
-                p.breakable()
-                p.text(key)
-                p.text("=")
-                step = len(key) + 1
-                p.indentation += step
-                p.pretty(value)
-                p.indentation -= step
-                first = False
-    p.end_group(1, ">")
-
-
 def _seq_pprinter_factory(start, end, basetype):
     """Factory that returns a pprint function useful for sequences.
 
@@ -531,16 +397,15 @@ def _seq_pprinter_factory(start, end, basetype):
         if cycle:
             return p.text(start + "..." + end)
         step = len(start)
-        p.begin_group(step, start)
-        for idx, x in p._enumerate(obj):
-            if idx:
+        with p.group(step, start, end):
+            for idx, x in p._enumerate(obj):
+                if idx:
+                    p.text(",")
+                    p.breakable()
+                p.pretty(x)
+            if len(obj) == 1 and type(obj) is tuple:
+                # Special case for 1-item tuples.
                 p.text(",")
-                p.breakable()
-            p.pretty(x)
-        if len(obj) == 1 and type(obj) is tuple:
-            # Special case for 1-item tuples.
-            p.text(",")
-        p.end_group(step, end)
 
     return inner
 
@@ -566,22 +431,20 @@ def _set_pprinter_factory(start, end, basetype):
             p.text(basetype.__name__ + "()")
         else:
             step = len(start)
-            p.begin_group(step, start)
-            # Like dictionary keys, we will try to sort the items if there
-            # aren't too many
-            items = obj
-            if not (p.max_seq_length and len(obj) >= p.max_seq_length):
-                try:
-                    items = sorted(obj)
-                except Exception:
-                    # Sometimes the items don't sort.
-                    pass
-            for idx, x in p._enumerate(items):
-                if idx:
-                    p.text(",")
-                    p.breakable()
-                p.pretty(x)
-            p.end_group(step, end)
+            with p.group(step, start, end):
+                # Like dictionary keys, try to sort the items if there aren't too many
+                items = obj
+                if not (p.max_seq_length and len(obj) >= p.max_seq_length):
+                    try:
+                        items = sorted(obj)
+                    except Exception:
+                        # Sometimes the items don't sort.
+                        pass
+                for idx, x in p._enumerate(items):
+                    if idx:
+                        p.text(",")
+                        p.breakable()
+                    p.pretty(x)
 
     return inner
 
@@ -602,15 +465,14 @@ def _dict_pprinter_factory(start, end, basetype=None):
 
         if cycle:
             return p.text("{...}")
-        p.begin_group(1, start)
-        for idx, key in p._enumerate(obj):
-            if idx:
-                p.text(",")
-                p.breakable()
-            p.pretty(key)
-            p.text(": ")
-            p.pretty(obj[key])
-        p.end_group(1, end)
+        with p.group(1, start, end):
+            for idx, key in p._enumerate(obj):
+                if idx:
+                    p.text(",")
+                    p.breakable()
+                p.pretty(key)
+                p.text(": ")
+                p.pretty(obj[key])
 
     inner.__name__ = f"_dict_pprinter_factory({start!r}, {end!r}, {basetype!r})"
     return inner
@@ -618,21 +480,11 @@ def _dict_pprinter_factory(start, end, basetype=None):
 
 def _super_pprint(obj, p, cycle):
     """The pprint for the super type."""
-    try:
-        # This section works around various pypy versions that don't do
-        # have the same attributes on super objects
-        obj.__thisclass__
-        obj.__self__
-    except AttributeError:  # pragma: no cover
-        assert PYPY
-        _repr_pprint(obj, p, cycle)
-        return
-    p.begin_group(8, "<super: ")
-    p.pretty(obj.__thisclass__)
-    p.text(",")
-    p.breakable()
-    p.pretty(obj.__self__)
-    p.end_group(8, ">")
+    with p.group(8, "<super: ", ">"):
+        p.pretty(obj.__thisclass__)
+        p.text(",")
+        p.breakable()
+        p.pretty(obj.__self__)
 
 
 def _re_pattern_pprint(obj, p, cycle):
@@ -720,13 +572,12 @@ def _exception_pprint(obj, p, cycle):
     if obj.__class__.__module__ not in ("exceptions", "builtins"):
         name = f"{obj.__class__.__module__}.{name}"
     step = len(name) + 1
-    p.begin_group(step, name + "(")
-    for idx, arg in enumerate(getattr(obj, "args", ())):
-        if idx:
-            p.text(",")
-            p.breakable()
-        p.pretty(arg)
-    p.end_group(step, ")")
+    with p.group(step, name + "(", ")"):
+        for idx, arg in enumerate(getattr(obj, "args", ())):
+            if idx:
+                p.text(",")
+                p.breakable()
+            p.pretty(arg)
 
 
 def _repr_float_counting_nans(obj, p, cycle):

--- a/hypothesis-python/tests/cover/test_falsifying_example_output.py
+++ b/hypothesis-python/tests/cover/test_falsifying_example_output.py
@@ -12,12 +12,6 @@ import pytest
 
 from hypothesis import Phase, example, given, settings, strategies as st
 
-OUTPUT_NO_BREAK = """
-Falsifying explicit example: test(
-    x={0!r}, y={0!r},
-)
-"""
-
 OUTPUT_WITH_BREAK = """
 Falsifying explicit example: test(
     x={0!r},
@@ -26,9 +20,9 @@ Falsifying explicit example: test(
 """
 
 
-@pytest.mark.parametrize("line_break,input", [(False, "0" * 10), (True, "0" * 100)])
-def test_inserts_line_breaks_only_at_appropriate_lengths(line_break, input):
-    @example(input, input)
+@pytest.mark.parametrize("n", [10, 100])
+def test_inserts_line_breaks_only_at_appropriate_lengths(n):
+    @example("0" * n, "0" * n)
     @given(st.text(), st.text())
     def test(x, y):
         assert x < y
@@ -36,8 +30,7 @@ def test_inserts_line_breaks_only_at_appropriate_lengths(line_break, input):
     with pytest.raises(AssertionError) as err:
         test()
 
-    expected = (OUTPUT_WITH_BREAK if line_break else OUTPUT_NO_BREAK).format(input)
-    assert expected.strip() == "\n".join(err.value.__notes__)
+    assert OUTPUT_WITH_BREAK.format("0" * n).strip() == "\n".join(err.value.__notes__)
 
 
 @given(kw=st.none())
@@ -61,4 +54,4 @@ def test_vararg_output(fn):
     with pytest.raises(AssertionError) as err:
         fn(1, 2, 3)
 
-    assert "1, 2, 3" in "\n".join(err.value.__notes__)
+    assert "1,\n    2,\n    3,\n" in "\n".join(err.value.__notes__)

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -49,7 +49,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
 from collections import Counter, OrderedDict, defaultdict, deque
-from io import StringIO
 
 import pytest
 
@@ -380,12 +379,10 @@ def test_basic_class():
 
     type_pprint_wrapper.called = False
 
-    stream = StringIO()
-    printer = pretty.RepresentationPrinter(stream)
+    printer = pretty.RepresentationPrinter()
     printer.type_pprinters[type] = type_pprint_wrapper
     printer.pretty(MyObj)
-    printer.flush()
-    output = stream.getvalue()
+    output = printer.getvalue()
 
     assert output == f"{__name__}.MyObj"
     assert type_pprint_wrapper.called
@@ -576,26 +573,6 @@ def test_re_evals():
         assert r.pattern == r2.pattern and r.flags == r2.flags
 
 
-class CustomStuff:
-    def __init__(self):
-        self.hi = 1
-        self.bye = "fish"
-        self.spoon = self
-
-    @property
-    def oops(self):
-        raise AttributeError("Nope")
-
-    def squirrels(self):
-        pass
-
-
-def test_custom():
-    assert "bye" not in pretty.pretty(CustomStuff())
-    assert "bye=" in pretty.pretty(CustomStuff(), verbose=True)
-    assert "squirrels" not in pretty.pretty(CustomStuff(), verbose=True)
-
-
 def test_print_builtin_function():
     assert pretty.pretty(abs) == "abs"
 
@@ -604,19 +581,8 @@ def test_pretty_function():
     assert pretty.pretty(test_pretty_function) == "test_pretty_function"
 
 
-def test_empty_printer():
-    printer = pretty.RepresentationPrinter(
-        StringIO(),
-        singleton_pprinters={},
-        type_pprinters={int: pretty._repr_pprint, list: pretty._repr_pprint},
-        deferred_pprinters={},
-    )
-    printer.pretty([1, 2, 3])
-    assert printer.output.getvalue() == "[1, 2, 3]"
-
-
 def test_breakable_at_group_boundary():
-    assert "\n" in pretty.pretty([[], "000000"], max_width=5)
+    assert "\n" in pretty.pretty([[], "0" * 80])
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -607,10 +607,9 @@ def _repr_call(*args, **kwargs):
 
 @pytest.mark.parametrize("func_name", ["f", "lambda: ...", "lambda *args: ..."])
 def test_repr_call(func_name):
-    if func_name.startswith(("lambda:", "lambda ")):
-        func_name = f"({func_name})"
+    fn = f"({func_name})" if func_name.startswith(("lambda:", "lambda ")) else func_name
     aas = "a" * 100
-    assert _repr_call(func_name, (1, 2), {}) == f"{func_name}(1, 2)"
-    assert _repr_call(func_name, (aas,), {}) == f"{func_name}(\n    {aas!r},\n)"
-    assert _repr_call(func_name, (), {"a": 1, "b": 2}) == f"{func_name}(a=1, b=2)"
-    assert _repr_call(func_name, (), {"x": aas}) == f"{func_name}(\n    x={aas!r},\n)"
+    assert _repr_call(func_name, (1, 2), {}) == f"{fn}(1, 2)"
+    assert _repr_call(func_name, (aas,), {}) == f"{fn}(\n    {aas!r},\n)"
+    assert _repr_call(func_name, (), {"a": 1, "b": 2}) == f"{fn}(a=1, b=2)"
+    assert _repr_call(func_name, (), {"x": aas}) == f"{fn}(\n    x={aas!r},\n)"

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -597,3 +597,20 @@ def test_breakable_at_group_boundary():
 )
 def test_nan_reprs(obj, rep):
     assert pretty.pretty(obj) == rep
+
+
+def _repr_call(*args, **kwargs):
+    p = pretty.RepresentationPrinter()
+    p.repr_call(*args, **kwargs)
+    return p.getvalue()
+
+
+@pytest.mark.parametrize("func_name", ["f", "lambda: ...", "lambda *args: ..."])
+def test_repr_call(func_name):
+    if func_name.startswith(("lambda:", "lambda ")):
+        func_name = f"({func_name})"
+    aas = "a" * 100
+    assert _repr_call(func_name, (1, 2), {}) == f"{func_name}(1, 2)"
+    assert _repr_call(func_name, (aas,), {}) == f"{func_name}(\n    {aas!r},\n)"
+    assert _repr_call(func_name, (), {"a": 1, "b": 2}) == f"{func_name}(a=1, b=2)"
+    assert _repr_call(func_name, (), {"x": aas}) == f"{func_name}(\n    x={aas!r},\n)"


### PR DESCRIPTION
This is a pretty large diff, but it's mostly mechanical refactorings to make our pretty-printer (borrowed from IPython in ~2015 and still compatible) feel Python-3-native, and a few small fixes and bits of interface sugar.

The motivation is that I've got a working implementation of #3529 on top of this, and I'm prototyping #3411 too - so getting these parts out of the way will make those diffs much easier to deal with 🙂 