### PR TITLE
Add `min_magnitude` & `max_magnitude` passthrough in complex-valued `from_dtype()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This release allows for more precise generation of complex numbers using
+:func:`~hypothesis.extra.numpy.from_dtype`, by supporting the ``width``,
+``min_magnitude``, and ``min_magnitude`` arguments (:issue:`3468`).
+
+Thanks to Felix Divo for this feature!

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -140,7 +140,7 @@ def from_dtype(
         )
     elif dtype.kind == "c":
         result = st.complex_numbers(
-            width=8 * dtype.itemsize,  # convert from bytes to bits
+            width=min(8 * dtype.itemsize, 128),  # convert from bytes to bits
             **compat_kw(
                 "min_magnitude",
                 "max_magnitude",

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -157,9 +157,8 @@ def from_dtype(
             lambda b: b[-1:] != b"\0"
         )
     elif dtype.kind == "u":
-        result = st.integers(
-            **compat_kw(min_value=0, max_value=2 ** (8 * dtype.itemsize) - 1)
-        )
+        kw = compat_kw(min_value=0, max_value=2 ** (8 * dtype.itemsize) - 1)
+        result = st.integers(**kw)
     elif dtype.kind == "i":
         overflow = 2 ** (8 * dtype.itemsize - 1)
         result = st.integers(**compat_kw(min_value=-overflow, max_value=overflow - 1))

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -93,8 +93,7 @@ def from_dtype(
     control the length or contents of strings, or exclude non-finite
     numbers. This is particularly useful when kwargs are passed through from
     :func:`arrays` which allow a variety of numeric dtypes, as it seamlessly
-    handles the ``width`` or representable bounds for you. See :issue:`2552`
-    for more detail.
+    handles the ``width`` or representable bounds for you.
     """
     check_type(np.dtype, dtype, "dtype")
     kwargs = {k: v for k, v in locals().items() if k != "dtype" and v is not None}

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -141,7 +141,7 @@ def from_dtype(
         )
     elif dtype.kind == "c":
         result = st.complex_numbers(
-            width=dtype.itemsize,
+            width=8 * dtype.itemsize,  # convert from bytes to bits
             **compat_kw(
                 "min_magnitude",
                 "max_magnitude",

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -34,8 +34,8 @@ from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
 from hypothesis.internal.validation import check_type
-from hypothesis.strategies._internal.strategies import T, check_strategy
 from hypothesis.strategies._internal.numbers import Real
+from hypothesis.strategies._internal.strategies import T, check_strategy
 from hypothesis.strategies._internal.utils import defines_strategy
 
 __all__ = [

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1652,7 +1652,7 @@ def complex_numbers(
     of (around) floating-point epsilon, due to implementation via
     the system ``sqrt`` function.
 
-    The width argument specifies the maximum number of bits of precision
+    The ``width`` argument specifies the maximum number of bits of precision
     required to represent the entire generated complex number.
     Valid values are 32, 64 or 128, which correspond to the real and imaginary
     components each having width 16, 32 or 64, respectively.

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -200,6 +200,9 @@ def test_arrays_gives_useful_error_on_inconsistent_time_unit():
         (complex, {"allow_nan": False}, lambda x: not np.isnan(x)),
         (complex, {"allow_infinity": False}, lambda x: not np.isinf(x)),
         (complex, {"allow_nan": False, "allow_infinity": False}, np.isfinite),
+        (complex, {"min_magnitude": 1e3}, lambda x: np.abs(x) >= 1e3),
+        (complex, {"max_magnitude": 1e2}, lambda x: np.abs(x) <= 1e2),
+        (complex, {"min_magnitude": 1, "max_magnitude": 1e6}, lambda x: 1 <= np.abs(x) <= 1e6),
         # Integer bounds, limited to the representable range
         ("int8", {"min_value": -1, "max_value": 1}, lambda x: -1 <= x <= 1),
         ("uint8", {"min_value": 1, "max_value": 2}, lambda x: 1 <= x <= 2),

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -202,7 +202,11 @@ def test_arrays_gives_useful_error_on_inconsistent_time_unit():
         (complex, {"allow_nan": False, "allow_infinity": False}, np.isfinite),
         (complex, {"min_magnitude": 1e3}, lambda x: np.abs(x) >= 1e3),
         (complex, {"max_magnitude": 1e2}, lambda x: np.abs(x) <= 1e2),
-        (complex, {"min_magnitude": 1, "max_magnitude": 1e6}, lambda x: 1 <= np.abs(x) <= 1e6),
+        (
+            complex,
+            {"min_magnitude": 1, "max_magnitude": 1e6},
+            lambda x: 1 <= np.abs(x) <= 1e6,
+        ),
         # Integer bounds, limited to the representable range
         ("int8", {"min_value": -1, "max_value": 1}, lambda x: -1 <= x <= 1),
         ("uint8", {"min_value": 1, "max_value": 2}, lambda x: 1 <= x <= 2),

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
+
 import numpy as np
 import pytest
 
@@ -197,15 +199,28 @@ def test_arrays_gives_useful_error_on_inconsistent_time_unit():
         (float, {"allow_nan": False}, lambda x: not np.isnan(x)),
         (float, {"allow_infinity": False}, lambda x: not np.isinf(x)),
         (float, {"allow_nan": False, "allow_infinity": False}, np.isfinite),
+        # Complex numbers: bounds and excluding nonfinites
         (complex, {"allow_nan": False}, lambda x: not np.isnan(x)),
         (complex, {"allow_infinity": False}, lambda x: not np.isinf(x)),
         (complex, {"allow_nan": False, "allow_infinity": False}, np.isfinite),
-        (complex, {"min_magnitude": 1e3}, lambda x: np.abs(x) >= 1e3),
-        (complex, {"max_magnitude": 1e2}, lambda x: np.abs(x) <= 1e2),
+        (
+            complex,
+            {"min_magnitude": 1e3},
+            lambda x: abs(x) >= 1e3 * (1 - sys.float_info.epsilon),
+        ),
+        (
+            complex,
+            {"max_magnitude": 1e2},
+            lambda x: abs(x) <= 1e2 * (1 + sys.float_info.epsilon),
+        ),
         (
             complex,
             {"min_magnitude": 1, "max_magnitude": 1e6},
-            lambda x: 1 <= np.abs(x) <= 1e6,
+            lambda x: (
+                (1 - sys.float_info.epsilon)
+                <= abs(x)
+                <= 1e6 * (1 + sys.float_info.epsilon)
+            ),
         ),
         # Integer bounds, limited to the representable range
         ("int8", {"min_value": -1, "max_value": 1}, lambda x: -1 <= x <= 1),


### PR DESCRIPTION
Closes  #3468.