### PR TITLE
WIP: explain-mode for parts of arguments

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch teaches the :ref:`explain phase <phases>` to comment on sub-parts
+from the :func:`~hypothesis.strategies.builds`, :func:`~hypothesis.strategies.tuples`,
+and :func:`~hypothesis.strategies.fixed_dictionaries` strategies.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -93,8 +93,10 @@ class BuildContext:
             start_idx = self.data.index
             obj = self.data.draw(s)
             end_idx = self.data.index
-            assert k is not None
-            kwargs[k] = obj
+            if k:
+                kwargs[k] = obj
+            else:
+                args.append(obj)
 
             # This high up the stack, we can't see or really do much with the conjecture
             # Example objects - not least because they're only materialized after the

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -518,6 +518,11 @@ class Shrinker:
         for start, end in sorted(
             self.shrink_target.arg_slices, key=lambda x: (-(x[1] - x[0]), x)
         ):
+            if any(
+                s <= start and end <= e  # subset of a slice we already know varies
+                for s, e in self.shrink_target.slice_comments
+            ):
+                continue
             # Check for any previous examples that match the prefix and suffix,
             # so we can skip if we found a passing example while shrinking.
             if any(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -11,6 +11,7 @@
 import copy
 from typing import Any, Iterable, Tuple, overload
 
+from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
@@ -28,6 +29,11 @@ from hypothesis.strategies._internal.strategies import (
     filter_not_satisfied,
 )
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
+from hypothesis.vendor.pretty import (
+    IDKey,
+    _dict_pprinter_factory,
+    _seq_pprinter_factory,
+)
 
 
 class TupleStrategy(SearchStrategy):
@@ -55,7 +61,16 @@ class TupleStrategy(SearchStrategy):
         return all(recur(e) for e in self.element_strategies)
 
     def do_draw(self, data):
-        return tuple(data.draw(e) for e in self.element_strategies)
+        context = current_build_context()
+        assert data is context.data
+        args, _, arg_labels = context.prep_args_kwargs_from_strategies(
+            self.element_strategies, {}
+        )
+        result = tuple(args)
+        context.known_object_printers[IDKey(result)].append(
+            _seq_pprinter_factory("(", ")", tuple, arg_labels=arg_labels)
+        )
+        return result
 
     def calc_is_empty(self, recur):
         return any(recur(e) for e in self.element_strategies)
@@ -301,7 +316,13 @@ class FixedKeysDictStrategy(MappedSearchStrategy):
         return f"FixedKeysDictStrategy({self.keys!r}, {self.mapped_strategy!r})"
 
     def pack(self, value):
-        return self.dict_type(zip(self.keys, value))
+        result = self.dict_type(zip(self.keys, value))
+        known_printers = current_build_context().known_object_printers
+        arg_labels = known_printers[IDKey(value)][-1].arg_labels
+        known_printers[IDKey(result)].append(
+            _dict_pprinter_factory({k: arg_labels[i] for i, k in enumerate(self.keys)})
+        )
+        return result
 
 
 class FixedAndOptionalKeysDictStrategy(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -319,9 +319,10 @@ class FixedKeysDictStrategy(MappedSearchStrategy):
         result = self.dict_type(zip(self.keys, value))
         known_printers = current_build_context().known_object_printers
         arg_labels = known_printers[IDKey(value)][-1].arg_labels
-        known_printers[IDKey(result)].append(
-            _dict_pprinter_factory({k: arg_labels[i] for i, k in enumerate(self.keys)})
-        )
+        # `if i in arg_labels` because some, e.g. generated with st.just(), don't have
+        # a corresponding part of the underlying buffer and therefore have no label.
+        klabels = {k: arg_labels[i] for i, k in enumerate(self.keys) if i in arg_labels}
+        known_printers[IDKey(result)].append(_dict_pprinter_factory(klabels))
         return result
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1013,8 +1013,11 @@ class BuildsStrategy(SearchStrategy):
         self.kwargs = kwargs
 
     def do_draw(self, data):
-        args = [data.draw(a) for a in self.args]
-        kwargs = {k: data.draw(v) for k, v in self.kwargs.items()}
+        context = current_build_context()
+        assert data is context.data, (data, context, context.data)
+        args, kwargs, arg_labels = context.prep_args_kwargs_from_strategies(
+            self.args, self.kwargs
+        )
         try:
             obj = self.target(*args, **kwargs)
         except TypeError as err:
@@ -1046,7 +1049,7 @@ class BuildsStrategy(SearchStrategy):
                 ) from err
             raise
 
-        current_build_context().record_call(obj, self.target, args, kwargs)
+        context.record_call(obj, self.target, args, kwargs, arg_labels)
         return obj
 
     def validate(self):

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -554,9 +554,9 @@ def _seq_pprinter_factory(start, end, basetype, arg_labels=None):
                     p.text(",")
                 # Optional comments are used to annotate which-parts-matter
                 if idx in comments:
-                    p.text(f"  # {comments[idx]}")
+                    p.text(f"  # {comments[idx]}")  # FIXME: uncovered
         if obj and force_split:
-            p.break_()
+            p.break_()  # FIXME: uncovered
         p.text(end)  # after dedent, if any
 
     inner.arg_labels = arg_labels
@@ -632,7 +632,7 @@ def _dict_pprinter_factory(arg_labels=None):
                 warnings.simplefilter("ignore", BytesWarning)
                 for idx, key in p._enumerate(obj):
                     if force_split:
-                        p.break_()
+                        p.break_()  # FIXME: uncovered
                     else:
                         p.breakable(" " if idx else "")
                     p.pretty(key)
@@ -642,9 +642,9 @@ def _dict_pprinter_factory(arg_labels=None):
                         p.text(",")
                     # Optional comments are used to annotate which-parts-matter
                     if key in comments:
-                        p.text(f"  # {comments[key]}")
+                        p.text(f"  # {comments[key]}")  # FIXME: uncovered
         if obj and force_split:
-            p.break_()
+            p.break_()  # FIXME: uncovered
         p.text("}")  # after dedent, if any
 
     inner.__name__ = "_dict_pprinter_factory()"

--- a/hypothesis-python/tests/cover/test_inquisitor.py
+++ b/hypothesis-python/tests/cover/test_inquisitor.py
@@ -1,0 +1,67 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from hypothesis import given, strategies as st
+
+from tests.conjecture.test_inquisitor import fails_with_output
+
+# @fails_with_output(
+#     """
+# Falsifying example: test_inquisitor_tuple(
+#     abc=(
+#         '',  # or any other generated value
+#         '',  # or any other generated value
+#         '',  # or any other generated value
+#     )
+# )
+# # The test sometimes passed when commented parts were varied together.
+# """
+# )
+# @given(st.tuples(st.text(), st.text(), st.text()))
+# def test_inquisitor_tuple(abc):
+#     assert all(abc)
+
+
+# @fails_with_output(
+#     """
+# Falsifying example: test_inquisitor_fixeddict(
+#     abc={
+#         'a': '',  # or any other generated value
+#         'b': '',  # or any other generated value
+#         'c': '',  # or any other generated value
+#     }
+# )
+# # The test sometimes passed when commented parts were varied together.
+# """
+# )
+# @given(st.fixed_dictionaries({"a": st.text(), "b": st.text(), "c": st.text()}))
+# def test_inquisitor_fixeddict(abc):
+#     assert all(abc.values())
+
+
+def fn(*args, **kwargs):
+    return [*args, *kwargs.values()]
+
+
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_fixeddict(
+    abc=fn(
+        '',  # or any other generated value
+        b='',  # or any other generated value
+        c='',  # or any other generated value
+    )
+)
+# The test sometimes passed when commented parts were varied together.
+"""
+)
+@given(st.builds(fn, st.text(), b=st.text(), c=st.text()))
+def test_inquisitor_builds(abc):
+    assert all(abc)

--- a/hypothesis-python/tests/cover/test_inquisitor.py
+++ b/hypothesis-python/tests/cover/test_inquisitor.py
@@ -12,38 +12,39 @@ from hypothesis import given, strategies as st
 
 from tests.conjecture.test_inquisitor import fails_with_output
 
-# @fails_with_output(
-#     """
-# Falsifying example: test_inquisitor_tuple(
-#     abc=(
-#         '',  # or any other generated value
-#         '',  # or any other generated value
-#         '',  # or any other generated value
-#     )
-# )
-# # The test sometimes passed when commented parts were varied together.
-# """
-# )
-# @given(st.tuples(st.text(), st.text(), st.text()))
-# def test_inquisitor_tuple(abc):
-#     assert all(abc)
+
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_tuple(
+    abc=(
+        '',  # or any other generated value
+        '',  # or any other generated value
+        '',  # or any other generated value
+    )
+)
+# The test sometimes passed when commented parts were varied together.
+"""
+)
+@given(st.tuples(st.text(), st.text(), st.text()))
+def test_inquisitor_tuple(abc):
+    assert all(abc)
 
 
-# @fails_with_output(
-#     """
-# Falsifying example: test_inquisitor_fixeddict(
-#     abc={
-#         'a': '',  # or any other generated value
-#         'b': '',  # or any other generated value
-#         'c': '',  # or any other generated value
-#     }
-# )
-# # The test sometimes passed when commented parts were varied together.
-# """
-# )
-# @given(st.fixed_dictionaries({"a": st.text(), "b": st.text(), "c": st.text()}))
-# def test_inquisitor_fixeddict(abc):
-#     assert all(abc.values())
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_fixeddict(
+    abc={
+        'a': '',  # or any other generated value
+        'b': '',  # or any other generated value
+        'c': '',  # or any other generated value
+    }
+)
+# The test sometimes passed when commented parts were varied together.
+"""
+)
+@given(st.fixed_dictionaries({"a": st.text(), "b": st.text(), "c": st.text()}))
+def test_inquisitor_fixeddict(abc):
+    assert all(abc.values())
 
 
 def fn(*args, **kwargs):
@@ -52,7 +53,7 @@ def fn(*args, **kwargs):
 
 @fails_with_output(
     """
-Falsifying example: test_inquisitor_fixeddict(
+Falsifying example: test_inquisitor_builds(
     abc=fn(
         '',  # or any other generated value
         b='',  # or any other generated value


### PR DESCRIPTION
This currently-broken spike aims to extend #3555 (original issue: #3411) to report on sub-parts of arguments.  Because this only makes sense for fixed-size collections - otherwise the minimal failing example would omit that part, so there'd be nothing to report on - we'll implement it for arguments to `st.builds()`, elements of `st.tuples()`, and for the non-optional keys in`st.fixed_dictionaries()`. 

Not a top priority right now, so I'm opening this just to mark where it's up to and ensure that we don't lose any progress.

---------

Because this means we might have *many* more reportable spans to report on, it might also require some performance optimizations.  The two obvious big ones are: 

1. refactor `ConjectureData` to natively support vary-this-span, which would save up to 50% of runtime when we retry on changed span size
   - easier: for changed-length spans, we can skip the retry if it's shorter on the assumption that valid shrinks have already been tried.  Maybe we can also use `generate_novel_prefix()` here, and exploit lexical ordering the same way?
3. reduce the number of failing examples we require before concluding that a part can vary.  
   - this is currently 100, but we could accept a higher false-report rate to go faster
   - or incorporate a time-based heuristic so that we only make that trade when the runtime would otherwise be too long.  For example, order the parts to check by nesting depth, abort at $timeout, and discard reports for the incomplete depth (or abort after finishing the current depth or a further timeout).