### PR TITLE
Improved patch files for failing examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,27 +122,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - task: check-py37-cover
-          - task: check-py37-niche
-          - task: check-py310-cover
-          - task: check-py310-niche
-          - task: check-py310-x86-cover
-            python.architecture: "x86"
-          - task: check-py310-x86-nocover
-            python.architecture: "x86"
-          - task: check-py310-x86-niche
-            python.architecture: "x86"
-          - task: check-py311-cover
-          - task: check-py311-niche
+          - python-version: "3.8"
+          - python-version: "3.9"
+          - python-version: "3.10"
+          - python-version: "3.11"
+          - python-version: "3.11"
+            python-architecture: "x86"
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.python-architecture }}
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
     - name: Restore cache
       uses: actions/cache@v3
@@ -151,7 +145,7 @@ jobs:
           ~\appdata\local\pip\cache
           vendor\bundle
           .tox
-        key: deps-${{ runner.os }}-${{ matrix.python-architecture }}-${{ hashFiles('requirements/*.txt') }}-${{ matrix.task }}
+        key: deps-${{ runner.os }}-${{ matrix.python-architecture }}-${{ hashFiles('requirements/*.txt') }}-${{ matrix.python-version }}
         restore-keys: |
           deps-${{ runner.os }}-${{ matrix.python-architecture }}-${{ hashFiles('requirements/*.txt') }}
           deps-${{ runner.os }}-${{ matrix.python-architecture }}

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release fixes some ``.patch``-file bugs from :ref:`version 6.75 <v6.75.0>`,
+and adds automatic support for writing ``@hypothesis.example()`` or ``@example()``
+depending on the current style in your test file - defaulting to the latter.
+
+Note that this feature requires :pypi:`libcst` to be installed, and :pypi:`black`
+is strongly recommended.  You can ensure you have the dependencies with
+``pip install "hypothesis[cli,codemods]"``.

--- a/hypothesis-python/scripts/other-tests.sh
+++ b/hypothesis-python/scripts/other-tests.sh
@@ -47,7 +47,9 @@ if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel ==
   pip install ".[codemods,cli]"
   $PYTEST tests/codemods/
   pip install "$(grep 'black==' ../requirements/coverage.txt)"
-  $PYTEST tests/patching/
+  if [ "$(python -c 'import sys; print(sys.version_info[:2] >= (3, 9))')" = "True" ] ; then
+    $PYTEST tests/patching/
+  fi
   pip uninstall -y libcst
 
   if [ "$(python -c 'import sys; print(sys.version_info[:2] == (3, 7))')" = "True" ] ; then

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -339,11 +339,11 @@ else:
         failing_examples = getattr(item, FAILING_EXAMPLES_KEY, None)
         if failing_examples and terminalreporter is not None:
             try:
-                from hypothesis.extra.patching import get_patch_for
+                from hypothesis.extra._patching import FAIL_MSG, get_patch_for
             except ImportError:
                 return
             # We'll save this as a triple of [filename, hunk_before, hunk_after].
-            triple = get_patch_for(item.obj, failing_examples)
+            triple = get_patch_for(item.obj, [(x, FAIL_MSG) for x in failing_examples])
             if triple is not None:
                 report.__dict__[FAILING_EXAMPLES_KEY] = json.dumps(triple)
 
@@ -363,7 +363,7 @@ else:
 
         if failing_examples:
             # This must have been imported already to write the failing examples
-            from hypothesis.extra.patching import gc_patches, make_patch, save_patch
+            from hypothesis.extra._patching import gc_patches, make_patch, save_patch
 
             patch = make_patch(failing_examples)
             try:

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -31,6 +31,7 @@ if sys.version_info < (3, 8):
     collect_ignore_glob.append("cover/*py38*")
 if sys.version_info < (3, 9):
     collect_ignore_glob.append("cover/*py39*")
+    collect_ignore_glob.append("patching/*")
 if sys.version_info < (3, 10):
     collect_ignore_glob.append("cover/*py310*")
 

