### PR TITLE
return_value and not_a_test_method health checks strict error fix

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,3 +3,5 @@ RELEASE_TYPE: minor
 This release turns ``HealthCheck.return_value`` and ``HealthCheck.not_a_test_method``
 into unconditional errors.  Passing them to ``suppress_health_check=`` is therefore a deprecated no-op.
 (:issue:`3568`).  Thanks to Reagan Lee for the patch!
+
+Separately, GraalPy can now run and pass most of the hypothesis test suite (:issue:`3587`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
 This release turns ``HealthCheck.return_value`` and ``HealthCheck.not_a_test_method``
-into unconditional errors, and therefore also deprecates access to those attributes.
+into unconditional errors.  Passing them to ``suppress_health_check=`` is therefore a deprecated no-op.
 (:issue:`3568`).  Thanks to Reagan Lee for the patch!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,5 @@
 RELEASE_TYPE: minor
 
-This patch deprecates ``return_value`` and ``not_a_test_method`` health checks and 
-turns them into unconditional errors (:issue:`3568`).
+This release turns ``HealthCheck.return_value`` and ``HealthCheck.not_a_test_method``
+into unconditional errors, and therefore also deprecates access to those attributes.
+(:issue:`3568`).  Thanks to Reagan Lee for the patch!

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -1735,7 +1735,7 @@ in the `Array API standard <https://data-apis.org/>`__ (see :pull:`3065`).
 This release makes :doc:`stateful testing <stateful>` more likely to tell you
 if you do something unexpected and unsupported:
 
-- The ``hypothesis.HealthCheck.return_value`` health check now applies to
+- The :obj:`~hypothesis.HealthCheck.return_value` health check now applies to
   :func:`~hypothesis.stateful.rule` and :func:`~hypothesis.stateful.initialize`
   rules, if they don't have ``target`` bundles, as well as
   :func:`~hypothesis.stateful.invariant`.
@@ -1833,7 +1833,7 @@ Thanks to Ruben Opdebeeck for this contribution!
 This release emits a more useful error message when :func:`@given() <hypothesis.given>`
 is applied to a coroutine function, i.e. one defined using ``async def`` (:issue:`3054`).
 
-This was previously only handled by the generic ``hypothesis.HealthCheck.return_value``
+This was previously only handled by the generic :obj:`~hypothesis.HealthCheck.return_value`
 health check, which doesn't direct you to use either :ref:`a custom executor <custom-function-execution>`
 or a library such as :pypi:`pytest-trio` or :pypi:`pytest-asyncio` to handle it for you.
 
@@ -8981,7 +8981,7 @@ with the standard library :mod:`python:unittest` module:
 
 - Applying :func:`@given <hypothesis.given>` to a non-test method which is
   overridden from :class:`python:unittest.TestCase`, such as ``setUp``,
-  raises a new health check ``<hypothesis.HealthCheck.not_a_test_method>``.
+  raises :attr:`a new health check <hypothesis.HealthCheck.not_a_test_method>`.
   (:issue:`991`)
 - Using :meth:`~python:unittest.TestCase.subTest` within a test decorated
   with :func:`@given <hypothesis.given>` would leak intermediate results

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -1735,7 +1735,7 @@ in the `Array API standard <https://data-apis.org/>`__ (see :pull:`3065`).
 This release makes :doc:`stateful testing <stateful>` more likely to tell you
 if you do something unexpected and unsupported:
 
-- The :obj:`~hypothesis.HealthCheck.return_value` health check now applies to
+- The ``hypothesis.HealthCheck.return_value`` health check now applies to
   :func:`~hypothesis.stateful.rule` and :func:`~hypothesis.stateful.initialize`
   rules, if they don't have ``target`` bundles, as well as
   :func:`~hypothesis.stateful.invariant`.
@@ -1833,7 +1833,7 @@ Thanks to Ruben Opdebeeck for this contribution!
 This release emits a more useful error message when :func:`@given() <hypothesis.given>`
 is applied to a coroutine function, i.e. one defined using ``async def`` (:issue:`3054`).
 
-This was previously only handled by the generic :obj:`~hypothesis.HealthCheck.return_value`
+This was previously only handled by the generic ``hypothesis.HealthCheck.return_value``
 health check, which doesn't direct you to use either :ref:`a custom executor <custom-function-execution>`
 or a library such as :pypi:`pytest-trio` or :pypi:`pytest-asyncio` to handle it for you.
 
@@ -8981,7 +8981,7 @@ with the standard library :mod:`python:unittest` module:
 
 - Applying :func:`@given <hypothesis.given>` to a non-test method which is
   overridden from :class:`python:unittest.TestCase`, such as ``setUp``,
-  raises :attr:`a new health check <hypothesis.HealthCheck.not_a_test_method>`.
+  raises a new health check ``<hypothesis.HealthCheck.not_a_test_method>``.
   (:issue:`991`)
 - Using :meth:`~python:unittest.TestCase.subTest` within a test decorated
   with :func:`@given <hypothesis.given>` would leak intermediate results

--- a/hypothesis-python/docs/healthchecks.rst
+++ b/hypothesis-python/docs/healthchecks.rst
@@ -14,7 +14,7 @@ Using a value of ``HealthCheck.all()`` will disable all health checks.
 .. autoclass:: hypothesis.HealthCheck
    :undoc-members:
    :inherited-members:
-   :exclude-members: all, return_value, not_a_test_method
+   :exclude-members: all
 
 
 .. _deprecation-policy:

--- a/hypothesis-python/docs/healthchecks.rst
+++ b/hypothesis-python/docs/healthchecks.rst
@@ -9,7 +9,7 @@ If this is expected, e.g. when generating large arrays or dataframes, you can se
 disable them with the :obj:`~hypothesis.settings.suppress_health_check` setting.
 The argument for this parameter is a list with elements drawn from any of
 the class-level attributes of the HealthCheck class.
-Using a value of ``HealthCheck.all()`` will disable all health checks.
+Using a value of ``list(HealthCheck)`` will disable all health checks.
 
 .. autoclass:: hypothesis.HealthCheck
    :undoc-members:

--- a/hypothesis-python/docs/healthchecks.rst
+++ b/hypothesis-python/docs/healthchecks.rst
@@ -14,7 +14,7 @@ Using a value of ``HealthCheck.all()`` will disable all health checks.
 .. autoclass:: hypothesis.HealthCheck
    :undoc-members:
    :inherited-members:
-   :exclude-members: all
+   :exclude-members: all, return_value, not_a_test_method
 
 
 .. _deprecation-policy:

--- a/hypothesis-python/scripts/other-tests.sh
+++ b/hypothesis-python/scripts/other-tests.sh
@@ -43,7 +43,7 @@ pip install "$(grep 'lark==' ../requirements/coverage.txt)"
 $PYTEST tests/lark/
 pip uninstall -y lark
 
-if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel == \'final\' and platform.python_implementation() != "PyPy")')" = "True" ] ; then
+if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel == \'final\' and platform.python_implementation() not in ("PyPy", "GraalVM"))')" = "True" ] ; then
   pip install ".[codemods,cli]"
   $PYTEST tests/codemods/
   pip uninstall -y libcst click
