### PR TITLE
Improve the documentation of `hypothesis.strategies.complex_numbers()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch improves the documentation of the parameters `allow_infinity` and `allow_nan`
+of :func:`hypothesis.strategies.complex_numbers`.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1642,8 +1642,9 @@ def complex_numbers(
     is an error to enable ``allow_nan``.  If ``max_magnitude`` is finite,
     it is an error to enable ``allow_infinity``.
 
-    ``allow_subnormal`` is applied to each part of the complex number
-    separately, as for :func:`~hypothesis.strategies.floats`.
+    ``allow_infinity``, ``allow_nan``, and ``allow_subnormal`` are
+    applied to each part of the complex number separately, as for
+    :func:`~hypothesis.strategies.floats`.
 
     The magnitude constraints are respected up to a relative error
     of (around) floating-point epsilon, due to implementation via


### PR DESCRIPTION
Previously, it was not clear from the documentation how these values are treated. Although the actual implementation is more complicated, I think this description (referring the users to `hypothesis.strategies.floats`) is sufficient.