### PR TITLE
Remove misplaced colon in tests/array_api/common.py __all__

### DIFF
--- a/hypothesis-python/tests/array_api/common.py
+++ b/hypothesis-python/tests/array_api/common.py
@@ -22,7 +22,7 @@ from hypothesis.extra.array_api import (
 from hypothesis.internal.floats import next_up
 
 __all__ = [
-    "MIN_VER_FOR_COMPLEX:",
+    "MIN_VER_FOR_COMPLEX",
     "installed_array_modules",
     "flushes_to_zero",
     "dtype_name_params",


### PR DESCRIPTION
This comma was copied from line 32 and pasted here but it does not belong in the `__all__` list.