--- a/hypothesis-python/tests/patching/callables.py
+++ b/hypothesis-python/tests/patching/callables.py
@@ -29,4 +29,11 @@ class Cases:
         """Indented method with existing example decorator."""
 
 
+@given(st.integers())
+@example(x=2).via("not a literal when repeated " * 2)
+@example(x=1).via("covering example")
+def covered(x):
+    """A test function with a removable explicit example."""
+
+
 # TODO: test function for insertion-order logic, once I get that set up.

--- a/hypothesis-python/tests/patching/test_patching.py
+++ b/hypothesis-python/tests/patching/test_patching.py
@@ -9,29 +9,48 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import re
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 
-from hypothesis.extra._patching import HEADER, get_patch_for, indent, make_patch
+from hypothesis.extra._patching import (
+    FAIL_MSG,
+    HEADER,
+    get_patch_for,
+    indent,
+    make_patch,
+)
+from hypothesis.internal.compat import WINDOWS
 
-from .callables import WHERE, Cases, fn
+from .callables import WHERE, Cases, covered, fn
+from .toplevel import WHERE_TOP, fn_top
 
 SIMPLE = (
     fn,
-    "fn(\n    x=1,\n)",
+    ("fn(\n    x=1,\n)", FAIL_MSG),
     indent('@example(x=1).via("discovered failure")', prefix="+"),
 )
 CASES = (
     Cases.mth,
-    'mth(\n    n=100,\n    label="a long label which forces a newline",\n)',
+    ('mth(\n    n=100,\n    label="a long label which forces a newline",\n)', FAIL_MSG),
     indent(
         '@example(n=100, label="a long label which forces a newline")'
         '.via(\n    "discovered failure"\n)',
         prefix="+    ",
     ),
+)
+TOPLEVEL = (
+    fn_top,
+    ("fn_top(\n    x=1,\n)", FAIL_MSG),
+    indent('@hypothesis.example(x=1).via("discovered failure")', prefix="+"),
+)
+COVERING = (
+    covered,
+    ("covered(\n    x=0,\n)", "covering example"),
+    indent('@example(x=1).via("covering example")', prefix="-")
+    + "\n"
+    + indent('@example(x=0).via("covering example")', prefix="+"),
 )
 
 
@@ -78,21 +97,48 @@ CASES_PATCH_BODY = f'''\
          """Indented method with existing example decorator."""
 
 '''
+TOPLEVEL_PATCH_BODY = f'''\
+--- {WHERE_TOP}
++++ {WHERE_TOP}
+@@ -19,5 +19,6 @@
+
+
+ @hypothesis.given(st.integers())
+{{0}}
+ def fn_top(x):
+     """A trivial test function."""
+'''
+COVERING_PATCH_BODY = f'''\
+--- {WHERE}
++++ {WHERE}
+@@ -31,7 +31,7 @@
+
+ @given(st.integers())
+ @example(x=2).via("not a literal when repeated " * 2)
+{{0}}
+ def covered(x):
+     """A test function with a removable explicit example."""
+
+'''
 
 
 @pytest.mark.parametrize(
-    "tst, example, expected, body",
+    "tst, example, expected, body, remove",
     [
-        pytest.param(*SIMPLE, SIMPLE_PATCH_BODY, id="simple"),
-        pytest.param(*CASES, CASES_PATCH_BODY, id="cases"),
+        pytest.param(*SIMPLE, SIMPLE_PATCH_BODY, (), id="simple"),
+        pytest.param(*CASES, CASES_PATCH_BODY, (), id="cases"),
+        pytest.param(*TOPLEVEL, TOPLEVEL_PATCH_BODY, (), id="toplevel"),
+        pytest.param(
+            *COVERING, COVERING_PATCH_BODY, ("covering example",), id="covering"
+        ),
     ],
 )
-def test_make_full_patch(tst, example, expected, body):
+def test_make_full_patch(tst, example, expected, body, remove):
     when = datetime.now()
     msg = "a message from the test"
     expected = HEADER.format(when=when, msg=msg) + body.format(expected)
 
