### PR TITLE
Fix recursives

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix failure to infer strategy for recursive types with default arguments.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,8 @@
 RELEASE_TYPE: patch
 
-Fix failure to infer strategy for recursive types with default arguments.
+:func:`~hypothesis.strategies.from_type` now works in cases where we use
+:func:`~hypothesis.strategies.builds` to create an instance and the constructor
+has an argument which would lead to recursion.  Previously, this would raise
+an error if the argument had a default value.
+
+Thanks to Joachim B Haga for reporting and fixing this problem.

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -168,3 +168,9 @@ class Found(Exception):
     """Signal that the example matches condition. Internal use only."""
 
     hypothesis_internal_never_escalate = True
+
+
+class RewindRecursive(Exception):
+    """Signal that the type inference should be rewound due to recursive types. Internal use only."""
+    def __init__(self, target):
+        self.target = target

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -172,5 +172,6 @@ class Found(Exception):
 
 class RewindRecursive(Exception):
     """Signal that the type inference should be rewound due to recursive types. Internal use only."""
+
     def __init__(self, target):
         self.target = target

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -988,7 +988,7 @@ if sys.version_info[:2] >= (3, 8):
 
 @cacheable
 @defines_strategy(never_lazy=True)
-def from_type(thing: Type[Ex], force_defer=False) -> SearchStrategy[Ex]:
+def from_type(thing: Type[Ex], *, force_defer: bool = False) -> SearchStrategy[Ex]:
     """Looks up the appropriate search strategy for the given type.
 
     ``from_type`` is used internally to fill in missing arguments to
@@ -1236,9 +1236,10 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
                 and p.default is not Parameter.empty
                 and p.kind in (Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY)
             ):
-                kwargs[k] = defer_recursion(hints[k],
-                                            lambda: just(p.default) | _from_type(hints[k],
-                                                                                 recurse_guard))
+                kwargs[k] = defer_recursion(
+                    hints[k],
+                    lambda: just(p.default) | _from_type(hints[k], recurse_guard),
+                )
         return builds(thing, **kwargs)
     # And if it's an abstract type, we'll resolve to a union of subclasses instead.
     subclasses = thing.__subclasses__()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1054,6 +1054,7 @@ def from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
             force_repr=f"from_type({thing!r})",
         )
 
+
 def _from_type(thing: Type[Ex], recurse_guard: list) -> SearchStrategy[Ex]:
     # TODO: We would like to move this to the top level, but pending some major
     # refactoring it's hard to do without creating circular imports.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1226,6 +1226,7 @@ def _from_type(thing: Type[Ex], recurse_guard: list) -> SearchStrategy[Ex]:
                 except RewindRecursive as rr:
                     if rr.target != hints[k]:
                         raise
+                    kwargs[k] = ...  # deferred resolution in builds()
                 finally:
                     recurse_guard.pop()
         return builds(thing, **kwargs)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -26,7 +26,7 @@ import pytest
 
 from hypothesis import HealthCheck, assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
-from hypothesis.internal.compat import get_type_hints
+from hypothesis.internal.compat import PYPY, get_type_hints
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types
@@ -580,6 +580,8 @@ class B:
         return f"B({self.nxt})"
 
 
+@pytest.mark.skipif(PYPY and sys.version_info[:2] < (3, 9),
+                    reason="mysterious failure on pypy/python<3.9")
 @given(nxt=st.from_type(A))
 def test_resolving_mutually_recursive_types(nxt):
     i = 0

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -541,6 +541,16 @@ def test_resolving_recursive_type(tree):
     assert isinstance(tree, Tree)
 
 
+class TypedTree(typing.TypedDict):
+    nxt: typing.Optional["TypedTree"]
+
+
+@given(tree=st.from_type(TypedTree))
+def test_resolving_recursive_typeddict(tree):
+    assert isinstance(tree, dict)
+    assert len(tree) == 1 and "nxt" in tree
+
+
 class MyList:
     def __init__(self, nxt: typing.Optional["MyList"] = None):
         self.nxt = nxt

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -541,12 +541,16 @@ def test_resolving_recursive_type(tree):
     assert isinstance(tree, Tree)
 
 
-class TypedTree(typing.TypedDict):
+class TypedTree(typing.TypedDict if sys.version_info[:2] >= (3, 8) else object):
     nxt: typing.Optional["TypedTree"]
 
 
-@given(tree=st.from_type(TypedTree))
-def test_resolving_recursive_typeddict(tree):
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 8),
+    reason="TypedDict not available in python<3.8",
+)
+def test_resolving_recursive_typeddict():
+    tree = st.from_type(TypedTree).example()
     assert isinstance(tree, dict)
     assert len(tree) == 1 and "nxt" in tree
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -540,6 +540,18 @@ def test_resolving_recursive_type():
     assert isinstance(st.builds(Tree).example(), Tree)
 
 
+class LinkedList:
+    def __init__(self, nxt: typing.Optional["LinkedList"]=None):
+        self.nxt = nxt
+
+    def __repr__(self):
+        return f"LinkedList({self.nxt})"
+
+
+def test_resolving_recursive_type_with_defaults():
+    assert isinstance(st.from_type(LinkedList).example(), LinkedList)
+
+
 class SomeClass:
     def __init__(self, value: int, next_node: typing.Optional["SomeClass"]) -> None:
         assert value > 0

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -577,6 +577,35 @@ def test_resolving_mutually_recursive_types():
         i += 1
 
 
+class A_with_default:
+    def __init__(self, nxt: typing.Optional["B_with_default"] = None):
+        self.nxt = nxt
+
+    def __repr__(self):
+        return f"A_with_default({self.nxt})"
+
+
+class B_with_default:
+    def __init__(self, nxt: typing.Optional["A_with_default"] = None):
+        self.nxt = nxt
+
+    def __repr__(self):
+        return f"B_with_default({self.nxt})"
+
+
+def test_resolving_mutually_recursive_types_with_defaults():
+    # This test is required to cover the raise/except part of the recursion
+    # check in from_type, see
+    # https://github.com/HypothesisWorks/hypothesis/issues/3655. If the
+    # skip-nondefaulted-args check is removed, this test becomes redundant.
+    nxt = st.from_type(A_with_default).example()
+    i = 0
+    while nxt:
+        assert isinstance(nxt, [A_with_default, B_with_default][i % 2])
+        nxt = nxt.nxt
+        i += 1
+
+
 class SomeClass:
     def __init__(self, value: int, next_node: typing.Optional["SomeClass"]) -> None:
         assert value > 0

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -580,8 +580,10 @@ class B:
         return f"B({self.nxt})"
 
 
-@pytest.mark.skipif(PYPY and sys.version_info[:2] < (3, 9),
-                    reason="mysterious failure on pypy/python<3.9")
+@pytest.mark.skipif(
+    PYPY and sys.version_info[:2] < (3, 9),
+    reason="mysterious failure on pypy/python<3.9",
+)
 @given(nxt=st.from_type(A))
 def test_resolving_mutually_recursive_types(nxt):
     i = 0
@@ -607,6 +609,10 @@ class B_with_default:
         return f"B_with_default({self.nxt})"
 
 
+@pytest.mark.skipif(
+    PYPY and sys.version_info[:2] < (3, 9),
+    reason="mysterious failure on pypy/python<3.9",
+)
 @given(nxt=st.from_type(A_with_default))
 def test_resolving_mutually_recursive_types_with_defaults(nxt):
     # This test is required to cover the raise/except part of the recursion

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -873,7 +873,7 @@ def test_signature_is_the_most_important_source(thing):
 
 
 class AnnotatedAndDefault:
-    def __init__(self, foo: bool = None):
+    def __init__(self, foo: typing.Optional[bool] = None):
         self.foo = foo
 
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -540,16 +540,41 @@ def test_resolving_recursive_type():
     assert isinstance(st.builds(Tree).example(), Tree)
 
 
-class LinkedList:
-    def __init__(self, nxt: typing.Optional["LinkedList"] = None):
+class MyList:
+    def __init__(self, nxt: typing.Optional["MyList"] = None):
         self.nxt = nxt
 
     def __repr__(self):
-        return f"LinkedList({self.nxt})"
+        return f"MyList({self.nxt})"
 
 
 def test_resolving_recursive_type_with_defaults():
-    assert isinstance(st.from_type(LinkedList).example(), LinkedList)
+    assert isinstance(st.from_type(MyList).example(), MyList)
+
+
+class A:
+    def __init__(self, nxt: typing.Optional["B"]):
+        self.nxt = nxt
+
+    def __repr__(self):
+        return f"A({self.nxt})"
+
+
+class B:
+    def __init__(self, nxt: typing.Optional["A"]):
+        self.nxt = nxt
+
+    def __repr__(self):
+        return f"B({self.nxt})"
+
+
+def test_resolving_mutually_recursive_types():
+    nxt = st.from_type(A).example()
+    i = 0
+    while nxt:
+        assert isinstance(nxt, [A, B][i % 2])
+        nxt = nxt.nxt
+        i += 1
 
 
 class SomeClass:

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -541,7 +541,7 @@ def test_resolving_recursive_type():
 
 
 class LinkedList:
-    def __init__(self, nxt: typing.Optional["LinkedList"]=None):
+    def __init__(self, nxt: typing.Optional["LinkedList"] = None):
         self.nxt = nxt
 
     def __repr__(self):

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -536,8 +536,9 @@ class Tree:
         return f"Tree({self.left}, {self.right})"
 
 
-def test_resolving_recursive_type():
-    assert isinstance(st.builds(Tree).example(), Tree)
+@given(tree=st.builds(Tree))
+def test_resolving_recursive_type(tree):
+    assert isinstance(tree, Tree)
 
 
 class MyList:
@@ -548,8 +549,9 @@ class MyList:
         return f"MyList({self.nxt})"
 
 
-def test_resolving_recursive_type_with_defaults():
-    assert isinstance(st.from_type(MyList).example(), MyList)
+@given(lst=st.from_type(MyList))
+def test_resolving_recursive_type_with_defaults(lst):
+    assert isinstance(lst, MyList)
 
 
 class A:
@@ -568,8 +570,8 @@ class B:
         return f"B({self.nxt})"
 
 
-def test_resolving_mutually_recursive_types():
-    nxt = st.from_type(A).example()
+@given(nxt=st.from_type(A))
+def test_resolving_mutually_recursive_types(nxt):
     i = 0
     while nxt:
         assert isinstance(nxt, [A, B][i % 2])
@@ -593,12 +595,12 @@ class B_with_default:
         return f"B_with_default({self.nxt})"
 
 
-def test_resolving_mutually_recursive_types_with_defaults():
+@given(nxt=st.from_type(A_with_default))
+def test_resolving_mutually_recursive_types_with_defaults(nxt):
     # This test is required to cover the raise/except part of the recursion
     # check in from_type, see
     # https://github.com/HypothesisWorks/hypothesis/issues/3655. If the
     # skip-nondefaulted-args check is removed, this test becomes redundant.
-    nxt = st.from_type(A_with_default).example()
     i = 0
     while nxt:
         assert isinstance(nxt, [A_with_default, B_with_default][i % 2])

--- a/hypothesis-python/tests/cover/test_regressions.py
+++ b/hypothesis-python/tests/cover/test_regressions.py
@@ -128,6 +128,7 @@ exc_instances = [
     errors.DeadlineExceeded(
         runtime=timedelta(seconds=1.5), deadline=timedelta(seconds=1.0)
     ),
+    errors.RewindRecursive(int),
 ]
 
 

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -379,7 +379,7 @@ class ConcreteBar(AbstractBar):
 
 def test_abstract_resolver_fallback():
     # We create our distinct strategies for abstract and concrete types
-    gen_abstractbar = _from_type(AbstractBar)
+    gen_abstractbar = _from_type(AbstractBar, [])
     gen_concretebar = st.builds(ConcreteBar, x=st.none())
     assert gen_abstractbar != gen_concretebar
 

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -24,7 +24,6 @@ from hypothesis.errors import (
 from hypothesis.internal.compat import get_type_hints
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal import types
-from hypothesis.strategies._internal.core import _from_type
 from hypothesis.strategies._internal.types import _global_type_lookup
 from hypothesis.strategies._internal.utils import _strategies
 
@@ -379,7 +378,7 @@ class ConcreteBar(AbstractBar):
 
 def test_abstract_resolver_fallback():
     # We create our distinct strategies for abstract and concrete types
-    gen_abstractbar = _from_type(AbstractBar, [])
+    gen_abstractbar = st.from_type(AbstractBar)
     gen_concretebar = st.builds(ConcreteBar, x=st.none())
     assert gen_abstractbar != gen_concretebar
 


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/3655.

This PR adds a parameter to `_from_type` in order to keep track of (some) already-seen types, and rewind if recursion is spotted.

Only type arguments are tracked, since this is where types become recursive - and where the bug was, since this was protected effectively only when the recursive type did not have default arguments. See first commit, which adds just a failing test for this.