### PR TITLE
Improved error messages for incompatible datetime & timedelta dtypes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch provides better error messages for datetime- and timedelta-related
+invalid dtypes in our Pandas extra (:issue:`3518`).
+Thanks to Nick Muoh at the PyCon Sprints!

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -18,16 +18,6 @@ Hypothesis 6.x
 
     .. include:: ../RELEASE.rst
 
-.. _v6.73.1:
-
--------------------
-6.73.1 - 2023-04-27
--------------------
-
-This patch updates our minimum Numpy version to 1.16, and restores compatibility
-with versions before 1.20, which were broken by a mistake in Hypothesis 6.72.4
-(:issue:`3625`).
-
 .. _v6.74.0:
 
 -------------------
@@ -37,6 +27,16 @@ with versions before 1.20, which were broken by a mistake in Hypothesis 6.72.4
 This release adds support for `nullable pandas dtypes <https://pandas.pydata.org/docs/user_guide/integer_na.html>`__
 in :func:`~hypothesis.extra.pandas` (:issue:`3604`).
 Thanks to Cheuk Ting Ho for implementing this at the PyCon sprints!
+
+.. _v6.73.1:
+
+-------------------
+6.73.1 - 2023-04-27
+-------------------
+
+This patch updates our minimum Numpy version to 1.16, and restores compatibility
+with versions before 1.20, which were broken by a mistake in Hypothesis 6.72.4
+(:issue:`3625`).
 
 .. _v6.73.0:
 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -92,8 +92,15 @@ def elements_and_dtype(elements, dtype, source=None):
         )
 
     if isinstance(dtype, type) and np.dtype(dtype).kind == "O" and dtype is not object:
+        err_msg = f"Passed dtype={dtype!r} is not a valid Pandas dtype."
+        if issubclass(dtype, datetime):
+            err_msg += ' To generate valid datetimes, pass `dtype="datetime64[ns]"`'
+            raise InvalidArgument(err_msg)
+        elif issubclass(dtype, timedelta):
+            err_msg += ' To generate valid timedeltas, pass `dtype="timedelta64[ns]"`'
+            raise InvalidArgument(err_msg)
         note_deprecation(
-            f"Passed dtype={dtype!r} is not a valid Pandas dtype.  We'll treat it as "
+            f"{err_msg}  We'll treat it as "
             "dtype=object for now, but this will be an error in a future version.",
             since="2021-12-31",
             has_codemod=False,

--- a/hypothesis-python/src/hypothesis/version.py
+++ b/hypothesis-python/src/hypothesis/version.py
@@ -8,5 +8,5 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-__version_info__ = (6, 73, 1)
+__version_info__ = (6, 74, 0)
 __version__ = ".".join(map(str, __version_info__))

--- a/hypothesis-python/tests/pandas/test_argument_validation.py
+++ b/hypothesis-python/tests/pandas/test_argument_validation.py
@@ -8,7 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from datetime import datetime
+import re
+from datetime import datetime, timedelta
 
 import pandas as pd
 import pytest
@@ -126,3 +127,17 @@ def test_pandas_nullable_types_class():
     ):
         st = pdst.series(dtype=pd.core.arrays.integer.Int8Dtype)
         find_any(st, lambda s: s.isna().any())
+
+
+@pytest.mark.parametrize(
+    "dtype_,expected_unit",
+    [
+        (datetime, "datetime64[ns]"),
+        (pd.Timestamp, "datetime64[ns]"),
+        (timedelta, "timedelta64[ns]"),
+        (pd.Timedelta, "timedelta64[ns]"),
+    ],
+)
+def test_invalid_datetime_or_timedelta_dtype_raises_error(dtype_, expected_unit):
+    with pytest.raises(InvalidArgument, match=re.escape(expected_unit)):
+        pdst.series(dtype=dtype_).example()

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -97,6 +97,9 @@ def update_changelog_and_version():
             assert CHANGELOG_BORDER.match(lines[i + 2]), repr(lines[i + 2])
             assert CHANGELOG_HEADER.match(lines[i + 3]), repr(lines[i + 3])
             assert CHANGELOG_BORDER.match(lines[i + 4]), repr(lines[i + 4])
+            assert lines[i + 3].startswith(
+                __version__
+            ), f"{__version__=}   {lines[i + 3]=}"
             beginning = "\n".join(lines[:i])
             rest = "\n".join(lines[i:])
             assert "\n".join((beginning, rest)) == contents


### PR DESCRIPTION
This fixes #3518. It picks up where the previous PR left off, and so closes #3580.