### PR TITLE
Single registration for builtin and `typing.` generic types

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release changes :func:`~hypothesis.strategies.register_type_strategy`
+for compatibility with :pep:`585`: we now store only a single strategy or
+resolver function which is used for both the builtin and the ``typing``
+module version of each type (:issue:`3635`).
+
+If you previously relied on registering separate strategies for e.g.
+``list`` vs ``typing.List``, you may need to use explicit strategies
+rather than inferring them from types.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -250,7 +250,7 @@ def is_a_new_type(thing):
         )
     # In 3.10 and later, NewType is actually a class - which simplifies things.
     # See https://bugs.python.org/issue44353 for links to the various patches.
-    return isinstance(thing, typing.NewType)  # pragma: no cover  # on 3.8, anyway
+    return isinstance(thing, typing.NewType)
 
 
 def is_a_union(thing):

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -27,7 +27,7 @@ import pytest
 
 from hypothesis import HealthCheck, assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed, SmallSearchSpaceWarning
-from hypothesis.internal.compat import PYPY, get_type_hints
+from hypothesis.internal.compat import PYPY, get_origin, get_type_hints
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types
@@ -232,7 +232,10 @@ def test_lookup_overrides_defaults():
 
 def test_register_generic_typing_strats():
     # I don't expect anyone to do this, but good to check it works as expected
-    with temp_registered(typing.Sequence, types._global_type_lookup[typing.Set]):
+    with temp_registered(
+        typing.Sequence,
+        types._global_type_lookup[get_origin(typing.Set) or typing.Set],
+    ):
         # We register sets for the abstract sequence type, which masks subtypes
         # from supertype resolution but not direct resolution
         assert_all_examples(

--- a/hypothesis-python/tests/ghostwriter/recorded/merge_dicts.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/merge_dicts.txt
@@ -9,12 +9,12 @@ from hypothesis import given, strategies as st
 
 @given(
     map1=st.one_of(
-        st.dictionaries(keys=st.text(), values=st.integers()),
         st.dictionaries(keys=st.text(), values=st.integers()).map(ChainMap),
+        st.dictionaries(keys=st.text(), values=st.integers()),
     ),
     map2=st.one_of(
-        st.dictionaries(keys=st.text(), values=st.integers()),
         st.dictionaries(keys=st.text(), values=st.integers()).map(ChainMap),
+        st.dictionaries(keys=st.text(), values=st.integers()),
     ),
 )
 def test_fuzz_merge_dicts(


### PR DESCRIPTION
This is a work in progress - at time of writing it fixes #3635, but breaks the special cases we have for bytestrings.

Once that's fixed it looks pretty good, but... arguably this bugfix is also a breaking change 😬.  Not entirely sure what we want to do about that, there's no real deprecation pathway possible so our options are probably either (a) ship it now, or (b) wait until the next major version - which I'd pull forward to the 3.7 EOL at the end of this month, I guess.

Thoughts?