### PR TITLE
fix: enables default encoding warning to ensure users set encoding

### DIFF
--- a/hypothesis-python/tests/codemods/test_codemod_cli.py
+++ b/hypothesis-python/tests/codemods/test_codemod_cli.py
@@ -32,34 +32,35 @@ AFTER += _unchanged
 del _unchanged
 
 
-def run(command, tmpdir=None, input=None):
+def run(command, *, cwd=None, input=None):
     return subprocess.run(
         command,
         input=input,
         capture_output=True,
         shell=True,
         text=True,
-        cwd=tmpdir,
+        cwd=cwd,
+        encoding="utf-8",
     )
 
 
-def test_codemod_single_file(tmpdir):
-    fname = tmpdir / "mycode.py"
-    fname.write(BEFORE)
-    result = run("hypothesis codemod mycode.py", tmpdir)
+def test_codemod_single_file(tmp_path):
+    fname = tmp_path / "mycode.py"
+    fname.write_text(BEFORE, encoding="utf-8")
+    result = run("hypothesis codemod mycode.py", cwd=tmp_path)
     assert result.returncode == 0
-    assert fname.read() == AFTER
+    assert fname.read_text(encoding="utf-8") == AFTER
 
 
-def test_codemod_multiple_files(tmpdir):
+def test_codemod_multiple_files(tmp_path):
     # LibCST had some trouble with multiprocessing on Windows
-    files = [tmpdir / "mycode1.py", tmpdir / "mycode2.py"]
+    files = [tmp_path / "mycode1.py", tmp_path / "mycode2.py"]
     for f in files:
-        f.write(BEFORE)
-    result = run("hypothesis codemod mycode1.py mycode2.py", tmpdir)
+        f.write_text(BEFORE, encoding="utf-8")
+    result = run("hypothesis codemod mycode1.py mycode2.py", cwd=tmp_path)
     assert result.returncode == 0
     for f in files:
-        assert f.read() == AFTER
+        assert f.read_text(encoding="utf-8") == AFTER
 
 
 def test_codemod_from_stdin():

--- a/hypothesis-python/tests/cover/test_lazy_import.py
+++ b/hypothesis-python/tests/cover/test_lazy_import.py
@@ -42,7 +42,6 @@ def test_hypothesis_does_not_import_test_runners(tmp_path):
     # It's unclear which of our dependencies is importing unittest, but
     # since I doubt it's causing any spurious failures I don't really care.
     # See https://github.com/HypothesisWorks/hypothesis/pull/2204
-    fname = str(tmp_path / "test.py")
-    with open(fname, "w") as f:
-        f.write(SHOULD_NOT_IMPORT_TEST_RUNNERS)
-    subprocess.check_call([sys.executable, fname])
+    fname = tmp_path / "test.py"
+    fname.write_text(SHOULD_NOT_IMPORT_TEST_RUNNERS, encoding="utf-8")
+    subprocess.check_call([sys.executable, str(fname)])

--- a/hypothesis-python/tests/cover/test_settings.py
+++ b/hypothesis-python/tests/cover/test_settings.py
@@ -283,10 +283,9 @@ if __name__ == '__main__':
 """
 
 
-def test_puts_the_database_in_the_home_dir_by_default(tmpdir):
-    script = tmpdir.join("assertlocation.py")
-    script.write(ASSERT_DATABASE_PATH)
-
+def test_puts_the_database_in_the_home_dir_by_default(tmp_path):
+    script = tmp_path.joinpath("assertlocation.py")
+    script.write_text(ASSERT_DATABASE_PATH, encoding="utf-8")
     subprocess.check_call([sys.executable, str(script)])
 
 

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
@@ -27,6 +27,12 @@ from hypothesis.extra.ghostwriter import (
 )
 
 
+def run(cmd, *, cwd=None):
+    return subprocess.run(
+        cmd, capture_output=True, shell=True, text=True, cwd=cwd, encoding="utf-8"
+    )
+
+
 @pytest.mark.parametrize(
     "cli,code",
     [
@@ -54,12 +60,7 @@ from hypothesis.extra.ghostwriter import (
     ],
 )
 def test_cli_python_equivalence(cli, code):
-    result = subprocess.run(
-        "hypothesis write " + cli,
-        capture_output=True,
-        shell=True,
-        text=True,
-    )
+    result = run("hypothesis write " + cli)
     result.check_returncode()
     cli_output = result.stdout.strip()
     assert not result.stderr
@@ -90,12 +91,7 @@ def test_cli_python_equivalence(cli, code):
 )
 def test_cli_too_many_functions(cli, err_msg):
     # Supplying multiple functions to writers that only cope with one
-    result = subprocess.run(
-        "hypothesis write " + cli,
-        capture_output=True,
-        shell=True,
-        text=True,
-    )
+    result = run("hypothesis write " + cli)
     assert result.returncode == 2
     assert "Error: " + err_msg in result.stderr
     assert ("Closest matches" in err_msg) == ("Closest matches" in result.stderr)
@@ -109,15 +105,9 @@ def sorter(seq: Sequence[int]) -> List[int]:
 """
 
 
-def test_can_import_from_scripts_in_working_dir(tmpdir):
-    (tmpdir / "mycode.py").write(CODE_TO_TEST)
-    result = subprocess.run(
-        "hypothesis write mycode.sorter",
-        capture_output=True,
-        shell=True,
-        text=True,
-        cwd=tmpdir,
-    )
+def test_can_import_from_scripts_in_working_dir(tmp_path):
+    (tmp_path / "mycode.py").write_text(CODE_TO_TEST, encoding="utf-8")
+    result = run("hypothesis write mycode.sorter", cwd=tmp_path)
     assert result.returncode == 0
     assert "Error: " not in result.stderr
 