@@ -55,10 +55,13 @@ if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel ==
     pip install "$(grep 'numpy==' ../requirements/coverage.txt)"
   fi
 
-  if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then\
-    $PYTEST tests/array_api
-    $PYTEST tests/numpy
-  fi
+  case "$(python -c 'import platform; print(platform.python_implementation())')" in
+    PyPy|GraalVM)
+      ;;
+    *)
+      $PYTEST tests/array_api
+      $PYTEST tests/numpy
+  esac
 
   pip install "$(grep 'black==' ../requirements/coverage.txt)"
   $PYTEST tests/ghostwriter/

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -445,7 +445,7 @@ class Phase(IntEnum):
         return f"Phase.{self.name}"
 
 class HealthCheckMeta(EnumMeta): 
-    @classmethod
+    # @classmethod
     def __iter__(cls) -> Iterator["HealthCheck"]:
         strict_errors = [HealthCheck.return_value, HealthCheck.not_a_test_method]
         for x in super().__iter__():

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -457,17 +457,7 @@ class HealthCheck(Enum):
 
     @classmethod
     def all(cls) -> List["HealthCheck"]:
-        attributes = list(HealthCheck)
-        strict_errors = [HealthCheck.return_value, HealthCheck.not_a_test_method]
-
-        for strict_error in strict_errors: 
-            attributes.remove(strict_error)
-
-        return attributes
-    
-    # @classmethod
-    # def __iter__(cls) -> Iterator["HealthCheck"]:
-    #     return iter(cls.all())
+        return list(HealthCheck)
 
     data_too_large = 1
     """Checks if too many examples are aborted for being too large.
@@ -489,18 +479,14 @@ class HealthCheck(Enum):
     testing."""
 
     return_value = 5
