### PR TITLE
Improve Github Artifacts database

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
 Improved the documentation regarding how to use :class:`~hypothesis.database.GitHubArtifactDatabase`
-and fixed an bug that occured in repositories with no existing artifacts.
+and fixed a bug that occurred in repositories with no existing artifacts.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Improved the documentation regarding how to use :class:`~hypothesis.database.GitHubArtifactDatabase`
+and fixed an bug that occured in repositories with no existing artifacts.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -2,3 +2,5 @@ RELEASE_TYPE: patch
 
 Improved the documentation regarding how to use :class:`~hypothesis.database.GitHubArtifactDatabase`
 and fixed a bug that occurred in repositories with no existing artifacts.
+
+Thanks to Agustín Covarrubias for this contribution.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -349,7 +349,7 @@ class GitHubArtifactDatabase(ExampleDatabase):
 
     .. note::
         You must provide `GITHUB_TOKEN` as an environment variable. In CI, Github Actions provides
-        this automatically, but you need to set it manually if you're running locally. In a developer machine,
+        this automatically, but it needs to be set manually for local usage. In a developer machine,
         this would usually be a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_.
         If the repository is private, it's necessary for the token to have `repo` scope
         in the case of a classic token, or `actions:read` in the case of a fine-grained token.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -568,11 +568,16 @@ class GitHubArtifactDatabase(ExampleDatabase):
         response_bytes = self._get_bytes(url)
         if response_bytes is None:
             return None
+
         artifacts = json.loads(response_bytes)["artifacts"]
+        artifacts = filter(lambda a: a["name"] == self.artifact_name, artifacts)
+
+        if not artifacts:
+            return None
 
         # Get the latest artifact from the list
         artifact = sorted(
-            filter(lambda a: a["name"] == self.artifact_name, artifacts),
+            artifacts,
             key=lambda a: a["created_at"],
         )[-1]
 

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -380,22 +380,22 @@ class GitHubArtifactDatabase(ExampleDatabase):
     .. code-block:: yaml
 
         - name: Download example database
-            uses: dawidd6/action-download-artifact@v2.24.3
-            with:
-                name: hypothesis-example-db
-                path: .hypothesis/examples
-                if_no_artifact_found: warn
-                workflow_conclusion: completed
+          uses: dawidd6/action-download-artifact@v2.24.3
+          with:
+            name: hypothesis-example-db
+            path: .hypothesis/examples
+            if_no_artifact_found: warn
+            workflow_conclusion: completed
 
         - name: Run tests
-            run: pytest
+          run: pytest
 
         - name: Upload example database
-            uses: actions/upload-artifact@v3
-            if: always()
-            with:
-                name: hypothesis-example-db
-                path: .hypothesis/examples
+          uses: actions/upload-artifact@v3
+          if: always()
+          with:
+            name: hypothesis-example-db
+            path: .hypothesis/examples
 
     In this workflow, we use `dawidd6/action-download-artifact <https://github.com/dawidd6/action-download-artifact>`_
     to download the latest artifact given that the official `actions/download-artifact <https://github.com/actions/download-artifact>`_

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -601,18 +601,15 @@ class GitHubArtifactDatabase(ExampleDatabase):
             return None
 
         artifacts = json.loads(response_bytes)["artifacts"]
-        artifacts = filter(lambda a: a["name"] == self.artifact_name, artifacts)
+        artifacts = [a for a in artifacts if a["name"] == self.artifact_name]
 
         if not artifacts:
             return None
 
         # Get the latest artifact from the list
-        artifact = sorted(
-            artifacts,
-            key=lambda a: a["created_at"],
-        )[-1]
-
+        artifact = max(artifacts, key=lambda a: a["created_at"])
         url = artifact["archive_download_url"]
+
         # Download the artifact
         artifact_bytes = self._get_bytes(url)
         if artifact_bytes is None:

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -348,7 +348,7 @@ class GitHubArtifactDatabase(ExampleDatabase):
     and developers can reproduce them locally without any manual effort.
 
     .. note::
-        You must provide `GITHUB_TOKEN` as an environment variable. In CI, Github Actions provides
+        You must provide ``GITHUB_TOKEN`` as an environment variable. In CI, Github Actions provides
         this automatically, but it needs to be set manually for local usage. In a developer machine,
         this would usually be a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_.
         If the repository is private, it's necessary for the token to have `repo` scope

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -347,6 +347,14 @@ class GitHubArtifactDatabase(ExampleDatabase):
     where the CI system can upload the resulting database as an artifact after each run,
     allowing developers to reproduce any failures by just running hypothesis.
 
+    .. note::
+        You must provide `GITHUB_TOKEN` as an environment variable. In CI, Github Actions provides
+        this automatically, but you need to set it manually if you're running locally. In a developer machine,
+        this would usually be a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_.
+        If the repository is private, it's necessary for the token to have `repo` scope
+        in the case of a classic token, or `actions:read` in the case of a fine-grained token.
+
+
     In most cases, this will be used
     through the :class:`~hypothesis.database.MultiplexedDatabase`,
     by combining a local directory-based database with this one. For example:
@@ -365,10 +373,6 @@ class GitHubArtifactDatabase(ExampleDatabase):
     .. note::
         Because this database is read-only, you always need to wrap it with the
         :class:`ReadOnlyDatabase`.
-
-    If you're using a private repository, you must provide `GITHUB_TOKEN` as an environment variable,
-    which would usually be a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
-    with the `repo` scope.
 
     The database automatically implements a simple file-based cache with a default expiration period
     of 1 day. You can adjust this through the `cache_timeout` property.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -378,6 +378,7 @@ class GitHubArtifactDatabase(ExampleDatabase):
     something like the following:
 
     .. code-block:: yaml
+
         - name: Download example database
             uses: dawidd6/action-download-artifact@v2.24.3
             with:

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -570,8 +570,7 @@ class GitHubArtifactDatabase(ExampleDatabase):
             if e.code == 401:
                 warning_message = (
                     "Authorization failed when trying to download artifact from GitHub. "
-                    "Check your $GITHUB_TOKEN environment variable "
-                    "or make the repository public."
+                    "Check that you have a valid GITHUB_TOKEN set in your environment."
                 )
             else:
                 warning_message = (


### PR DESCRIPTION
As a follow-up on #3576, I've added some improvements to the artifacts database:

- [X] Fixed a bug that was triggered on repositories without any pre-existing artifacts
- [X] Clarified the documentation on the use of tokens, given that public access still requires a personal token.
- [x] Added an example of an Actions workflow using the database.

For now, I've decided to only exemplify basic workflows that enable sharing the example database of normal hypothesis runs (essentially making replication of CI failures a little faster). 

Hypofuzz isn't supported yet, as we still need to figure out the data race, plus update Hypofuzz to support changes in Hypothesis's internal API.