### PR TITLE
Raise AttributeError in errors module

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+``hypothesis.errors`` will now raise :py:exc:`AttributeError` when attempting
+to access an undefined attribute, rather than returning :py:obj:`None`.

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -132,6 +132,8 @@ def __getattr__(name):
         )
         return BaseExceptionGroup
 
+    raise AttributeError(f"Module 'hypothesis.errors' has no attribute {name}")
+
 
 class DeadlineExceeded(_Trimmable):
     """Raised when an individual test body has taken too long to run."""

--- a/hypothesis-python/tests/cover/test_escalation.py
+++ b/hypothesis-python/tests/cover/test_escalation.py
@@ -72,5 +72,10 @@ def test_multiplefailures_deprecation():
     assert exc is BaseExceptionGroup
 
 
+def test_errors_attribute_error():
+    with pytest.raises(AttributeError):
+        errors.ThisIsNotARealAttributeDontCreateSomethingWithThisName
+
+
 def test_handles_null_traceback():
     esc.get_interesting_origin(Exception())


### PR DESCRIPTION
Previously, `hypothesis.errors` would return `None` when any arbitrary attribute was accessed.

This should fix the issue we are seeing in [running CPython's test suite](https://github.com/python/cpython/pull/22863#issuecomment-1529085181).