### PR TITLE
Validate args to `st.recursive()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+New input validation for :func:`~hypothesis.strategies.recursive`
+will raise an error rather than hanging indefinitely if passed
+invalid ``max_leaves=`` arguments.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
@@ -11,8 +11,10 @@
 import threading
 from contextlib import contextmanager
 
+from hypothesis.errors import InvalidArgument
 from hypothesis.internal.lazyformat import lazyformat
 from hypothesis.internal.reflection import get_pretty_function_description
+from hypothesis.internal.validation import check_type
 from hypothesis.strategies._internal.strategies import (
     OneOfStrategy,
     SearchStrategy,
@@ -97,6 +99,11 @@ class RecursiveStrategy(SearchStrategy):
         check_strategy(extended, f"extend({self.limited_base!r})")
         self.limited_base.validate()
         extended.validate()
+        check_type(int, self.max_leaves, "max_leaves")
+        if self.max_leaves <= 0:
+            raise InvalidArgument(
+                f"max_leaves={self.max_leaves!r} must be greater than zero"
+            )
 
     def do_draw(self, data):
         count = 0

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -978,6 +978,7 @@ class FilteredStrategy(SearchStrategy[Ex]):
 
 @check_function
 def check_strategy(arg, name=""):
+    assert isinstance(name, str)
     if not isinstance(arg, SearchStrategy):
         hint = ""
         if isinstance(arg, (list, tuple)):

--- a/hypothesis-python/tests/cover/test_recursive.py
+++ b/hypothesis-python/tests/cover/test_recursive.py
@@ -73,3 +73,18 @@ def test_can_exclude_branching_with_max_leaves(t):
 @given(st.recursive(st.none(), lambda x: st.one_of(x, x)))
 def test_issue_1502_regression(s):
     pass
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        st.recursive(None, st.lists),
+        st.recursive(st.none(), lambda x: None),
+        st.recursive(st.none(), st.lists, max_leaves=-1),
+        st.recursive(st.none(), st.lists, max_leaves=0),
+        st.recursive(st.none(), st.lists, max_leaves=1.0),
+    ],
+)
+def test_invalid_args(s):
+    with pytest.raises(InvalidArgument):
+        s.example()


### PR DESCRIPTION
Fixes #3672.

All of this new input validation will only catch things that were already errors or hangs, so we don't need a deprecation period, but I've made it a `minor` release since some exception types might change for already-broken things and hey, version numbers are free.