### PR TITLE
add name to extra.pandas.range_indexes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds the option to pass in a name (as a static string, rather than a strategy) when creating a pandas `RangeIndex`
+    * :class:`pandas.RangeIndex` created via :func:`~hypothesis.extra.pandas.range_indexes`
+
+Hacked together by Sam Watts :) 

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: minor
 
-This release adds the option to pass in a name when creating a pandas `RangeIndex`
-    * :class:`pandas.RangeIndex` created via :func:`~hypothesis.extra.pandas.range_indexes`
+:func:`~hypothesis.extra.pandas.range_indexes` now accepts a ``name=`` argument,
+to generate named :class:`pandas.RangeIndex` objects.
 
-Hacked together by Sam Watts :) 
+Thanks to Sam Watts for this new feature!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: minor
 
-This release adds the option to pass in a name (as a static string, rather than a strategy) when creating a pandas `RangeIndex`
+This release adds the option to pass in a name when creating a pandas `RangeIndex`
     * :class:`pandas.RangeIndex` created via :func:`~hypothesis.extra.pandas.range_indexes`
 
 Hacked together by Sam Watts :) 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -12,6 +12,7 @@ from collections import OrderedDict, abc
 from copy import copy
 from datetime import datetime, timedelta
 from typing import Any, List, Optional, Sequence, Set, Union
+from functools import partial
 
 import attr
 import numpy as np
@@ -166,6 +167,7 @@ DEFAULT_MAX_SIZE = 10
 def range_indexes(
     min_size: int = 0,
     max_size: Optional[int] = None,
+    name: Optional[str] = None,
 ) -> st.SearchStrategy[pandas.RangeIndex]:
     """Provides a strategy which generates an :class:`~pandas.Index` whose
     values are 0, 1, ..., n for some n.
@@ -175,13 +177,17 @@ def range_indexes(
     * min_size is the smallest number of elements the index can have.
     * max_size is the largest number of elements the index can have. If None
       it will default to some suitable value based on min_size.
+    * name is the name of the index. Unlike the other index names, this should
+        be a string rather than a search strategy. If None, the index will have no name.
     """
     check_valid_size(min_size, "min_size")
     check_valid_size(max_size, "max_size")
     if max_size is None:
         max_size = min([min_size + DEFAULT_MAX_SIZE, 2**63 - 1])
     check_valid_interval(min_size, max_size, "min_size", "max_size")
-    return st.integers(min_size, max_size).map(pandas.RangeIndex)
+    
+    p = partial(pandas.RangeIndex, name=name)
+    return st.integers(min_size, max_size).map(p)
 
 
 @cacheable

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -11,8 +11,8 @@
 from collections import OrderedDict, abc
 from copy import copy
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Sequence, Set, Union
 from functools import partial
+from typing import Any, List, Optional, Sequence, Set, Union
 
 import attr
 import numpy as np
@@ -185,7 +185,7 @@ def range_indexes(
     if max_size is None:
         max_size = min([min_size + DEFAULT_MAX_SIZE, 2**63 - 1])
     check_valid_interval(min_size, max_size, "min_size", "max_size")
-    
+
     p = partial(pandas.RangeIndex, name=name)
     return st.integers(min_size, max_size).map(p)
 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -11,7 +11,6 @@
 from collections import OrderedDict, abc
 from copy import copy
 from datetime import datetime, timedelta
-from functools import partial
 from typing import Any, List, Optional, Sequence, Set, Union
 
 import attr

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -167,7 +167,7 @@ DEFAULT_MAX_SIZE = 10
 def range_indexes(
     min_size: int = 0,
     max_size: Optional[int] = None,
-    name: Optional[str] = None,
+    name: st.SearchStrategy[Optional[str]] = st.none(),
 ) -> st.SearchStrategy[pandas.RangeIndex]:
     """Provides a strategy which generates an :class:`~pandas.Index` whose
     values are 0, 1, ..., n for some n.
@@ -177,17 +177,16 @@ def range_indexes(
     * min_size is the smallest number of elements the index can have.
     * max_size is the largest number of elements the index can have. If None
       it will default to some suitable value based on min_size.
-    * name is the name of the index. Unlike the other index names, this should
-        be a string rather than a search strategy. If None, the index will have no name.
+    * name is the name of the index. If st.none(), the index will have no name.
     """
     check_valid_size(min_size, "min_size")
     check_valid_size(max_size, "max_size")
     if max_size is None:
         max_size = min([min_size + DEFAULT_MAX_SIZE, 2**63 - 1])
     check_valid_interval(min_size, max_size, "min_size", "max_size")
+    check_strategy(name)
 
-    p = partial(pandas.RangeIndex, name=name)
-    return st.integers(min_size, max_size).map(p)
+    return st.builds(pandas.RangeIndex, st.integers(min_size, max_size), name=name)
 
 
 @cacheable

--- a/hypothesis-python/tests/pandas/test_argument_validation.py
+++ b/hypothesis-python/tests/pandas/test_argument_validation.py
@@ -73,6 +73,7 @@ BAD_ARGS = [
     e(pdst.range_indexes, 1, 0),
     e(pdst.range_indexes, min_size="0"),
     e(pdst.range_indexes, max_size="1"),
+    e(pdst.range_indexes, name=""),
     e(pdst.series),
     e(pdst.series, dtype="not a dtype"),
     e(pdst.series, elements="not a strategy"),

--- a/hypothesis-python/tests/pandas/test_indexes.py
+++ b/hypothesis-python/tests/pandas/test_indexes.py
@@ -62,7 +62,7 @@ def test_arbitrary_range_index(i, j, data):
     data.draw(pdst.range_indexes(i, j))
 
 
-@given(pdst.range_indexes(name="test_name"))
+@given(pdst.range_indexes(name=st.just("test_name")))
 def test_name_passed_on_range_indexes(s):
     assert s.name == "test_name"
 

--- a/hypothesis-python/tests/pandas/test_indexes.py
+++ b/hypothesis-python/tests/pandas/test_indexes.py
@@ -47,7 +47,7 @@ def test_unique_indexes_of_many_small_values(ix):
 
 
 @given(pdst.indexes(dtype="int8", name=st.just("test_name")))
-def test_name_passed_on(s):
+def test_name_passed_on_indexes(s):
     assert s.name == "test_name"
 
 
@@ -60,6 +60,11 @@ def test_arbitrary_range_index(i, j, data):
     if j is not None:
         i, j = sorted((i, j))
     data.draw(pdst.range_indexes(i, j))
+
+
+@given(pdst.range_indexes(name="test_name"))
+def test_name_passed_on_range_indexes(s):
+    assert s.name == "test_name"
 
 
 @given(pdst.range_indexes())


### PR DESCRIPTION
I had some tests where I had to add the index name as part of the actual test when using `range_indexes`. This should allow this to be done from the strategy itself, which is a bit cleaner
