### PR TITLE
ensured that ghostwriter does not use deprecated aliases

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -128,7 +128,7 @@ their individual contributions.
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Nick Anyos <https://www.github.com/NickAnyos>`_
 * `Nick Muoh <https://github.com/OdinTech3>`_ (nickspirit3@gmail.com)
-* `Nicolas Ganz <https://www.github.com/ThunderKey>`_
+* `Nicolas Erni <https://www.github.com/ThunderKey>`_
 * `Nikita Sobolev <https://github.com/sobolevn>`_ (mail@sobolevn.me)
 * `Oleg Höfling <https://github.com/hoefling>`_ (oleg.hoefling@gmail.com)
 * `Paul Ganssle <https://ganssle.io>`_ (paul@ganssle.io)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release ensures that Ghostwriter does not use the deprecated aliases
+for the ``collections.abc`` classes in ``collections``.

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -714,6 +714,11 @@ def _get_module_helper(obj):
     # The goal is to show location from which obj should usually be accessed, rather
     # than what we assume is an internal submodule which defined it.
     module_name = obj.__module__
+
+    # if "collections.abc" is used don't use the deprecated aliases in "collections"
+    if module_name == "collections.abc":
+        return module_name
+
     dots = [i for i, c in enumerate(module_name) if c == "."] + [None]
     for idx in dots:
         if getattr(sys.modules.get(module_name[:idx]), obj.__name__, None) is obj:

--- a/hypothesis-python/tests/ghostwriter/recorded/sequence_from_collections.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/sequence_from_collections.txt
@@ -1,0 +1,11 @@
+# This test code was written by the `hypothesis.extra.ghostwriter` module
+# and is provided under the Creative Commons Zero public domain dedication.
+
+import collections.abc
+import test_expected_output
+from hypothesis import given, strategies as st
+
+
+@given(items=st.one_of(st.binary(), st.lists(st.integers())))
+def test_fuzz_sequence_from_collections(items: collections.abc.Sequence[int]) -> None:
+    test_expected_output.sequence_from_collections(items=items)

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -17,6 +17,7 @@ To update the recorded outputs, run `pytest --hypothesis-update-outputs ...`.
 import ast
 import base64
 import builtins
+import collections.abc
 import operator
 import pathlib
 import re
@@ -106,6 +107,17 @@ else:
         return sum(items)
 
 
+if sys.version_info[:2] >= (3, 9):
+    CollectionsSequence = collections.abc.Sequence
+else:
+    # in older versions collections.abc was not generic
+    CollectionsSequence = Sequence
+
+
+def sequence_from_collections(items: CollectionsSequence[int]) -> int:
+    return min(items)
+
+
 # Note: for some of the `expected` outputs, we replace away some small
 #       parts which vary between minor versions of Python.
 @pytest.mark.parametrize(
@@ -128,6 +140,10 @@ else:
         ),
         ("optional_union_parameter", ghostwriter.magic(optional_union_parameter)),
         ("union_sequence_parameter", ghostwriter.magic(union_sequence_parameter)),
+        pytest.param(
+            ("sequence_from_collections", ghostwriter.magic(sequence_from_collections)),
+            marks=pytest.mark.skipif("sys.version_info[:2] < (3, 9)"),
+        ),
         pytest.param(
             ("add_custom_classes", ghostwriter.magic(add_custom_classes)),
             marks=pytest.mark.skipif("sys.version_info[:2] < (3, 10)"),


### PR DESCRIPTION
`collections` contains deprecated aliases for `collections.abc` classes. This commit ensures that those are not used anymore.

I've ignored the tests for Python versions < 3.9, because there the `collections.abc` classes were no generics.

Plus: I've changed my name after marrying :slightly_smiling_face: 