### PR TITLE
Replace flake8 and its plugins with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,6 +15,6 @@ ignore =
     B008,B011,
     # flake8-bandit security warnings we disagree with or don't mind
     S101,S102,S105,S110,S307,S311,S404,S6
-select =
+extend-select =
     # enable checks for self-or-cls param name, use of raise-from
     B902,B904

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+Ruff supports over 500 lint rules and can be used to replace Flake8 (plus dozens of
+plugins), isort, pydocstyle, yesqa, eradicate, pyupgrade, and autoflake, all while
+executing (in Rust) tens or hundreds of times faster than any individual tool.
+- https://ruff.rs

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
-Ruff supports over 500 lint rules and can be used to replace Flake8 (plus dozens of
-plugins), isort, pydocstyle, yesqa, eradicate, pyupgrade, and autoflake, all while
-executing (in Rust) tens or hundreds of times faster than any individual tool.
-- https://ruff.rs
+
+This patch updates our linter stack to use :pypi:`ruff`, and fixes some
+previously-ignored lints.  Thanks to Christian Clauss for his careful
+review and :pull:`3651`!

--- a/hypothesis-python/src/_hypothesis_ftz_detector.py
+++ b/hypothesis-python/src/_hypothesis_ftz_detector.py
@@ -145,5 +145,5 @@ if __name__ == "__main__":
     # To test without skipping to a known answer, uncomment the following line and
     # change the last element of key from `name` to `-len(name)` so that we check
     # grequests before gevent.
-    ## KNOWN_EVER_CULPRITS = [c for c in KNOWN_EVER_CULPRITS if c != "gevent"]
+    # # KNOWN_EVER_CULPRITS = [c for c in KNOWN_EVER_CULPRITS if c != "gevent"]
     print(identify_ftz_culprits())

--- a/hypothesis-python/src/_hypothesis_ftz_detector.py
+++ b/hypothesis-python/src/_hypothesis_ftz_detector.py
@@ -145,5 +145,5 @@ if __name__ == "__main__":
     # To test without skipping to a known answer, uncomment the following line and
     # change the last element of key from `name` to `-len(name)` so that we check
     # grequests before gevent.
-    # # KNOWN_EVER_CULPRITS = [c for c in KNOWN_EVER_CULPRITS if c != "gevent"]
+    # KNOWN_EVER_CULPRITS = [c for c in KNOWN_EVER_CULPRITS if c != "gevent"]
     print(identify_ftz_culprits())

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -190,7 +190,7 @@ else:
         from hypothesis import core
         from hypothesis.internal.detection import is_hypothesis_test
 
-        ## See https://github.com/pytest-dev/pytest/issues/9159
+        # See https://github.com/pytest-dev/pytest/issues/9159
         # TODO: add `pytest_version >= (7, 2) or` once the issue above is fixed.
         core.pytest_shows_exceptiongroups = (
             item.config.getoption("tbstyle", "auto") == "native"
@@ -221,7 +221,7 @@ else:
                 ("reproduce_example", "_hypothesis_internal_use_reproduce_failure"),
             ]:
                 if hasattr(item.obj, attribute):
-                    from hypothesis.errors import InvalidArgument
+                    from hypothesis.errors import InvalidArgument  # noqa: F811
 
                     raise_hypothesis_usage_error(message % (name,))
             yield
@@ -237,7 +237,9 @@ else:
             # work, the test object is probably something weird
             # (e.g a stateful test wrapper), so we skip the function-scoped
             # fixture check.
