### PR TITLE
Tests: Don't force endianness of Pandas timestamp columns

### DIFF
--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -137,7 +137,7 @@ def column_strategy(draw):
     )
 
 
-@given(pdst.data_frames(pdst.columns(1, dtype=np.dtype("<M8[ns]"))))
+@given(pdst.data_frames(pdst.columns(1, dtype=np.dtype("M8[ns]"))))
 def test_data_frames_with_timestamp_columns(df):
     pass
 


### PR DESCRIPTION
When the test run on big endian system, the byte order confused Pandas 1.5. Older Pandas coerced the byte order to the native one anyway.

See https://github.com/HypothesisWorks/hypothesis/issues/2894 and https://github.com/pandas-dev/pandas/issues/51041