### PR TITLE
Officially support `api_version=2022.12` in `extra.array_api`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release adds support for the Array API's `2022.12 release
+<https://data-apis.org/array-api/2022.12/>`_ via the ``api_version`` argument in
+:func:`~hypothesis.extra.array_api.make_strategies_namespace`. Concretely this
+involves complex support in its existing strategies, plus an introduced
+:func:`xps.complex_dtypes` strategy.
+
+Additionally this release now treats :ref:`hypothesis.extra.array_api
+<array-api>` as stable, meaning breaking changes should only happen with major
+releases of Hypothesis.

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -59,10 +59,6 @@ pandas bug.
 Array API
 ---------
 
-.. tip::
-   The Array API standard is not yet finalised, so this module will make breaking
-   changes if necessary to support newer versions of the standard.
-
 Hypothesis offers strategies for `Array API <https://data-apis.org/>`_ adopting
 libraries in the ``hypothesis.extra.array_api`` package. See :issue:`3037` for
 more details.  If you want to test with :pypi:`CuPy`, :pypi:`Dask`, :pypi:`JAX`,
@@ -74,9 +70,6 @@ or just ``numpy.array_api`` - this is the extension for you!
 The resulting namespace contains all our familiar strategies like
 :func:`~xps.arrays` and :func:`~xps.from_dtype`, but based on the Array API
 standard semantics and returning objects from the ``xp`` module:
-
-..
-    TODO: for next released xp version, include complex_dtypes here
 
 .. automodule:: xps
    :members:
@@ -90,6 +83,7 @@ standard semantics and returning objects from the ``xp`` module:
         integer_dtypes,
         unsigned_integer_dtypes,
         floating_dtypes,
+        complex_dtypes,
         valid_tuple_axes,
         broadcastable_shapes,
         mutually_broadcastable_shapes,

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -69,10 +69,10 @@ __all__ = [
 ]
 
 
-RELEASED_VERSIONS = ("2021.12",)
+RELEASED_VERSIONS = ("2021.12", "2022.12")
 NOMINAL_VERSIONS = RELEASED_VERSIONS + ("draft",)
 assert sorted(NOMINAL_VERSIONS) == list(NOMINAL_VERSIONS)  # sanity check
-NominalVersion = Literal["2021.12", "draft"]
+NominalVersion = Literal["2021.12", "2022.12", "draft"]
 assert get_args(NominalVersion) == NOMINAL_VERSIONS  # sanity check
 
 
@@ -1150,7 +1150,7 @@ if np is not None:
 
     mock_xp = SimpleNamespace(
         __name__="mock",
-        __array_api_version__="2021.12",
+        __array_api_version__="2022.12",
         # Data types
         int8=np.int8,
         int16=np.int16,

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -194,7 +194,7 @@ def _from_dtype(
     allow_subnormal: Optional[bool] = None,
     exclude_min: Optional[bool] = None,
     exclude_max: Optional[bool] = None,
-) -> st.SearchStrategy[Union[bool, int, float]]:
+) -> st.SearchStrategy[Union[bool, int, float, complex]]:
     """Return a strategy for any value of the given dtype.
 
     Values generated are of the Python scalar which is
@@ -936,7 +936,7 @@ def make_strategies_namespace(
         allow_subnormal: Optional[bool] = None,
         exclude_min: Optional[bool] = None,
         exclude_max: Optional[bool] = None,
-    ) -> st.SearchStrategy[Union[bool, int, float]]:
+    ) -> st.SearchStrategy[Union[bool, int, float, complex]]:
         return _from_dtype(
             xp,
             api_version,  # type: ignore[arg-type]

--- a/hypothesis-python/tests/array_api/common.py
+++ b/hypothesis-python/tests/array_api/common.py
@@ -29,8 +29,7 @@ __all__ = [
 ]
 
 
-# This should be updated to the next spec release, which should include complex numbers
-MIN_VER_FOR_COMPLEX: NominalVersion = "draft"
+MIN_VER_FOR_COMPLEX: NominalVersion = "2022.12"
 if len(RELEASED_VERSIONS) > 1:
     assert MIN_VER_FOR_COMPLEX == RELEASED_VERSIONS[1]
 

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -185,7 +185,17 @@ def test_arbitrary_data_frames(data):
         column_name = data_frame_columns[i]
         values = df[column_name]
         if c.unique:
-            assert len(set(values)) == len(values)
+            # NA values should always be treated as unique to each other, so we
+            # just ignore them here. Note NA values in the ecosystem can have
+            # different identity behaviours, e.g.
+            #
+            #     >>> set([float("nan"), float("nan")])
+            #     {nan, nan}
+            #     >>> set([pd.NaT, pd.NaT])
+            #     {NaT}
+            #
+            non_na_values = values.dropna()
+            assert len(set(non_na_values)) == len(non_na_values)
 
 
 @given(


### PR DESCRIPTION
This PR updates refs of `api_version` from `draft` to `2022.12`, and allows one to specify the new release i.e. `make_strategies_namespace(xp, api_version=2022.12)`. I also updated our complex branch in `xps.from_dtype()` to use the now-specified behaviour of `xp.finfo()` working with complex dtypes (getting the component float's info).

Additionally, this PR removes the beware-breaking-changes note in the respective docs—I think that's fine at this point right?

I was going to do min/max magnitude passthrough to `xps.from_dtype()`, but given https://github.com/HypothesisWorks/hypothesis/issues/3573 I think it can wait :sweat_smile: