### PR TITLE
events for more mark_invalid() cases

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ their individual contributions.
 * `Bryant Eisenbach <https://github.com/fubuloubu>`_
 * `Buck Evan, copyright Google LLC <https://github.com/bukzor>`_
 * `Cameron McGill <https://www.github.com/Cameron-JM>`_
+* `Carl Meyer <https://www.github.com/carljm>`_
 * `Charles O'Farrell <https://www.github.com/charleso>`_
 * `Charlie Tanksley <https://www.github.com/charlietanksley>`_
 * `Chase Garner <https://www.github.com/chasegarner>`_ (chase@garner.red)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Hypothesis will now record an event for more cases where data is marked
+invalid, including for exceeding the internal depth limit.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -936,10 +936,10 @@ class ConjectureData:
         strategy.validate()
 
         if strategy.is_empty:
-            self.mark_invalid()
+            self.mark_invalid("strategy is empty")
 
         if self.depth >= MAX_DEPTH:
-            self.mark_invalid()
+            self.mark_invalid("max depth exceeded")
 
         if label is None:
             assert isinstance(strategy.label, int)
@@ -1132,7 +1132,9 @@ class ConjectureData:
     ) -> None:
         self.conclude_test(Status.INTERESTING, interesting_origin)
 
-    def mark_invalid(self):
+    def mark_invalid(self, why: str | None = None):
+        if why is not None:
+            self.note_event(why)
         self.conclude_test(Status.INVALID)
 
     def mark_overrun(self):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -21,6 +21,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    NoReturn,
     Optional,
     Sequence,
     Set,
@@ -726,7 +727,7 @@ Overrun = _Overrun()
 global_test_counter = 0
 
 
-MAX_DEPTH = 100
+MAX_DEPTH = 200
 
 
 class DataObserver:
@@ -1119,7 +1120,7 @@ class ConjectureData:
         self,
         status: Status,
         interesting_origin: Optional[InterestingOrigin] = None,
-    ) -> None:
+    ) -> NoReturn:
         assert (interesting_origin is None) or (status == Status.INTERESTING)
         self.__assert_not_frozen("conclude_test")
         self.interesting_origin = interesting_origin
@@ -1129,15 +1130,15 @@ class ConjectureData:
 
     def mark_interesting(
         self, interesting_origin: Optional[InterestingOrigin] = None
-    ) -> None:
+    ) -> NoReturn:
         self.conclude_test(Status.INTERESTING, interesting_origin)
 
-    def mark_invalid(self, why: Optional[str] = None):
+    def mark_invalid(self, why: Optional[str] = None) -> NoReturn:
         if why is not None:
             self.note_event(why)
         self.conclude_test(Status.INVALID)
 
-    def mark_overrun(self):
+    def mark_overrun(self) -> NoReturn:
         self.conclude_test(Status.OVERRUN)
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1132,7 +1132,7 @@ class ConjectureData:
     ) -> None:
         self.conclude_test(Status.INTERESTING, interesting_origin)
 
-    def mark_invalid(self, why: str | None = None):
+    def mark_invalid(self, why: Optional[str] = None):
         if why is not None:
             self.note_event(why)
         self.conclude_test(Status.INVALID)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -727,7 +727,7 @@ Overrun = _Overrun()
 global_test_counter = 0
 
 
-MAX_DEPTH = 200
+MAX_DEPTH = 100
 
 
 class DataObserver:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -452,7 +452,7 @@ class many:
             self.data.stop_example()
             return False
 
-    def reject(self, why: str | None = None):
+    def reject(self, why: Optional[str] = None):
         """Reject the last example (i.e. don't count it towards our budget of
         elements because it's not going to go in the final collection)."""
         assert self.count > 0

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -452,7 +452,7 @@ class many:
             self.data.stop_example()
             return False
 
-    def reject(self):
+    def reject(self, why: str | None = None):
         """Reject the last example (i.e. don't count it towards our budget of
         elements because it's not going to go in the final collection)."""
         assert self.count > 0
@@ -463,7 +463,7 @@ class many:
         # failing too fast when we reject the first draw.
         if self.rejections > max(3, 2 * self.count):
             if self.count < self.min_size:
-                self.data.mark_invalid()
+                self.data.mark_invalid(why)
             else:
                 self.force_stop = True
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -452,7 +452,7 @@ class many:
             self.data.stop_example()
             return False
 
