### PR TITLE
Implement support for parameterized numpy types - np.ndarray[int] etc

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,6 @@
 RELEASE_TYPE: minor
 
-Implement support for :func:`hypothesis.strategies.from_type` to handle generic
-and parameterized numpy array types (:class:`numpy.ndarray[scalar type] <numpy.ndarray>`,
-numpy.typing.ArrayLike, etc).
+:func:`~hypothesis.strategies.from_type` now handles numpy array types:
+:obj:`np.typing.ArrayLike <numpy.typing.ArrayLike>`,
+:obj:`np.typing.NDArray <numpy.typing.NDArray>`, and parameterized
+versions including :class:`np.ndarray[shape, elem_type] <numpy.ndarray>`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,5 @@
 RELEASE_TYPE: minor
 
-Implement support for :func:`hypothesis.strategies.from_type` to handle generic numpy types (such
-as :class:`numpy.typing.ArrayLike`) and parameterized numpy arrays (such as
-:class:`numpy.ndarray[scalar type] <numpy.ndarray>` or
-:class:`numpy.typing.NDArray[scalar type] <numpy.typing.NDArray>`). This closes :issue:`3150`.
+Implement support for :func:`hypothesis.strategies.from_type` to handle generic
+and parameterized numpy array types (:class:`numpy.ndarray[scalar type] <numpy.ndarray>`,
+numpy.typing.ArrayLike, etc).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Implement support for parameterized numpy arrays, with scaffolding
+for extra modules to register for early type resolution (resolving
+composite types).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,6 @@
 RELEASE_TYPE: minor
 
-Implement support for parameterized numpy arrays, with scaffolding
-for extra modules to register for early type resolution (resolving
-composite types).
+Implement support for :func:`hypothesis.strategies.from_type` to handle generic numpy types (such
+as :class:`numpy.typing.ArrayLike`) and parameterized numpy arrays (such as
+:class:`numpy.ndarray[scalar type] <numpy.ndarray>` or
+:class:`numpy.typing.NDArray[scalar type] <numpy.typing.NDArray>`). This closes :issue:`3150`.

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -999,7 +999,6 @@ def integer_array_indices(
     )
 
 
-@defines_strategy(never_lazy=True)
 def _from_type(thing: Type[Ex]) -> Optional[st.SearchStrategy[Ex]]:
     """Called by st.from_type to try to infer a strategy for thing using numpy.
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1049,24 +1049,28 @@ def _from_type(thing: Type[Ex]) -> Optional[st.SearchStrategy[Ex]]:
     we return None.
     """
 
-    base_strats = st.one_of([
-        st.booleans(),
-        st.integers(),
-        st.floats(),
-        st.complex_numbers(),
-        st.text(),
-        st.binary(),
-    ])
+    base_strats = st.one_of(
+        [
+            st.booleans(),
+            st.integers(),
+            st.floats(),
+            st.complex_numbers(),
+            st.text(),
+            st.binary(),
+        ]
+    )
     # np.array(arr_like) (1.24.3) fails if mixing strings and non-ascii
     # bytestrings (ex: ['', b'\x80'])
-    base_strats_ascii = st.one_of([
-        st.booleans(),
-        st.integers(),
-        st.floats(),
-        st.complex_numbers(),
-        st.text(),
-        st.binary().filter(bytes.isascii),
-    ])
+    base_strats_ascii = st.one_of(
+        [
+            st.booleans(),
+            st.integers(),
+            st.floats(),
+            st.complex_numbers(),
+            st.text(),
+            st.binary().filter(bytes.isascii),
+        ]
+    )
 
     if thing == np.dtype:
         return array_dtypes()
