### PR TITLE
"Inquisitor": annotate parts of a minimal failing example which may vary

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,25 @@
+RELEASE_TYPE: minor
+
+This release upgrades the :ref:`explain phase <phases>` (:issue:`3411`).
+
+* Following the first failure, Hypothesis will (:ref:`usually <phases>`) track which
+  lines of code were executed by passing and failing examples, and report where they
+  diverged - with some heuristics to drop unhelpful reports.  This is an existing
+  feature, now upgraded and newly enabled by default.
+
+* After shrinking to a minimal failing example, Hypothesis will try to find parts of
+  the example -- e.g. separate args to :func:`@given() <hypothesis.given>` -- which
+  can vary freely without changing the result of that minimal failing example.
+  If the automated experiments run without finding a passing variation, we leave a
+  comment in the final report:
+
+  .. code-block:: python
+
+      test_x_divided_by_y(
+          x=0,  # or any other generated value
+          y=0,
+      )
+
+Just remember that the *lack* of an explanation sometimes just means that Hypothesis
+couldn't efficiently find one, not that no explanation (or simpler failing example)
+exists.

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -60,11 +60,36 @@ Hypothesis divides tests into logically distinct phases:
 4. Mutating examples for :ref:`targeted property-based testing <targeted-search>` (requires generate phase).
 5. Attempting to shrink an example found in previous phases (other than phase 1 - explicit examples cannot be shrunk).
    This turns potentially large and complicated examples which may be hard to read into smaller and simpler ones.
-6. Attempting to explain the cause of the failure, by identifying suspicious lines of code
-   (e.g. the earliest lines which are never run on passing inputs, and always run on failures).
+6. Attempting to explain why your test failed (requires shrink phase).
+
+.. note::
+
+   The explain phase has two parts, each of which is best-effort - if Hypothesis can't
+   find a useful explanation, we'll just print the minimal failing example.
+
+   Following the first failure, Hypothesis will (:ref:`usually <phases>`) track which
+   lines of code are always run on failing but never on passing inputs.
    This relies on :func:`python:sys.settrace`, and is therefore automatically disabled on
    PyPy or if you are using :pypi:`coverage` or a debugger.  If there are no clearly
    suspicious lines of code, :pep:`we refuse the temptation to guess <20>`.
+
+   After shrinking to a minimal failing example, Hypothesis will try to find parts of
+   the example -- e.g. separate args to :func:`@given() <hypothesis.given>` -- which
+   can vary freely without changing the result of that minimal failing example.
+   If the automated experiments run without finding a passing variation, we leave a
+   comment in the final report:
+
+   .. code-block:: python
+
+       test_x_divided_by_y(
+           x=0,  # or any other generated value
+           y=0,
+       )
+
+   Just remember that the *lack* of an explanation sometimes just means that Hypothesis
+   couldn't efficiently find one, not that no explanation (or simpler failing example)
+   exists.
+
 
 The phases setting provides you with fine grained control over which of these run,
 with each phase corresponding to a value on the :class:`~hypothesis.Phase` enum:

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -75,7 +75,7 @@ from hypothesis.internal.compat import (
     int_from_bytes,
 )
 from hypothesis.internal.conjecture.data import ConjectureData, Status