-            settings = getattr(item.obj, "_hypothesis_internal_use_settings", None)
+            settings = getattr(  # noqa: F811
+                item.obj, "_hypothesis_internal_use_settings", None
+            )
 
             # Check for suspicious use of function-scoped fixtures, but only
             # if the corresponding health check is not suppressed.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -465,7 +465,7 @@ class HealthCheck(Enum, metaclass=HealthCheckMeta):
     def all(cls) -> List["HealthCheck"]:
         # Skipping of deprecated attributes is handled in HealthCheckMeta.__iter__
         note_deprecation(
-            f"`Healthcheck.all()` is deprecated; use `list(HealthCheck)` instead.",
+            "`Healthcheck.all()` is deprecated; use `list(HealthCheck)` instead.",
             since="2023-04-16",
             has_codemod=True,
         )

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -50,7 +50,7 @@ try:
     from typing import get_origin as get_origin
 except ImportError:
     # remove at Python 3.7 end-of-life
-    from collections.abc import Callable as _Callable
+    from collections.abc import Callable as _Callable  # noqa: F811
 
     def get_origin(tp: Any) -> typing.Optional[Any]:  # type: ignore # pragma: no cover
         """Get the unsubscripted version of a type.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -11,6 +11,8 @@
 from bisect import bisect_right, insort
 from collections import Counter
 
+import attr
+
 from hypothesis.errors import InvalidState
 from hypothesis.internal.conjecture.dfa import DFA, cached
 from hypothesis.internal.conjecture.junkdrawer import (
@@ -77,8 +79,6 @@ is somewhat intrinsic. We should only use it in testing or for
 learning languages offline that we can record for later use.
 
 """
-
-import attr  # noqa: E402
 
 
 @attr.s(slots=True)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/dfa/lstar.py
