### PR TITLE
Run Python 3.12 beta in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,9 @@ jobs:
           - check-py311-cover
           - check-py311-nocover
           - check-py311-niche
-          # - check-py312-cover
-          # - check-py312-nocover
-          # - check-py312-niche
+          - check-py312-cover
+          - check-py312-nocover
+          - check-py312-niche
           # - check-py313-cover
           - check-quality
           ## Skip all the (inactive/old) Rust and Ruby tests pending fixes

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+We now test against Python 3.12 beta in CI, and this patch
+fixes some new deprecations.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -429,7 +429,7 @@ def from_typing_type(thing):
         # Except for sequences of integers, or unions which include integer!
         # See https://github.com/HypothesisWorks/hypothesis/issues/2257
         #
-        # This block drops ByteString from the types that can be generated
+        # This block drops bytes from the types that can be generated
         # if there is more than one allowed type, and the element type is
         # not either `int` or a Union with `int` as one of its elements.
         elem_type = (getattr(thing, "__args__", None) or ["not int"])[0]
@@ -450,7 +450,7 @@ def from_typing_type(thing):
         and thing.__forward_arg__ in vars(builtins)
     ):
         return st.from_type(getattr(builtins, thing.__forward_arg__))
-    # Before Python 3.9, we sometimes have e.g. ByteString from both the typing
+    # Before Python 3.9, we sometimes have e.g. Sequence from both the typing
     # module, and collections.abc module.  Discard any type which is not it's own
     # origin, where the origin is also in the mapping.
     for t in sorted(mapping, key=type_sorting_key):

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -211,7 +211,11 @@ def test_uninspectable_from_type():
 
 def _check_instances(t):
     # See https://github.com/samuelcolvin/pydantic/discussions/2508
-    return t.__module__ != "typing" and not t.__module__.startswith("pydantic")
+    return (
+        t.__module__ != "typing"
+        and t.__name__ != "ByteString"
+        and not t.__module__.startswith("pydantic")
+    )
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
@@ -134,7 +134,7 @@ def test_bound_type_cheking_only_forward_ref():
         st.builds(typechecking_only_fun).example()
 
 
-def test_bound_type_cheking_only_forward_ref_wrong_type():
+def test_bound_type_checking_only_forward_ref_wrong_type():
     """We should check ``ForwardRef`` parameter name correctly."""
     with utils.temp_registered(ForwardRef("WrongType"), st.just(1)):
         with pytest.raises(ResolutionFailed):

--- a/hypothesis-python/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis-python/tests/datetime/test_dateutil_timezones.py
@@ -9,18 +9,26 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime as dt
+import sys
+import warnings
 
 import pytest
-from dateutil import tz, zoneinfo
 
 from hypothesis import assume, given
 from hypothesis.errors import FailedHealthCheck, InvalidArgument
-from hypothesis.extra.dateutil import timezones
 from hypothesis.strategies import data, datetimes, just, sampled_from, times
 from hypothesis.strategies._internal.datetime import datetime_does_not_exist
 
 from tests.common.debug import assert_all_examples, find_any, minimal
 from tests.common.utils import fails_with
+
+with warnings.catch_warnings():
+    if sys.version_info[:2] >= (3, 12):
+        # Prior to https://github.com/dateutil/dateutil/pull/1285/
+        warnings.simplefilter("ignore", DeprecationWarning)
+    from dateutil import tz, zoneinfo
+
+from hypothesis.extra.dateutil import timezones
 
 
 def test_utc_is_minimal():

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -9,14 +9,13 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime as dt
+import sys
+import warnings
 
 import pytest
-import pytz
-from dateutil.tz import datetime_exists
 
 from hypothesis import assume, given
 from hypothesis.errors import InvalidArgument
-from hypothesis.extra.pytz import timezones
 from hypothesis.strategies import data, datetimes, just, sampled_from, times
 from hypothesis.strategies._internal.datetime import datetime_does_not_exist
 
@@ -26,6 +25,16 @@ from tests.common.debug import (
     find_any,
     minimal,
 )
+
+with warnings.catch_warnings():
+    if sys.version_info[:2] >= (3, 12):
+        # See https://github.com/stub42/pytz/issues/105 and
+        # https://github.com/dateutil/dateutil/pull/1285/
+        warnings.simplefilter("ignore", DeprecationWarning)
+    import pytz
+    from dateutil.tz import datetime_exists
+
+from hypothesis.extra.pytz import timezones
 
 
 def test_utc_is_minimal():

--- a/hypothesis-python/tests/nocover/test_from_type_recipe.py
+++ b/hypothesis-python/tests/nocover/test_from_type_recipe.py
@@ -11,7 +11,14 @@
 from hypothesis import given, strategies as st
 from hypothesis.strategies._internal.types import _global_type_lookup
 
-TYPES = sorted((x for x in _global_type_lookup if x.__module__ != "typing"), key=str)
+TYPES = sorted(
+    (
+        x
+        for x in _global_type_lookup
+        if x.__module__ != "typing" and x.__name__ != "ByteString"
+    ),
+    key=str,
+)
 
 
 def everything_except(excluded_types):


### PR DESCRIPTION
Fixes #3663.  Let's see how well this works...

- [x] blocked on https://github.com/pytest-dev/pytest/pull/10894
  - [x] which is in turn waiting for [3.12b2, expected June 6th](https://peps.python.org/pep-0693/)
- [x] ignore warnings in `dateutil` and `pytz` from the deprecation of `datetime.utcfromtimestamp()`
- [x] deprecation of `{collections.abc,typing}.ByteString` https://github.com/python/cpython/issues/91896 - we'll ignore these too for now to preserve old behavior on old versions
- [x] handle `TypeVar` objects earlier - seems sufficient for all old use-cases and we can handle the new syntax later if needed