-    triple = get_patch_for(tst, [example])
+    triple = get_patch_for(tst, [example], strip_via=remove)
     got = make_patch([triple], when=when, msg=msg)
     stripped = strip_trailing_whitespace(got)
 
@@ -103,7 +149,7 @@ def test_make_full_patch(tst, example, expected, body):
 def test_invalid_syntax_cases_dropped(n):
     tst, example, expected = SIMPLE
     example_ls = [example] * n
-    example_ls.insert(-1, "fn(\n    x=<__main__.Cls object at 0x>,\n)")
+    example_ls.insert(-1, ("fn(\n    x=<__main__.Cls object at 0x>,\n)", FAIL_MSG))
 
     got = get_patch_for(tst, example_ls)
     if n == 0:
@@ -117,7 +163,42 @@ def test_invalid_syntax_cases_dropped(n):
 
 def test_irretrievable_callable():
     # Check that we return None instead of raising an exception
-    tst = deepcopy(fn)
-    tst.__module__ = "this.does.not.exist"
-    triple = get_patch_for(tst, [SIMPLE[1]])
+    old_module = fn.__module__
+    try:
+        fn.__module__ = "this.does.not.exist"
+        triple = get_patch_for(fn, [(SIMPLE[1], FAIL_MSG)])
+    finally:
+        fn.__module__ = old_module
     assert triple is None
+
+
+TESTSCRIPT_DUMPS_PATCH = """
+from hypothesis import Phase, given, settings, strategies as st
+
+@settings(phases=list(Phase))
+@given(st.integers(0, 10), st.integers(0, 10))
+def test_failing_pbt(x, y):
+    assert not x
+"""
+ADDED_LINES = """
++@example(
++    x=1,
++    y=0,  # or any other generated value
++).via("discovered failure")
+"""
+
+
+@pytest.mark.skipif(WINDOWS, reason="backslash support is tricky")
+def test_pytest_reports_patch_file_location(pytester):
+    script = pytester.makepyfile(TESTSCRIPT_DUMPS_PATCH)
+    result = pytester.runpytest(script)
+    result.assert_outcomes(failed=1)
+
+    fname_pat = r"\.hypothesis/patches/\d{4}-\d\d-\d\d--[0-9a-f]{8}.patch"
+    pattern = f"`git apply ({fname_pat})` to add failing examples to your code\\."
+    print(f"pattern={pattern!r}")
+    print(f"result.stdout=\n{indent(str(result.stdout), '    ')}")
+    fname = re.search(pattern, str(result.stdout)).group(1)
+    patch = Path(pytester.path).joinpath(fname).read_text()
+    print(patch)
+    assert ADDED_LINES in patch

--- a/hypothesis-python/tests/patching/toplevel.py
+++ b/hypothesis-python/tests/patching/toplevel.py
@@ -1,0 +1,23 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""A stable file for which we can write patches.  Don't move stuff around!"""
+
+from pathlib import Path
+
+import hypothesis
+import hypothesis.strategies as st
+
+WHERE_TOP = Path(__file__).relative_to(Path.cwd())
+
+
+@hypothesis.given(st.integers())
+def fn_top(x):
+    """A trivial test function."""

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -207,6 +207,7 @@ def format():
             o.write("\n")
 
     codespell("--write-changes", *files_to_format, *doc_files_to_format)
+    pip_tool("ruff", "--fix-only", "."),
     pip_tool("shed", *files_to_format, *doc_files_to_format)
 
 


### PR DESCRIPTION
Bugfixes and enhancements following https://github.com/HypothesisWorks/hypothesis/pull/3631, along with the remaining features for https://github.com/Zac-HD/hypofuzz/issues/13 downstream 😁

Notably we now detect and handle modules that just `import hypothesis` by writing `@hypothesis.example(...)` (CPython, you're welcome), have the ability to _remove_ obsolete examples with known `.via(...)` tags (the core motivation for that method!), and skip the timestamp when computing the file hash, so that we write otherwise-identical patches to the same location instead of exploding the directory with repeated runs.