### PR TITLE
Drop Python 3.7 at end of life (2023-06-27)

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release drops support for Python 3.7, `which reached end of life on
+2023-06-27 <https://devguide.python.org/versions/>`__.

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -182,12 +182,6 @@ and then tell ``setuptools`` that this is your ``"hypothesis"`` entry point:
 
 And that's all it takes!
 
-.. note::
-    On Python 3.7, where the ``importlib.metadata`` module
-    is not in the standard library, loading entry points requires either the
-    :pypi:`importlib_metadata` (preferred) or :pypi:`setuptools` (fallback)
-    package to be installed.
-
 
 Interaction with :pypi:`pytest-cov`
 -----------------------------------

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -76,9 +76,7 @@ extras = {
     "django": ["django>=3.2"],
 }
 
-extras["all"] = sorted(
-    set(sum(extras.values(), ["importlib_metadata>=3.6; python_version<'3.8'"]))
-)
+extras["all"] = sorted(set(sum(extras.values(), [])))
 
 
 setuptools.setup(

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -14,10 +14,10 @@ import warnings
 
 import setuptools
 
-if sys.version_info[:2] < (3, 7):
+if sys.version_info[:2] < (3, 8):
     raise Exception(
         "You are trying to install Hypothesis using Python "
-        f"{sys.version.split()[0]}, but it requires Python 3.7 or later."
+        f"{sys.version.split()[0]}, but it requires Python 3.8 or later."
         "Update `pip` and `setuptools`, try again, and you will automatically "
         "get the latest compatible version of Hypothesis instead.  "
         "See also https://python3statement.org/practicalities/"
@@ -103,7 +103,7 @@ setuptools.setup(
         "exceptiongroup>=1.0.0 ; python_version<'3.11'",
         "sortedcontainers>=2.1.0,<3.0.0",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Hypothesis",
@@ -116,7 +116,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/hypothesis-python/src/hypothesis/_error_if_old.py
+++ b/hypothesis-python/src/hypothesis/_error_if_old.py
@@ -13,11 +13,11 @@ import sys
 from hypothesis.version import __version__
 
 message = """
-Hypothesis {} requires Python 3.7 or later.
+Hypothesis {} requires Python 3.8 or later.
 
 This can only happen if your packaging toolchain is older than python_requires.
 See https://packaging.python.org/guides/distributing-packages-using-setuptools/
 """
 
-if sys.version_info[:2] < (3, 7):
+if sys.version_info[:2] < (3, 8):
     raise Exception(message.format(__version__))

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -162,7 +162,7 @@ class settings(metaclass=settingsMeta):
             if database not in (not_set, None):  # type: ignore
                 raise InvalidArgument(
                     "derandomize=True implies database=None, so passing "
-                    f"database={database!r} too is invalid."
+                    f"{database=} too is invalid."
                 )
             database = None
 
@@ -191,7 +191,7 @@ class settings(metaclass=settingsMeta):
         if not callable(_test):
             raise InvalidArgument(
                 "settings objects can be called as a decorator with @given, "
-                f"but decorated test={test!r} is not callable."
+                f"but decorated {test=} is not callable."
             )
         if inspect.isclass(test):
             from hypothesis.stateful import RuleBasedStateMachine

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -206,7 +206,7 @@ def target(observation: Union[int, float], *, label: str = "") -> Union[int, flo
     """
     check_type((int, float), observation, "observation")
     if not math.isfinite(observation):
-        raise InvalidArgument(f"observation={observation!r} must be a finite float.")
+        raise InvalidArgument(f"{observation=} must be a finite float.")
     check_type(str, label, "label")
 
     context = _current_build_context.value
@@ -215,12 +215,12 @@ def target(observation: Union[int, float], *, label: str = "") -> Union[int, flo
             "Calling target() outside of a test is invalid.  "
             "Consider guarding this call with `if currently_in_test_context(): ...`"
         )
-    verbose_report(f"Saw target(observation={observation!r}, label={label!r})")
+    verbose_report(f"Saw target({observation!r}, {label=})")
 
     if label in context.data.target_observations:
         raise InvalidArgument(
-            f"Calling target({observation!r}, label={label!r}) would overwrite "
-            f"target({context.data.target_observations[label]!r}, label={label!r})"
+            f"Calling target({observation!r}, {label=}) would overwrite "
+            f"target({context.data.target_observations[label]!r}, {label=})"
         )
     else:
         context.data.target_observations[label] = observation

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -200,7 +200,7 @@ class example:
             )
         ):
             raise InvalidArgument(
-                f"raises={raises!r} must be an exception type or tuple of exception types"
+                f"{raises=} must be an exception type or tuple of exception types"
             )
         if condition:
             self._this_example = attr.evolve(

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -208,7 +208,7 @@ class example:
             )
         return self
 
-    def via(self, *whence: str) -> "example":
+    def via(self, whence: str, /) -> "example":
         """Attach a machine-readable label noting whence this example came.
 
         The idea is that tools will be able to add ``@example()`` cases for you, e.g.
@@ -243,25 +243,10 @@ class example:
                 pass
 
         """
-        if len(whence) != 1 or not isinstance(whence[0], str):
+        if not isinstance(whence, str):
             raise InvalidArgument(".via() must be passed a string")
         # This is deliberately a no-op at runtime; the tools operate on source code.
         return self
-
-    if sys.version_info[:2] >= (3, 8):
-        # We want a positional-only argument, and on Python 3.8+ we'll get it.
-        __sig = get_signature(via)
-        via = define_function_signature(
-            name=via.__name__,
-            docstring=via.__doc__,
-            signature=__sig.replace(
-                parameters=[
-                    p.replace(kind=inspect.Parameter.POSITIONAL_ONLY)
-                    for p in __sig.parameters.values()
-                ]
-            ),
-        )(via)
-        del __sig
 
 
 def seed(seed: Hashable) -> Callable[[TestFunc], TestFunc]:

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -64,7 +64,7 @@ def _db_for_path(path=None):
                 HypothesisWarning(
                     "The database setting is not configured, and the default "
                     "location is unusable - falling back to an in-memory "
-                    f"database for this session.  path={path!r}"
+                    f"database for this session.  {path=}"
                 )
             )
             return InMemoryExampleDatabase()

--- a/hypothesis-python/src/hypothesis/entry_points.py
+++ b/hypothesis-python/src/hypothesis/entry_points.py
@@ -15,47 +15,17 @@ custom types, running the relevant code when *hypothesis* is imported instead of
 your package.
 """
 
-try:
-    # We prefer to use importlib.metadata, or the backport on Python <= 3.7,
-    # because it's much faster than pkg_resources (200ms import time speedup).
+import importlib.metadata
+
+
+def get_entry_points():
     try:
-        from importlib import metadata as importlib_metadata
-    except ImportError:
-        import importlib_metadata  # type: ignore  # mypy thinks this is a redefinition
-
-    def get_entry_points():
-        try:
-            eps = importlib_metadata.entry_points(group="hypothesis")
-        except TypeError:  # pragma: no cover
-            # Load-time selection requires Python >= 3.10 or importlib_metadata >= 3.6,
-            # so we'll retain this fallback logic for some time to come.  See also
-            # https://importlib-metadata.readthedocs.io/en/latest/using.html
-            eps = importlib_metadata.entry_points().get("hypothesis", [])
-        yield from eps
-
-except ImportError:
-    # But if we're not on Python >= 3.8 and the importlib_metadata backport
-    # is not installed, we fall back to pkg_resources anyway.
-    try:
-        import pkg_resources
-    except ImportError:
-        import warnings
-
-        from hypothesis.errors import HypothesisWarning
-
-        warnings.warn(
-            "Under Python <= 3.7, Hypothesis requires either the importlib_metadata "
-            "or setuptools package in order to load plugins via entrypoints.",
-            HypothesisWarning,
-        )
-
-        def get_entry_points():
-            yield from ()
-
-    else:
-
-        def get_entry_points():
-            yield from pkg_resources.iter_entry_points("hypothesis")
+        eps = importlib.metadata.entry_points(group="hypothesis")
+    except TypeError:  # pragma: no cover
+        # Load-time selection requires Python >= 3.10.  See also
+        # https://importlib-metadata.readthedocs.io/en/latest/using.html
+        eps = importlib.metadata.entry_points().get("hypothesis", [])
+    yield from eps
 
 
 def run():

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -294,7 +294,7 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
                 "Hypothesis does not yet support generalised ufunc signatures "
                 "with multiple output arrays - mostly because we don't know of "
                 "anyone who uses them!  Please get in touch with us to fix that."
-                f"\n (signature={signature!r})"
+                f"\n ({signature=})"
             )
         if re.match(
             (
@@ -305,7 +305,7 @@ def _hypothesis_parse_gufunc_signature(signature, all_checks=True):
             signature,
         ):
             raise InvalidArgument(
-                f"signature={signature!r} matches Numpy's regex for gufunc signatures, "
+                f"{signature=} matches Numpy's regex for gufunc signatures, "
                 f"but contains shapes with more than {NDIM_MAX} dimensions and is thus invalid."
             )
         raise InvalidArgument(f"{signature!r} is not a valid gufunc signature")

--- a/hypothesis-python/src/hypothesis/extra/_patching.py
+++ b/hypothesis-python/src/hypothesis/extra/_patching.py
@@ -209,7 +209,7 @@ def make_patch(triples, *, msg="Hypothesis: add explicit examples", when=None):
 
 
 def save_patch(patch: str, *, slug: str = "") -> Path:  # pragma: no cover
-    assert re.fullmatch(r"|[a-z]+-", slug), f"malformed slug={slug!r}"
+    assert re.fullmatch(r"|[a-z]+-", slug), f"malformed {slug=}"
     now = date.today().isoformat()
     cleaned = re.sub(r"^Date: .+?$", "", patch, count=1, flags=re.MULTILINE)
     hash8 = hashlib.sha1(cleaned.encode()).hexdigest()[:8]

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -8,12 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import sys
-
-if sys.version_info[:2] < (3, 8):
-    raise RuntimeError("The Array API standard requires Python 3.8 or later")
-
 import math
+import sys
 from numbers import Real
 from types import SimpleNamespace
 from typing import (

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -563,7 +563,7 @@ def _arrays(
         raise InvalidArgument(f"shape={shape} is not a valid shape or strategy")
     check_argument(
         all(isinstance(x, int) and x >= 0 for x in shape),
-        f"shape={shape!r}, but all dimensions must be non-negative integers.",
+        f"{shape=}, but all dimensions must be non-negative integers.",
     )
 
     if elements is None:
@@ -802,7 +802,7 @@ def indices(
     check_type(tuple, shape, "shape")
     check_argument(
         all(isinstance(x, int) and x >= 0 for x in shape),
-        f"shape={shape!r}, but all dimensions must be non-negative integers.",
+        f"{shape=}, but all dimensions must be non-negative integers.",
     )
     check_type(bool, allow_newaxis, "allow_newaxis")
     check_type(bool, allow_ellipsis, "allow_ellipsis")
@@ -896,7 +896,7 @@ def make_strategies_namespace(
         check_argument(
             isinstance(xp.__array_api_version__, str)
             and xp.__array_api_version__ in RELEASED_VERSIONS,
-            f"xp.__array_api_version__={xp.__array_api_version__!r}, but it must "
+            f"{xp.__array_api_version__=}, but it must "
             f"be a valid version string {RELEASED_VERSIONS}. {not_available_msg}",
         )
         api_version = xp.__array_api_version__
@@ -904,7 +904,7 @@ def make_strategies_namespace(
     else:
         check_argument(
             isinstance(api_version, str) and api_version in NOMINAL_VERSIONS,
-            f"api_version={api_version!r}, but it must be None, or a valid version "
+            f"{api_version=}, but it must be None, or a valid version "
             f"string in {RELEASED_VERSIONS}. {not_available_msg}",
         )
         inferred_version = False

--- a/hypothesis-python/src/hypothesis/extra/codemods.py
+++ b/hypothesis-python/src/hypothesis/extra/codemods.py
@@ -126,7 +126,7 @@ class HypothesisFixComplexMinMagnitude(VisitorBasedCodemodCommand):
         return updated_node
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_fn(import_path):
     mod, fn = import_path.rsplit(".", 1)
     return getattr(importlib.import_module(mod), fn)

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -53,7 +53,7 @@ def integers_for_field(min_value, max_value):
     return inner
 
 
-@lru_cache()
+@lru_cache
 def timezones():
     # From Django 4.0, the default is to use zoneinfo instead of pytz.
     assert getattr(django.conf.settings, "USE_TZ", False)

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -186,7 +186,7 @@ def _for_form_ip(field):
         return st.ip_addresses(v=4).map(str)
     if validate_ipv6_address in field.default_validators:
         return _ipv6_strings
-    raise ResolutionFailed(f"No IP version validator on field={field!r}")
+    raise ResolutionFailed(f"No IP version validator on {field=}")
 
 
 @register_for(dm.DecimalField)
@@ -275,11 +275,11 @@ def register_field_strategy(
     ``strategy`` must be a :class:`~hypothesis.strategies.SearchStrategy`.
     """
     if not issubclass(field_type, (dm.Field, df.Field)):
-        raise InvalidArgument(f"field_type={field_type!r} must be a subtype of Field")
+        raise InvalidArgument(f"{field_type=} must be a subtype of Field")
     check_type(st.SearchStrategy, strategy, "strategy")
     if field_type in _global_field_lookup:
         raise InvalidArgument(
-            f"field_type={field_type!r} already has a registered "
+            f"{field_type=} already has a registered "
             f"strategy ({_global_field_lookup[field_type]!r})"
         )
     if issubclass(field_type, dm.AutoField):

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -11,7 +11,6 @@
 import sys
 import unittest
 from functools import partial
-from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Optional, Type, Union
 
 from django import forms as df, test as dt
@@ -22,7 +21,6 @@ from django.db import IntegrityError, models as dm
 from hypothesis import reject, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.django._fields import from_field
-from hypothesis.internal.reflection import define_function_signature
 from hypothesis.strategies._internal.utils import defines_strategy
 
 if sys.version_info >= (3, 10):
@@ -66,7 +64,7 @@ class StaticLiveServerTestCase(HypothesisTestCase, dst.StaticLiveServerTestCase)
 
 @defines_strategy()
 def from_model(
-    *model: Type[dm.Model], **field_strategies: Union[st.SearchStrategy, EllipsisType]
+    model: Type[dm.Model], /, **field_strategies: Union[st.SearchStrategy, EllipsisType]
 ) -> st.SearchStrategy:
     """Return a strategy for examples of ``model``.
 
@@ -93,17 +91,10 @@ def from_model(
     ``...`` (:obj:`python:Ellipsis`) as a keyword argument to infer a strategy for
     a field which has a default value instead of using the default.
     """
-    if len(model) == 1:
-        m_type = model[0]
-    elif len(model) > 1:
-        raise TypeError("Too many positional arguments")
-    else:
-        raise TypeError("Missing required positional argument `model`")
-
-    if not issubclass(m_type, dm.Model):
+    if not issubclass(model, dm.Model):
         raise InvalidArgument(f"model={model!r} must be a subtype of Model")
 
-    fields_by_name = {f.name: f for f in m_type._meta.concrete_fields}
+    fields_by_name = {f.name: f for f in model._meta.concrete_fields}
     for name, value in sorted(field_strategies.items()):
         if value is ...:
             field_strategies[name] = from_field(fields_by_name[name])
@@ -116,31 +107,18 @@ def from_model(
             field_strategies[name] = from_field(field)
 
     for field in field_strategies:
-        if m_type._meta.get_field(field).primary_key:
+        if model._meta.get_field(field).primary_key:
             # The primary key is generated as part of the strategy. We
             # want to find any existing row with this primary key and
             # overwrite its contents.
             kwargs = {field: field_strategies.pop(field)}
             kwargs["defaults"] = st.fixed_dictionaries(field_strategies)  # type: ignore
-            return _models_impl(st.builds(m_type.objects.update_or_create, **kwargs))
+            return _models_impl(st.builds(model.objects.update_or_create, **kwargs))
 
     # The primary key is not generated as part of the strategy, so we
     # just match against any row that has the same value for all
     # fields.
-    return _models_impl(st.builds(m_type.objects.get_or_create, **field_strategies))
-
-
-if sys.version_info[:2] >= (3, 8):
-    # See notes above definition of st.builds() - this signature is compatible
-    # and better matches the semantics of the function.  Great for documentation!
-    sig = signature(from_model)
-    params = list(sig.parameters.values())
-    params[0] = params[0].replace(kind=Parameter.POSITIONAL_ONLY)
-    from_model = define_function_signature(
-        name=from_model.__name__,
-        docstring=from_model.__doc__,
-        signature=sig.replace(parameters=params),
-    )(from_model)
+    return _models_impl(st.builds(model.objects.get_or_create, **field_strategies))
 
 
 @st.composite

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -92,7 +92,7 @@ def from_model(
     a field which has a default value instead of using the default.
     """
     if not issubclass(model, dm.Model):
-        raise InvalidArgument(f"model={model!r} must be a subtype of Model")
+        raise InvalidArgument(f"{model=} must be a subtype of Model")
 
     fields_by_name = {f.name: f for f in model._meta.concrete_fields}
     for name, value in sorted(field_strategies.items()):
@@ -165,7 +165,7 @@ def from_form(
     # ImageField
     form_kwargs = form_kwargs or {}
     if not issubclass(form, df.BaseForm):
-        raise InvalidArgument(f"form={form!r} must be a subtype of Form")
+        raise InvalidArgument(f"{form=} must be a subtype of Form")
 
     # Forms are a little bit different from models. Model classes have
     # all their fields defined, whereas forms may have different fields

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -1329,7 +1329,7 @@ def fuzz(
     or :func:`~hypothesis.strategies.binary`.  After that, you have a test!
     """
     if not callable(func):
-        raise InvalidArgument(f"Got non-callable func={func!r}")
+        raise InvalidArgument(f"Got non-callable {func=}")
     except_ = _check_except(except_)
     _check_style(style)
 
@@ -1389,7 +1389,7 @@ def idempotent(
             assert result == repeat, (result, repeat)
     """
     if not callable(func):
-        raise InvalidArgument(f"Got non-callable func={func!r}")
+        raise InvalidArgument(f"Got non-callable {func=}")
     except_ = _check_except(except_)
     _check_style(style)
 
@@ -1628,14 +1628,14 @@ def binary_operation(
         )
     """
     if not callable(func):
-        raise InvalidArgument(f"Got non-callable func={func!r}")
+        raise InvalidArgument(f"Got non-callable {func=}")
     except_ = _check_except(except_)
     _check_style(style)
     check_type(bool, associative, "associative")
     check_type(bool, commutative, "commutative")
     if distributes_over is not None and not callable(distributes_over):
         raise InvalidArgument(
-            f"distributes_over={distributes_over!r} must be an operation which "
+            f"{distributes_over=} must be an operation which "
             f"distributes over {func.__name__}"
         )
     if not any([associative, commutative, identity, distributes_over]):
@@ -1811,7 +1811,7 @@ def ufunc(
         hypothesis write numpy.matmul
     """
     if not _is_probably_ufunc(func):
-        raise InvalidArgument(f"func={func!r} does not seem to be a ufunc")
+        raise InvalidArgument(f"{func=} does not seem to be a ufunc")
     except_ = _check_except(except_)
     _check_style(style)
 

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -103,13 +103,15 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
+    get_origin,
 )
 
 import black
 
 from hypothesis import Verbosity, find, settings, strategies as st
 from hypothesis.errors import InvalidArgument, SmallSearchSpaceWarning
-from hypothesis.internal.compat import get_args, get_origin, get_type_hints
+from hypothesis.internal.compat import get_type_hints
 from hypothesis.internal.reflection import get_signature, is_mock
 from hypothesis.internal.validation import check_type
 from hypothesis.provisional import domains

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -885,7 +885,7 @@ def basic_indices(
     check_type(tuple, shape, "shape")
     check_argument(
         all(isinstance(x, int) and x >= 0 for x in shape),
-        f"shape={shape!r}, but all dimensions must be non-negative integers.",
+        f"{shape=}, but all dimensions must be non-negative integers.",
     )
     check_type(bool, allow_ellipsis, "allow_ellipsis")
     check_type(bool, allow_newaxis, "allow_newaxis")
@@ -978,11 +978,11 @@ def integer_array_indices(
     check_type(tuple, shape, "shape")
     check_argument(
         shape and all(isinstance(x, int) and x > 0 for x in shape),
-        f"shape={shape!r} must be a non-empty tuple of integers > 0",
+        f"{shape=} must be a non-empty tuple of integers > 0",
     )
     check_strategy(result_shape, "result_shape")
     check_argument(
-        np.issubdtype(dtype, np.integer), f"dtype={dtype!r} must be an integer dtype"
+        np.issubdtype(dtype, np.integer), f"{dtype=} must be an integer dtype"
     )
     signed = np.issubdtype(dtype, np.signedinteger)
 

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -87,12 +87,12 @@ def elements_and_dtype(elements, dtype, source=None):
 
     if isinstance(dtype, type) and issubclass(dtype, IntegerDtype):
         raise InvalidArgument(
-            f"Passed dtype={dtype!r} is a dtype class, please pass in an instance of this class."
+            f"Passed {dtype=} is a dtype class, please pass in an instance of this class."
             "Otherwise it would be treated as dtype=object"
         )
 
     if isinstance(dtype, type) and np.dtype(dtype).kind == "O" and dtype is not object:
-        err_msg = f"Passed dtype={dtype!r} is not a valid Pandas dtype."
+        err_msg = f"Passed {dtype=} is not a valid Pandas dtype."
         if issubclass(dtype, datetime):
             err_msg += ' To generate valid datetimes, pass `dtype="datetime64[ns]"`'
             raise InvalidArgument(err_msg)
@@ -109,7 +109,7 @@ def elements_and_dtype(elements, dtype, source=None):
 
     if isinstance(dtype, st.SearchStrategy):
         raise InvalidArgument(
-            f"Passed dtype={dtype!r} is a strategy, but we require a concrete dtype "
+            f"Passed {dtype=} is a strategy, but we require a concrete dtype "
             "here.  See https://stackoverflow.com/q/74355937 for workaround patterns."
         )
 
@@ -654,7 +654,7 @@ def data_frames(
                                 value, (float, int, str, bool, datetime, timedelta)
                             ):
                                 raise ValueError(
-                                    f"Failed to add value={value!r} to column "
+                                    f"Failed to add {value=} to column "
                                     f"{c.name} with dtype=None.  Maybe passing "
                                     "dtype=object would help?"
                                 ) from err

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -204,49 +204,6 @@ def get_type_hints(thing):
     return hints
 
 
-def update_code_location(code, newfile, newlineno):
-    """Take a code object and lie shamelessly about where it comes from.
-
-    Why do we want to do this? It's for really shallow reasons involving
-    hiding the hypothesis_temporary_module code from test runners like
-    pytest's verbose mode. This is a vastly disproportionate terrible
-    hack that I've done purely for vanity, and if you're reading this
-    code you're probably here because it's broken something and now
-    you're angry at me. Sorry.
-    """
-    if hasattr(code, "replace"):
-        # Python 3.8 added positional-only params (PEP 570), and thus changed
-        # the layout of code objects.  In beta1, the `.replace()` method was
-        # added to facilitate future-proof code.  See BPO-37032 for details.
-        return code.replace(co_filename=newfile, co_firstlineno=newlineno)
-
-    else:  # pragma: no cover
-        # This field order is accurate for 3.5 - 3.7, but not 3.8 when a new field
-        # was added for positional-only arguments.  However it also added a .replace()
-        # method that we use instead of field indices, so they're fine as-is.
-        CODE_FIELD_ORDER = [
-            "co_argcount",
-            "co_kwonlyargcount",
-            "co_nlocals",
-            "co_stacksize",
-            "co_flags",
-            "co_code",
-            "co_consts",
-            "co_names",
-            "co_varnames",
-            "co_filename",
-            "co_name",
-            "co_firstlineno",
-            "co_lnotab",
-            "co_freevars",
-            "co_cellvars",
-        ]
-        unpacked = [getattr(code, name) for name in CODE_FIELD_ORDER]
-        unpacked[CODE_FIELD_ORDER.index("co_filename")] = newfile
-        unpacked[CODE_FIELD_ORDER.index("co_firstlineno")] = newlineno
-        return type(code)(*unpacked)
-
-
 # Under Python 2, math.floor and math.ceil returned floats, which cannot
 # represent large integers - eg `float(2**53) == float(2**53 + 1)`.
 # We therefore implement them entirely in (long) integer operations.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -14,62 +14,7 @@ import platform
 import sys
 import typing
 from functools import partial
-from typing import Any, ForwardRef, Tuple
-
-try:
-    from typing import get_args as get_args
-except ImportError:
-    # remove at Python 3.7 end-of-life
-    from collections.abc import Callable as _Callable
-
-    def get_args(
-        tp: Any,
-    ) -> Tuple[Any, ...]:  # pragma: no cover
-        """
-        Examples
-        --------
-        >>> assert get_args(int) == ()
-        >>> assert get_args(Dict[str, int]) == (str, int)
-        >>> assert get_args(Union[int, Union[T, int], str][int]) == (int, str)
-        >>> assert get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
-        >>> assert get_args(Callable[[], T][int]) == ([], int)
-        """
-        if hasattr(tp, "__origin__") and hasattr(tp, "__args__"):
-            args = tp.__args__
-            if (
-                getattr(tp, "__origin__", None) is _Callable
-                and args
-                and args[0] is not Ellipsis
-            ):
-                args = (list(args[:-1]), args[-1])
-            return args
-        return ()
-
-
-try:
-    from typing import get_origin as get_origin
-except ImportError:
-    # remove at Python 3.7 end-of-life
-    from collections.abc import Callable as _Callable  # noqa: F811
-
-    def get_origin(tp: Any) -> typing.Optional[Any]:  # type: ignore # pragma: no cover
-        """Get the unsubscripted version of a type.
-        This supports generic types, Callable, Tuple, Union, Literal, Final and ClassVar.
-        Return None for unsupported types. Examples::
-            get_origin(Literal[42]) is Literal
-            get_origin(int) is None
-            get_origin(ClassVar[int]) is ClassVar
-            get_origin(Generic) is Generic
-            get_origin(Generic[T]) is Generic
-            get_origin(Union[T, int]) is Union
-            get_origin(List[Tuple[T, T]][int]) == list
-        """
-        if hasattr(tp, "__origin__"):
-            return tp.__origin__
-        if tp is typing.Generic:
-            return typing.Generic
-        return None
-
+from typing import Any, ForwardRef, get_args
 
 try:
     BaseExceptionGroup = BaseExceptionGroup

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -110,9 +110,7 @@ class Shrinker:
         self.check_invariants(value)
         if not self.left_is_better(value, self.current):
             if value != self.current and (value == value):
-                self.debug(
-                    f"Rejected {value!r} as worse than self.current={self.current!r}"
-                )
+                self.debug(f"Rejected {value!r} as worse than {self.current=}")
             return False
         if value in self.__seen:
             return False

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -471,7 +471,7 @@ class many:
 SMALLEST_POSITIVE_FLOAT: float = next_up(0.0) or sys.float_info.min
 
 
-@lru_cache()
+@lru_cache
 def _calc_p_continue(desired_avg: float, max_size: int) -> float:
     """Return the p_continue which will generate the desired average size."""
     assert desired_avg <= max_size, (desired_avg, max_size)

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -22,10 +22,7 @@ from hypothesis.errors import HypothesisWarning, InvalidArgument
 from hypothesis.internal.compat import GRAALPY, PYPY
 
 if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):
-        from typing import Protocol
-    else:
-        from typing_extensions import Protocol
+    from typing import Protocol
 
     # we can't use this at runtime until from_type supports
     # protocols -- breaks ghostwriter tests

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -110,7 +110,7 @@ def register_random(r: RandomLike) -> None:
            register_random(rng)
     """
     if not (hasattr(r, "seed") and hasattr(r, "getstate") and hasattr(r, "setstate")):
-        raise InvalidArgument(f"r={r!r} does not have all the required methods")
+        raise InvalidArgument(f"{r=} does not have all the required methods")
 
     if r in RANDOMS_TO_MANAGE.values():
         return

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -27,7 +27,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import _patch as PatchType
 
-from hypothesis.internal.compat import PYPY, is_typed_named_tuple, update_code_location
+from hypothesis.internal.compat import PYPY, is_typed_named_tuple
 from hypothesis.utils.conventions import not_set
 from hypothesis.vendor.pretty import pretty
 
@@ -608,8 +608,11 @@ def impersonate(target):
     """
 
     def accept(f):
-        f.__code__ = update_code_location(
-            f.__code__, target.__code__.co_filename, target.__code__.co_firstlineno
+        # Lie shamelessly about where this code comes from, to hide the hypothesis
+        # internals from pytest, ipython, and other runtime introspection.
+        f.__code__ = f.__code__.replace(
+            co_filename=target.__code__.co_filename,
+            co_firstlineno=target.__code__.co_firstlineno,
         )
         f.__name__ = target.__name__
         f.__module__ = target.__module__

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -61,7 +61,7 @@ def _clean_source(src: str) -> bytes:
     # lines - i.e. any decorators, so that adding `@example()`s keeps the same key.
     try:
         funcdef = ast.parse(src).body[0]
-        if sys.version_info[:2] == (3, 7) or (sys.version_info[:2] == (3, 8) and PYPY):
+        if sys.version_info[:2] == (3, 8) and PYPY:
             # We can't get a line number of the (async) def here, so as a best-effort
             # approximation we'll use str.split instead and hope for the best.
             tag = "async def " if isinstance(funcdef, ast.AsyncFunctionDef) else "def "

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -462,7 +462,7 @@ class Bundle(SearchStrategy[Ex]):
         consume = self.__reference_strategy.consume
         if consume is False:
             return f"Bundle(name={self.name!r})"
-        return f"Bundle(name={self.name!r}, consume={consume!r})"
+        return f"Bundle(name={self.name!r}, {consume=})"
 
     def calc_is_empty(self, recur):
         # We assume that a bundle will grow over time

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -387,7 +387,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
     TestCase = TestCaseProperty()
 
     @classmethod
-    @lru_cache()
+    @lru_cache
     def _to_test_case(cls):
         class StateMachineTestCase(TestCase):
             settings = Settings(deadline=None, suppress_health_check=list(HealthCheck))

--- a/hypothesis-python/src/hypothesis/statistics.py
+++ b/hypothesis-python/src/hypothesis/statistics.py
@@ -32,11 +32,11 @@ def describe_targets(best_targets):
         return []
     elif len(best_targets) == 1:
         label, score = next(iter(best_targets.items()))
-        return [f"Highest target score: {score:g}  (label={label!r})"]
+        return [f"Highest target score: {score:g}  ({label=})"]
     else:
         lines = ["Highest target scores:"]
         for label, score in sorted(best_targets.items(), key=lambda x: x[::-1]):
-            lines.append(f"{score:>16g}  (label={label!r})")
+            lines.append(f"{score:>16g}  ({label=})")
         return lines
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -137,7 +137,7 @@ else:
 if sys.version_info >= (3, 8):
     from typing import Protocol
 elif TYPE_CHECKING:
-    from typing_extensions import Protocol
+    from typing import Protocol
 else:  # pragma: no cover
     Protocol = object
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -285,7 +285,7 @@ def lists(
     if unique_by is not None:
         if not (callable(unique_by) or isinstance(unique_by, tuple)):
             raise InvalidArgument(
-                f"unique_by={unique_by!r} is not a callable or tuple of callables"
+                f"{unique_by=} is not a callable or tuple of callables"
             )
         if callable(unique_by):
             unique_by = (unique_by,)
@@ -337,7 +337,7 @@ def lists(
             element_count = len(elements.elements)
             if min_size > element_count:
                 raise InvalidArgument(
-                    f"Cannot create a collection of min_size={min_size!r} unique "
+                    f"Cannot create a collection of {min_size=} unique "
                     f"elements with values drawn from only {element_count} distinct "
                     "elements"
                 )
@@ -580,7 +580,7 @@ def characters(
     ):
         raise InvalidArgument(
             "Nothing is excluded by other arguments, so passing only "
-            f"whitelist_characters={whitelist_characters!r} would have no effect.  "
+            f"{whitelist_characters=} would have no effect.  "
             "Also pass whitelist_categories=(), or use "
             f"sampled_from({whitelist_characters!r}) instead."
         )
@@ -590,8 +590,7 @@ def characters(
     if overlap:
         raise InvalidArgument(
             f"Characters {sorted(overlap)!r} are present in both "
-            f"whitelist_characters={whitelist_characters!r}, and "
-            f"blacklist_characters={blacklist_characters!r}"
+            f"{whitelist_characters=} and {blacklist_characters=}"
         )
     blacklist_categories = as_general_categories(
         blacklist_categories, "blacklist_categories"
@@ -613,8 +612,7 @@ def characters(
     if both_cats:
         raise InvalidArgument(
             f"Categories {sorted(both_cats)!r} are present in both "
-            f"whitelist_categories={whitelist_categories!r}, and "
-            f"blacklist_categories={blacklist_categories!r}"
+            f"{whitelist_categories=} and {blacklist_categories=}"
         )
 
     return OneCharStringStrategy(
@@ -1112,7 +1110,7 @@ def _from_type(thing: Type[Ex], recurse_guard: List[Type[Ex]]) -> SearchStrategy
                 "`from __future__ import annotations` instead of forward-reference "
                 "strings."
             )
-        raise InvalidArgument(f"thing={thing!r} must be a type")  # pragma: no cover
+        raise InvalidArgument(f"{thing=} must be a type")  # pragma: no cover
     if thing in types.NON_RUNTIME_TYPES:
         # Some code like `st.from_type(TypeAlias)` does not make sense.
         # Because there are types in python that do not exist in runtime.
@@ -1296,16 +1294,16 @@ def fractions(
 
     if max_denominator is not None:
         if max_denominator < 1:
-            raise InvalidArgument(f"max_denominator={max_denominator!r} must be >= 1")
+            raise InvalidArgument(f"{max_denominator=} must be >= 1")
         if min_value is not None and min_value.denominator > max_denominator:
             raise InvalidArgument(
-                f"The min_value={min_value!r} has a denominator greater than the "
-                f"max_denominator={max_denominator!r}"
+                f"The {min_value=} has a denominator greater than the "
+                f"{max_denominator=}"
             )
         if max_value is not None and max_value.denominator > max_denominator:
             raise InvalidArgument(
-                f"The max_value={max_value!r} has a denominator greater than the "
-                f"max_denominator={max_denominator!r}"
+                f"The {max_value=} has a denominator greater than the "
+                f"{max_denominator=}"
             )
 
     if min_value is not None and min_value == max_value:
@@ -1365,9 +1363,7 @@ def _as_finite_decimal(
     if value.is_infinite() and (value < 0 if "min" in name else value > 0):
         if allow_infinity or allow_infinity is None:
             return None
-        raise InvalidArgument(
-            f"allow_infinity={allow_infinity!r}, but {name}={value!r}"
-        )
+        raise InvalidArgument(f"{allow_infinity=}, but {name}={value!r}")
     # This could be infinity, quiet NaN, or signalling NaN
     raise InvalidArgument(f"Invalid {name}={value!r}")
 
@@ -1405,7 +1401,7 @@ def decimals(
     # Convert min_value and max_value to Decimal values, and validate args
     check_valid_integer(places, "places")
     if places is not None and places < 0:
-        raise InvalidArgument(f"places={places!r} may not be negative")
+        raise InvalidArgument(f"{places=} may not be negative")
     min_value = _as_finite_decimal(min_value, "min_value", allow_infinity)
     max_value = _as_finite_decimal(max_value, "max_value", allow_infinity)
     check_valid_interval(min_value, max_value, "min_value", "max_value")
@@ -1435,7 +1431,7 @@ def decimals(
         if min_num is not None and max_num is not None and min_num > max_num:
             raise InvalidArgument(
                 f"There are no decimals with {places} places between "
-                f"min_value={min_value!r} and max_value={max_value!r}"
+                f"{min_value=} and {max_value=}"
             )
         strat = integers(min_num, max_num).map(int_to_decimal)
     else:
@@ -1701,21 +1697,17 @@ def complex_numbers(
     if allow_infinity is None:
         allow_infinity = bool(max_magnitude is None)
     elif allow_infinity and max_magnitude is not None:
-        raise InvalidArgument(
-            f"Cannot have allow_infinity={allow_infinity!r} with "
-            f"max_magnitude={max_magnitude!r}"
-        )
+        raise InvalidArgument(f"Cannot have {allow_infinity=} with {max_magnitude=}")
     if allow_nan is None:
         allow_nan = bool(min_magnitude == 0 and max_magnitude is None)
     elif allow_nan and not (min_magnitude == 0 and max_magnitude is None):
         raise InvalidArgument(
-            f"Cannot have allow_nan={allow_nan!r}, min_magnitude={min_magnitude!r} "
-            f"max_magnitude={max_magnitude!r}"
+            f"Cannot have {allow_nan=}, {min_magnitude=}, {max_magnitude=}"
         )
     check_type(bool, allow_subnormal, "allow_subnormal")
     if width not in (32, 64, 128):
         raise InvalidArgument(
-            f"width={width!r}, but must be 32, 64 or 128 (other complex dtypes "
+            f"{width=}, but must be 32, 64 or 128 (other complex dtypes "
             "such as complex192 or complex256 are not supported)"
             # For numpy, these types would be supported (but not by CPython):
             # https://numpy.org/doc/stable/reference/arrays.scalars.html#complex-floating-point-types
@@ -1828,7 +1820,7 @@ def uuids(
     check_type(bool, allow_nil, "allow_nil")
     if version not in (None, 1, 2, 3, 4, 5):
         raise InvalidArgument(
-            f"version={version!r}, but version must be in "
+            f"{version=}, but version must be in "
             "(None, 1, 2, 3, 4, 5) to pass to the uuid.UUID constructor."
         )
     random_uuids = shared(
@@ -1975,10 +1967,10 @@ def register_type_strategy(
     from hypothesis.strategies._internal import types
 
     if not types.is_a_type(custom_type):
-        raise InvalidArgument(f"custom_type={custom_type!r} must be a type")
+        raise InvalidArgument(f"{custom_type=} must be a type")
     if custom_type in types.NON_RUNTIME_TYPES:
         raise InvalidArgument(
-            f"custom_type={custom_type!r} is not allowed to be registered, "
+            f"{custom_type=} is not allowed to be registered, "
             f"because there is no such thing as a runtime instance of {custom_type!r}"
         )
     elif not (isinstance(strategy, SearchStrategy) or callable(strategy)):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -23,7 +23,6 @@ from functools import lru_cache, reduce
 from inspect import Parameter, Signature, isabstract, isclass
 from types import FunctionType
 from typing import (
-    TYPE_CHECKING,
     Any,
     AnyStr,
     Callable,
@@ -34,6 +33,7 @@ from typing import (
     List,
     Optional,
     Pattern,
+    Protocol,
     Sequence,
     Set,
     Tuple,
@@ -132,14 +132,6 @@ elif typing.TYPE_CHECKING:  # pragma: no cover
     from builtins import ellipsis as EllipsisType
 else:
     EllipsisType = type(Ellipsis)  # pragma: no cover
-
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-elif TYPE_CHECKING:
-    from typing import Protocol
-else:  # pragma: no cover
-    Protocol = object
 
 
 @cacheable
@@ -1549,7 +1541,7 @@ class DrawFn(Protocol):
     def __init__(self):
         raise TypeError("Protocols cannot be instantiated")  # pragma: no cover
 
-    # On Python 3.8+, Protocol overrides our signature for __init__,
+    # Protocol overrides our signature for __init__,
     # so we override it right back to make the docs look nice.
     __signature__: Signature = Signature(parameters=[])
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -215,13 +215,13 @@ def datetimes(
     check_type(dt.datetime, min_value, "min_value")
     check_type(dt.datetime, max_value, "max_value")
     if min_value.tzinfo is not None:
-        raise InvalidArgument(f"min_value={min_value!r} must not have tzinfo")
+        raise InvalidArgument(f"{min_value=} must not have tzinfo")
     if max_value.tzinfo is not None:
-        raise InvalidArgument(f"max_value={max_value!r} must not have tzinfo")
+        raise InvalidArgument(f"{max_value=} must not have tzinfo")
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     if not isinstance(timezones, SearchStrategy):
         raise InvalidArgument(
-            f"timezones={timezones!r} must be a SearchStrategy that can "
+            f"{timezones=} must be a SearchStrategy that can "
             "provide tzinfo for datetimes (either None or dt.tzinfo objects)"
         )
     return DatetimeStrategy(min_value, max_value, timezones, allow_imaginary)
@@ -258,9 +258,9 @@ def times(
     check_type(dt.time, min_value, "min_value")
     check_type(dt.time, max_value, "max_value")
     if min_value.tzinfo is not None:
-        raise InvalidArgument(f"min_value={min_value!r} must not have tzinfo")
+        raise InvalidArgument(f"{min_value=} must not have tzinfo")
     if max_value.tzinfo is not None:
-        raise InvalidArgument(f"max_value={max_value!r} must not have tzinfo")
+        raise InvalidArgument(f"{max_value=} must not have tzinfo")
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     return TimeStrategy(min_value, max_value, timezones)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
@@ -96,7 +96,7 @@ class FeatureFlags:
                 disabled.append(name)
             else:
                 enabled.append(name)
-        return f"FeatureFlags(enabled={enabled!r}, disabled={disabled!r})"
+        return f"FeatureFlags({enabled=}, {disabled=})"
 
 
 class FeatureStrategy(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -93,7 +93,7 @@ def ip_addresses(
     if v is not None:
         check_type(int, v, "v")
         if v not in (4, 6):
-            raise InvalidArgument(f"v={v!r}, but only v=4 or v=6 are valid")
+            raise InvalidArgument(f"{v=}, but only v=4 or v=6 are valid")
     if network is None:
         # We use the reserved-address registries to boost the chance
         # of generating one of the various special types of address.
@@ -113,6 +113,6 @@ def ip_addresses(
     check_type((IPv4Network, IPv6Network), network, "network")
     assert isinstance(network, (IPv4Network, IPv6Network))  # for Mypy
     if v not in (None, network.version):
-        raise InvalidArgument(f"v={v!r} is incompatible with network={network!r}")
+        raise InvalidArgument(f"{v=} is incompatible with {network=}")
     addr_type = IPv4Address if network.version == 4 else IPv6Address
     return integers(int(network[0]), int(network[-1])).map(addr_type)  # type: ignore

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -423,13 +423,11 @@ def floats(
     if allow_nan is None:
         allow_nan = bool(min_value is None and max_value is None)
     elif allow_nan and (min_value is not None or max_value is not None):
-        raise InvalidArgument(
-            f"Cannot have allow_nan={allow_nan!r}, with min_value or max_value"
-        )
+        raise InvalidArgument(f"Cannot have {allow_nan=}, with min_value or max_value")
 
     if width not in (16, 32, 64):
         raise InvalidArgument(
-            f"Got width={width!r}, but the only valid values "
+            f"Got {width=}, but the only valid values "
             "are the integers 16, 32, and 64."
         )
 
@@ -472,7 +470,7 @@ def floats(
                 "writeup - and good luck!"
             )
         raise FloatingPointError(
-            f"Got allow_subnormal={allow_subnormal!r}, but we can't represent "
+            f"Got {allow_subnormal=}, but we can't represent "
             f"subnormal floats right now, in violation of the IEEE-754 floating-point "
             f"specification.  {ftz_msg}"
         )
@@ -488,18 +486,18 @@ def floats(
     if min_value != min_arg:
         raise InvalidArgument(
             f"min_value={min_arg!r} cannot be exactly represented as a float "
-            f"of width {width} - use min_value={min_value!r} instead."
+            f"of width {width} - use {min_value=} instead."
         )
     if max_value != max_arg:
         raise InvalidArgument(
             f"max_value={max_arg!r} cannot be exactly represented as a float "
-            f"of width {width} - use max_value={max_value!r} instead."
+            f"of width {width} - use {max_value=} instead."
         )
 
     if exclude_min and (min_value is None or min_value == math.inf):
-        raise InvalidArgument(f"Cannot exclude min_value={min_value!r}")
+        raise InvalidArgument(f"Cannot exclude {min_value=}")
     if exclude_max and (max_value is None or max_value == -math.inf):
-        raise InvalidArgument(f"Cannot exclude max_value={max_value!r}")
+        raise InvalidArgument(f"Cannot exclude {max_value=}")
 
     assumed_allow_subnormal = allow_subnormal is None or allow_subnormal
     if min_value is not None and (
@@ -543,7 +541,7 @@ def floats(
             "and max_value=%r" % (width, min_arg, max_arg)
         )
         if exclude_min or exclude_max:
-            msg += f", exclude_min={exclude_min!r} and exclude_max={exclude_max!r}"
+            msg += f", {exclude_min=} and {exclude_max=}"
         raise InvalidArgument(msg)
 
     if allow_infinity is None:
@@ -551,8 +549,7 @@ def floats(
     elif allow_infinity:
         if min_value is not None and max_value is not None:
             raise InvalidArgument(
-                f"Cannot have allow_infinity={allow_infinity!r}, "
-                "with both min_value and max_value"
+                f"Cannot have {allow_infinity=}, with both min_value and max_value"
             )
     elif min_value == math.inf:
         if min_arg == math.inf:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -388,7 +388,7 @@ def convert_kwargs(name, kwargs):
         if args[-1] is signature.parameters[name].default:
             args.pop()
         else:
-            break  # pragma: no cover  # Only on Python < 3.8
+            break
 
     return (args, kwargs)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -27,15 +27,11 @@ import typing
 import uuid
 from pathlib import PurePath
 from types import FunctionType
+from typing import get_origin
 
 from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed
-from hypothesis.internal.compat import (
-    PYPY,
-    BaseExceptionGroup,
-    ExceptionGroup,
-    get_origin,
-)
+from hypothesis.internal.compat import PYPY, BaseExceptionGroup, ExceptionGroup
 from hypothesis.internal.conjecture.utils import many as conjecture_utils_many
 from hypothesis.strategies._internal.datetime import zoneinfo  # type: ignore
 from hypothesis.strategies._internal.ipaddress import (
@@ -84,11 +80,7 @@ try:
 except AttributeError:  # pragma: no cover
     pass  # `typing_extensions` might not be installed
 
-FinalTypes: tuple = ()
-try:
-    FinalTypes += (typing.Final,)
-except AttributeError:  # pragma: no cover
-    pass  # Is missing for `python<3.8`
+FinalTypes: tuple = (typing.Final,)
 try:
     FinalTypes += (typing_extensions.Final,)
 except AttributeError:  # pragma: no cover
@@ -98,7 +90,7 @@ ConcatenateTypes: tuple = ()
 try:
     ConcatenateTypes += (typing.Concatenate,)
 except AttributeError:  # pragma: no cover
-    pass  # Is missing for `python<3.8`
+    pass  # Is missing for `python<3.10`
 try:
     ConcatenateTypes += (typing_extensions.Concatenate,)
 except AttributeError:  # pragma: no cover
@@ -108,7 +100,7 @@ ParamSpecTypes: tuple = ()
 try:
     ParamSpecTypes += (typing.ParamSpec,)
 except AttributeError:  # pragma: no cover
-    pass  # Is missing for `python<3.8`
+    pass  # Is missing for `python<3.10`
 try:
     ParamSpecTypes += (typing_extensions.ParamSpec,)
 except AttributeError:  # pragma: no cover
@@ -118,7 +110,7 @@ TypeGuardTypes: tuple = ()
 try:
     TypeGuardTypes += (typing.TypeGuard,)
 except AttributeError:  # pragma: no cover
-    pass  # Is missing for `python<3.8`
+    pass  # Is missing for `python<3.10`
 try:
     TypeGuardTypes += (typing_extensions.TypeGuard,)
 except AttributeError:  # pragma: no cover
@@ -153,8 +145,7 @@ typing_root_type = (typing._Final, typing._GenericAlias)  # type: ignore
 # We use this to disallow all non-runtime types from being registered and resolved.
 # By "non-runtime" we mean: types that do not really exist in python's
 # and are just added for more fancy type annotations.
-# `Final` is a great example: it just indicates
-# that this value can't be reassigned.
+# `Final` is a great example: it just indicates that this value can't be reassigned.
 NON_RUNTIME_TYPES = (
     typing.Any,
     *ClassVarTypes,
@@ -187,15 +178,15 @@ for name in (
 
 def type_sorting_key(t):
     """Minimise to None, then non-container types, then container types."""
-    if not (is_a_type(t) or is_typing_literal(t)):  # This branch is for Python < 3.8
-        raise InvalidArgument(f"thing={t} must be a type")  # pragma: no cover
     if t is None or t is type(None):  # noqa: E721
         return (-1, repr(t))
-    t = getattr(t, "__origin__", t)
-    if not isinstance(t, type):  # pragma: no cover
-        # Some generics in the typing module are not actually types in 3.7
-        return (2, repr(t))
-    return (int(issubclass(t, collections.abc.Container)), repr(t))
+    t = getattr(t, "__origin__", t)  # TODO: get_origin?
+    try:
+        is_container = int(issubclass(t, collections.abc.Container))
+    except Exception:  # pragma: no cover
+        # e.g. `typing_extensions.Literal` is not a container
+        is_container = 0
+    return (is_container, repr(t))
 
 
 def _compatible_args(args, superclass_args):
@@ -362,7 +353,7 @@ def from_typing_type(thing):
         elif len(elem_types) == 1 and elem_types[0] == ():
             return st.tuples()  # Empty tuple; see issue #1583
         return st.tuples(*map(st.from_type, elem_types))
-    if hasattr(typing, "Final") and getattr(thing, "__origin__", None) == typing.Final:
+    if getattr(thing, "__origin__", None) == typing.Final:
         return st.one_of([st.from_type(t) for t in thing.__args__])
     if is_typing_literal(thing):
         args_dfs_stack = list(thing.__args__)
@@ -391,7 +382,7 @@ def from_typing_type(thing):
         raise ResolutionFailed(f"Cannot resolve {thing} to a strategy")
 
     # Some "generic" classes are not generic *in* anything - for example both
-    # Hashable and Sized have `__args__ == ()` on Python 3.7 or later.
+    # Hashable and Sized have `__args__ == ()`
     origin = getattr(thing, "__origin__", thing)
     if (
         origin in vars(collections.abc).values()
@@ -663,6 +654,7 @@ _global_type_lookup.update(
             # this generates strings that should able to be parsed into integers
             st.from_regex(r"\A-?\d+\Z").filter(functools.partial(can_cast, int)),
         ),
+        typing.SupportsIndex: st.integers() | st.booleans(),
         typing.SupportsBytes: st.one_of(
             st.booleans(),
             st.binary(),
@@ -674,8 +666,6 @@ _global_type_lookup.update(
         typing.TextIO: st.builds(io.StringIO, st.text()),
     }
 )
-if hasattr(typing, "SupportsIndex"):  # pragma: no branch  # new in Python 3.8
-    _global_type_lookup[typing.SupportsIndex] = st.integers() | st.booleans()
 
 
 # The "extra" lookups define a callable that either resolves to a strategy for
@@ -850,9 +840,8 @@ def resolve_ChainMap(thing):
     return resolve_Dict(thing).map(collections.ChainMap)
 
 
-@register("OrderedDict", st.builds(dict).map(collections.OrderedDict))
+@register(typing.OrderedDict, st.builds(dict).map(collections.OrderedDict))
 def resolve_OrderedDict(thing):
-    # typing.OrderedDict is new in Python 3.7.2
     return resolve_Dict(thing).map(collections.OrderedDict)
 
 

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -26,9 +26,6 @@ run()
 # Skip collection of tests which require the Django test runner,
 # or that don't work on the current version of Python.
 collect_ignore_glob = ["django/*"]
-if sys.version_info < (3, 8):
-    collect_ignore_glob.append("array_api")
-    collect_ignore_glob.append("cover/*py38*")
 if sys.version_info < (3, 9):
     collect_ignore_glob.append("cover/*py39*")
     collect_ignore_glob.append("patching/*")

--- a/hypothesis-python/tests/cover/test_asyncio.py
+++ b/hypothesis-python/tests/cover/test_asyncio.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import asyncio
-import sys
 import warnings
 from unittest import TestCase
 
@@ -18,14 +17,11 @@ import pytest
 from hypothesis import assume, given, strategies as st
 from hypothesis.internal.compat import PYPY
 
-if sys.version_info < (3, 8):
-    coro_decorator = asyncio.coroutine
-else:
 
-    def coro_decorator(f):
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="ignore", category=DeprecationWarning)
-            return asyncio.coroutine(f)
+def coro_decorator(f):
+    with warnings.catch_warnings():
+        warnings.simplefilter(action="ignore", category=DeprecationWarning)
+        return asyncio.coroutine(f)
 
 
 class TestAsyncio(TestCase):

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -72,7 +72,7 @@ def test_given_shrinks_pytest_helper_errors():
     def inner(x):
         final_value[0] = x
         if x > 100:
-            pytest.fail(f"x={x!r} is too big!")
+            pytest.fail(f"{x=} is too big!")
 
     with pytest.raises(Failed):
         inner()
@@ -87,7 +87,7 @@ def test_pytest_skip_skips_shrinking():
     def inner(x):
         values.append(x)
         if x > 100:
-            pytest.skip(f"x={x!r} is too big!")
+            pytest.skip(f"{x=} is too big!")
 
     with pytest.raises(Skipped):
         inner()

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -261,7 +261,7 @@ def test_rewrite_filter_chains_with_some_unhandled(data, predicates, s):
     # Whatever value we draw is in fact valid for these strategies
     value = data.draw(s)
     for p in predicates:
-        assert p(value), f"p={p!r}, value={value}"
+        assert p(value), f"{p=}, value={value}"
 
     # No matter the order of the filters, we get the same resulting structure
     unwrapped = s.wrapped_strategy

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -28,7 +28,7 @@ import pytest
 
 from hypothesis import HealthCheck, assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed, SmallSearchSpaceWarning
-from hypothesis.internal.compat import PYPY, get_origin, get_type_hints
+from hypothesis.internal.compat import PYPY, get_type_hints
 from hypothesis.internal.conjecture.junkdrawer import stack_depth_of_caller
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import from_type
@@ -242,7 +242,7 @@ def test_register_generic_typing_strats():
     # I don't expect anyone to do this, but good to check it works as expected
     with temp_registered(
         typing.Sequence,
-        types._global_type_lookup[get_origin(typing.Set) or typing.Set],
+        types._global_type_lookup[typing.get_origin(typing.Set) or typing.Set],
     ):
         # We register sets for the abstract sequence type, which masks subtypes
         # from supertype resolution but not direct resolution
@@ -553,14 +553,10 @@ def test_resolving_recursive_type(tree):
     assert isinstance(tree, Tree)
 
 
-class TypedTree(typing.TypedDict if sys.version_info[:2] >= (3, 8) else object):
+class TypedTree(typing.TypedDict):
     nxt: typing.Optional["TypedTree"]
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 8),
-    reason="TypedDict not available in python<3.8",
-)
 def test_resolving_recursive_typeddict():
     tree = st.from_type(TypedTree).example()
     assert isinstance(tree, dict)

--- a/hypothesis-python/tests/cover/test_validation.py
+++ b/hypothesis-python/tests/cover/test_validation.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import functools
-import sys
 
 import pytest
 
@@ -275,13 +274,3 @@ def test_check_strategy_might_suggest_sampled_from():
     with pytest.raises(InvalidArgument, match="such as st.sampled_from"):
         check_strategy_((1, 2, 3))
     check_strategy_(integers(), "passes for our custom coverage check")
-
-
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 8), reason="only on 3.7")
-def test_explicit_error_from_array_api_before_py38():
-    with pytest.raises(
-        RuntimeError, match=r"The Array API standard requires Python 3\.8 or later"
-    ):
-        from hypothesis.extra import array_api
-
-        assert array_api  # avoid unused-name lint error

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime as dt
-import sys
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -196,11 +195,6 @@ class TestPosOnlyArg(TestCase):
         pass
 
     def test_from_model_signature(self):
-        if sys.version_info[:2] <= (3, 7):
-            self.assertRaises(TypeError, from_model().example)
-            self.assertRaises(TypeError, from_model(Car, None).example)
-            self.assertRaises(TypeError, from_model(model=Customer).example)
-        else:
-            self.assertRaises(TypeError, from_model)
-            self.assertRaises(TypeError, from_model, Car, None)
-            self.assertRaises(TypeError, from_model, model=Customer)
+        self.assertRaises(TypeError, from_model)
+        self.assertRaises(TypeError, from_model, Car, None)
+        self.assertRaises(TypeError, from_model, model=Customer)

--- a/hypothesis-python/tests/patching/test_patching.py
+++ b/hypothesis-python/tests/patching/test_patching.py
@@ -196,7 +196,7 @@ def test_pytest_reports_patch_file_location(pytester):
 
     fname_pat = r"\.hypothesis/patches/\d{4}-\d\d-\d\d--[0-9a-f]{8}.patch"
     pattern = f"`git apply ({fname_pat})` to add failing examples to your code\\."
-    print(f"pattern={pattern!r}")
+    print(f"{pattern=}")
     print(f"result.stdout=\n{indent(str(result.stdout), '    ')}")
     fname = re.search(pattern, str(result.stdout)).group(1)
     patch = Path(pytester.path).joinpath(fname).read_text()

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -8,8 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import sys
-
 import pytest
 
 from hypothesis.internal.compat import WINDOWS, escape_unicode_characters
@@ -102,8 +100,7 @@ def test_healthcheck_traceback_is_hidden(testdir):
     timeout_token = ": FailedHealthCheck"
     def_line = get_line_num(def_token, result)
     timeout_line = get_line_num(timeout_token, result)
-    expected = 6 if sys.version_info[:2] < (3, 8) else 7
-    assert timeout_line - def_line == expected
+    assert timeout_line - def_line == 7
 
 
 COMPOSITE_IS_NOT_A_TEST = """

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -9,10 +9,10 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import collections
-import sys
-from typing import Callable, DefaultDict, Dict, List, Literal, NewType, Type, Union
+from typing import Callable, DefaultDict, Dict, List, NewType, Type, Union
 
 import pytest
+import typing_extensions
 from typing_extensions import (
     Annotated,
     Concatenate,
@@ -35,12 +35,12 @@ from tests.common.debug import assert_all_examples, find_any
 
 @pytest.mark.parametrize("value", ["dog", b"goldfish", 42, 63.4, -80.5, False])
 def test_typing_extensions_Literal(value):
-    assert from_type(Literal[value]).example() == value
+    assert from_type(typing_extensions.Literal[value]).example() == value
 
 
 @given(st.data())
 def test_typing_extensions_Literal_nested(data):
-    lit = Literal
+    lit = typing_extensions.Literal
     values = [
         (lit["hamster", 0], ("hamster", 0)),
         (lit[26, False, "bunny", 130], (26, False, "bunny", 130)),
@@ -49,7 +49,7 @@ def test_typing_extensions_Literal_nested(data):
         (lit[1, lit[2], 3], {1, 2, 3}),
         (lit[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
         # See https://github.com/HypothesisWorks/hypothesis/pull/2886
-        (Union[Literal["hamster"], Literal["bunny"]], {"hamster", "bunny"}),
+        (Union[lit["hamster"], lit["bunny"]], {"hamster", "bunny"}),  # noqa
         (Union[lit[lit[1], lit[2]], lit[lit[3], lit[4]]], {1, 2, 3, 4}),
     ]
     literal_type, flattened_literals = data.draw(st.sampled_from(values))
@@ -160,7 +160,6 @@ def test_non_runtime_type_cannot_be_registered(non_runtime_type):
         st.register_type_strategy(non_runtime_type, st.none())
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 7), reason="requires python3.8 or higher")
 def test_callable_with_concatenate():
     P = ParamSpec("P")
     func_type = Callable[Concatenate[int, P], None]
@@ -175,7 +174,6 @@ def test_callable_with_concatenate():
         st.register_type_strategy(func_type, st.none())
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 7), reason="requires python3.8 or higher")
 def test_callable_with_paramspec():
     P = ParamSpec("P")
     func_type = Callable[P, None]
@@ -190,7 +188,6 @@ def test_callable_with_paramspec():
         st.register_type_strategy(func_type, st.none())
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 7), reason="requires python3.8 or higher")
 def test_callable_return_typegard_type():
     strategy = st.from_type(Callable[[], TypeGuard[int]])
     with pytest.raises(

--- a/hypothesis-python/tests/typing_extensions/test_backported_types.py
+++ b/hypothesis-python/tests/typing_extensions/test_backported_types.py
@@ -10,13 +10,12 @@
 
 import collections
 import sys
-from typing import Callable, DefaultDict, Dict, List, NewType, Type, Union
+from typing import Callable, DefaultDict, Dict, List, Literal, NewType, Type, Union
 
 import pytest
 from typing_extensions import (
     Annotated,
     Concatenate,
-    Literal,
     NotRequired,
     ParamSpec,
     Required,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ select = [
 ]
 ignore = ["C408", "E731", "E741", "S101", "UP031"]
 line-length = 125
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.per-file-ignores]
 "hypothesis-python/src/hypothesis/internal/compat.py" = ["F401"]


### PR DESCRIPTION
Closes #3657.

Do not merge until https://devguide.python.org/versions/ shows Python 3.7 as end of life.