-    """Deprecated, now a strict error.
-    
-    Checks if your tests return a non-None value (which will be ignored and
+    """Checks if your tests return a non-None value (which will be ignored and
     is unlikely to do what you want)."""
 
     large_base_example = 7
     """Checks if the natural example to shrink towards is very large."""
 
     not_a_test_method = 8
-    """Deprecated, now a strict error.
-
-    Checks if :func:`@given <hypothesis.given>` has been applied to a
+    """Checks if :func:`@given <hypothesis.given>` has been applied to a
     method defined by :class:`python:unittest.TestCase` (i.e. not a test)."""
 
     function_scoped_fixture = 9

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -489,14 +489,18 @@ class HealthCheck(Enum):
     testing."""
 
     return_value = 5
-    """Checks if your tests return a non-None value (which will be ignored and
+    """Deprecated, now a strict error.
+    
+    Checks if your tests return a non-None value (which will be ignored and
     is unlikely to do what you want)."""
 
     large_base_example = 7
     """Checks if the natural example to shrink towards is very large."""
 
     not_a_test_method = 8
-    """Checks if :func:`@given <hypothesis.given>` has been applied to a
+    """Deprecated, now a strict error.
+
+    Checks if :func:`@given <hypothesis.given>` has been applied to a
     method defined by :class:`python:unittest.TestCase` (i.e. not a test)."""
 
     function_scoped_fixture = 9

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -445,9 +445,6 @@ class Phase(IntEnum):
         return f"Phase.{self.name}"
 
 
-__DEPRECATED_HEALTHCHECK_NAMES = ("return_value", "not_a_test_method")
-
-
 @unique
 class HealthCheck(Enum):
     """Arguments for :attr:`~hypothesis.settings.suppress_health_check`.
@@ -462,11 +459,11 @@ class HealthCheck(Enum):
         return iter(
             attribute
             for attribute in super().__iter__()
-            if attribute.name not in __DEPRECATED_HEALTHCHECK_NAMES
+            if attribute.name not in ("return_value", "not_a_test_method")
         )
 
     def __getattr__(self, name):
-        if name in __DEPRECATED_HEALTHCHECK_NAMES:
+        if name in ("return_value", "not_a_test_method"):
             note_deprecation(
                 f"HealthCheck.{name} is deprecated and cannot be suppressed.",
                 since="RELEASEDAY",

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -455,25 +455,15 @@ class HealthCheck(Enum):
     def __repr__(self):
         return f"{self.__class__.__name__}.{self.name}"
 
-    def __iter__(self):
-        return iter(
-            attribute
-            for attribute in super().__iter__()
-            if attribute.name not in ("return_value", "not_a_test_method")
-        )
-
-    def __getattr__(self, name):
-        if name in ("return_value", "not_a_test_method"):
-            note_deprecation(
-                f"HealthCheck.{name} is deprecated and cannot be suppressed.",
-                since="RELEASEDAY",
-                has_codemod=False,
-            )
-        return super().__getattr__(name)
-
     @classmethod
     def all(cls) -> List["HealthCheck"]:
-        return list(HealthCheck)
+        attributes = list(HealthCheck)
+        strict_errors = [HealthCheck.return_value, HealthCheck.not_a_test_method]
+        print("ahaha, all() works")
+        for strict_error in strict_errors: 
+            attributes.remove(strict_error)
+
+        return attributes
 
     data_too_large = 1
     """Checks if too many examples are aborted for being too large.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -464,8 +464,9 @@ class HealthCheck(Enum, metaclass=HealthCheckMeta):
 
     @classmethod
     def all(cls) -> List["HealthCheck"]:
-        attributes = list(HealthCheck)
-        return attributes
+        # Skipping of deprecated attributes is handled in HealthCheckMeta.__iter__
+        # TODO: note_deprecation() and write a codemod for HC.all() -> list(HC)
+        return list(HealthCheck)
 
     data_too_large = 1
     """Checks if too many examples are aborted for being too large.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -594,9 +594,8 @@ def validate_health_check_suppressions(suppressions):
             )
         if s in (HealthCheck.return_value, HealthCheck.not_a_test_method):
             note_deprecation(
-                "The return_value health check is now always enabled, "
-                "and cannot be suppressed.",
-                since="2023-03-06",
+                f"The {s.name} health check is deprecated, because this is always an error.",
+                since="RELEASEDAY",
                 has_codemod=False,
             )
     return suppressions

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import warnings
 from enum import Enum, IntEnum, unique
-from typing import TYPE_CHECKING, Any, Collection, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Collection, Dict, Iterator, List, Optional, TypeVar, Union
 
 import attr
 
@@ -459,11 +459,14 @@ class HealthCheck(Enum):
     def all(cls) -> List["HealthCheck"]:
         attributes = list(HealthCheck)
         strict_errors = [HealthCheck.return_value, HealthCheck.not_a_test_method]
-        print("ahaha, all() works")
         for strict_error in strict_errors: 
             attributes.remove(strict_error)
 
         return attributes
+    
+    @classmethod
+    def __iter__(cls) -> Iterator["HealthCheck"]:
+        return super().__iter__(cls.all())
 
     data_too_large = 1
     """Checks if too many examples are aborted for being too large.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -593,6 +593,13 @@ def validate_health_check_suppressions(suppressions):
                 f"Non-HealthCheck value {s!r} of type {type(s).__name__} "
                 "is invalid in suppress_health_check."
             )
+        if s in (HealthCheck.return_value, HealthCheck.not_a_test_method):
+            note_deprecation(
+                "The return_value health check is now always enabled, "
+                "and cannot be suppressed.",
+                since="2023-03-06",
+                has_codemod=False,
+            )
     return suppressions
 
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import warnings
 from enum import Enum, EnumMeta, IntEnum, unique
-from typing import TYPE_CHECKING, Any, Collection, Dict, Iterator, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Collection, Dict, List, Optional, TypeVar, Union
 
 import attr
 
@@ -444,13 +444,12 @@ class Phase(IntEnum):
     def __repr__(self):
         return f"Phase.{self.name}"
 
-class HealthCheckMeta(EnumMeta): 
-    # @classmethod
-    def __iter__(cls) -> Iterator["HealthCheck"]:
-        strict_errors = [HealthCheck.return_value, HealthCheck.not_a_test_method]
-        for x in super().__iter__():
-            if x not in strict_errors:
-                yield x
+
+class HealthCheckMeta(EnumMeta):
+    def __iter__(self):
+        deprecated = (HealthCheck.return_value, HealthCheck.not_a_test_method)
+        return iter(x for x in super().__iter__() if x not in deprecated)
+
 
 @unique
 class HealthCheck(Enum, metaclass=HealthCheckMeta):

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -457,7 +457,17 @@ class HealthCheck(Enum):
 
     @classmethod
     def all(cls) -> List["HealthCheck"]:
-        return list(HealthCheck)
+        attributes = list(HealthCheck)
+        strict_errors = [HealthCheck.return_value, HealthCheck.not_a_test_method]
+
+        for strict_error in strict_errors: 
+            attributes.remove(strict_error)
+
+        return attributes
+    
+    # @classmethod
+    # def __iter__(cls) -> Iterator["HealthCheck"]:
+    #     return iter(cls.all())
 
     data_too_large = 1
     """Checks if too many examples are aborted for being too large.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1495,7 +1495,7 @@ def find(
     if settings is None:
         settings = Settings(max_examples=2000)
     settings = Settings(
-        settings, suppress_health_check=HealthCheck.all(), report_multiple_bugs=False
+        settings, suppress_health_check=list(HealthCheck), report_multiple_bugs=False
     )
 
     if database_key is None and settings.database is not None:

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -94,6 +94,7 @@ else:
             Concatenate, ParamSpec = None, None
 
 PYPY = platform.python_implementation() == "PyPy"
+GRAALPY = platform.python_implementation() == "GraalVM"
 WINDOWS = platform.system() == "Windows"
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
@@ -261,7 +261,7 @@ def normalize(
 
     runner = ConjectureRunner(
         test_function,
-        settings=settings(database=None, suppress_health_check=HealthCheck.all()),
+        settings=settings(database=None, suppress_health_check=list(HealthCheck)),
         ignore_limits=True,
         random=random,
     )

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -19,7 +19,7 @@ from weakref import WeakValueDictionary
 
 import hypothesis.core
 from hypothesis.errors import HypothesisWarning, InvalidArgument
-from hypothesis.internal.compat import PYPY
+from hypothesis.internal.compat import GRAALPY, PYPY
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 8):
@@ -59,7 +59,7 @@ class NumpyRandomWrapper:
 NP_RANDOM = None
 
 
-if not PYPY:
+if not (PYPY or GRAALPY):
 
     def _get_platform_base_refcount(r: Any) -> int:
         return sys.getrefcount(r)
@@ -68,7 +68,7 @@ if not PYPY:
     # the given platform / version of Python.
     _PLATFORM_REF_COUNT = _get_platform_base_refcount(object())
 else:  # pragma: no cover
-    # PYPY doesn't have `sys.getrefcount`
+    # PYPY and GRAALPY don't have `sys.getrefcount`
     _PLATFORM_REF_COUNT = -1
 
 
@@ -118,8 +118,8 @@ def register_random(r: RandomLike) -> None:
     if r in RANDOMS_TO_MANAGE.values():
         return
 
-    if not PYPY:  # pragma: no branch
-        # PYPY does not have `sys.getrefcount`
+    if not (PYPY or GRAALPY):  # pragma: no branch
+        # PYPY and GRAALPY do not have `sys.getrefcount`
         gc.collect()
         if not gc.get_referrers(r):
             if sys.getrefcount(r) <= _PLATFORM_REF_COUNT:

--- a/hypothesis-python/src/hypothesis/internal/healthcheck.py
+++ b/hypothesis-python/src/hypothesis/internal/healthcheck.py
@@ -9,16 +9,14 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from hypothesis.errors import FailedHealthCheck
-from hypothesis._settings import HealthCheck, note_deprecation
+
 
 def fail_health_check(settings, message, label):
     # Tell pytest to omit the body of this function from tracebacks
     # https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
     __tracebackhide__ = True
 
-    if label in [HealthCheck.return_value, HealthCheck.not_a_test_method]: 
-        note_deprecation("The return_value and not_a_test_method health checks are deprecated, and are now strict errors.", since="2023-02-13", has_codemod=False)
-    elif label in settings.suppress_health_check: # Put if the label == (the two words I'm looking out for)
+    if label in settings.suppress_health_check:
         return
     message += (
         "\nSee https://hypothesis.readthedocs.io/en/latest/health"

--- a/hypothesis-python/src/hypothesis/internal/healthcheck.py
+++ b/hypothesis-python/src/hypothesis/internal/healthcheck.py
@@ -9,14 +9,16 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from hypothesis.errors import FailedHealthCheck
-
+from hypothesis._settings import HealthCheck, note_deprecation
 
 def fail_health_check(settings, message, label):
     # Tell pytest to omit the body of this function from tracebacks
     # https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
     __tracebackhide__ = True
 
-    if label in settings.suppress_health_check:
+    if label in [HealthCheck.return_value, HealthCheck.not_a_test_method]: 
+        note_deprecation("The return_value and not_a_test_method health checks are deprecated, and are now strict errors.", since="2023-02-13", has_codemod=False)
+    elif label in settings.suppress_health_check: # Put if the label == (the two words I'm looking out for)
         return
     message += (
         "\nSee https://hypothesis.readthedocs.io/en/latest/health"

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -100,7 +100,7 @@ def run_state_machine_as_test(state_machine_factory, *, settings=None, _min_step
             settings = state_machine_factory.TestCase.settings
             check_type(Settings, settings, "state_machine_factory.TestCase.settings")
         except AttributeError:
-            settings = Settings(deadline=None, suppress_health_check=HealthCheck.all())
+            settings = Settings(deadline=None, suppress_health_check=list(HealthCheck))
     check_type(Settings, settings, "settings")
     check_type(int, _min_steps, "_min_steps")
     if _min_steps < 0:
@@ -390,7 +390,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
     @lru_cache()
     def _to_test_case(cls):
         class StateMachineTestCase(TestCase):
-            settings = Settings(deadline=None, suppress_health_check=HealthCheck.all())
+            settings = Settings(deadline=None, suppress_health_check=list(HealthCheck))
 
             def runTest(self):
                 run_state_machine_as_test(cls)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -329,7 +329,7 @@ class SearchStrategy(Generic[Ex]):
             deadline=None,
             verbosity=Verbosity.quiet,
             phases=(Phase.generate,),
-            suppress_health_check=HealthCheck.all(),
+            suppress_health_check=list(HealthCheck),
         )
         def example_generating_inner_function(ex):
             self.__examples.append(ex)

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -50,7 +50,7 @@ def minimal(definition, condition=lambda x: True, settings=None, timeout_after=1
     @given(definition)
     @Settings(
         parent=settings,
-        suppress_health_check=HealthCheck.all(),
+        suppress_health_check=list(HealthCheck),
         report_multiple_bugs=False,
         derandomize=True,
         database=None,

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -21,7 +21,7 @@ SOME_LABEL = calc_label_from_name("some label")
 
 
 TEST_SETTINGS = settings(
-    max_examples=5000, database=None, suppress_health_check=HealthCheck.all()
+    max_examples=5000, database=None, suppress_health_check=list(HealthCheck)
 )
 
 
@@ -56,7 +56,7 @@ def shrinking_from(start):
                 settings=settings(
                     max_examples=5000,
                     database=None,
-                    suppress_health_check=HealthCheck.all(),
+                    suppress_health_check=list(HealthCheck),
                 ),
             )
             runner.cached_test_function(start)

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -19,7 +19,7 @@ from hypothesis.internal.conjecture.datatree import DataTree
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
 TEST_SETTINGS = settings(
-    max_examples=5000, database=None, suppress_health_check=HealthCheck.all()
+    max_examples=5000, database=None, suppress_health_check=list(HealthCheck)
 )
 
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -483,7 +483,7 @@ def test_debug_data(capsys):
         settings=settings(
             max_examples=5000,
             database=None,
-            suppress_health_check=HealthCheck.all(),
+            suppress_health_check=list(HealthCheck),
             verbosity=Verbosity.debug,
         ),
     )
@@ -722,7 +722,7 @@ def test_database_clears_secondary_key():
     runner = ConjectureRunner(
         f,
         settings=settings(
-            max_examples=1, database=database, suppress_health_check=HealthCheck.all()
+            max_examples=1, database=database, suppress_health_check=list(HealthCheck)
         ),
         database_key=key,
     )
@@ -755,7 +755,7 @@ def test_database_uses_values_from_secondary_key():
     runner = ConjectureRunner(
         f,
         settings=settings(
-            max_examples=1, database=database, suppress_health_check=HealthCheck.all()
+            max_examples=1, database=database, suppress_health_check=list(HealthCheck)
         ),
         database_key=key,
     )
@@ -789,7 +789,7 @@ def test_exit_because_max_iterations():
     runner = ConjectureRunner(
         f,
         settings=settings(
-            max_examples=1, database=None, suppress_health_check=HealthCheck.all()
+            max_examples=1, database=None, suppress_health_check=list(HealthCheck)
         ),
     )
 
@@ -1220,7 +1220,7 @@ def test_populates_the_pareto_front():
             settings=settings(
                 max_examples=5000,
                 database=InMemoryExampleDatabase(),
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
             ),
             database_key=b"stuff",
         )
@@ -1241,7 +1241,7 @@ def test_pareto_front_contains_smallest_valid_when_not_targeting():
             settings=settings(
                 max_examples=5000,
                 database=InMemoryExampleDatabase(),
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
             ),
             database_key=b"stuff",
         )
@@ -1262,7 +1262,7 @@ def test_pareto_front_contains_different_interesting_reasons():
             settings=settings(
                 max_examples=5000,
                 database=InMemoryExampleDatabase(),
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
             ),
             database_key=b"stuff",
         )
@@ -1285,7 +1285,7 @@ def test_database_contains_only_pareto_front():
         runner = ConjectureRunner(
             test,
             settings=settings(
-                max_examples=500, database=db, suppress_health_check=HealthCheck.all()
+                max_examples=500, database=db, suppress_health_check=list(HealthCheck)
             ),
             database_key=b"stuff",
         )
@@ -1326,7 +1326,7 @@ def test_clears_defunct_pareto_front():
             settings=settings(
                 max_examples=10000,
                 database=db,
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
                 phases=[Phase.reuse],
             ),
             database_key=b"stuff",

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -29,7 +29,7 @@ def test_pareto_front_contains_different_interesting_reasons():
             settings=settings(
                 max_examples=5000,
                 database=InMemoryExampleDatabase(),
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
             ),
             database_key=b"stuff",
         )