-from hypothesis.internal.conjecture.engine import ConjectureRunner
+from hypothesis.internal.conjecture.engine import BUFFER_SIZE, ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
@@ -1413,7 +1413,7 @@ def given(
                 # This inner part is all that the fuzzer will actually run,
                 # so we keep it as small and as fast as possible.
                 if isinstance(buffer, io.IOBase):
-                    buffer = buffer.read()
+                    buffer = buffer.read(BUFFER_SIZE)
                 assert isinstance(buffer, (bytes, bytearray, memoryview))
                 data = ConjectureData.for_buffer(buffer)
                 try:

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -760,12 +760,13 @@ class StateForActualGivenExecution:
                         args = self.stuff.args
                         kwargs = dict(self.stuff.kwargs)
                         if example_kwargs is None:
-                            a, kw, _ = context.prep_args_kwargs_from_strategies(
+                            a, kw, argslices = context.prep_args_kwargs_from_strategies(
                                 (), self.stuff.given_kwargs
                             )
                             assert not a, "strategies all moved to kwargs by now"
                         else:
                             kw = example_kwargs
+                            argslices = {}
                         kwargs.update(kw)
                         if expected_failure is not None:
                             nonlocal text_repr
@@ -785,7 +786,11 @@ class StateForActualGivenExecution:
                                     args,
                                     kwargs,
                                     force_split=True,
+                                    arg_slices=argslices,
                                 )
+                            if (0, 0) in context.data.slice_comments:
+                                printer.break_()
+                                printer.text("# " + context.data.slice_comments[(0, 0)])
                             report(printer.getvalue())
                         return test(*args, **kwargs)
 
@@ -966,6 +971,7 @@ class StateForActualGivenExecution:
             fragments = []
 
             ran_example = ConjectureData.for_buffer(falsifying_example.buffer)
+            ran_example.slice_comments = falsifying_example.slice_comments
             assert info.__expected_exception is not None
             try:
                 with with_reporter(fragments.append):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -776,6 +776,8 @@ class ConjectureResult:
     tags: FrozenSet[StructuralCoverageTag] = attr.ib()
     forced_indices: FrozenSet[int] = attr.ib(repr=False)
     examples: Examples = attr.ib(repr=False)
+    arg_slices: Set[Tuple[int, int]] = attr.ib(repr=False)
+    slice_comments: Dict[Tuple[int, int], str] = attr.ib(repr=False)
 
     index: int = attr.ib(init=False)
 
@@ -860,6 +862,11 @@ class ConjectureData:
         self.depth = -1
         self.__example_record = ExampleRecord()
 
+        # Slice indices for discrete reportable parts that which-parts-matter can
+        # try varying, to report if the minimal example always fails anyway.
+        self.arg_slices: Set[Tuple[int, int]] = set()
+        self.slice_comments: Dict[Tuple[int, int], str] = {}
+
         self.extra_information = ExtraInformation()
 
         self.start_example(TOP_LABEL)
@@ -893,6 +900,8 @@ class ConjectureData:
                 target_observations=self.target_observations,
                 tags=frozenset(self.tags),
                 forced_indices=frozenset(self.forced_indices),
+                arg_slices=self.arg_slices,
+                slice_comments=self.slice_comments,
             )
             assert self.__result is not None
             self.blocks.transfer_ownership(self.__result)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -985,7 +985,13 @@ class ConjectureRunner:
         return s.shrink_target
 
     def new_shrinker(self, example, predicate=None, allow_transition=None):
-        return Shrinker(self, example, predicate, allow_transition)
+        return Shrinker(
+            self,
+            example,
+            predicate,
+            allow_transition,
+            explain=Phase.explain in self.settings.phases,
+        )
 
     def cached_test_function(self, buffer, error_on_discard=False, extend=0):
         """Checks the tree to see if we've tested this buffer, and returns the
@@ -1075,6 +1081,17 @@ class ConjectureRunner:
         except TypeError:
             pass
         return result
+
+    def passing_buffers(self, prefix=b""):
+        """Return a collection of bytestrings which cause the test to pass.
+
+        Optionally restrict this by a certain prefix, which is useful for explain mode.
+        """
+        return frozenset(
+            buf
+            for buf in self.__data_cache
+            if buf.startswith(prefix) and self.__data_cache[buf].status == Status.VALID
+        )
 
 
 class ContainsDiscard(Exception):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -261,7 +261,7 @@ class Shrinker:
         accept.__name__ = fn.__name__
         return property(accept)
 
-    def __init__(self, engine, initial, predicate, allow_transition):
+    def __init__(self, engine, initial, predicate, allow_transition, explain):
         """Create a shrinker for a particular engine, with a given starting
         point and predicate. When shrink() is called it will attempt to find an
         example for which predicate is True and which is strictly smaller than
@@ -299,6 +299,8 @@ class Shrinker:
         # Extra DFAs that may be installed. This is used solely for
         # testing and learning purposes.
         self.extra_dfas = {}
+
+        self.should_explain = explain
 
     @derived_value  # type: ignore
     def cached_calculations(self):
@@ -437,12 +439,15 @@ class Shrinker:
         if not any(self.shrink_target.buffer) or self.incorporate_new_buffer(
             bytes(len(self.shrink_target.buffer))
         ):
+            self.explain()
             return
 
         try:
             self.greedy_shrink()
         except StopShrinking:
-            pass
+            # If we stopped shrinking because we're making slow progress (instead of
+            # reaching a local optimum), don't run the explain-phase logic.
+            self.should_explain = False
         finally:
             if self.engine.report_debug_info:
 
@@ -488,6 +493,138 @@ class Shrinker:
                             )
                         )
                 self.debug("")