@@ -141,15 +131,9 @@ class MyClass:
 
 
 @pytest.mark.parametrize("func", ["my_staticmethod", "my_classmethod"])
-def test_can_import_from_class(tmpdir, func):
-    (tmpdir / "mycode.py").write(CLASS_CODE_TO_TEST)
-    result = subprocess.run(
-        f"hypothesis write mycode.MyClass.{func}",
-        capture_output=True,
-        shell=True,
-        text=True,
-        cwd=tmpdir,
-    )
+def test_can_import_from_class(tmp_path, func):
+    (tmp_path / "mycode.py").write_text(CLASS_CODE_TO_TEST, encoding="utf-8")
+    result = run(f"hypothesis write mycode.MyClass.{func}", cwd=tmp_path)
     assert result.returncode == 0
     assert "Error: " not in result.stderr
 
@@ -162,29 +146,17 @@ def test_can_import_from_class(tmpdir, func):
         ("my_func", " and 'my_func' attribute", "attribute"),
     ],
 )
-def test_error_import_from_class(tmpdir, classname, thing, kind):
-    (tmpdir / "mycode.py").write(CLASS_CODE_TO_TEST)
-    result = subprocess.run(
-        f"hypothesis write mycode.{classname}.XX",
-        capture_output=True,
-        shell=True,
-        text=True,
-        cwd=tmpdir,
-    )
+def test_error_import_from_class(tmp_path, classname, thing, kind):
+    (tmp_path / "mycode.py").write_text(CLASS_CODE_TO_TEST, encoding="utf-8")
+    result = run(f"hypothesis write mycode.{classname}.XX", cwd=tmp_path)
     msg = f"Error: Found the 'mycode' module{thing}, but it doesn't have a 'XX' {kind}."
     assert result.returncode == 2
     assert msg in result.stderr
 
 
-def test_magic_discovery_from_module(tmpdir):
-    (tmpdir / "mycode.py").write(CLASS_CODE_TO_TEST)
-    result = subprocess.run(
-        f"hypothesis write mycode",
-        capture_output=True,
-        shell=True,
-        text=True,
-        cwd=tmpdir,
-    )
+def test_magic_discovery_from_module(tmp_path):
+    (tmp_path / "mycode.py").write_text(CLASS_CODE_TO_TEST, encoding="utf-8")
+    result = run(f"hypothesis write mycode", cwd=tmp_path)
     assert result.returncode == 0
     assert "my_func" in result.stdout
     assert "MyClass.my_staticmethod" in result.stdout
@@ -223,15 +195,9 @@ class OtherClass:
 """
 
 
-def test_roundtrip_correct_pairs(tmpdir):
-    (tmpdir / "mycode.py").write(ROUNDTRIP_CODE_TO_TEST)
-    result = subprocess.run(
-        f"hypothesis write mycode",
-        capture_output=True,
-        shell=True,
-        text=True,
-        cwd=tmpdir,
-    )
+def test_roundtrip_correct_pairs(tmp_path):
+    (tmp_path / "mycode.py").write_text(ROUNDTRIP_CODE_TO_TEST, encoding="utf-8")
+    result = run(f"hypothesis write mycode", cwd=tmp_path)
     assert result.returncode == 0
     for scope1, scope2 in itertools.product(
         ["mycode.MyClass", "mycode.OtherClass", "mycode"], repeat=2
@@ -244,15 +210,9 @@ def test_roundtrip_correct_pairs(tmpdir):
             assert round_trip_code not in result.stdout
 
 
-def test_empty_module_is_not_error(tmpdir):
-    (tmpdir / "mycode.py").write("# Nothing to see here\n")
-    result = subprocess.run(
-        "hypothesis write mycode",
-        capture_output=True,
-        shell=True,
-        text=True,
-        cwd=tmpdir,
-    )
+def test_empty_module_is_not_error(tmp_path):
+    (tmp_path / "mycode.py").write_text("# Nothing to see here\n", encoding="utf-8")
+    result = run("hypothesis write mycode", cwd=tmp_path)
     assert result.returncode == 0
     assert "Error: " not in result.stderr
     assert "# Found no testable functions" in result.stdout

--- a/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py
+++ b/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py
@@ -53,6 +53,7 @@ def write_for(mod):
             capture_output=True,
             timeout=10,
             text=True,
+            encoding="utf-8",
         )
     except subprocess.SubprocessError as e:
         # Only report the error if we could load _but not process_ the module

--- a/hypothesis-python/tests/pytest/test_pytest_detection.py
+++ b/hypothesis-python/tests/pytest/test_pytest_detection.py
@@ -24,9 +24,9 @@ assert not core.running_under_pytest
 """
 
 
-def test_is_not_running_under_pytest(tmpdir):
-    pyfile = tmpdir.join("test.py")
-    pyfile.write(FILE_TO_RUN)
+def test_is_not_running_under_pytest(tmp_path):
+    pyfile = tmp_path.joinpath("test.py")
+    pyfile.write_text(FILE_TO_RUN, encoding="utf-8")
     subprocess.check_call([sys.executable, str(pyfile)])
 
 

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -15,6 +15,7 @@ passenv=
     # Allow CI builds (or user builds) to force coloured terminal output.
     PY_COLORS
 setenv=
+    # PYTHONWARNDEFAULTENCODING=1  # TODO: enable this
     brief: HYPOTHESIS_PROFILE=speedy
 commands =
     full: bash scripts/basic-test.sh


### PR DESCRIPTION
Adds the `PYTHONWARNDEFAULTENCODING=1` to tox.ini as an env variable to enable warnings for encodings.  See also https://peps.python.org/pep-0597/