### PR TITLE
Fix recursion issues

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Fixes some lingering issues with inference of recursive types
+in `~hypothesis.strategies.from_type`. Closes :issue:`3525`.
+

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -117,6 +117,7 @@ from hypothesis.internal.validation import check_type
 from hypothesis.provisional import domains
 from hypothesis.strategies._internal.collections import ListStrategy
 from hypothesis.strategies._internal.core import BuildsStrategy
+from hypothesis.strategies._internal.deferred import DeferredStrategy
 from hypothesis.strategies._internal.flatmapped import FlatMapStrategy
 from hypothesis.strategies._internal.lazy import LazyStrategy, unwrap_strategies
 from hypothesis.strategies._internal.strategies import (
@@ -668,6 +669,8 @@ def _valid_syntax_repr(strategy):
     # Flatten and de-duplicate any one_of strategies, whether that's from resolving
     # a Union type or combining inputs to multiple functions.
     try:
+        if isinstance(strategy, DeferredStrategy):
+            strategy = strategy.wrapped_strategy
         if isinstance(strategy, OneOfStrategy):
             seen = set()
             elems = []

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -279,11 +279,7 @@ def biased_coin(
                 # becomes i > falsey.
                 result = i > falsey
 
-            if i > 1:  # pragma: no branch
-                # Thanks to bytecode optimisations on CPython >= 3.7 and PyPy
-                # (see https://bugs.python.org/issue2506), coverage incorrectly
-                # thinks that this condition is always true.  You can trivially
-                # check by adding `else: assert False` and running the tests.
+            if i > 1:
                 data.draw_bits(bits, forced=int(result))
         break
     data.stop_example()

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -335,7 +335,7 @@ def extract_lambda_source(f):
                 break
             except SyntaxError:
                 continue
-    if tree is None and source and source[0] in ["@", "."]:
+    if tree is None and source.startswith(("@", ".")):
         # This will always eventually find a valid expression because the
         # decorator or chained operator must be a valid Python function call,
         # so will eventually be syntactically valid and break out of the loop.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -335,10 +335,10 @@ def extract_lambda_source(f):
                 break
             except SyntaxError:
                 continue
-    if tree is None and source.startswith("@"):
-        # This will always eventually find a valid expression because
-        # the decorator must be a valid Python function call, so will
-        # eventually be syntactically valid and break out of the loop.
+    if tree is None and source and source[0] in ["@", "."]:
+        # This will always eventually find a valid expression because the
+        # decorator or chained operator must be a valid Python function call,
+        # so will eventually be syntactically valid and break out of the loop.
         # Thus, this loop can never terminate normally.
         for i in range(len(source) + 1):
             p = source[1:i]

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -234,7 +234,7 @@ class UniqueListStrategy(ListStrategy):
         while elements.more():
             value = filtered.do_filtered_draw(data)
             if value is filter_not_satisfied:
-                elements.reject("Aborted test because unable to satisfy {filtered!r}")
+                elements.reject(f"Aborted test because unable to satisfy {filtered!r}")
             else:
                 for key, seen in zip(self.keys, seen_sets):
                     seen.add(key(value))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1025,12 +1025,12 @@ def _from_type_deferred(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # underlying strategy wherever possible, as a form of user education, but
     # would prefer to fall back to the default "from_type(...)" repr instead of
     # "deferred(...)" for recursive types or invalid arguments.
-    thing_repr = nicerepr(thing)
-    if hasattr(thing, "__module__"):
-        module_prefix = f"{thing.__module__}."
-        if not thing_repr.startswith(module_prefix):
-            thing_repr = module_prefix + thing_repr
     try:
+        thing_repr = nicerepr(thing)
+        if hasattr(thing, "__module__"):
+            module_prefix = f"{thing.__module__}."
+            if not thing_repr.startswith(module_prefix):
+                thing_repr = module_prefix + thing_repr
         repr_ = f"from_type({thing_repr})"
     except Exception:  # pragma: no cover
         repr_ = None

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -942,14 +942,13 @@ def builds(
             from hypothesis.strategies._internal.types import _global_type_lookup
 
             for kw, t in infer_for.items():
-                if (
-                    getattr(t, "__module__", None) in ("builtins", "typing")
-                    or t in _global_type_lookup
-                ):
+                if t in _global_type_lookup:
                     kwargs[kw] = from_type(t)
                 else:
                     # We defer resolution of these type annotations so that the obvious
-                    # approach to registering recursive types just works.  See
+                    # approach to registering recursive types just works.  I.e.,
+                    # if we're inside `register_type_strategy(cls, builds(cls, ...))`
+                    # and `...` contains recursion on `cls`.  See
                     # https://github.com/HypothesisWorks/hypothesis/issues/3026
                     kwargs[kw] = deferred(lambda t=t: from_type(t))  # type: ignore
     return BuildsStrategy(target, args, kwargs)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -209,7 +209,7 @@ def sampled_from(
             repr_ = f"sampled_from({elements.__module__}.{elements.__name__})"
         else:
             repr_ = f"sampled_from({elements!r})"
-    except Exception:
+    except Exception:  # pragma: no cover
         repr_ = None
     if isclass(elements) and issubclass(elements, enum.Flag):
         # Combinations of enum.Flag members are also members.  We generate
@@ -1032,7 +1032,7 @@ def _from_type_deferred(thing: Type[Ex]) -> SearchStrategy[Ex]:
             thing_repr = module_prefix + thing_repr
     try:
         repr_ = f"from_type({thing_repr})"
-    except Exception:
+    except Exception:  # pragma: no cover
         repr_ = None
     return LazyStrategy(
         lambda thing: deferred(lambda: _from_type(thing)),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -117,12 +117,16 @@ class LazyStrategy(SearchStrategy):
         return self.__wrapped_strategy
 
     def filter(self, condition):
+        try:
+            repr_ = f"{self!r}{_repr_filter(condition)}"
+        except Exception:
+            repr_ = None
         return LazyStrategy(
             self.function,
             self.__args,
             self.__kwargs,
             self.__filters + (condition,),
-            force_repr=f"{self!r}{_repr_filter(condition)}",
+            force_repr=repr_,
         )
 
     def do_validate(self):

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -671,6 +671,7 @@ def test_resolving_recursive_type_with_registered_constraint():
     with temp_registered(
         SomeClass, st.builds(SomeClass, value=st.integers(min_value=1))
     ):
+
         @given(s=st.from_type(SomeClass))
         def test(s):
             assert isinstance(s, SomeClass)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -671,7 +671,11 @@ def test_resolving_recursive_type_with_registered_constraint():
     with temp_registered(
         SomeClass, st.builds(SomeClass, value=st.integers(min_value=1))
     ):
-        find_any(st.from_type(SomeClass), lambda s: s.next_node is None)
+        @given(s=st.from_type(SomeClass))
+        def test(s):
+            assert isinstance(s, SomeClass)
+
+        test()
 
 
 def test_resolving_recursive_type_with_registered_constraint_not_none():

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -142,11 +142,7 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
     @given(data=st.data())
     def test(data):
         try:
-            # We may get a warning here about not resetting recursionlimit,
-            # since it was changed during execution; ignore it.
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                data.draw(shared_strategy)
+            data.draw(shared_strategy)
         except Exception as exc:
             errors.append(exc)
 
@@ -154,14 +150,19 @@ def test_drawing_from_recursive_strategy_is_thread_safe():
 
     original_recursionlimit = sys.getrecursionlimit()
 
-    for _ in range(4):
-        threads.append(threading.Thread(target=test))
+    # We may get a warning here about not resetting recursionlimit,
+    # since it was changed during execution; ignore it.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
 
-    for thread in threads:
-        thread.start()
+        for _ in range(4):
+            threads.append(threading.Thread(target=test))
 
-    for thread in threads:
-        thread.join()
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
 
     # Cleanup: reset the recursion limit that was (probably) not reset
     # automatically in the threaded test.


### PR DESCRIPTION
Trying to finally kill that recursion zombie.

 `from_type` didn't properly detect recursion on types that went through `types.from_typing_type`. Fixed by moving the recurse-guard list to a `ContextVar`. (yep, I should have taken your advice on that in the first place @Zac-HD)

Additionally:
- ~~when `nicerepr` encounters an error (RecursionError for example), convert it to a warning and return a string anyway. This is what made it easy to identify the problem in the first place,~~
- hard-code the stack depth increment as 2000 to avoid inconsistency between test runners (pytest seems to bump it from 1000 to 3000 during test execution, for example, and other packages may interfere),
- some other minor stuff which I'll comment in the code.

Closes: #3525