+        self.explain()
+
+    def explain(self):
+        if not self.should_explain or not self.shrink_target.arg_slices:
+            return
+        from hypothesis.internal.conjecture.engine import BUFFER_SIZE
+
+        self.max_stall = 1e999
+        shrink_target = self.shrink_target
+        buffer = shrink_target.buffer
+        chunks = defaultdict(list)
+
+        # Before we start running experiments, let's check for known inputs which would
+        # make them redundant.  The shrinking process means that we've already tried many
+        # variations on the minimal example, so this can save a lot of time.
+        seen_passing_buffers = self.engine.passing_buffers(
+            prefix=buffer[: min(self.shrink_target.arg_slices)[0]]
+        )
+
+        # Now that we've shrunk to a minimal failing example, it's time to try
+        # varying each part that we've noted will go in the final report.  Consider
+        # slices in largest-first order
+        for start, end in sorted(
+            self.shrink_target.arg_slices, key=lambda x: (-(x[1] - x[0]), x)
+        ):
+            # Check for any previous examples that match the prefix and suffix,
+            # so we can skip if we found a passing example while shrinking.
+            if any(
+                seen.startswith(buffer[:start]) and seen.endswith(buffer[end:])
+                for seen in seen_passing_buffers
+            ):
+                continue
+
+            # Run our experiments
+            n_same_failures = 0
+            note = "or any other generated value"
+            # TODO: is 100 same-failures out of 500 attempts a good heuristic?
+            for n_attempt in range(500):  # pragma: no branch
+                # no-branch here because we don't coverage-test the abort-at-500 logic.
+
+                if n_attempt - 10 > n_same_failures * 5:
+                    # stop early if we're seeing mostly invalid examples
+                    break  # pragma: no cover
+
+                buf_attempt_fixed = bytearray(buffer)
+                buf_attempt_fixed[start:end] = [
+                    self.random.randint(0, 255) for _ in range(end - start)
+                ]
+                result = self.engine.cached_test_function(
+                    buf_attempt_fixed, extend=BUFFER_SIZE - len(buf_attempt_fixed)
+                )
+
+                # Turns out this was a variable-length part, so grab the infix...
+                if (
+                    result.status == Status.OVERRUN
+                    or len(buf_attempt_fixed) != len(result.buffer)
+                    or not result.buffer.endswith(buffer[end:])
+                ):
+                    for ex, res in zip(shrink_target.examples, result.examples):
+                        assert ex.start == res.start
+                        assert ex.start <= start
+                        assert ex.label == res.label
+                        if start == ex.start and end == ex.end:
+                            res_end = res.end
+                            break
+                    else:
+                        raise NotImplementedError("Expected matching prefixes")
+
+                    buf_attempt_fixed = (
+                        buffer[:start] + result.buffer[start:res_end] + buffer[end:]
+                    )
+                    chunks[(start, end)].append(result.buffer[start:res_end])
+                    result = self.engine.cached_test_function(buf_attempt_fixed)
+
+                    if (
+                        result.status == Status.OVERRUN
+                        or len(buf_attempt_fixed) != len(result.buffer)
+                        or not result.buffer.endswith(buffer[end:])
+                    ):
+                        raise NotImplementedError("This should never happen")
+                else:
+                    chunks[(start, end)].append(result.buffer[start:end])
+
+                if shrink_target is not self.shrink_target:  # pragma: no cover
+                    # If we've shrunk further without meaning to, bail out.
+                    self.shrink_target.slice_comments.clear()
+                    return
+                if result.status == Status.VALID:
+                    # The test passed, indicating that this param can't vary freely.
+                    # However, it's really hard to write a simple and reliable covering
+                    # test, because of our `seen_passing_buffers` check above.
+                    break  # pragma: no cover
+                elif self.__predicate(result):  # pragma: no branch
+                    n_same_failures += 1
+                    if n_same_failures >= 100:
+                        self.shrink_target.slice_comments[(start, end)] = note
+                        break
+
+        # Finally, if we've found multiple independently-variable parts, check whether
+        # they can all be varied together.
+        if len(self.shrink_target.slice_comments) <= 1:
+            return
+        n_same_failures_together = 0
+        chunks_by_start_index = sorted(chunks.items())
+        for _ in range(500):  # pragma: no branch
+            # no-branch here because we don't coverage-test the abort-at-500 logic.
+            new_buf = bytearray()
+            prev_end = 0
+            for (start, end), ls in chunks_by_start_index:
+                assert prev_end <= start < end, "these chunks must be nonoverlapping"
+                new_buf.extend(buffer[prev_end:start])
+                new_buf.extend(self.random.choice(ls))
+                prev_end = end
+
+            result = self.engine.cached_test_function(new_buf)
+
+            # This *can't* be a shrink because none of the components were.
+            assert shrink_target is self.shrink_target
+            if result.status == Status.VALID:
+                # TODO: cover this branch.
+                #       I might need to save or retrieve passing chunks too???
+                self.shrink_target.slice_comments[
+                    (0, 0)
+                ] = "The test sometimes passed when commented parts were varied together."
+                break  # Test passed, this param can't vary freely.
+            elif self.__predicate(result):  # pragma: no branch
+                n_same_failures_together += 1
+                if n_same_failures_together >= 100:
+                    self.shrink_target.slice_comments[
+                        (0, 0)
+                    ] = "The test always failed when commented parts were varied together."
+                    break
 
     def greedy_shrink(self):
         """Run a full set of greedy shrinks (that is, ones that will only ever

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -1,0 +1,71 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from hypothesis import given, settings, strategies as st
+
+
+def fails_with_output(expected, error=AssertionError, **kw):
+    def _inner(f):
+        def _new():
+            with pytest.raises(error) as err:
+                settings(print_blob=False, derandomize=True, **kw)(f)()
+            got = "\n".join(err.value.__notes__).strip() + "\n"
+            assert got == expected.strip() + "\n"
+
+        return _new
+
+    return _inner
+
+
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_comments_basic_fail_if_either(
+    a=False,  # or any other generated value
+    b=True,
+    c=[],  # or any other generated value
+    d=True,
+    e=False,  # or any other generated value
+)
+# The test always failed when commented parts were varied together.
+"""
+)
+@given(st.booleans(), st.booleans(), st.lists(st.none()), st.booleans(), st.booleans())
+def test_inquisitor_comments_basic_fail_if_either(a, b, c, d, e):
+    assert not (b and d)
+
+
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_comments_basic_fail_if_not_all(
+    a='',  # or any other generated value
+    b='',  # or any other generated value
+    c='',  # or any other generated value
+)
+# The test sometimes passed when commented parts were varied together.
+"""
+)
+@given(st.text(), st.text(), st.text())
+def test_inquisitor_comments_basic_fail_if_not_all(a, b, c):
+    assert a and b and c
+
+
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_no_together_comment_if_single_argument(
+    a='',
+    b='',  # or any other generated value
+)
+"""
+)
+@given(st.text(), st.text())
+def test_inquisitor_no_together_comment_if_single_argument(a, b):
+    assert a

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -13,7 +13,15 @@ import random
 
 import pytest
 