@@ -1093,14 +1097,17 @@ def _from_type(thing: Type[Ex]) -> Optional[st.SearchStrategy[Ex]]:
             # _NestedSequence[_SupportsArray], but guaranteeing equal size
             st.integers(min_value=0, max_value=4).flatmap(
                 lambda s: st.one_of(
-                    st.recursive(st.lists(
-                        base_strats_ascii,
-                        min_size=s, max_size=s
-                    ), extend=st.tuples),
-                    st.recursive(arrays(
-                        scalar_dtypes(),
-                        array_shapes(min_dims=s, max_dims=s, min_side=s, max_side=s),
-                    ), extend=st.tuples),
+                    st.recursive(
+                        st.lists(base_strats_ascii, min_size=s, max_size=s),
+                        extend=st.tuples,
+                    ),
+                    st.recursive(
+                        arrays(
+                            scalar_dtypes(),
+                            array_shapes(min_dims=s, max_dims=s, min_side=s, max_side=s),
+                        ),
+                        extend=st.tuples,
+                    ),
                 ),
             ),
         )

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -62,7 +62,6 @@ def _try_import(mod_name: str, attr_name: str) -> Any:
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike, NDArray
 else:
-    DTypeLike = _try_import("numpy.typing", "DTypeLike")
     NDArray = _try_import("numpy.typing", "NDArray")
 
 ArrayLike = _try_import("numpy.typing", "ArrayLike")
@@ -1073,7 +1072,14 @@ def _from_type(thing: Type[Ex]) -> Optional[st.SearchStrategy[Ex]]:
     )
 
     if thing == np.dtype:
