### PR TITLE
Fix flaky recursionerror

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Fixes occasional recursion-limit-exceeded errors at validate- and draw-time for
+deeply nested strategies. Closes: 3671

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-Fixes occasional recursion-limit-exceeded errors at validate- and draw-time for
-deeply nested strategies. Closes: 3671
+Fixes occasional recursion-limit-exceeded errors when validating
+deeply nested strategies. Closes: :issue:`3671`

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,6 +76,7 @@ from hypothesis.internal.compat import (
 )
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE, ConjectureRunner
+from hypothesis.internal.conjecture.junkdrawer import ensure_free_stackframes
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
@@ -614,9 +615,10 @@ def process_arguments_to_given(wrapped_test, arguments, kwargs, given_kwargs, pa
 
     arguments = tuple(arguments)
 
-    for k, s in given_kwargs.items():
-        check_strategy(s, name=k)
-        s.validate()
+    with ensure_free_stackframes():
+        for k, s in given_kwargs.items():
+            check_strategy(s, name=k)
+            s.validate()
 
     stuff = Stuff(selfy=selfy, args=arguments, kwargs=kwargs, given_kwargs=given_kwargs)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -34,11 +34,7 @@ import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
-from hypothesis.internal.conjecture.junkdrawer import (
-    IntList,
-    ensure_free_stackframes,
-    uniform,
-)
+from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 
 if TYPE_CHECKING:
@@ -955,12 +951,11 @@ class ConjectureData:
                 return strategy.do_draw(self)
             else:
                 assert start_time is not None
-                with ensure_free_stackframes():
-                    strategy.validate()
-                    try:
-                        return strategy.do_draw(self)
-                    finally:
-                        self.draw_times.append(time.perf_counter() - start_time)
+                strategy.validate()
+                try:
+                    return strategy.do_draw(self)
+                finally:
+                    self.draw_times.append(time.perf_counter() - start_time)
         finally:
             self.stop_example()
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -34,7 +34,7 @@ import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
-from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
+from hypothesis.internal.conjecture.junkdrawer import ensure_free_stackframes, IntList, uniform
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 
 if TYPE_CHECKING:
@@ -951,9 +951,9 @@ class ConjectureData:
                 return strategy.do_draw(self)
             else:
                 assert start_time is not None
-                strategy.validate()
                 try:
-                    return strategy.do_draw(self)
+                    with ensure_free_stackframes():
+                        return strategy.do_draw(self)
                 finally:
                     self.draw_times.append(time.perf_counter() - start_time)
         finally:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -951,11 +951,12 @@ class ConjectureData:
                 return strategy.do_draw(self)
             else:
                 assert start_time is not None
-                try:
-                    with ensure_free_stackframes():
+                with ensure_free_stackframes():
+                    strategy.validate()
+                    try:
                         return strategy.do_draw(self)
-                finally:
-                    self.draw_times.append(time.perf_counter() - start_time)
+                    finally:
+                        self.draw_times.append(time.perf_counter() - start_time)
         finally:
             self.stop_example()
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -34,7 +34,11 @@ import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
-from hypothesis.internal.conjecture.junkdrawer import ensure_free_stackframes, IntList, uniform
+from hypothesis.internal.conjecture.junkdrawer import (
+    IntList,
+    ensure_free_stackframes,
+    uniform,
+)
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 
 if TYPE_CHECKING:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -37,7 +37,7 @@ from hypothesis.internal.conjecture.datatree import (
     PreviouslyUnseenBehaviour,
     TreeRecordingObserver,
 )
-from hypothesis.internal.conjecture.junkdrawer import clamp, stack_depth_of_caller
+from hypothesis.internal.conjecture.junkdrawer import clamp, ensure_free_stackframes
 from hypothesis.internal.conjecture.pareto import NO_SCORE, ParetoFront, ParetoOptimiser
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
 from hypothesis.internal.healthcheck import fail_health_check
@@ -133,9 +133,6 @@ class ConjectureRunner:
         # executed test case.
         self.__data_cache = LRUReusedCache(CACHE_SIZE)
 
-        # We ensure that the test has this much stack space remaining, no matter
-        # the size of the stack when called, to de-flake RecursionErrors (#2494).
-        self.__recursion_limit = sys.getrecursionlimit()
         self.__pending_call_explanation = None
 
     def explain_next_call_as(self, explanation):
@@ -169,32 +166,22 @@ class ConjectureRunner:
         """Run ``self._test_function``, but convert a ``StopTest`` exception
         into a normal return and avoid raising Flaky for RecursionErrors.
         """
-        depth = stack_depth_of_caller()
-        # Because we add to the recursion limit, to be good citizens we also add
-        # a check for unbounded recursion.  The default limit is 1000, so this can
-        # only ever trigger if something really strange is happening and it's hard
-        # to imagine an intentionally-deeply-recursive use of this code.
-        assert depth <= 1000, (
-            "Hypothesis would usually add %d to the stack depth of %d here, "
-            "but we are already much deeper than expected.  Aborting now, to "
-            "avoid extending the stack limit in an infinite loop..."
-            % (self.__recursion_limit, depth)
-        )
-        try:
-            sys.setrecursionlimit(depth + self.__recursion_limit)
-            self._test_function(data)
-        except StopTest as e:
-            if e.testcounter == data.testcounter:
-                # This StopTest has successfully stopped its test, and can now
-                # be discarded.
-                pass
-            else:
-                # This StopTest was raised by a different ConjectureData. We
-                # need to re-raise it so that it will eventually reach the
-                # correct engine.
-                raise
-        finally:
-            sys.setrecursionlimit(self.__recursion_limit)
+        # We ensure that the test has this much stack space remaining, no
+        # matter the size of the stack when called, to de-flake RecursionErrors
+        # (#2494, #3671).
+        with ensure_free_stackframes():
+            try:
+                self._test_function(data)
+            except StopTest as e:
+                if e.testcounter == data.testcounter:
+                    # This StopTest has successfully stopped its test, and can now
+                    # be discarded.
+                    pass
+                else:
+                    # This StopTest was raised by a different ConjectureData. We
+                    # need to re-raise it so that it will eventually reach the
+                    # correct engine.
+                    raise
 
     def test_function(self, data):
         if self.__pending_call_explanation is not None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
-import sys
 import time
 from collections import defaultdict
 from contextlib import contextmanager

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -277,62 +277,41 @@ def stack_depth_of_caller() -> int:
 
 class ensure_free_stackframes:
     """Context manager that ensures there are at least N free stackframes. The
-    value of N is chosen to be the recursionlimit at import time, unless
-    specified.
+    value of N is chosen to be the recursion limit at import time, or at least
+    500.
     """
 
-    lock: Lock = Lock()
-    nesting: int = 0
     initial_maxdepth: int = sys.getrecursionlimit()
-    original_maxdepth: int
-    changed_maxdepth: int
-
-    def __init__(self, free_depth: Optional[int] = None):
-        self.requested_free_depth = free_depth or self.initial_maxdepth
 
     def __enter__(self):
-        cls = type(self)
         cur_depth = stack_depth_of_caller()
-        # The lock protects against concurrent access to this method, but other
-        # callers of sys.setrecursionlimit() will mess things up.
-        with cls.lock:
-            cur_maxdepth = sys.getrecursionlimit()
-            if cls.nesting == 0:
-                cls.original_maxdepth = cur_maxdepth
-            new_maxdepth = cur_depth + self.requested_free_depth
-            if new_maxdepth > cur_maxdepth:  # pragma: no branch
-                # Because we add to the recursion limit, to be good citizens we
-                # also add a check for unbounded recursion.  The default limit
-                # is 1000, so this can only ever trigger if something really
-                # strange is happening and it's hard to imagine an
-                # intentionally-deeply-recursive use of this code.
-                assert cur_depth <= cls.initial_maxdepth, (
-                    "Hypothesis would usually add %d to the stack depth of %d here, "
-                    "but we are already much deeper than expected.  Aborting now, to "
-                    "avoid extending the stack limit in an infinite loop..."
-                    % (new_maxdepth - cur_maxdepth, cur_maxdepth)
-                )
-                cls.changed_maxdepth = new_maxdepth
-                sys.setrecursionlimit(new_maxdepth)
-            cls.nesting += 1
+        self.old_maxdepth = sys.getrecursionlimit()
+        self.new_maxdepth = cur_depth + max(self.initial_maxdepth, 500)
+        # Because we add to the recursion limit, to be good citizens we
+        # also add a check for unbounded recursion.  The default limit
+        # is 1000, so this can only ever trigger if something really
+        # strange is happening and it's hard to imagine an
+        # intentionally-deeply-recursive use of this code.
+        assert cur_depth <= self.initial_maxdepth, (
+            "Hypothesis would usually add %d to the stack depth of %d here, "
+            "but we are already much deeper than expected.  Aborting now, to "
+            "avoid extending the stack limit in an infinite loop..."
+            % (self.new_maxdepth - self.old_maxdepth, self.old_maxdepth)
+        )
+        sys.setrecursionlimit(self.new_maxdepth)
 
     def __exit__(self, *args, **kwargs):
-        cls = type(self)
         # Because the recursion limit is increased by an amount which
         # depends on concurrent callers, we can't reset the stack limit
         # until there are no other callers.
-        assert cls.nesting > 0
-        with cls.lock:
-            cls.nesting -= 1
-            if cls.nesting == 0:  # pragma: no branch
-                if cls.changed_maxdepth == sys.getrecursionlimit():
-                    sys.setrecursionlimit(cls.original_maxdepth)
-                else:  # pragma: nocover
-                    warnings.warn(
-                        "The recursion limit will not be reset, since it was "
-                        "changed outside of hypothesis during execution of a test.",
-                        HypothesisWarning,
-                    )
+        if self.new_maxdepth == sys.getrecursionlimit():
+            sys.setrecursionlimit(self.old_maxdepth)
+        else:
+            warnings.warn(  # pragma: nocover
+                "The recursion limit will not be reset, since it was changed "
+                "from another thread or during execution of a test.",
+                HypothesisWarning,
+            )
 
 
 def find_integer(f: Callable[[int], bool]) -> int:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -301,9 +301,6 @@ class ensure_free_stackframes:
         sys.setrecursionlimit(self.new_maxdepth)
 
     def __exit__(self, *args, **kwargs):
-        # Because the recursion limit is increased by an amount which
-        # depends on concurrent callers, we can't reset the stack limit
-        # until there are no other callers.
         if self.new_maxdepth == sys.getrecursionlimit():
             sys.setrecursionlimit(self.old_maxdepth)
         else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -302,7 +302,7 @@ class ensure_free_stackframes:
     def __exit__(self, *args, **kwargs):
         if self.new_maxdepth == sys.getrecursionlimit():
             sys.setrecursionlimit(self.old_maxdepth)
-        else:  # pragma: nocover
+        else:  # pragma: no cover
             warnings.warn(
                 "The recursion limit will not be reset, since it was changed "
                 "from another thread or during execution of a test.",

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -296,7 +296,7 @@ class ensure_free_stackframes:
             self.nesting += 1
             self.cur_maxdepth = sys.getrecursionlimit()
             new_maxdepth = cur_depth + self.requested_free_depth
-            if new_maxdepth > self.cur_maxdepth:
+            if new_maxdepth > self.cur_maxdepth:  # pragma: no branch
                 # Because we add to the recursion limit, to be good citizens we
                 # also add a check for unbounded recursion.  The default limit
                 # is 1000, so this can only ever trigger if something really
@@ -317,7 +317,7 @@ class ensure_free_stackframes:
         # until there are no other callers.
         with self.lock:
             self.nesting -= 1
-            if self.nesting == 0:
+            if self.nesting == 0:  # pragma: no branch
                 if self.new_maxdepth == sys.getrecursionlimit():
                     sys.setrecursionlimit(self.cur_maxdepth)
                 else:  # pragma: nocover

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -280,6 +280,7 @@ class ensure_free_stackframes:
     value of N is chosen to be the recursionlimit at import time, unless
     specified.
     """
+
     lock: Lock = Lock()
     nesting: int = 0
     org_maxdepth: int = sys.getrecursionlimit()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -16,7 +16,6 @@ import array
 import sys
 import warnings
 from random import Random
-from threading import Lock
 from typing import (
     Callable,
     Dict,
@@ -303,8 +302,8 @@ class ensure_free_stackframes:
     def __exit__(self, *args, **kwargs):
         if self.new_maxdepth == sys.getrecursionlimit():
             sys.setrecursionlimit(self.old_maxdepth)
-        else:
-            warnings.warn(  # pragma: nocover
+        else:  # pragma: nocover
+            warnings.warn(
                 "The recursion limit will not be reset, since it was changed "
                 "from another thread or during execution of a test.",
                 HypothesisWarning,

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -27,6 +27,7 @@ from numbers import Real
 import pytest
 
 from hypothesis import HealthCheck, assume, given, settings, strategies as st
+from hypothesis.internal.conjecture.junkdrawer import stack_depth_of_caller
 from hypothesis.errors import InvalidArgument, ResolutionFailed, SmallSearchSpaceWarning
 from hypothesis.internal.compat import PYPY, get_origin, get_type_hints
 from hypothesis.internal.reflection import get_pretty_function_description
@@ -613,7 +614,8 @@ def test_resolving_mutually_recursive_types(nxt):
 
 def test_resolving_mutually_recursive_types_with_limited_stack():
     orig_recursionlimit = sys.getrecursionlimit()
-    sys.setrecursionlimit(100)
+    current_stack_depth = stack_depth_of_caller()
+    sys.setrecursionlimit(current_stack_depth + 100)
     try:
 
         @given(nxt=st.from_type(A))
@@ -622,7 +624,7 @@ def test_resolving_mutually_recursive_types_with_limited_stack():
 
         test()
     finally:
-        assert sys.getrecursionlimit() == 100
+        assert sys.getrecursionlimit() == current_stack_depth + 100
         sys.setrecursionlimit(orig_recursionlimit)
 
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -612,17 +612,13 @@ def test_resolving_mutually_recursive_types(nxt):
 
 
 def test_resolving_mutually_recursive_types_with_limited_stack():
-    @given(nxt=st.from_type(A))
-    def test(nxt):
-        i = 0
-        while nxt:
-            assert isinstance(nxt, [A, B][i % 2])
-            nxt = nxt.nxt
-            i += 1
-
     orig_recursionlimit = sys.getrecursionlimit()
     sys.setrecursionlimit(100)
     try:
+        @given(nxt=st.from_type(A))
+        def test(nxt):
+            pass
+
         test()
     finally:
         assert sys.getrecursionlimit() == 100

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -27,9 +27,9 @@ from numbers import Real
 import pytest
 
 from hypothesis import HealthCheck, assume, given, settings, strategies as st
-from hypothesis.internal.conjecture.junkdrawer import stack_depth_of_caller
 from hypothesis.errors import InvalidArgument, ResolutionFailed, SmallSearchSpaceWarning
 from hypothesis.internal.compat import PYPY, get_origin, get_type_hints
+from hypothesis.internal.conjecture.junkdrawer import stack_depth_of_caller
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import from_type
 from hypothesis.strategies._internal import types

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -625,6 +625,7 @@ def test_resolving_mutually_recursive_types_with_limited_stack():
     try:
         test()
     finally:
+        assert sys.getrecursionlimit() == 100
         sys.setrecursionlimit(orig_recursionlimit)
 
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -615,6 +615,7 @@ def test_resolving_mutually_recursive_types_with_limited_stack():
     orig_recursionlimit = sys.getrecursionlimit()
     sys.setrecursionlimit(100)
     try:
+
         @given(nxt=st.from_type(A))
         def test(nxt):
             pass

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
 import threading
 import warnings
 
@@ -151,6 +152,8 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
 
     threads = []
 
+    original_recursionlimit = sys.getrecursionlimit()
+
     for _ in range(4):
         threads.append(threading.Thread(target=test))
 
@@ -159,6 +162,10 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
 
     for thread in threads:
         thread.join()
+
+    # Cleanup: reset the recursion limit that was (probably) not reset
+    # automatically in the threaded test.
+    sys.setrecursionlimit(original_recursionlimit)
 
     assert not errors
 

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import threading
+import warnings
 
 from hypothesis import HealthCheck, given, settings, strategies as st
 
@@ -140,7 +141,11 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
     @given(data=st.data())
     def test(data):
         try:
-            data.draw(shared_strategy)
+            # We may get a warning here about not resetting recursionlimit,
+            # since it was changed during execution; ignore it.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                data.draw(shared_strategy)
         except Exception as exc:
             errors.append(exc)
 


### PR DESCRIPTION
This fixes #3671 by applying the `ConjectureData` trick of extending the stack limit by the current stack depth also upon strategy validation and draw.

The implementation is slightly complicated by "best-effort thread safety", but acceptably so IMO.