@@ -78,7 +78,7 @@ learning languages offline that we can record for later use.
 
 """
 
-import attr
+import attr  # noqa: E402
 
 
 @attr.s(slots=True)

--- a/hypothesis-python/tests/array_api/common.py
+++ b/hypothesis-python/tests/array_api/common.py
@@ -22,7 +22,7 @@ from hypothesis.extra.array_api import (
 from hypothesis.internal.floats import next_up
 
 __all__ = [
-    "MIN_VER_FOR_COMPLEX:",
+    "MIN_VER_FOR_COMPLEX",
     "installed_array_modules",
     "flushes_to_zero",
     "dtype_name_params",

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -540,7 +540,7 @@ def test_required_args(target, args, kwargs, expected):
 
 
 # fmt: off
-pi = "π"; is_str_pi = lambda x: x == pi  # noqa: E731
+pi = "π"; is_str_pi = lambda x: x == pi  # noqa: E702,E731
 # fmt: on
 
 

--- a/hypothesis-python/tests/ghostwriter/example_code/future_annotations.py
+++ b/hypothesis-python/tests/ghostwriter/example_code/future_annotations.py
@@ -30,5 +30,5 @@ def merge_dicts(
     return {**map1, **map2}
 
 
-def invalid_types(attr1: int, attr2: UnknownClass, attr3: str) -> None:
+def invalid_types(attr1: int, attr2: UnknownClass, attr3: str) -> None:  # noqa: F821
     pass

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter_cli.py
@@ -156,7 +156,7 @@ def test_error_import_from_class(tmp_path, classname, thing, kind):
 
 def test_magic_discovery_from_module(tmp_path):
     (tmp_path / "mycode.py").write_text(CLASS_CODE_TO_TEST, encoding="utf-8")
-    result = run(f"hypothesis write mycode", cwd=tmp_path)
+    result = run("hypothesis write mycode", cwd=tmp_path)
     assert result.returncode == 0
     assert "my_func" in result.stdout
     assert "MyClass.my_staticmethod" in result.stdout
@@ -197,7 +197,7 @@ class OtherClass:
 
 def test_roundtrip_correct_pairs(tmp_path):
     (tmp_path / "mycode.py").write_text(ROUNDTRIP_CODE_TO_TEST, encoding="utf-8")
-    result = run(f"hypothesis write mycode", cwd=tmp_path)
+    result = run("hypothesis write mycode", cwd=tmp_path)
     assert result.returncode == 0
     for scope1, scope2 in itertools.product(
         ["mycode.MyClass", "mycode.OtherClass", "mycode"], repeat=2

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -12,7 +12,7 @@ import pytest
 
 from hypothesis import given
 from hypothesis.errors import Flaky
-from hypothesis.strategies import composite, integers
+from hypothesis.strategies import composite, integers, none
 
 
 @pytest.mark.parametrize(
@@ -36,7 +36,7 @@ def test_exception_propagates_fine_from_strategy(e):
         raise e
         # this line will not be executed, but must be here
         # to pass draw function static reference check
-        return draw(st.none())
+        return draw(none())
 
     @given(interrupt_eventually())
     def test_do_nothing(x):
@@ -105,7 +105,7 @@ from hypothesis import given, note, strategies as st
 @st.composite
 def things(draw):
     raise {exception}
-    # this line will not be executed, but must be here 
+    # this line will not be executed, but must be here
     # to pass draw function static reference check
     return draw(st.none())
 

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -258,7 +258,7 @@ def test_float_subnormal_generation(allow_subnormal, width):
         lambda n: n != 0
     )
     smallest_normal = width_smallest_normals[width]
-    condition = lambda n: -smallest_normal < n < smallest_normal
+    condition = lambda n: -smallest_normal < n < smallest_normal  # noqa: E731
     if allow_subnormal:
         find_any(strat, condition)
     else:
@@ -273,7 +273,7 @@ def test_complex_subnormal_generation(allow_subnormal, width):
         lambda n: n.real != 0 and n.imag != 0
     )
     smallest_normal = width_smallest_normals[width / 2]
-    condition = lambda n: (
+    condition = lambda n: (  # noqa: E731
         -smallest_normal < n.real < smallest_normal
         or -smallest_normal < n.imag < smallest_normal
     )

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -258,11 +258,10 @@ def test_float_subnormal_generation(allow_subnormal, width):
         lambda n: n != 0
     )
     smallest_normal = width_smallest_normals[width]
-    condition = lambda n: -smallest_normal < n < smallest_normal  # noqa: E731
     if allow_subnormal:
-        find_any(strat, condition)
+        find_any(strat, lambda n: -smallest_normal < n < smallest_normal)
     else:
-        assert_no_examples(strat, condition)
+        assert_no_examples(strat, lambda n: -smallest_normal < n < smallest_normal)
 
 
 @pytest.mark.parametrize("allow_subnormal", [False, True])
@@ -273,10 +272,13 @@ def test_complex_subnormal_generation(allow_subnormal, width):
         lambda n: n.real != 0 and n.imag != 0
     )
     smallest_normal = width_smallest_normals[width / 2]
-    condition = lambda n: (  # noqa: E731
-        -smallest_normal < n.real < smallest_normal
-        or -smallest_normal < n.imag < smallest_normal
-    )
+
+    def condition(n):
+        return (
+            -smallest_normal < n.real < smallest_normal
+            or -smallest_normal < n.imag < smallest_normal
+        )
+
     if allow_subnormal:
         find_any(strat, condition)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,10 @@
 [tool.ruff]
 select = [
   "ASYNC",  # flake8-async
-  "C90",    # McCabe cyclomatic complexity
   "E",      # pycodestyle
   "G",      # flake8-logging-format
   "INT",    # flake8-gettext
   "PLE",    # Pylint errors
-  "PLR091", # Pylint Refactor just for max-args, max-branches, etc.
-  "PYI",    # flake8-pyi
   "T10",    # flake8-debugger
   "TID",    # flake8-tidy-imports
   "UP",     # pyupgrade
@@ -49,24 +46,10 @@ select = [
   # "S",    # flake8-bandit
   # "SIM",  # flake8-simplify
   # "SLF",  # flake8-self
-  # "T20",  # flake8-print
   # "TCH",  # flake8-type-checking
   # "TD",   # flake8-todos
   # "TRY",  # tryceratops
 ]
-ignore = ["E731", "E741", "UP031"]
+ignore = ["E731", "E741", "S101", "UP031"]
 line-length = 125
 target-version = "py37"
-
-[tool.ruff.mccabe]
-max-complexity = 45
-
-[tool.ruff.pylint]
-max-args = 13
-max-branches = 44
-max-returns = 24
-max-statements = 124
-
-[tool.ruff.per-file-ignores]
-"hypothesis-python/tests/*" = ["S101"]
-"whole-repo-tests/*" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,72 @@
+[tool.ruff]
+select = [
+  "ASYNC",  # flake8-async
+  "C90",    # McCabe cyclomatic complexity
+  "E",      # pycodestyle
+  "G",      # flake8-logging-format
+  "INT",    # flake8-gettext
+  "PLE",    # Pylint errors
+  "PLR091", # Pylint Refactor just for max-args, max-branches, etc.
+  "PYI",    # flake8-pyi
+  "T10",    # flake8-debugger
+  "TID",    # flake8-tidy-imports
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "A",    # flake8-builtins
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "B",    # flake8-bugbear
+  # "BLE",  # flake8-blind-except
+  # "C4",   # flake8-comprehensions
+  # "COM",  # flake8-commas
+  # "D",    # pydocstyle
+  # "DJ",   # flake8-django
+  # "DTZ",  # flake8-datetimez
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "EXE",  # flake8-executable
+  # "F",    # Pyflakes
+  # "FA",   # flake8-future-annotations
+  # "FBT",  # flake8-boolean-trap
+  # "FLY",  # flynt
+  # "I",    # isort
+  # "ICN",  # flake8-import-conventions
+  # "INP",  # flake8-no-pep420
+  # "ISC",  # flake8-implicit-str-concat
+  # "N",    # pep8-naming
+  # "NPY",  # NumPy-specific rules
+  # "PD",   # pandas-vet
+  # "PGH",  # pygrep-hooks
+  # "PIE",  # flake8-pie
+  # "PL",   # Pylint
+  # "PT",   # flake8-pytest-style
+  # "PTH",  # flake8-use-pathlib
+  # "Q",    # flake8-quotes
+  # "RET",  # flake8-return
+  # "RSE",  # flake8-raise
+  # "RUF",  # Ruff-specific rules
+  # "S",    # flake8-bandit
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TCH",  # flake8-type-checking
+  # "TD",   # flake8-todos
+  # "TRY",  # tryceratops
+]
+ignore = ["E731", "E741", "UP031"]
+line-length = 125
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 45
+
+[tool.ruff.pylint]
+max-args = 13
+max-branches = 44
+max-returns = 24
+max-statements = 124
+
+[tool.ruff.per-file-ignores]
+"hypothesis-python/tests/*" = ["S101"]
+"whole-repo-tests/*" = ["S101"]

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -8,13 +8,10 @@ alabaster==0.7.13
     # via sphinx
 asgiref==3.6.0
     # via django
-astor==0.8.1
-    # via flake8-simplify
 asttokens==2.2.1
     # via stack-data
 attrs==23.1.0
     # via
-    #   flake8-bugbear
     #   hypothesis (hypothesis-python/setup.py)
 autoflake==2.1.1
     # via shed
@@ -22,8 +19,6 @@ babel==2.12.1
     # via sphinx
 backcall==0.2.0
     # via ipython
-bandit==1.7.5
-    # via flake8-bandit
 beautifulsoup4==4.12.2
     # via sphinx-codeautolink
 black==23.3.0
@@ -83,49 +78,7 @@ filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-flake8==6.0.0
-    # via
-    #   -r requirements/tools.in
-    #   flake8-2020
-    #   flake8-bandit
-    #   flake8-bugbear
-    #   flake8-builtins
-    #   flake8-comprehensions
-    #   flake8-datetimez
-    #   flake8-docstrings
-    #   flake8-mutable
-    #   flake8-noqa
-    #   flake8-simplify
-flake8-2020==1.8.0
-    # via -r requirements/tools.in
-flake8-bandit==4.1.1
-    # via -r requirements/tools.in
-flake8-bugbear==23.5.9
-    # via -r requirements/tools.in
-flake8-builtins==2.1.0
-    # via -r requirements/tools.in
-flake8-comprehensions==3.12.0
-    # via -r requirements/tools.in
-flake8-datetimez==20.10.0
-    # via -r requirements/tools.in
-flake8-docstrings==1.7.0
-    # via -r requirements/tools.in
-flake8-mutable==1.2.0
-    # via -r requirements/tools.in
-flake8-noqa==1.3.1
-    # via -r requirements/tools.in
-flake8-pie==0.16.0
-    # via -r requirements/tools.in
-flake8-plugin-utils==1.3.2
-    # via
-    #   flake8-pytest-style
-    #   flake8-return
-flake8-pytest-style==1.7.2
-    # via -r requirements/tools.in
-flake8-return==1.2.0
-    # via -r requirements/tools.in
-flake8-simplify==0.20.0
-    # via -r requirements/tools.in
+ruff==0.0.269
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
@@ -168,8 +121,6 @@ markupsafe==2.1.2
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
@@ -220,16 +171,11 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pycodestyle==2.10.0
-    # via flake8
 pycparser==2.21
     # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
 pyflakes==3.0.1
     # via
     #   autoflake
-    #   flake8
 pygments==2.15.1
     # via
     #   ipython
@@ -359,8 +305,6 @@ types-redis==4.5.5.2
 typing-extensions==4.5.0
     # via
     #   -r requirements/tools.in
-    #   flake8-noqa
-    #   flake8-pie
     #   libcst
     #   mypy
     #   typing-inspect

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -73,12 +73,7 @@ def codespell(*files):
 
 @task()
 def lint():
-    pip_tool(
-        "flake8",
-        *(f for f in tools.all_files() if f.endswith(".py")),
-        "--config",
-        os.path.join(tools.ROOT, ".flake8"),
-    )
+    pip_tool("ruff", "."),
     codespell(*(f for f in tools.all_files() if not f.endswith("by-domain.txt")))
 
 
@@ -331,7 +326,7 @@ def upgrade_requirements():
     if has_diff(hp.PYTHON_SRC) and not os.path.isfile(hp.RELEASE_FILE):
         msg = hp.get_autoupdate_message(domainlist_changed=has_diff(hp.DOMAINS_LIST))
         with open(hp.RELEASE_FILE, mode="w") as f:
-            f.write(f"RELEASE_TYPE: patch\n\n" + msg)
+            f.write(f"RELEASE_TYPE: patch\n\n{msg}")
     update_python_versions()
     subprocess.call(["git", "add", "."], cwd=tools.ROOT)
 

--- a/whole-repo-tests/test_rst_is_valid.py
+++ b/whole-repo-tests/test_rst_is_valid.py
@@ -31,6 +31,6 @@ def test_passes_rst_lint():
     pip_tool("rst-lint", *(f for f in ALL_RST if not is_sphinx(f)))
 
 
-def disabled_test_passes_ruff():
-    """How do we get ruff to test .rst files?!?"""
-    pip_tool("ruff", *ALL_RST)
+def disabled_test_passes_flake8():
+    # TODO: get these whitespace checks without flake8?
+    pip_tool("flake8", "--select=W191,W291,W292,W293,W391", *ALL_RST)

--- a/whole-repo-tests/test_rst_is_valid.py
+++ b/whole-repo-tests/test_rst_is_valid.py
@@ -31,5 +31,6 @@ def test_passes_rst_lint():
     pip_tool("rst-lint", *(f for f in ALL_RST if not is_sphinx(f)))
 
 
-def test_passes_flake8():
-    pip_tool("flake8", "--select=W191,W291,W292,W293,W391", *ALL_RST)
+def disabled_test_passes_ruff():
+    """How do we get ruff to test .rst files?!?"""
+    pip_tool("ruff", *ALL_RST)


### PR DESCRIPTION
Closes #3650

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

This PR could have replaced `autoflake` but it might be better to get used to `ruff --fix` before throwing that switch.