@@ -52,7 +52,7 @@ def test_database_contains_only_pareto_front():
         runner = ConjectureRunner(
             test,
             settings=settings(
-                max_examples=500, database=db, suppress_health_check=HealthCheck.all()
+                max_examples=500, database=db, suppress_health_check=list(HealthCheck)
             ),
             database_key=b"stuff",
         )
@@ -93,7 +93,7 @@ def test_clears_defunct_pareto_front():
             settings=settings(
                 max_examples=10000,
                 database=db,
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
                 phases=[Phase.reuse],
             ),
             database_key=b"stuff",
@@ -121,7 +121,7 @@ def test_down_samples_the_pareto_front():
             settings=settings(
                 max_examples=1000,
                 database=db,
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
                 phases=[Phase.reuse],
             ),
             database_key=b"stuff",
@@ -151,7 +151,7 @@ def test_stops_loading_pareto_front_if_interesting():
             settings=settings(
                 max_examples=1000,
                 database=db,
-                suppress_health_check=HealthCheck.all(),
+                suppress_health_check=list(HealthCheck),
                 phases=[Phase.reuse],
             ),
             database_key=b"stuff",

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -118,7 +118,7 @@ def test_too_small_to_be_useful_coin():
 @example([0, 2, 47])
 @settings(
     deadline=None,
-    suppress_health_check=HealthCheck.all(),
+    suppress_health_check=list(HealthCheck),
     phases=[Phase.explicit] if IN_COVERAGE_TESTS else settings.default.phases,
 )
 @given(st.lists(st.fractions(min_value=0, max_value=1), min_size=1))

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -101,7 +101,7 @@ def test_failure_sequence_inducing(building, testing, rnd):
     @settings(
         verbosity=Verbosity.quiet,
         database=None,
-        suppress_health_check=HealthCheck.all(),
+        suppress_health_check=list(HealthCheck),
         phases=no_shrink,
     )
     def test(x):

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -57,7 +57,7 @@ def test_slow_generation_inline_fails_a_health_check():
 def test_default_health_check_can_weaken_specific():
     import random
 
