### PR TITLE
improve type rendering in st.from_type

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Improve the type rendered in `st.from_type`, which improves the coverage
+of Ghostwriter.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-Improve the type rendered in `st.from_type`, which improves the coverage
-of Ghostwriter.
+Improve the type rendered in :func:`~hypothesis.strategies.from_type`,
+which improves the coverage of Ghostwriter.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1060,14 +1060,11 @@ def _from_type_deferred(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # underlying strategy wherever possible, as a form of user education, but
     # would prefer to fall back to the default "from_type(...)" repr instead of
     # "deferred(...)" for recursive types or invalid arguments.
-    if (
-        thing.__repr__ == object.__repr__
-        and hasattr(thing, "__module__")
-        and hasattr(thing, "__qualname__")
-    ):
-        thing_repr = f"{thing.__module__}.{thing.__qualname__}"
-    else:
-        thing_repr = repr(thing)
+    thing_repr = nicerepr(thing)
+    if hasattr(thing, "__module__"):
+        module_prefix = f"{thing.__module__}."
+        if not thing_repr.startswith(module_prefix):
+            thing_repr = module_prefix + thing_repr
     return LazyStrategy(
         lambda thing: deferred(lambda: _from_type(thing, [])),
         (thing,),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1060,11 +1060,19 @@ def _from_type_deferred(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # underlying strategy wherever possible, as a form of user education, but
     # would prefer to fall back to the default "from_type(...)" repr instead of
     # "deferred(...)" for recursive types or invalid arguments.
+    if (
+        thing.__repr__ == object.__repr__
+        and hasattr(thing, "__module__")
+        and hasattr(thing, "__qualname__")
+    ):
+        thing_repr = f"{thing.__module__}.{thing.__qualname__}"
+    else:
+        thing_repr = repr(thing)
     return LazyStrategy(
         lambda thing: deferred(lambda: _from_type(thing, [])),
         (thing,),
         {},
-        force_repr=f"from_type({thing!r})",
+        force_repr=f"from_type({thing_repr})",
     )
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -20,6 +20,7 @@ import io
 import ipaddress
 import numbers
 import os
+import random
 import re
 import sys
 import typing
@@ -597,6 +598,7 @@ _global_type_lookup: typing.Dict[
     super: st.builds(super, st.from_type(type)),
     re.Match: st.text().map(lambda c: re.match(".", c, flags=re.DOTALL)).filter(bool),
     re.Pattern: st.builds(re.compile, st.sampled_from(["", b""])),
+    random.Random: st.randoms(),
     # Pull requests with more types welcome!
 }
 if zoneinfo is not None:  # pragma: no branch

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -845,6 +845,11 @@ def test_hashable_type_unhashable_value():
     )
 
 
+class _EmptyClass:
+    def __init__(self, value=-1) -> None:
+        pass
+
+
 @pytest.mark.parametrize(
     "typ,repr_",
     [
@@ -852,6 +857,7 @@ def test_hashable_type_unhashable_value():
         (typing.List[str], "lists(text())"),
         ("not a type", "from_type('not a type')"),
         (random.Random, "from_type(random.Random)"),
+        (_EmptyClass, "from_type(tests.cover.test_lookup._EmptyClass)"),
         (
             st.SearchStrategy[str],
             "from_type(hypothesis.strategies.SearchStrategy[str])",

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -856,7 +856,7 @@ class _EmptyClass:
         (int, "integers()"),
         (typing.List[str], "lists(text())"),
         ("not a type", "from_type('not a type')"),
-        (random.Random, "from_type(random.Random)"),
+        (random.Random, "randoms()"),
         (_EmptyClass, "from_type(tests.cover.test_lookup._EmptyClass)"),
         (
             st.SearchStrategy[str],

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -15,6 +15,7 @@ import datetime
 import enum
 import inspect
 import io
+import random
 import re
 import string
 import sys
@@ -850,6 +851,11 @@ def test_hashable_type_unhashable_value():
         (int, "integers()"),
         (typing.List[str], "lists(text())"),
         ("not a type", "from_type('not a type')"),
+        (random.Random, "from_type(random.Random)"),
+        (
+            st.SearchStrategy[str],
+            "from_type(hypothesis.strategies.SearchStrategy[str])",
+        ),
     ],
 )
 def test_repr_passthrough(typ, repr_):

--- a/hypothesis-python/tests/ghostwriter/recorded/hypothesis_module_magic.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/hypothesis_module_magic.txt
@@ -9,8 +9,6 @@ from hypothesis import given, settings, strategies as st
 from random import Random
 from typing import Hashable
 
-# TODO: replace st.nothing() with an appropriate strategy
-
 
 @given(condition=st.from_type(object))
 def test_fuzz_assume(condition: object) -> None:
@@ -50,7 +48,7 @@ def test_fuzz_note(value: str) -> None:
     hypothesis.note(value=value)
 
 
-@given(r=st.nothing())
+@given(r=st.from_type(random.Random))
 def test_fuzz_register_random(r: random.Random) -> None:
     hypothesis.register_random(r=r)
 

--- a/hypothesis-python/tests/ghostwriter/recorded/hypothesis_module_magic.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/hypothesis_module_magic.txt
@@ -6,7 +6,6 @@ import hypothesis
 import random
 import typing
 from hypothesis import given, settings, strategies as st
-from random import Random
 from typing import Hashable
 
 
@@ -24,7 +23,7 @@ def test_fuzz_event(value: str) -> None:
     specifier=st.from_type(st.SearchStrategy),
     condition=st.functions(like=lambda *a, **k: None, returns=st.booleans()),
     settings=st.from_type(typing.Optional[hypothesis.settings]),
-    random=st.from_type(typing.Optional[random.Random]),
+    random=st.one_of(st.none(), st.randoms()),
     database_key=st.one_of(st.none(), st.binary()),
 )
 def test_fuzz_find(
@@ -48,7 +47,7 @@ def test_fuzz_note(value: str) -> None:
     hypothesis.note(value=value)
 
 
-@given(r=st.from_type(random.Random))
+@given(r=st.randoms())
 def test_fuzz_register_random(r: random.Random) -> None:
     hypothesis.register_random(r=r)
 


### PR DESCRIPTION
Currently the representation of lazy `st.from_type(MyClass)` were `from_type(<class 'some_module.MyClass'>)`. This patch changes it to do the following:

1. If a `__repr__` is defined on the type that is different to `object.__repr__` it just uses the representation. This is for example the case for `Optional[...]`.
2. If `__module__` and `__qualname__` are not defined also use the representation of the object.
3. ~If `__module__` is `"builtins"` just use the `__qualname__`.~ I could not find an object that would fallback to this lazy from_type, therefore I've omitted this.
4. Otherwise, use `f"{__module__}.{___qualname__}"`.

I did consider using `_get_qualname` from Ghostwriter, but this would either need to be made public and referenced or extracted, which is both a bit suboptimal.