### PR TITLE
Using map is more efficient.

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -55,7 +55,7 @@ class TupleStrategy(SearchStrategy):
         return all(recur(e) for e in self.element_strategies)
 
     def do_draw(self, data):
-        return tuple(data.draw(e) for e in self.element_strategies)
+        return tuple(map(data.draw, self.element_strategies))
 
     def calc_is_empty(self, recur):
         return any(recur(e) for e in self.element_strategies)


### PR DESCRIPTION
Depending on the number of elements it can be significantly faster. For [example](https://colab.research.google.com/gist/ttsugriy/230e87a91b5609931a976b2d09cfb240/list-comprehensions-vs-map.ipynb), for 256 elements it can be ~2X faster.