-    @settings(HEALTH_CHECK_SETTINGS, suppress_health_check=HealthCheck.all())
+    @settings(HEALTH_CHECK_SETTINGS, suppress_health_check=list(HealthCheck))
     @given(st.lists(st.integers(), min_size=1))
     def test(x):
         random.choice(x)
@@ -152,11 +152,12 @@ def test_the_slow_test_health_check_can_be_disabled():
 
 def test_the_slow_test_health_only_runs_if_health_checks_are_on():
     @given(st.integers())
-    @settings(suppress_health_check=HealthCheck.all(), deadline=None)
+    @settings(suppress_health_check=list(HealthCheck), deadline=None)
     def a(x):
         time.sleep(1000)
 
     a()
+
 
 def test_large_base_example_fails_health_check():
     @given(st.binary(min_size=7000, max_size=7000))

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -158,16 +158,6 @@ def test_the_slow_test_health_only_runs_if_health_checks_are_on():
 
     a()
 
-
-def test_returning_non_none_does_not_fail_if_health_check_disabled():
-    @given(st.integers())
-    @settings(suppress_health_check=HealthCheck.all())
-    def a(x):
-        return 1
-
-    a()
-
-
 def test_large_base_example_fails_health_check():
     @given(st.binary(min_size=7000, max_size=7000))
     def test(b):

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -31,7 +31,7 @@ from hypothesis.strategies import (
 from tests.common.debug import find_any
 
 
-@settings(suppress_health_check=HealthCheck.all())
+@settings(suppress_health_check=list(HealthCheck))
 @given(data())
 def test_fuzz_floats_bounds(data):
     width = data.draw(sampled_from([64, 32, 16]))

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -16,16 +16,17 @@ import pytest
 from hypothesis import core, find, given, register_random, strategies as st
 from hypothesis.errors import HypothesisWarning, InvalidArgument
 from hypothesis.internal import entropy
-from hypothesis.internal.compat import PYPY
+from hypothesis.internal.compat import GRAALPY, PYPY
 from hypothesis.internal.entropy import deterministic_PRNG
 
 
-def gc_on_pypy():
+def gc_collect():
     # CPython uses reference counting, so objects (without circular refs)
     # are collected immediately on `del`, breaking weak references.
-    # PyPy doesn't, so we use this function in tests before counting the
+    # Python implementations with other garbage collection strategies may
+    # or may not, so we use this function in tests before counting the
     # surviving references to ensure that they're deterministic.
-    if PYPY:
+    if PYPY or GRAALPY:
         gc.collect()
 
 
@@ -58,14 +59,14 @@ def test_cannot_register_non_Random():
     "ignore:It looks like `register_random` was passed an object that could be garbage collected"
 )
 def test_registering_a_Random_is_idempotent():
