### PR TITLE
Pass tuple shape to `xp.full()` in `xps.arrays()` for improved PyTorch support

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch tweaks :func:`xps.arrays` internals to improve PyTorch compatibility.
+Specifically, ``torch.full()`` does not accept integers as the shape argument
+(n.b. technically "size" in torch), but such behaviour is expected in internal
+code, so we copy the ``torch`` module and patch in a working ``full()`` function.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -959,6 +959,28 @@ def make_strategies_namespace(
             exclude_max=exclude_max,
         )
 
+    # torch.full() does not accept integers as the shape argument (n.b.
+    # technically "size" in torch), but such behaviour is expected in
+    # xps.arrays(), so we copy xp and patch in a working function.
+    if xp is sys.modules.get("torch", object()):
+
+        class PatchedArrayModule:
+            def __getattr__(self, attr):
+                return getattr(xp, attr)
+
+            @property
+            def __name__(self):
+                return "torch<modified>"
+
+            def full(self, shape, *a, **kw):
+                if isinstance(shape, int):
+                    shape = (shape,)
+                return xp.full(shape, *a, **kw)
+
+        arrays_xp = PatchedArrayModule()
+    else:
+        arrays_xp = xp
+
     @defines_strategy(force_reusable_values=True)
     def arrays(
         dtype: Union[
@@ -971,7 +993,7 @@ def make_strategies_namespace(
         unique: bool = False,
     ) -> st.SearchStrategy:
         return _arrays(
-            xp,
+            arrays_xp,
             api_version,  # type: ignore[arg-type]
             dtype,
             shape,

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
 from copy import copy
 from functools import lru_cache
 from types import SimpleNamespace
@@ -138,3 +139,27 @@ def test_raises_on_invalid_dunder_version():
     xp.__array_api_version__ = None
     with pytest.raises(InvalidArgument):
         make_strategies_namespace(xp)
+
+
+@pytest.mark.filterwarnings(f"ignore:.*{MOCK_WARN_MSG}.*")
+def test_patch_torch_full(monkeypatch):
+    """When xp is torch, full() is patched so xps.arrays() can work.
+
+    See https://github.com/HypothesisWorks/hypothesis/pull/3542
+    """
+    xp = make_mock_xp()
+    old_full = copy(xp.full)
+
+    def bad_full(shape, *a, **kw):
+        bad_full.__counter += 1
+        if isinstance(shape, int):
+            raise AttributeError("xp.full() has not been patched correctly")
+        return old_full(shape, *a, **kw)
+
+    bad_full.__counter = 0
+    xp.full = bad_full
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, "torch", xp)
+        xps = make_strategies_namespace(xp)
+        xps.arrays(xp.int8, 5).example()
+        assert bad_full.__counter > 0  # sanity check

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -10,7 +10,6 @@
 
 import sys
 from copy import copy
-from functools import lru_cache
 from types import SimpleNamespace
 from typing import Tuple
 

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -31,7 +31,6 @@ from hypothesis.extra.array_api import (
 MOCK_WARN_MSG = f"determine.*{mock_xp.__name__}.*Array API"
 
 
-@lru_cache()
 def make_mock_xp(*, exclude: Tuple[str, ...] = ()) -> SimpleNamespace:
     xp = copy(mock_xp)
     assert isinstance(exclude, tuple)  # sanity check


### PR DESCRIPTION
We can't currently use `xps.arrays()` as-is with `torch` due to [`torch.full()`](https://pytorch.org/docs/stable/generated/torch.full.html#torch.full) not supporting integers (i.e. shorthands for 1-D shapes with the size of the integer) in its `size` argument (or what we treat as the `shape` argument). This PR simply makes it so we're always passing tuples for the `shape`/`size` argument here.

This non-compliance with the Array API has been noted as something to fix (https://github.com/pytorch/pytorch/issues/70906), so could very well see movement at some point. It feels icky for me to make such a change when we're already correctly assuming behaviour, but seems like the kind of simple change that gets us a nice win immediately. Selfishly it's useful in `array-api-tests` to better support testing `torch` one or two compliance/compatibility efforts :sweat_smile:

In any case, note we still are assuming integers-as-`shape` in `tests/array_api/`, and I thought not to change that too. Having the test suite more easily test `torch` would be nice, but there's other issues (e.g. `t.size` is not a property https://github.com/pytorch/pytorch/issues/58741) that I'd want to mull over more and address all at once.

<sup>The Array API had its `2022.12` release (and this time it actually was in december :tada:), so I'll have to get round to updating one or two things.</sup>