-        return array_dtypes()
+        # Note: Parameterized dtypes and DTypeLike are not supported.
+        return st.one_of(
+            scalar_dtypes(),
+            byte_string_dtypes(),
+            unicode_string_dtypes(),
+            array_dtypes(),
+            nested_dtypes(),
+        )
 
     if thing == ArrayLike:
         # We override the default type resolution to ensure the "coercible to

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -12,7 +12,6 @@ import math
 from typing import (
     TYPE_CHECKING,
     Any,
-    List,
     Mapping,
     Optional,
     Sequence,
@@ -991,8 +990,9 @@ def _from_type(thing: Type[Ex]) -> st.SearchStrategy[Ex]:
     If we can infer a dtype strategy for thing, we return that; otherwise,
     returns None (or raises).
     """
+
     def unpack_generic(thing):
-        if (real_thing := get_origin(thing)):
+        if real_thing := get_origin(thing):
             return (real_thing, get_args(thing))
         else:
             return (thing, ())
@@ -1021,7 +1021,7 @@ def _from_type(thing: Type[Ex]) -> st.SearchStrategy[Ex]:
                         dtype = scalar_dtypes()
                     else:  # Typed, npt.NDArray[type]
                         dtype = np.dtype(dtype_args[0])
-                else: # np.ndarray[Any, type]
+                else:  # np.ndarray[Any, type]
                     dtype = args[1]
         else:
             dtype = shape = None
@@ -1034,8 +1034,14 @@ def _from_type(thing: Type[Ex]) -> st.SearchStrategy[Ex]:
         return array_dtypes()
 
     real_thing, args = unpack_generic(thing)
-    base_strats = [st.booleans(), st.integers(), st.floats(),
-                   st.complex_numbers(), st.text(), st.binary()]
+    base_strats = [
+        st.booleans(),
+        st.integers(),
+        st.floats(),
+        st.complex_numbers(),
+        st.text(),
+        st.binary(),
+    ]
 
     if real_thing == np._typing._nested_sequence._NestedSequence:
         # We have to override the default resolution to ensure sequences are of
@@ -1064,7 +1070,7 @@ def _from_type(thing: Type[Ex]) -> st.SearchStrategy[Ex]:
             st.recursive(st.tuples(), st.tuples),
             st.recursive(st.one_of(base_strats), st.tuples),
             st.from_type(np.ndarray),
-         )
+        )
 
     if isinstance(real_thing, type):
         if issubclass(real_thing, np.generic):

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1059,8 +1059,8 @@ def _from_type(thing: Type[Ex]) -> Optional[st.SearchStrategy[Ex]]:
             st.binary(),
         ]
     )
-    # np.array(arr_like) (1.24.3) fails if mixing strings and non-ascii
-    # bytestrings (ex: ['', b'\x80'])
+    # don't mix strings and non-ascii bytestrings (ex: ['', b'\x80']). See
+    # https://github.com/numpy/numpy/issues/23899.
     base_strats_ascii = st.one_of(
         [
             st.booleans(),

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -50,8 +50,8 @@ from hypothesis.strategies._internal.strategies import Ex, T, check_strategy
 from hypothesis.strategies._internal.utils import defines_strategy
 
 
-def _try_import(fq_name: str) -> Any:
-    mod_name, _, attr_name = fq_name.rpartition(".")
+def _try_import(mod_name: str, attr_name: str) -> Any:
+    assert "." not in attr_name
     try:
         mod = importlib.import_module(mod_name)
         return getattr(mod, attr_name, None)
@@ -62,12 +62,12 @@ def _try_import(fq_name: str) -> Any:
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike, NDArray
 else:
-    DTypeLike = _try_import("numpy.typing.DTypeLike")
-    NDArray = _try_import("numpy.typing.NDArray")
+    DTypeLike = _try_import("numpy.typing", "DTypeLike")
+    NDArray = _try_import("numpy.typing", "NDArray")
 
-ArrayLike = _try_import("numpy.typing.ArrayLike")
-_NestedSequence = _try_import("numpy._typing._nested_sequence._NestedSequence")
-_SupportsArray = _try_import("numpy._typing._array_like._SupportsArray")
+ArrayLike = _try_import("numpy.typing", "ArrayLike")
+_NestedSequence = _try_import("numpy._typing._nested_sequence", "_NestedSequence")
+_SupportsArray = _try_import("numpy._typing._array_like", "_SupportsArray")
 
 __all__ = [
     "BroadcastableShapes",

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1104,7 +1104,9 @@ def _from_type(thing: Type[Ex]) -> Optional[st.SearchStrategy[Ex]]:
                     st.recursive(
                         arrays(
                             scalar_dtypes(),
-                            array_shapes(min_dims=s, max_dims=s, min_side=s, max_side=s),
+                            array_shapes(
+                                min_dims=s, max_dims=s, min_side=s, max_side=s
+                            ),
                         ),
                         extend=st.tuples,
                     ),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1109,11 +1109,9 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
     if thing not in types._global_type_lookup:
         for (module, resolver) in types._global_extra_lookup.items():
             if module in sys.modules:
-                try:
-                    return resolver(thing)
-                except Exception as e:
-                    pass
-
+                strat = resolver(thing)
+                if strat is not None:
+                    return strat
     if not isinstance(thing, type):
         if types.is_a_new_type(thing):
             # Check if we have an explicitly registered strategy for this thing,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1107,7 +1107,7 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
     # Let registered extra modules handle their own recognized types first, before
     # e.g. Unions are resolved
     if thing not in types._global_type_lookup:
-        for (module, resolver) in types._global_extra_lookup.items():
+        for module, resolver in types._global_extra_lookup.items():
             if module in sys.modules:
                 strat = resolver(thing)
                 if strat is not None:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1104,6 +1104,16 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
         finally:
             recurse_guard.pop()
 
+    # Let registered extra modules handle their own recognized types first, before
+    # e.g. Unions are resolved
+    if thing not in types._global_type_lookup:
+        for (module, resolver) in types._global_extra_lookup.items():
+            if module in sys.modules:
+                try:
+                    return resolver(thing)
+                except Exception as e:
+                    pass
+
     if not isinstance(thing, type):
         if types.is_a_new_type(thing):
             # Check if we have an explicitly registered strategy for this thing,
@@ -1187,6 +1197,7 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
     # We need to work with their type instead.
     if isinstance(thing, TypeVar) and type(thing) in types._global_type_lookup:
         return as_strategy(types._global_type_lookup[type(thing)], thing)
+
     # If there's no explicitly registered strategy, maybe a subtype of thing
     # is registered - if so, we can resolve it to the subclass strategy.
     # We'll start by checking if thing is from from the typing module,
@@ -1215,16 +1226,6 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
     # may be able to fall back on type annotations.
     if issubclass(thing, enum.Enum):
         return sampled_from(thing)
-    # Handle numpy types. If numpy is not imported, the type cannot be numpy related.
-    if "numpy" in sys.modules:
-        import numpy as np
-
-        if issubclass(thing, np.generic):
-            dtype = np.dtype(thing)
-            if dtype.kind not in "OV":
-                from hypothesis.extra.numpy import from_dtype
-
-                return from_dtype(dtype)
     # Finally, try to build an instance by calling the type object.  Unlike builds(),
     # this block *does* try to infer strategies for arguments with default values.
     # That's because of the semantic different; builds() -> "call this with ..."

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -14,7 +14,6 @@ import datetime
 import decimal
 import fractions
 import functools
-import importlib
 import inspect
 import io
 import ipaddress
@@ -671,13 +670,10 @@ def _from_numpy_type(thing: typing.Type) -> typing.Optional[st.SearchStrategy]:
 
 
 _global_extra_lookup: typing.Dict[
-    str,
-    typing.Callable[[typing.Type], typing.Optional[st.SearchStrategy]]
+    str, typing.Callable[[typing.Type], typing.Optional[st.SearchStrategy]]
 ] = {
     "numpy": _from_numpy_type,
 }
-
-
 
 
 def register(type_, fallback=None, *, module=typing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -601,7 +601,9 @@ if sys.version_info[:2] >= (3, 9):
 # avoid the performance hit of importing anything here, we defer it until the
 # method is actually called.
 _global_extra_lookup: typing.Dict[str, typing.Callable[[type], st.SearchStrategy]] = {
-    "numpy": lambda thing: importlib.import_module("hypothesis.extra.numpy")._from_type(thing)
+    "numpy": lambda thing: importlib.import_module("hypothesis.extra.numpy")._from_type(
+        thing
+    ),
 }
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -595,18 +595,6 @@ if sys.version_info[:2] >= (3, 9):
     _global_type_lookup[os._Environ] = st.just(os.environ)
 
 
-# These extras define a callable that either resolves to a strategy for this
-# narrowly extra-specific type, or returns None to proceed with normal type
-# resolution. The callable will only be called if the module is installed. To
-# avoid the performance hit of importing anything here, we defer it until the
-# method is actually called.
-_global_extra_lookup: typing.Dict[str, typing.Callable[[type], st.SearchStrategy]] = {
-    "numpy": lambda thing: importlib.import_module("hypothesis.extra.numpy")._from_type(
-        thing
-    ),
-}
-
-
 _global_type_lookup.update(
     {
         # Note: while ByteString notionally also represents the bytearray and
@@ -667,6 +655,29 @@ _global_type_lookup.update(
 )
 if hasattr(typing, "SupportsIndex"):  # pragma: no branch  # new in Python 3.8
     _global_type_lookup[typing.SupportsIndex] = st.integers() | st.booleans()
+
+
+# The "extra" lookups define a callable that either resolves to a strategy for
+# this narrowly extra-specific type, or returns None to proceed with normal
+# type resolution. The callable will only be called if the module is
+# installed. To avoid the performance hit of importing anything here, we defer
+# it until the method is called the first time, at which point we replace the
+# entry in the lookup table with the direct call.
+def _from_numpy_type(thing: typing.Type) -> typing.Optional[st.SearchStrategy]:
+    from hypothesis.extra.numpy import _from_type
+
+    _global_extra_lookup["numpy"] = _from_type
+    return _from_type(thing)
+
+
+_global_extra_lookup: typing.Dict[
+    str,
+    typing.Callable[[typing.Type], typing.Optional[st.SearchStrategy]]
+] = {
+    "numpy": _from_numpy_type,
+}
+
+
 
 
 def register(type_, fallback=None, *, module=typing):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -596,10 +596,10 @@ if sys.version_info[:2] >= (3, 9):
 
 
 # These extras define a callable that either resolves to a strategy for this
-# narrowly extra-specific type, or raises any exception to proceed with normal
-# type resolution. The callable will only be called if the module is
-# installed. To avoid the performance hit of importing anything here, we defer
-# it until the method is actually called.
+# narrowly extra-specific type, or returns None to proceed with normal type
+# resolution. The callable will only be called if the module is installed. To
+# avoid the performance hit of importing anything here, we defer it until the
+# method is actually called.
 _global_extra_lookup: typing.Dict[str, typing.Callable[[type], st.SearchStrategy]] = {
     "numpy": lambda thing: importlib.import_module("hypothesis.extra.numpy")._from_type(thing)
 }

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -17,7 +17,6 @@ from hypothesis import assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as nps
 from hypothesis.internal.floats import width_smallest_normals
-from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import SearchStrategy
 
 from tests.common.debug import assert_no_examples, find_any

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -284,10 +284,3 @@ def test_complex_subnormal_generation(allow_subnormal, width):
         find_any(strat, condition)
     else:
         assert_no_examples(strat, condition)
-
-
-@pytest.mark.parametrize("dtype", STANDARD_TYPES)
-def test_resolves_and_varies_numpy_type(dtype):
-    # Check that we find an instance that is not equal to the default
-    x = find_any(from_type(dtype.type), lambda x: x != type(x)())
-    assert isinstance(x, dtype.type)

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -23,6 +23,8 @@ from tests.common.debug import find_any
 
 STANDARD_TYPES_TYPE = [dtype.type for dtype in STANDARD_TYPES]
 
+needs_np_typing = {"reason": "numpy.typing is not available"}
+needs_np_private_typing = {"reason": "numpy._typing is not available"}
 
 @given(dtype=from_type(np.dtype))
 def test_resolves_dtype_type(dtype):
@@ -64,10 +66,7 @@ def test_resolves_specified_ndarray_type(typ):
     assert arr.dtype.type == typ
 
 
-@pytest.mark.skipif(
-    NDArray is None,
-    reason="numpy.typing is not available",
-)
+@pytest.mark.skipif(NDArray is None, **needs_np_typing)
 @pytest.mark.parametrize("typ", STANDARD_TYPES_TYPE)
 def test_resolves_specified_NDArray_type(typ):
     arr = from_type(NDArray[typ]).example()
@@ -75,10 +74,7 @@ def test_resolves_specified_NDArray_type(typ):
     assert arr.dtype.type == typ
 
 
-@pytest.mark.skipif(
-    ArrayLike is None,
-    reason="numpy.typing is not available",
-)
+@pytest.mark.skipif(ArrayLike is None, **needs_np_typing)
 @given(arr_like=from_type(ArrayLike))
 def test_resolves_ArrayLike_type(arr_like):
     arr = np.array(arr_like)
@@ -88,10 +84,7 @@ def test_resolves_ArrayLike_type(arr_like):
     # we just did).
 
 
-@pytest.mark.skipif(
-    _NestedSequence is None,
-    reason="numpy._typing is not available",
-)
+@pytest.mark.skipif(_NestedSequence is None, **needs_np_private_typing)
 def test_resolves_specified_NestedSequence():
     @given(seq=from_type(_NestedSequence[int]))
     def test(seq):
@@ -109,28 +102,19 @@ def test_resolves_specified_NestedSequence():
     test()
 
 
-@pytest.mark.skipif(
-    _NestedSequence is None,
-    reason="numpy._typing is not available",
-)
+@pytest.mark.skipif(_NestedSequence is None, **needs_np_private_typing)
 @given(seq=from_type(_NestedSequence))
 def test_resolves_unspecified_NestedSequence(seq):
     assert hasattr(seq, "__iter__")
 
 
-@pytest.mark.skipif(
-    _SupportsArray is None,
-    reason="numpy._typing is not available",
-)
+@pytest.mark.skipif(_SupportsArray is None, **needs_np_private_typing)
 @given(arr=from_type(_SupportsArray))
 def test_resolves_unspecified_SupportsArray(arr):
     assert hasattr(arr, "__array__")
 
 
-@pytest.mark.skipif(
-    _SupportsArray is None,
-    reason="numpy._typing is not available",
-)
+@pytest.mark.skipif(_SupportsArray is None, **needs_np_private_typing)
 def test_resolves_SupportsArray():
     @given(arr=from_type(_SupportsArray[int]))
     def test(arr):
@@ -140,10 +124,7 @@ def test_resolves_SupportsArray():
     test()
 
 
-@pytest.mark.skipif(
-    _NestedSequence is None or _SupportsArray is None,
-    reason="numpy._typing is not available",
-)
+@pytest.mark.skipif(_NestedSequence is None or _SupportsArray is None, **needs_np_private_typing)
 def test_resolve_ArrayLike_equivalent():
     # This is the current (1.24.3) definition of ArrayLike,
     # with problematic parts commented out.

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -31,7 +31,9 @@ def test_resolves_dtype_type(dtype):
 
 @pytest.mark.parametrize("typ", [np.object_, np.void])
 def test_does_not_resolve_nonscalar_types(typ):
-    assert from_type(typ) == builds(typ)
+    # Comparing the objects directly fails on Windows,
+    # so compare their reprs instead.
+    assert repr(from_type(typ)) == repr(builds(typ))
 
 
 @pytest.mark.parametrize("typ", STANDARD_TYPES_TYPE)

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -26,6 +26,7 @@ STANDARD_TYPES_TYPE = [dtype.type for dtype in STANDARD_TYPES]
 needs_np_typing = {"reason": "numpy.typing is not available"}
 needs_np_private_typing = {"reason": "numpy._typing is not available"}
 
+
 @given(dtype=from_type(np.dtype))
 def test_resolves_dtype_type(dtype):
     assert isinstance(dtype, np.dtype)
@@ -124,7 +125,9 @@ def test_resolves_SupportsArray():
     test()
 
 
-@pytest.mark.skipif(_NestedSequence is None or _SupportsArray is None, **needs_np_private_typing)
+@pytest.mark.skipif(
+    _NestedSequence is None or _SupportsArray is None, **needs_np_private_typing
+)
 def test_resolve_ArrayLike_equivalent():
     # This is the current (1.24.3) definition of ArrayLike,
     # with problematic parts commented out.

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -1,3 +1,13 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
 import sys
 import typing
 
@@ -5,13 +15,14 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from hypothesis import assume, given
+from hypothesis import given
 from hypothesis.strategies import from_type
 
+from .test_from_dtype import STANDARD_TYPES
 from tests.common.debug import find_any
 
-from .test_from_dtype import STANDARD_TYPES
 STANDARD_TYPES_TYPE = [dtype.type for dtype in STANDARD_TYPES]
+
 
 @given(dtype=from_type(np.dtype))
 def test_resolves_dtype_type(dtype):
@@ -59,3 +70,19 @@ def test_resolves_ArrayLike_type(arr_like):
     # The variation is too large to assert anything else about arr, but the
     # ArrayLike contract just says that it can be coerced intto an array (which
     # we just did).
+
+
+@given(seq=from_type(np._typing._nested_sequence._NestedSequence[int]))
+def test_resolves_NestedSequence(seq):
+    assert hasattr(seq, "__iter__")
+
+
+@given(arr=from_type(np._typing._array_like._SupportsArray))
+def test_resolves_unspecified_SupportsArray(arr):
+    assert hasattr(arr, "__array__")
+
+
+@given(arr=from_type(np._typing._array_like._SupportsArray[int]))
+def test_resolves_SupportsArray(arr):
+    assert hasattr(arr, "__array__")
+    assert np.asarray(arr).dtype.kind == "i"

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -68,12 +68,26 @@ def test_resolves_ArrayLike_type(arr_like):
     arr = np.array(arr_like)
     assert isinstance(arr, np.ndarray)
     # The variation is too large to assert anything else about arr, but the
-    # ArrayLike contract just says that it can be coerced intto an array (which
+    # ArrayLike contract just says that it can be coerced into an array (which
     # we just did).
 
 
 @given(seq=from_type(np._typing._nested_sequence._NestedSequence[int]))
-def test_resolves_NestedSequence(seq):
+def test_resolves_specified_NestedSequence(seq):
+    assert hasattr(seq, "__iter__")
+
+    def flatten(lst):
+        for el in lst:
+            try:
+                yield from flatten(el)
+            except TypeError:
+                yield el
+
+    assert all(isinstance(i, int) for i in flatten(seq))
+
+
+@given(seq=from_type(np._typing._nested_sequence._NestedSequence))
+def test_resolves_unspecified_NestedSequence(seq):
     assert hasattr(seq, "__iter__")
 
 

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -1,36 +1,66 @@
+import sys
+import typing
+
 import numpy as np
 import numpy.typing as npt
 import pytest
 
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis.strategies import from_type
 
 from tests.common.debug import find_any
 
 from .test_from_dtype import STANDARD_TYPES
+STANDARD_TYPES_TYPE = [dtype.type for dtype in STANDARD_TYPES]
 
 @given(dtype=from_type(np.dtype))
 def test_resolves_dtype_type(dtype):
     assert isinstance(dtype, np.dtype)
 
 
-@pytest.mark.parametrize("dtype", STANDARD_TYPES)
-def test_resolves_and_varies_numpy_scalar_type(dtype):
+@pytest.mark.parametrize("typ", STANDARD_TYPES_TYPE)
+def test_resolves_and_varies_numpy_scalar_type(typ):
     # Check that we find an instance that is not equal to the default
-    x = find_any(from_type(dtype.type), lambda x: x != type(x)())
-    assert isinstance(x, dtype.type)
+    x = find_any(from_type(typ), lambda x: x != type(x)())
+    assert isinstance(x, typ)
 
 
 @pytest.mark.parametrize("atype", [np.ndarray, npt.NDArray])
 def test_resolves_unspecified_array_type(atype):
-    s = from_type(atype)
-    assert isinstance(s.example(), np.ndarray)
+    assert isinstance(from_type(atype).example(), np.ndarray)
 
 
-@pytest.mark.parametrize("atype", [np.ndarray, npt.NDArray])
-@pytest.mark.parametrize("dtype", STANDARD_TYPES)
-def test_resolves_specified_array_type(atype, dtype):
-    typ = atype[dtype.type]
-    s = from_type(typ)
-    assert isinstance(s.example(), np.ndarray)
-    assert s.example().dtype.kind == dtype.kind
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 9),
+    reason="Type subscription requires python >= 3.9",
+)
+@pytest.mark.parametrize("typ", STANDARD_TYPES_TYPE)
+def test_resolves_specified_ndarray_type(typ):
+    arr = from_type(np.ndarray[typ]).example()
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype.type == typ
+
+    arr = from_type(np.ndarray[typing.Any, typ]).example()
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype.type == typ
+
+
+@pytest.mark.parametrize("typ", STANDARD_TYPES_TYPE)
+def test_resolves_specified_NDArray_type(typ):
+    arr = from_type(npt.NDArray[typ]).example()
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype.type == typ
+
+
+@given(arr_like=from_type(npt.ArrayLike))
+def test_resolves_ArrayLike_type(arr_like):
+    arr = np.array(arr_like)
+    if arr.size:
+        # We can't just check arr.dtype, since f.x. huge integers generate an
+        # array of dtype "O", with instances of int as elements. So check the
+        # dtype associated with the elements' types instead.
+        types = [type(e) for e in arr.flat]
+        assert len(set(types)) == 1
+        assert np.dtype(types[0]) in STANDARD_TYPES
+    else:
+        assert arr.dtype in STANDARD_TYPES

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -55,12 +55,7 @@ def test_resolves_specified_NDArray_type(typ):
 @given(arr_like=from_type(npt.ArrayLike))
 def test_resolves_ArrayLike_type(arr_like):
     arr = np.array(arr_like)
-    if arr.size:
-        # We can't just check arr.dtype, since f.x. huge integers generate an
-        # array of dtype "O", with instances of int as elements. So check the
-        # dtype associated with the elements' types instead.
-        types = [type(e) for e in arr.flat]
-        assert len(set(types)) == 1
-        assert np.dtype(types[0]) in STANDARD_TYPES
-    else:
-        assert arr.dtype in STANDARD_TYPES
+    assert isinstance(arr, np.ndarray)
+    # The variation is too large to assert anything else about arr, but the
+    # ArrayLike contract just says that it can be coerced intto an array (which
+    # we just did).

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -138,3 +138,39 @@ def test_resolves_SupportsArray():
         assert np.asarray(arr).dtype.kind == "i"
 
     test()
+
+
+@pytest.mark.skipif(
+    _NestedSequence is None or _SupportsArray is None,
+    reason="numpy._typing is not available",
+)
+def test_resolve_ArrayLike_equivalent():
+    # This is the current (1.24.3) definition of ArrayLike,
+    # with problematic parts commented out.
+    ArrayLike_like = typing.Union[
+        _SupportsArray,
+        # _NestedSequence[_SupportsArray],
+        bool,
+        int,
+        float,
+        complex,
+        str,
+        bytes,
+        _NestedSequence[
+            typing.Union[
+                bool,
+                int,
+                float,
+                complex,
+                str,
+                # bytes,
+            ]
+        ],
+    ]
+
+    @given(arr_like=from_type(ArrayLike_like))
+    def test(arr_like):
+        arr = np.array(arr_like)
+        assert isinstance(arr, np.ndarray)
+
+    test()

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -1,0 +1,36 @@
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from hypothesis import given
+from hypothesis.strategies import from_type
+
+from tests.common.debug import find_any
+
+from .test_from_dtype import STANDARD_TYPES
+
+@given(dtype=from_type(np.dtype))
+def test_resolves_dtype_type(dtype):
+    assert isinstance(dtype, np.dtype)
+
+
+@pytest.mark.parametrize("dtype", STANDARD_TYPES)
+def test_resolves_and_varies_numpy_scalar_type(dtype):
+    # Check that we find an instance that is not equal to the default
+    x = find_any(from_type(dtype.type), lambda x: x != type(x)())
+    assert isinstance(x, dtype.type)
+
+
+@pytest.mark.parametrize("atype", [np.ndarray, npt.NDArray])
+def test_resolves_unspecified_array_type(atype):
+    s = from_type(atype)
+    assert isinstance(s.example(), np.ndarray)
+
+
+@pytest.mark.parametrize("atype", [np.ndarray, npt.NDArray])
+@pytest.mark.parametrize("dtype", STANDARD_TYPES)
+def test_resolves_specified_array_type(atype, dtype):
+    typ = atype[dtype.type]
+    s = from_type(typ)
+    assert isinstance(s.example(), np.ndarray)
+    assert s.example().dtype.kind == dtype.kind


### PR DESCRIPTION
A follow-up on https://github.com/HypothesisWorks/hypothesis/pull/3668, addressing https://github.com/HypothesisWorks/hypothesis/issues/3150 (draft, for discussion).

I believe something like this is the easiest way to support arbitrary and parameterized special types such as `np.ndarray[int]`. Allowing the numpy extra to inspect the type before other partial resolutions means we can compare directly with e.g. `np.typing.ArrayLike`, which is (IMO) much easier than digesting the inner types of the union. Mind, if the union is not consumed by the specialized resolver then it will get another crack at the inner types later.

I did try to make it sort-of-generic by adding a lookup table for specialized resolvers. The lookup table only considers installed modules though, not the actual module of the type.