-    gc_on_pypy()
+    gc_collect()
     n_registered = len(entropy.RANDOMS_TO_MANAGE)
     r = random.Random()
     register_random(r)
     register_random(r)
     assert len(entropy.RANDOMS_TO_MANAGE) == n_registered + 1
     del r
-    gc_on_pypy()
+    gc_collect()
     assert len(entropy.RANDOMS_TO_MANAGE) == n_registered
 
 
@@ -150,7 +151,7 @@ def test_find_does_not_pollute_state():
     "ignore:It looks like `register_random` was passed an object that could be garbage collected"
 )
 def test_evil_prng_registration_nonsense():
-    gc_on_pypy()
+    gc_collect()
     n_registered = len(entropy.RANDOMS_TO_MANAGE)
     r1, r2, r3 = random.Random(1), random.Random(2), random.Random(3)
     s2 = r2.getstate()
@@ -165,7 +166,7 @@ def test_evil_prng_registration_nonsense():
 
     with deterministic_PRNG(0):
         del r1
-        gc_on_pypy()
+        gc_collect()
         assert k not in entropy.RANDOMS_TO_MANAGE, "r1 has been garbage-collected"
         assert len(entropy.RANDOMS_TO_MANAGE) == n_registered + 1
 
@@ -229,5 +230,5 @@ def test_register_random_within_nested_function_scope():
         assert len(entropy.RANDOMS_TO_MANAGE) == n_registered + 1
 
     f()
-    gc_on_pypy()
+    gc_collect()
     assert len(entropy.RANDOMS_TO_MANAGE) == n_registered

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -484,16 +484,18 @@ def test_note_deprecation_checks_has_codemod():
     ):
         note_deprecation("This is bad", since="2021-01-01", has_codemod=True)
 
+def test_deprecated_settings_warn_on_set_settings():
+    with validate_deprecation(): # pytest.warns(HypothesisDeprecationWarning):
+        settings(suppress_health_check=[HealthCheck.return_value])
+    with validate_deprecation(): # pytest.warns(HypothesisDeprecationWarning):
+        settings(suppress_health_check=[HealthCheck.not_a_test_method])
 
-def test_deprecated_settings_warn_on_access():
-    with validate_deprecation():
-        retval = HealthCheck.return_value
-    with validate_deprecation():
-        method = HealthCheck.not_a_test_method
-    # but .all() or iteration *don't* warn
-    ls = list(HealthCheck)
+def test_deprecated_settings_not_in_settings_all_list():
     al = HealthCheck.all()
-    # finally, check the lists are identical and omit deprecated members
-    assert ls == al
-    assert retval not in ls
-    assert method not in al
+    ls = list(HealthCheck)
+
+    assert HealthCheck.return_value not in al
+    assert HealthCheck.not_a_test_method not in al
+
+    assert HealthCheck.return_value not in ls
+    assert HealthCheck.not_a_test_method not in ls

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -484,11 +484,13 @@ def test_note_deprecation_checks_has_codemod():
     ):
         note_deprecation("This is bad", since="2021-01-01", has_codemod=True)
 
