### PR TITLE
Exclude `.arpa` tld names from `domains()` strategy

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,10 @@
 version: 2
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats:
+  - htmlzip
+  - epub
+  # - pdf  # busted by latex crash on unicode U+030A combining ring above, in text() docs
 
 # Optionally set the version of Python and requirements required to build your docs
 build:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -79,6 +79,7 @@ their individual contributions.
 * `James Lamb <https://github.com/jameslamb>`_
 * `Jenny Rouleau <https://github.com/jennyrou>`_
 * `Jens Heinrich <https://github.com/JensHeinrich>`_
+* `Jens Tröger <https://github.com/jenstroeger>`_
 * `Jeremy Thurgood <https://github.com/jerith>`_
 * `J.J. Green <http://soliton.vm.bytemark.co.uk/pub/jjg/>`_
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release adds an optional ``domains=`` parameter to the
+:func:`~hypothesis.strategies.emails` strategy, and excludes
+the special-use :wikipedia:`.arpa` domain from the default
+strategy (:issue:`3567`).
+
+Thanks to Jens Tröger for reporting and fixing this bug!

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -34,17 +34,17 @@ FRAGMENT_SAFE_CHARACTERS = URL_SAFE_CHARACTERS | {"?", "/"}
 # The file contains additional information about the date that it was last updated.
 try:  # pragma: no cover
     traversable = resources.files("hypothesis.vendor") / "tlds-alpha-by-domain.txt"
-    _tlds = traversable.read_text().splitlines()
+    _comment, *_tlds = traversable.read_text().splitlines()
 except (AttributeError, ValueError):  # pragma: no cover  # .files() was added in 3.9
-    _tlds = resources.read_text(
+    _comment, *_tlds = resources.read_text(
         "hypothesis.vendor", "tlds-alpha-by-domain.txt"
     ).splitlines()
-
-assert _tlds[0].startswith("#")
+assert _comment.startswith("#")
 
 # Remove special-use domain names from the list. For more discussion
 # see https://github.com/HypothesisWorks/hypothesis/pull/3572
-TOP_LEVEL_DOMAINS = ["COM"] + sorted(filter(lambda tld: tld != "ARPA", _tlds[1:]), key=len)
+TOP_LEVEL_DOMAINS = ["COM"] + sorted((d for d in _tlds if d != "ARPA"), key=len)
+
 
 class DomainNameStrategy(st.SearchStrategy):
     @staticmethod

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -41,8 +41,10 @@ except (AttributeError, ValueError):  # pragma: no cover  # .files() was added i
     ).splitlines()
 
 assert _tlds[0].startswith("#")
-TOP_LEVEL_DOMAINS = ["COM"] + sorted(_tlds[1:], key=len)
 
+# Remove special-use domain names from the list. For more discussion
+# see https://github.com/HypothesisWorks/hypothesis/pull/3572
+TOP_LEVEL_DOMAINS = ["COM"] + sorted(filter(lambda tld: tld != "ARPA", _tlds[1:]), key=len)
 
 class DomainNameStrategy(st.SearchStrategy):
     @staticmethod

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2014,20 +2014,20 @@ def deferred(definition: Callable[[], SearchStrategy[Ex]]) -> SearchStrategy[Ex]
 
 def domains():
     import hypothesis.provisional
+
     return hypothesis.provisional.domains()
 
 
 @defines_strategy(force_reusable_values=True)
