### PR TITLE
Update pinned dependencies

### DIFF
--- a/hypothesis-python/tests/cover/test_complex_numbers.py
+++ b/hypothesis-python/tests/cover/test_complex_numbers.py
@@ -13,7 +13,7 @@ import sys
 
 import pytest
 
-from hypothesis import given, reject, strategies as st
+from hypothesis import HealthCheck, given, reject, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import complex_numbers
 
@@ -62,6 +62,7 @@ def test_max_magnitude_zero(val):
     assert val == 0
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(st.data(), st.integers(-5, 5).map(lambda x: 10**x))
 def test_min_magnitude_respected(data, mag):
     c = data.draw(complex_numbers(min_magnitude=mag))

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -869,6 +869,7 @@ def test_mutually_broadcastable_shapes_shrinking_with_singleton_out_of_bounds(
         assert smallest == (min_side,) * min_dims
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(
     num_shapes=st.integers(1, 4),
     min_dims=st.integers(1, 32),

--- a/hypothesis-python/tests/pandas/test_data_frame.py
+++ b/hypothesis-python/tests/pandas/test_data_frame.py
@@ -242,7 +242,7 @@ def test_will_fill_missing_columns_in_tuple_row(df):
         assert d == 7
 
 
-@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@settings(suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.too_slow])
 @given(
     pdst.data_frames(
         index=pdst.range_indexes(10, 10),

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -14,7 +14,7 @@ click==8.1.3
     # via
     #   -r requirements/coverage.in
     #   black
-coverage==7.2.5
+coverage==7.2.6
     # via -r requirements/coverage.in
 dpcontracts==0.6.0
     # via -r requirements/coverage.in
@@ -24,13 +24,13 @@ exceptiongroup==1.1.1 ; python_version < "3.11"
     #   pytest
 execnet==1.9.0
     # via pytest-xdist
-fakeredis==2.12.1
+fakeredis==2.13.0
     # via -r requirements/coverage.in
 iniconfig==2.0.0
     # via pytest
 lark==1.1.5
     # via -r requirements/coverage.in
-libcst==0.4.9
+libcst==1.0.0
     # via -r requirements/coverage.in
 mypy-extensions==1.0.0
     # via
@@ -84,12 +84,12 @@ tomli==2.0.1
     # via
     #   black
     #   pytest
-typing-extensions==4.5.0
+typing-extensions==4.6.2
     # via
     #   -r requirements/coverage.in
     #   libcst
     #   typing-inspect
-typing-inspect==0.8.0
+typing-inspect==0.9.0
     # via libcst
 tzdata==2023.3
     # via pandas

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -2,21 +2,6 @@ codespell
 coverage
 django
 dpcontracts
-flake8
-flake8-2020
-flake8-bandit
-flake8-builtins
-flake8-bugbear
-flake8-comprehensions
-flake8-datetimez
-flake8-docstrings
-flake8-mutable
-flake8-noqa
-flake8-pie
-flake8-pytest-style
-flake8-return
-flake8-simplify
-# flake8-strftime  # See https://github.com/python-formate/flake8_strftime/issues/47
 ipython
 lark
 libcst
@@ -27,6 +12,7 @@ pytest
 python-dateutil
 requests
 restructuredtext-lint
+ruff
 shed
 sphinx
 sphinx-codeautolink

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -6,13 +6,12 @@
 #
 alabaster==0.7.13
     # via sphinx
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asttokens==2.2.1
     # via stack-data
 attrs==23.1.0
-    # via
-    #   hypothesis (hypothesis-python/setup.py)
+    # via hypothesis (hypothesis-python/setup.py)
 autoflake==2.1.1
     # via shed
 babel==2.12.1
@@ -27,7 +26,7 @@ bleach==6.0.0
     # via readme-renderer
 build==0.10.0
     # via pip-tools
-cachetools==5.3.0
+cachetools==5.3.1
     # via tox
 certifi==2023.5.7
     # via requests
@@ -47,7 +46,7 @@ colorama==0.4.6
     # via tox
 com2ann==0.3.0
     # via shed
-coverage==7.2.5
+coverage==7.2.6
     # via -r requirements/tools.in
 cryptography==40.0.2
     # via
@@ -78,11 +77,6 @@ filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-ruff==0.0.269
-gitdb==4.0.10
-    # via gitpython
-gitpython==3.1.31
-    # via bandit
 idna==3.4
     # via requests
 imagesize==1.4.1
@@ -111,7 +105,7 @@ keyring==23.13.1
     # via twine
 lark==1.1.5
     # via -r requirements/tools.in
-libcst==0.4.9
+libcst==1.0.0
     # via
     #   -r requirements/tools.in
     #   shed
@@ -146,8 +140,6 @@ parso==0.8.3
     # via jedi
 pathspec==0.11.1
     # via black
-pbr==5.11.1
-    # via stevedore
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
@@ -174,8 +166,7 @@ pure-eval==0.2.2
 pycparser==2.21
     # via cffi
 pyflakes==3.0.1
-    # via
-    #   autoflake
+    # via autoflake
 pygments==2.15.1
     # via
     #   ipython
@@ -186,7 +177,7 @@ pyproject-api==1.5.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pyright==1.1.309
+pyright==1.1.310
     # via -r requirements/tools.in
 pytest==7.3.1
     # via -r requirements/tools.in
@@ -195,12 +186,10 @@ python-dateutil==2.8.2
 pyupgrade==3.4.0
     # via shed
 pyyaml==6.0
-    # via
-    #   bandit
-    #   libcst
+    # via libcst
 readme-renderer==37.3
     # via twine
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/tools.in
     #   requests-toolbelt
@@ -213,24 +202,20 @@ restructuredtext-lint==1.4.0
 rfc3986==2.0.0
     # via twine
 rich==13.3.5
-    # via
-    #   bandit
-    #   twine
+    # via twine
+ruff==0.0.270
+    # via -r requirements/tools.in
 secretstorage==3.3.3
     # via keyring
-shed==2023.5.1
+shed==2023.5.2
     # via -r requirements/tools.in
 six==1.16.0
     # via
     #   asttokens
     #   bleach
     #   python-dateutil
-smmap==5.0.0
-    # via gitdb
 snowballstemmer==2.2.0
-    # via
-    #   pydocstyle
-    #   sphinx
+    # via sphinx
 sortedcontainers==2.4.0
     # via hypothesis (hypothesis-python/setup.py)
 soupsieve==2.4.1
@@ -246,7 +231,7 @@ sphinx-codeautolink==0.15.0
     # via -r requirements/tools.in
 sphinx-hoverxref==1.3.0
     # via -r requirements/tools.in
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==1.2.1
     # via -r requirements/tools.in
 sphinx-selective-exclude==1.0.3
     # via -r requirements/tools.in
@@ -270,8 +255,6 @@ sqlparse==0.4.4
     # via django
 stack-data==0.6.2
     # via ipython
-stevedore==5.1.0
-    # via bandit
 tokenize-rt==5.0.0
     # via pyupgrade
 tomli==2.0.1
@@ -284,7 +267,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.5.1
+tox==4.5.2
     # via -r requirements/tools.in
 traitlets==5.9.0
     # via
@@ -302,13 +285,14 @@ types-pytz==2023.3.0.0
     # via -r requirements/tools.in
 types-redis==4.5.5.2
     # via -r requirements/tools.in
-typing-extensions==4.5.0
+typing-extensions==4.6.2
     # via
     #   -r requirements/tools.in
+    #   asgiref
     #   libcst
     #   mypy
     #   typing-inspect
-typing-inspect==0.8.0
+typing-inspect==0.9.0
     # via libcst
 urllib3==2.0.2
     # via


### PR DESCRIPTION
Automatically update pinned dependencies; manually added a check that no deps were deleted from `*.in` files (inspired by a regression this wouldn't have fixed).

Also fixes #3647, fixes #3648, fixes #3649.