-from hypothesis import core, find, given, register_random, strategies as st
+from hypothesis import (
+    Phase,
+    core,
+    find,
+    given,
+    register_random,
+    settings,
+    strategies as st,
+)
 from hypothesis.errors import HypothesisWarning, InvalidArgument
 from hypothesis.internal import entropy
 from hypothesis.internal.compat import GRAALPY, PYPY
@@ -31,6 +39,7 @@ def gc_collect():
 
 
 def test_can_seed_random():
+    @settings(phases=(Phase.generate, Phase.shrink))
     @given(st.random_module())
     def test(r):
         raise AssertionError

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -303,7 +303,7 @@ def test_stops_immediately_if_not_report_multiple_bugs():
 def test_stops_immediately_on_replay():
     seen = set()
 
-    @settings(database=InMemoryExampleDatabase())
+    @settings(database=InMemoryExampleDatabase(), phases=tuple(Phase)[:-1])
     @given(st.integers())
     def test(x):
         seen.add(x)

--- a/hypothesis-python/tests/nocover/test_collective_minimization.py
+++ b/hypothesis-python/tests/nocover/test_collective_minimization.py
@@ -10,7 +10,7 @@
 
 import pytest
 
-from hypothesis import settings
+from hypothesis import Phase, settings
 from hypothesis.errors import Unsatisfiable
 from hypothesis.strategies import lists
 
@@ -31,7 +31,7 @@ def test_can_collectively_minimize(spec):
         xs = minimal(
             lists(spec, min_size=n, max_size=n),
             lambda x: len(set(map(repr, x))) >= 2,
-            settings(max_examples=2000),
+            settings(max_examples=2000, phases=(Phase.generate, Phase.shrink)),
         )
         assert len(xs) == n
         assert 2 <= len(set(map(repr, xs))) <= 3

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -20,7 +20,7 @@ setenv=
 commands =
     full: bash scripts/basic-test.sh
     brief: python -bb -X dev -m pytest -n auto tests/cover/test_testdecorators.py {posargs}
-    cover: python -bb -X dev -m pytest -n auto tests/cover/ tests/pytest/ {posargs}
+    cover: python -bb -X dev -m pytest -n auto tests/cover/ tests/pytest/ tests/conjecture/test_inquisitor.py {posargs}
     nocover: python -bb -X dev -m pytest -n auto tests/nocover/ {posargs}
     niche: bash scripts/other-tests.sh
     custom: python -bb -X dev -m pytest {posargs}


### PR DESCRIPTION
Closes #3411.  Excitingly, this is also the last big new feature I'm writing for my PhD - from here it's all maintainance and thesis-writing ✍️:tada: 

Remaining things to do:
- [x] make fixed_dicts work even when optional keys are possible
- [x] for all-parts check, include same-width spans in the option (might already work?)
- [x] write more tests for confidence and coverage
- [x] check that there's no low-hanging performance problems

After merge,
- follow-up PR to add support for tuple elements and fixed-dict elements - I have a proof-of-concept branch
- open an issue about explain-mode for stateful tests, and possible hooks for Schemathesis
- #3551 and then consider enabling the `explain` phase by default
