### PR TITLE
Add support for GraalPy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch allows GraalPy to run and pass most of the hypothesis test suite
+(:issue:`3587`).

--- a/hypothesis-python/scripts/other-tests.sh
+++ b/hypothesis-python/scripts/other-tests.sh
@@ -43,7 +43,7 @@ pip install "$(grep 'lark==' ../requirements/coverage.txt)"
 $PYTEST tests/lark/
 pip uninstall -y lark
 
-if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel == \'final\' and platform.python_implementation() != "PyPy")')" = "True" ] ; then
+if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel == \'final\' and platform.python_implementation() not in ("PyPy", "GraalVM"))')" = "True" ] ; then
   pip install ".[codemods,cli]"
   $PYTEST tests/codemods/
   pip uninstall -y libcst click
@@ -55,10 +55,13 @@ if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel ==
     pip install "$(grep 'numpy==' ../requirements/coverage.txt)"
   fi
 
-  if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then\
-    $PYTEST tests/array_api
-    $PYTEST tests/numpy
-  fi
+  case "$(python -c 'import platform; print(platform.python_implementation())')" in
+    PyPy|GraalVM)
+      ;;
+    *)
+      $PYTEST tests/array_api
+      $PYTEST tests/numpy
+  esac
 
   pip install "$(grep 'black==' ../requirements/coverage.txt)"
   $PYTEST tests/ghostwriter/

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -94,6 +94,7 @@ else:
             Concatenate, ParamSpec = None, None
 
 PYPY = platform.python_implementation() == "PyPy"
+GRAALPY = platform.python_implementation() == "GraalVM"
 WINDOWS = platform.system() == "Windows"
 
 

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -19,7 +19,7 @@ from weakref import WeakValueDictionary
 
 import hypothesis.core
 from hypothesis.errors import HypothesisWarning, InvalidArgument
-from hypothesis.internal.compat import PYPY
+from hypothesis.internal.compat import GRAALPY, PYPY
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 8):
@@ -59,7 +59,7 @@ class NumpyRandomWrapper:
 NP_RANDOM = None
 
 
-if not PYPY:
+if not (PYPY or GRAALPY):
 
     def _get_platform_base_refcount(r: Any) -> int:
         return sys.getrefcount(r)
@@ -68,7 +68,7 @@ if not PYPY:
     # the given platform / version of Python.
     _PLATFORM_REF_COUNT = _get_platform_base_refcount(object())
 else:  # pragma: no cover
-    # PYPY doesn't have `sys.getrefcount`
+    # PYPY and GRAALPY don't have `sys.getrefcount`
     _PLATFORM_REF_COUNT = -1
 
 
@@ -118,8 +118,8 @@ def register_random(r: RandomLike) -> None:
     if r in RANDOMS_TO_MANAGE.values():
         return
 
-    if not PYPY:  # pragma: no branch
-        # PYPY does not have `sys.getrefcount`
+    if not (PYPY or GRAALPY):  # pragma: no branch
+        # PYPY and GRAALPY do not have `sys.getrefcount`
         gc.collect()
         if not gc.get_referrers(r):
             if sys.getrefcount(r) <= _PLATFORM_REF_COUNT:

--- a/hypothesis-python/tests/django/toystore/test_basic_configuration.py
+++ b/hypothesis-python/tests/django/toystore/test_basic_configuration.py
@@ -17,7 +17,7 @@ from django.test import TestCase as DjangoTestCase
 from hypothesis import HealthCheck, Verbosity, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django import TestCase, TransactionTestCase
-from hypothesis.internal.compat import PYPY
+from hypothesis.internal.compat import GRAALPY, PYPY
 from hypothesis.strategies import integers
 
 from tests.django.toystore.models import Company
@@ -40,7 +40,7 @@ class TestConstraintsWithTransactions(SomeStuff, TestCase):
     pass
 
 
-if not PYPY:
+if not (PYPY or GRAALPY):
     # xfail
     # This is excessively slow in general, but particularly on pypy. We just
     # disable it altogether there as it's a niche case.


### PR DESCRIPTION
There are some checks for PyPy, but the branches for PyPy are really related to GC differences to CPython which apply to GraalPy just the same. With these changes I can pass most of the test suite on GraalPy (modulo some bugs on our end)