-    def reject(self, why: Optional[str] = None):
+    def reject(self, why: Optional[str] = None) -> None:
         """Reject the last example (i.e. don't count it towards our budget of
         elements because it's not going to go in the final collection)."""
         assert self.count > 0

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -234,7 +234,7 @@ class UniqueListStrategy(ListStrategy):
         while elements.more():
             value = filtered.do_filtered_draw(data)
             if value is filter_not_satisfied:
-                elements.reject()
+                elements.reject("Aborted test because unable to satisfy {filtered!r}")
             else:
                 for key, seen in zip(self.keys, seen_sets):
                     seen.add(key(value))
@@ -274,7 +274,7 @@ class UniqueSampledListStrategy(UniqueListStrategy):
                     value = (value,) + data.draw(self.tuple_suffixes)
                 result.append(value)
             else:
-                should_draw.reject()
+                should_draw.reject("UniqueSampledListStrategy filter not satisfied or value already seen")
         assert self.max_size >= len(result) >= self.min_size
         return result
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -274,7 +274,9 @@ class UniqueSampledListStrategy(UniqueListStrategy):
                     value = (value,) + data.draw(self.tuple_suffixes)
                 result.append(value)
             else:
-                should_draw.reject("UniqueSampledListStrategy filter not satisfied or value already seen")
+                should_draw.reject(
+                    "UniqueSampledListStrategy filter not satisfied or value already seen"
+                )
         assert self.max_size >= len(result) >= self.min_size
         return result
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -156,7 +156,7 @@ class DatetimeStrategy(SearchStrategy):
 
         # If we happened to end up with a disallowed imaginary time, reject it.
         if (not self.allow_imaginary) and datetime_does_not_exist(result):
-            data.mark_invalid()
+            data.mark_invalid("nonexistent datetime")
         return result
 
     def draw_naive_datetime_and_combine(self, data, tz):
@@ -165,8 +165,7 @@ class DatetimeStrategy(SearchStrategy):
             return replace_tzinfo(dt.datetime(**result), timezone=tz)
         except (ValueError, OverflowError):
             msg = "Failed to draw a datetime between %r and %r with timezone from %r."
-            data.note_event(msg % (self.min_value, self.max_value, self.tz_strat))
-            data.mark_invalid()
+            data.mark_invalid(msg % (self.min_value, self.max_value, self.tz_strat))
 
 
 @defines_strategy(force_reusable_values=True)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -529,8 +529,7 @@ class SampledFromStrategy(SearchStrategy):
     def do_draw(self, data):
         result = self.do_filtered_draw(data)
         if result is filter_not_satisfied:
-            data.note_event(f"Aborted test because unable to satisfy {self!r}")
-            data.mark_invalid()
+            data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")
         return result
 
     def get_element(self, i):
@@ -944,8 +943,7 @@ class FilteredStrategy(SearchStrategy[Ex]):
         if result is not filter_not_satisfied:
             return result
 
-        data.note_event(f"Aborted test because unable to satisfy {self!r}")
-        data.mark_invalid()
+        data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")
         raise NotImplementedError("Unreachable, for Mypy")
 
     def note_retried(self, data):

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -90,6 +90,15 @@ def test_can_mark_invalid():
     assert x.status == Status.INVALID
 
 
+def test_can_mark_invalid_with_why():
+    x = ConjectureData.for_buffer(b"")
+    with pytest.raises(StopTest):
+        x.mark_invalid("some reason")
+    assert x.frozen
+    assert x.status == Status.INVALID
+    assert x.events == {"some reason"}
+
+
 class BoomStrategy(SearchStrategy):
     def do_draw(self, data):
         data.draw_bytes(1)


### PR DESCRIPTION
This PR adds a `why` argument to `ConjectureData.mark_invalid()` (and `many.reject()` which can call through to it), which can optionally take a string description of the reason for the data to be marked as invalid, and will record an event.

I didn't try to ensure that every single callsite now provides these arguments (there can always be follow-up PRs to add more where it seems useful), but I covered the ones where I felt able to provide something (hopefully) sensible.

The specific case I wanted to cover was `MAX_DEPTH` invalidation, since I have a use case where I'm getting >99% invalidation due to that, and prior to this PR it was invisible in the statistics, making me dive into internals to understand what was happening. With this PR I now see:

```
    - Events:
      * 99.29%, max depth exceeded
```

I think ideally this message would give more info on what the user can do to avoid this, but at the moment I don't know enough to say more than maybe "use less recursive strategies."

See https://github.com/HypothesisWorks/hypothesis/issues/3643 for discussion.