### PR TITLE
[TYP] return array dtype is always unkown but it's actually specified as parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,6 +60,7 @@ their individual contributions.
 * `Felix Sheldon <https://www.github.com/darkpaw>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
+* `Francesc Elies <https://www.github.com/FrancescElies>`_
 * `Gabe Joseph <https://github.com/gjoseph92>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
 * `George Macon <https://www.github.com/gmacon>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ First off: It's great that you want to contribute to Hypothesis! Thanks!
 Just tell me how to make a pull request
 ---------------------------------------
 
-1. Make you change and ensure it has adequate tests
+1. Make your change and ensure it has adequate tests
 2. Create ``hypothesis-python/RELEASE.rst`` with ``RELEASE_TYPE: patch``
    for small bugfixes, or ``minor`` for new features.  See recent PRs for examples.
 3. Add yourself to the list in ``AUTHORS.rst`` and open a PR!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+Numpy array strategy returned dtype is always unkown but it's actually specified
+as parameter. 
+
+This patch made that relationship between dtype parameters and returned strategy
+dtype explicit.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,4 @@
 RELEASE_TYPE: patch
 
-Numpy array strategy returned dtype is always unkown but it's actually specified
-as parameter. 
-
-This patch made that relationship between dtype parameters and returned strategy
-dtype explicit.
+This patch fixes type annotations for the :func:`~hypothesis.extra.numpy.arrays`
+strategy.  Thanks to Francesc Elies for :pull:`3602`.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -383,8 +383,8 @@ def arrays(
     dtype: D,
     shape: Union[int, st.SearchStrategy[int], Shape, st.SearchStrategy[Shape]],
     *,
-    elements: Optional[Union[st.SearchStrategy, Mapping[str, Any]]] = None,
-    fill: Optional[st.SearchStrategy[Any]] = None,
+    elements: Optional[Union[st.SearchStrategy[D], Mapping[str, Any]]] = None,
+    fill: Optional[st.SearchStrategy[D]] = None,
     unique: bool = False,
 ) -> st.SearchStrategy[NDArray[D]]:
     r"""Returns a strategy for generating :class:`numpy:numpy.ndarray`\ s.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -380,7 +380,7 @@ D = TypeVar("D", bound=DTypeLike)
 
 @defines_strategy(force_reusable_values=True)
 def arrays(
-    dtype: D,
+    dtype: Union[D, st.SearchStrategy[D]],
     shape: Union[int, st.SearchStrategy[int], Shape, st.SearchStrategy[Shape]],
     *,
     elements: Optional[Union[st.SearchStrategy[D], Mapping[str, Any]]] = None,

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -383,8 +383,8 @@ def arrays(
     dtype: Union[D, st.SearchStrategy[D]],
     shape: Union[int, st.SearchStrategy[int], Shape, st.SearchStrategy[Shape]],
     *,
-    elements: Optional[Union[st.SearchStrategy[D], Mapping[str, Any]]] = None,
-    fill: Optional[st.SearchStrategy[D]] = None,
+    elements: Optional[Union[st.SearchStrategy[Any], Mapping[str, Any]]] = None,
+    fill: Optional[st.SearchStrategy[Any]] = None,
     unique: bool = False,
 ) -> st.SearchStrategy[NDArray[D]]:
     r"""Returns a strategy for generating :class:`numpy:numpy.ndarray`\ s.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
-from typing import Any, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -37,6 +37,7 @@ from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal.numbers import Real
 from hypothesis.strategies._internal.strategies import T, check_strategy
 from hypothesis.strategies._internal.utils import defines_strategy
+from numpy.typing import DTypeLike, NDArray
 
 __all__ = [
     "BroadcastableShapes",
@@ -374,15 +375,18 @@ def fill_for(elements, unique, fill, name=""):
     return fill
 
 
+D = TypeVar("D", bound=DTypeLike)
+
+
 @defines_strategy(force_reusable_values=True)
 def arrays(
-    dtype: Any,
+    dtype: D,
     shape: Union[int, st.SearchStrategy[int], Shape, st.SearchStrategy[Shape]],
     *,
     elements: Optional[Union[st.SearchStrategy, Mapping[str, Any]]] = None,
     fill: Optional[st.SearchStrategy[Any]] = None,
     unique: bool = False,
-) -> st.SearchStrategy[np.ndarray]:
+) -> st.SearchStrategy[NDArray[D]]:
     r"""Returns a strategy for generating :class:`numpy:numpy.ndarray`\ s.
 
     * ``dtype`` may be any valid input to :class:`~numpy:numpy.dtype`
@@ -900,8 +904,8 @@ def integer_array_indices(
     shape: Shape,
     *,
     result_shape: st.SearchStrategy[Shape] = array_shapes(),
-    dtype: np.dtype = "int",
-) -> st.SearchStrategy[Tuple[np.ndarray, ...]]:
+    dtype: D = np.int32,
+) -> st.SearchStrategy[Tuple[NDArray[D], ...]]:
     """Return a search strategy for tuples of integer-arrays that, when used
     to index into an array of shape ``shape``, given an array whose shape
     was drawn from ``result_shape``.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -904,7 +904,7 @@ def integer_array_indices(
     shape: Shape,
     *,
     result_shape: st.SearchStrategy[Shape] = array_shapes(),
-    dtype: D = np.int32,
+    dtype: D = np.int_,
 ) -> st.SearchStrategy[Tuple[NDArray[D], ...]]:
     """Return a search strategy for tuples of integer-arrays that, when used
     to index into an array of shape ``shape``, given an array whose shape

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -12,6 +12,7 @@ import math
 from typing import Any, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
+from numpy.typing import DTypeLike, NDArray
 
 from hypothesis import strategies as st
 from hypothesis._settings import note_deprecation
@@ -37,7 +38,6 @@ from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal.numbers import Real
 from hypothesis.strategies._internal.strategies import T, check_strategy
 from hypothesis.strategies._internal.utils import defines_strategy
-from numpy.typing import DTypeLike, NDArray
 
 __all__ = [
     "BroadcastableShapes",
@@ -464,6 +464,7 @@ def arrays(
         )
     # From here on, we're only dealing with values and it's relatively simple.
     dtype = np.dtype(dtype)
+    assert isinstance(dtype, np.dtype)  # help mypy out a bit...
     if elements is None or isinstance(elements, Mapping):
         if dtype.kind in ("m", "M") and "[" not in dtype.str:
             # For datetime and timedelta dtypes, we have a tricky situation -


### PR DESCRIPTION
Given the following example
```python
import numpy as np
from hypothesis.extra.numpy import arrays

a = arrays(np.int32, shape=2)
reveal_type(a)
```

On master running the typechecker the ndarray dtype is unkown
```
# mytest.py:5: note: Revealed type is "hypothesis.strategies._internal.strategies.SearchStrategy[numpy.ndarray[Any, Any]]"
```

If my understanding is correct, after this pr the dtype parameter will be taken into account.
```
# mytest.py:5: note: Revealed type is "hypothesis.strategies._internal.strategies.SearchStrategy[numpy.ndarray[Any, numpy.dtype[def (Union[typing.SupportsInt, builtins.str, builtins.bytes, typing.SupportsIndex] =) -> numpy.signedinteger[numpy._typing._32Bit]]]]"
```