-def emails(*, domains: SearchStrategy[str] = LazyStrategy(domains, (), {})) -> SearchStrategy[str]:
+def emails(
+    *, domains: SearchStrategy[str] = LazyStrategy(domains, (), {})
+) -> SearchStrategy[str]:
     """A strategy for generating email addresses as unicode strings. The
     address format is specified in :rfc:`5322#section-3.4.1`. Values shrink
     towards shorter local-parts and host domains.
 
     If ``domains`` is given then it must be a strategy that generates domain
-    names for the emails. By default, the internal :func:`hypothesis.provisional.domains` strategy
-    is used that does *not* produce any `special-use domain names
-    <https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml>`_
-    (which yield invalid email addresses).
+    names for the emails, defaulting to :func:`~hypothesis.provisional.domains`.
 
     This strategy is useful for generating "user data" for tests, as
     mishandling of email addresses is a common source of bugs.
@@ -2035,7 +2035,7 @@ def emails(*, domains: SearchStrategy[str] = LazyStrategy(domains, (), {})) -> S
     local_chars = string.ascii_letters + string.digits + "!#$%&'*+-/=^_`{|}~"
     local_part = text(local_chars, min_size=1, max_size=64)
     # TODO: include dot-atoms, quoted strings, escaped chars, etc in local part
-    return builds("{}@{}".format, local_part, domains()).filter(
+    return builds("{}@{}".format, local_part, domains).filter(
         lambda addr: len(addr) <= 254
     )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2012,17 +2012,26 @@ def deferred(definition: Callable[[], SearchStrategy[Ex]]) -> SearchStrategy[Ex]
     return DeferredStrategy(definition)
 
 
+def domains():
+    import hypothesis.provisional
+    return hypothesis.provisional.domains()
+
+
 @defines_strategy(force_reusable_values=True)
-def emails() -> SearchStrategy[str]:
+def emails(*, domains: SearchStrategy[str] = LazyStrategy(domains, (), {})) -> SearchStrategy[str]:
     """A strategy for generating email addresses as unicode strings. The
     address format is specified in :rfc:`5322#section-3.4.1`. Values shrink
     towards shorter local-parts and host domains.
 
+    If ``domains`` is given then it must be a strategy that generates domain
+    names for the emails. By default, the internal :func:`hypothesis.provisional.domains` strategy
+    is used that does *not* produce any `special-use domain names
+    <https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml>`_
+    (which yield invalid email addresses).
+
     This strategy is useful for generating "user data" for tests, as
     mishandling of email addresses is a common source of bugs.
     """
-    from hypothesis.provisional import domains
-
     local_chars = string.ascii_letters + string.digits + "!#$%&'*+-/=^_`{|}~"
     local_part = text(local_chars, min_size=1, max_size=64)
     # TODO: include dot-atoms, quoted strings, escaped chars, etc in local part

--- a/hypothesis-python/tests/nocover/test_emails.py
+++ b/hypothesis-python/tests/nocover/test_emails.py
@@ -9,13 +9,19 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from hypothesis import given
-from hypothesis.strategies import emails
+from hypothesis.strategies import emails, just
 
 
 @given(emails())
-def test_is_valid_email(address):
+def test_is_valid_email(address: str):
     local, at_, domain = address.rpartition("@")
     assert len(address) <= 254
     assert at_ == "@"
     assert local
     assert domain
+    assert not domain.lower().endswith(".arpa")
+
+
+@given(emails(domains=just("mydomain.com")))
+def test_can_restrict_email_domains(address: str):
+    assert address.endswith("@mydomain.com")


### PR DESCRIPTION
Fixes #3567, closes #3582.

@Zac-HD this is a Draft PR for now because we need to discuss a few things:

- turns out that the list of default top-level domain names did not contain [special-use domain names](https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.txt), except `arpa`: https://github.com/HypothesisWorks/hypothesis/blob/600fc8a5da217778bc4e9bba8c9a71ca3116147a/hypothesis-python/src/hypothesis/provisional.py#L44 Should I add them?
- Alternatively we’d remove `arpa` from that list and inverse the logic when creating the list to draw from in the PR.
- Hardwire the special-use domain names, or use a vendor file?
- I wasn’t sure about your preference re import naming.

Things to do for me:
- [x] Add tests, and
- [x] Add to [AUTHORS.rst](https://github.com/HypothesisWorks/hypothesis/blob/master/CONTRIBUTING.rst#just-tell-me-how-to-make-a-pull-request).