+
 def test_deprecated_settings_warn_on_set_settings():
-    with validate_deprecation(): 
+    with validate_deprecation():
         settings(suppress_health_check=[HealthCheck.return_value])
-    with validate_deprecation(): 
+    with validate_deprecation():
         settings(suppress_health_check=[HealthCheck.not_a_test_method])
+
 
 def test_deprecated_settings_not_in_settings_all_list():
     al = HealthCheck.all()

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -485,9 +485,9 @@ def test_note_deprecation_checks_has_codemod():
         note_deprecation("This is bad", since="2021-01-01", has_codemod=True)
 
 def test_deprecated_settings_warn_on_set_settings():
-    with validate_deprecation(): # pytest.warns(HypothesisDeprecationWarning):
+    with validate_deprecation(): 
         settings(suppress_health_check=[HealthCheck.return_value])
-    with validate_deprecation(): # pytest.warns(HypothesisDeprecationWarning):
+    with validate_deprecation(): 
         settings(suppress_health_check=[HealthCheck.not_a_test_method])
 
 def test_deprecated_settings_not_in_settings_all_list():

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -495,9 +495,6 @@ def test_deprecated_settings_warn_on_set_settings():
 def test_deprecated_settings_not_in_settings_all_list():
     al = HealthCheck.all()
     ls = list(HealthCheck)
