### PR TITLE
Support immutable arrays (i.e. JAX) in `extra.array_api`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+In preparation for supporting JAX in :ref:`hypothesis.extra.array_api <array-api>`,
+this release supports immutable arrays being generated via :func:`xps.arrays`.
+In particular, we internally removed an instance of in-place array modification,
+which isn't possible for an immutable array.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -1169,7 +1169,6 @@ if np is not None:
         full=np.full,
         zeros=np.zeros,
         ones=np.ones,
-        linspace=np.linspace,
         # Manipulation functions
         reshape=np.reshape,
         # Element-wise functions

--- a/hypothesis-python/tests/array_api/conftest.py
+++ b/hypothesis-python/tests/array_api/conftest.py
@@ -12,7 +12,7 @@ import warnings
 from importlib import import_module
 from os import getenv
 from types import ModuleType, SimpleNamespace
-from typing import Tuple
+from typing import List, Tuple
 
 import pytest
 
@@ -46,7 +46,7 @@ class InvalidArgumentWarning(UserWarning):
 
 
 name_to_entry_point = installed_array_modules()
-xp_and_xps_pairs: Tuple[ModuleType, SimpleNamespace] = []
+xp_and_xps_pairs: List[Tuple[ModuleType, SimpleNamespace]] = []
 with warnings.catch_warnings():
     # We ignore all warnings here as many array modules warn on import. Ideally
     # we would just ignore ImportWarning, but no one seems to use it!

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -425,7 +425,7 @@ def test_array_element_rewriting(xp, xps, data, start, size):
             unique=True,
         )
     )
-    x_set_expect = xp.linspace(start, start + size - 1, size, dtype=xp.int64)
+    x_set_expect = xp.arange(start, start + size, dtype=xp.int64)
     x_set = xp.sort(xp.unique_values(x))
     assert xp.all(x_set == x_set_expect)
 

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -47,7 +47,7 @@ def test_warning_on_noncompliant_xp():
 @pytest.mark.filterwarnings(f"ignore:.*{MOCK_WARN_MSG}.*")
 @pytest.mark.parametrize(
     "stratname, args, attr",
-    [("from_dtype", ["int8"], "iinfo"), ("arrays", ["int8", 5], "full")],
+    [("from_dtype", ["int8"], "iinfo"), ("arrays", ["int8", 5], "asarray")],
 )
 def test_error_on_missing_attr(stratname, args, attr):
     """Strategies raise helpful error when using array modules that lack

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import sys
 from copy import copy
 from types import SimpleNamespace
 from typing import Tuple
@@ -137,27 +136,3 @@ def test_raises_on_invalid_dunder_version():
     xp.__array_api_version__ = None
     with pytest.raises(InvalidArgument):
         make_strategies_namespace(xp)
-
-
-@pytest.mark.filterwarnings(f"ignore:.*{MOCK_WARN_MSG}.*")
-def test_patch_torch_full(monkeypatch):
-    """When xp is torch, full() is patched so xps.arrays() can work.
-
-    See https://github.com/HypothesisWorks/hypothesis/pull/3542
-    """
-    xp = make_mock_xp()
-    old_full = copy(xp.full)
-
-    def bad_full(shape, *a, **kw):
-        bad_full.__counter += 1
-        if isinstance(shape, int):
-            raise AttributeError("xp.full() has not been patched correctly")
-        return old_full(shape, *a, **kw)
-
-    bad_full.__counter = 0
-    xp.full = bad_full
-    with monkeypatch.context() as m:
-        m.setitem(sys.modules, "torch", xp)
-        xps = make_strategies_namespace(xp)
-        xps.arrays(xp.int8, 5).example()
-        assert bad_full.__counter > 0  # sanity check

--- a/hypothesis-python/tests/array_api/test_pretty.py
+++ b/hypothesis-python/tests/array_api/test_pretty.py
@@ -13,6 +13,7 @@ from inspect import signature
 import pytest
 
 from hypothesis.errors import InvalidArgument
+from hypothesis.extra import array_api
 from hypothesis.extra.array_api import make_strategies_namespace
 
 from tests.array_api.common import MIN_VER_FOR_COMPLEX
@@ -96,8 +97,9 @@ def test_inferred_version_strategies_namespace_repr(xp):
 
 
 @pytest.mark.filterwarnings("ignore::hypothesis.errors.HypothesisWarning")
-def test_specified_version_strategies_namespace_repr(xp):
+def test_specified_version_strategies_namespace_repr(xp, monkeypatch):
     """Strategies namespace has good repr when api_version is specified."""
+    monkeypatch.setattr(array_api, "_args_to_xps", {})  # ignore cached versions
     xps = make_strategies_namespace(xp, api_version="2021.12")
     expected = f"make_strategies_namespace({xp.__name__}, api_version='2021.12')"
     assert repr(xps) == expected


### PR DESCRIPTION
Currently we can't generate arrays for JAX, because we assign values to arrays but JAX arrays are immutable.

https://github.com/HypothesisWorks/hypothesis/blob/661af850bbfcb091a820eb16c84f56048c8e21c8/hypothesis-python/src/hypothesis/extra/array_api.py#L449

This PR has `array_api.ArrayStrategy` instead prepare a builtin list `result_obj` to be passed to `xp.asarray`. Makes it kinda annoying to still do our sanity checks (e.g. see introduction and usage of `fill_mask`), but seems quite palatable if it lets us support JAX. I'll mull over the implementation details anywho.

Running https://github.com/google/jax/pull/16099 on `tests/array_api/` via `HYPOTHESIS_TEST_ARRAY_API=jax.experimental.array_api pytest tests/array_api/` gets some errors, which I'll need to explore. FWIW it's okay if adopting libraries error on stuff because they don't comply with a specific feature, but it just needs investigating to make sure it isn't a bug in either the adopting library or Hypothesis.

Importantly I'll also need to check that other libraries will play nicely with the `asarray` usage too.

cc @asmeurer @jakevdp