-
-    assert HealthCheck.return_value not in al
-    assert HealthCheck.not_a_test_method not in al
-
+    assert al == ls
     assert HealthCheck.return_value not in ls
     assert HealthCheck.not_a_test_method not in ls

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypothesis import example, given, strategies as st
 from hypothesis._settings import (
+    HealthCheck,
     Phase,
     Verbosity,
     default_variable,
@@ -33,7 +34,7 @@ from hypothesis.errors import (
 from hypothesis.stateful import RuleBasedStateMachine, rule
 from hypothesis.utils.conventions import not_set
 
-from tests.common.utils import counts_calls, fails_with
+from tests.common.utils import counts_calls, fails_with, validate_deprecation
 
 
 def test_has_docstrings():
@@ -482,3 +483,13 @@ def test_note_deprecation_checks_has_codemod():
         match="The `hypothesis codemod` command-line tool",
     ):
         note_deprecation("This is bad", since="2021-01-01", has_codemod=True)
+
+
+def test_deprecated_settings_warn_on_access():
+    with validate_deprecation():
+        HealthCheck.return_value
+    with validate_deprecation():
+        HealthCheck.not_a_test_method
+    # but .all() or iteration *don't* warn
+    list(HealthCheck)
+    HealthCheck.all()

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -487,9 +487,13 @@ def test_note_deprecation_checks_has_codemod():
 
 def test_deprecated_settings_warn_on_access():
     with validate_deprecation():
-        HealthCheck.return_value
+        retval = HealthCheck.return_value
     with validate_deprecation():
-        HealthCheck.not_a_test_method
+        method = HealthCheck.not_a_test_method
     # but .all() or iteration *don't* warn
-    list(HealthCheck)
-    HealthCheck.all()
+    ls = list(HealthCheck)
+    al = HealthCheck.all()
+    # finally, check the lists are identical and omit deprecated members
+    assert ls == al
+    assert retval not in ls
+    assert method not in al

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -44,7 +44,7 @@ def unique_events(stats):
 
 def test_notes_hard_to_satisfy():
     @given(st.integers())
-    @settings(suppress_health_check=HealthCheck.all())
+    @settings(suppress_health_check=list(HealthCheck))
     def test(i):
         assume(i == 13)
 

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -371,7 +371,7 @@ def test_named_tuples_are_of_right_type(litter):
 
 @fails_with(AttributeError)
 @given(integers().map(lambda x: x.nope))
-@settings(suppress_health_check=HealthCheck.all())
+@settings(suppress_health_check=list(HealthCheck))
 def test_fails_in_reify(x):
     pass
 

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -17,7 +17,7 @@ from django.test import TestCase as DjangoTestCase
 from hypothesis import HealthCheck, Verbosity, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django import TestCase, TransactionTestCase
-from hypothesis.internal.compat import PYPY
+from hypothesis.internal.compat import GRAALPY, PYPY
 from hypothesis.strategies import integers
 
 from tests.django.toystore.models import Company
@@ -40,7 +40,7 @@ class TestConstraintsWithTransactions(SomeStuff, TestCase):
     pass
 
 
-if not PYPY:
+if not (PYPY or GRAALPY):
     # xfail
     # This is excessively slow in general, but particularly on pypy. We just
     # disable it altogether there as it's a niche case.

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -57,7 +57,7 @@ class TestWorkflow(VanillaTestCase):
         class LocalTest(TestCase):
             @given(integers().map(break_the_db))
             @settings(
-                suppress_health_check=HealthCheck.all(), verbosity=Verbosity.quiet
+                suppress_health_check=list(HealthCheck), verbosity=Verbosity.quiet
             )
             def test_does_not_break_other_things(self, unused):
                 pass

--- a/hypothesis-python/tests/nocover/test_boundary_exploration.py
+++ b/hypothesis-python/tests/nocover/test_boundary_exploration.py
@@ -18,7 +18,7 @@ from tests.common.utils import no_shrink
 
 
 @pytest.mark.parametrize("strat", [st.text(min_size=5)])
-@settings(phases=no_shrink, deadline=None, suppress_health_check=HealthCheck.all())
+@settings(phases=no_shrink, deadline=None, suppress_health_check=list(HealthCheck))
 @given(st.data())
 def test_explore_arbitrary_function(strat, data):
     cache = {}

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -105,7 +105,7 @@ def run_language_test_for(root, data, seed):
         settings=settings(
             max_examples=1,
             database=None,
-            suppress_health_check=HealthCheck.all(),
+            suppress_health_check=list(HealthCheck),
             verbosity=Verbosity.quiet,
             # Restore the global default phases, so that we don't inherit the
             # phases setting from the outer test.
@@ -121,7 +121,7 @@ def run_language_test_for(root, data, seed):
 
 
 @settings(
-    suppress_health_check=HealthCheck.all(),
+    suppress_health_check=list(HealthCheck),
     deadline=None,
     phases=set(settings.default.phases) - {Phase.shrink},
 )

--- a/hypothesis-python/tests/nocover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/nocover/test_given_error_conditions.py
@@ -17,7 +17,7 @@ from hypothesis.strategies import integers
 
 def test_raises_unsatisfiable_if_all_false():
     @given(integers())
-    @settings(max_examples=50, suppress_health_check=HealthCheck.all())
+    @settings(max_examples=50, suppress_health_check=list(HealthCheck))
     def test_assume_false(x):
         reject()
 

--- a/hypothesis-python/tests/nocover/test_testdecorators.py
+++ b/hypothesis-python/tests/nocover/test_testdecorators.py
@@ -17,7 +17,7 @@ from hypothesis.errors import InvalidArgument, Unsatisfiable
 
 
 def test_contains_the_test_function_name_in_the_exception_string():
-    look_for_one = settings(max_examples=1, suppress_health_check=HealthCheck.all())
+    look_for_one = settings(max_examples=1, suppress_health_check=list(HealthCheck))
 
     @given(st.integers())
     @look_for_one

--- a/hypothesis-python/tests/pytest/test_statistics.py
+++ b/hypothesis-python/tests/pytest/test_statistics.py
@@ -35,7 +35,7 @@ def test_all_valid(x):
     pass
 
 
-@settings(max_examples=100, suppress_health_check=HealthCheck.all())
+@settings(max_examples=100, suppress_health_check=list(HealthCheck))
 @given(integers())
 def test_iterations(x):
     assume(x == 13)

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -39,7 +39,7 @@ def test_can_shrink_in_variable_sized_context(n):
 @example(1.7976931348623157e308)
 @example(1.5)
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
-@settings(deadline=None, suppress_health_check=HealthCheck.all())
+@settings(deadline=None, suppress_health_check=list(HealthCheck))
 def test_shrinks_downwards_to_integers(f):
     g = minimal(
         st.floats().filter(lambda x: x >= f),
@@ -50,7 +50,7 @@ def test_shrinks_downwards_to_integers(f):
 
 @example(1)
 @given(st.integers(1, 2**16 - 1))
-@settings(deadline=None, suppress_health_check=HealthCheck.all(), max_examples=10)
+@settings(deadline=None, suppress_health_check=list(HealthCheck), max_examples=10)
 def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats().filter(lambda x: b < x < 2**53 and int(x) != x),

--- a/hypothesis-python/tests/quality/test_integers.py
+++ b/hypothesis-python/tests/quality/test_integers.py
@@ -47,7 +47,7 @@ def problems(draw):
 @example((1, b"\x00\x00\x06\x01"))
 @example(problem=(32768, b"\x03\x01\x00\x00\x00\x00\x00\x01\x00\x02\x01"))
 @settings(
-    suppress_health_check=HealthCheck.all(),
+    suppress_health_check=list(HealthCheck),
     deadline=None,
     max_examples=10,
     verbosity=Verbosity.normal,
@@ -75,7 +75,7 @@ def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
         f,
         random=Random(0),
         settings=settings(
-            suppress_health_check=HealthCheck.all(),
+            suppress_health_check=list(HealthCheck),
             phases=(Phase.shrink,),
             database=None,
             verbosity=Verbosity.debug,

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -53,7 +53,7 @@ LOTS = 10**6
 
 TEST_SETTINGS = settings(
     database=None,
-    suppress_health_check=HealthCheck.all(),
+    suppress_health_check=list(HealthCheck),
     max_examples=LOTS,
     deadline=None,
 )

--- a/hypothesis-python/tests/quality/test_shrinking_order.py
+++ b/hypothesis-python/tests/quality/test_shrinking_order.py
@@ -42,7 +42,7 @@ def learner_for(strategy):
         settings=settings(
             database=None,
             verbosity=Verbosity.quiet,
-            suppress_health_check=HealthCheck.all(),
+            suppress_health_check=list(HealthCheck),
         ),
         random=Random(0),
         ignore_limits=True,

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -39,7 +39,7 @@ def problem(draw):
 base_settings = settings(
     database=None,
     deadline=None,
-    suppress_health_check=HealthCheck.all(),
+    suppress_health_check=list(HealthCheck),
     max_examples=10,
     verbosity=Verbosity.normal,
     phases=(Phase.explicit, Phase.generate),


### PR DESCRIPTION
This addresses parts of issue #3568. 

Currently, some of the tests fail because (I believe) ```note_deprecation``` causes an undefined error with Pytest before their expected ```FailedHealthCheck``` message in tests that explicitly test for ```return_value``` (and ```not_a_test_method```). An example of this is the ```test_stateful_returnvalue_healthcheck``` test.

Example below
![Screen Shot 2023-02-13 at 1 06 30 PM](https://user-images.githubusercontent.com/96998476/218574501-27c8e48a-211c-4f1e-9f15-ff6a097d4111.png)

Edit: I can solve the majority of tests above by adding in a catch_warning, though I'm not sure whether or not editing the tests themselves would be advised

