### PR TITLE
Enable `PYTHONWARNDEFAULTENCODING=1` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           - check-py39-nose
           - check-py39-pytest46
           - check-py39-pytest54
-          - check-pytest62
+          # - check-pytest62
           - check-django42
           - check-django41
           - check-django32

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch updates some internal code for selftests.
+There is no user-visible change.

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -9,13 +9,14 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime
-import os
 import sys
 import types
+from pathlib import Path
 
 import sphinx_rtd_theme
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+root = Path(__file__).parent.parent
+sys.path.append(str(root / "src"))
 
 
 autodoc_member_order = "bysource"
@@ -44,16 +45,14 @@ author = "David R. MacIver"
 copyright = f"2013-{datetime.datetime.utcnow().year}, {author}"
 
 _d = {}
-with open(
-    os.path.join(os.path.dirname(__file__), "..", "src", "hypothesis", "version.py")
-) as f:
-    exec(f.read(), _d)
-    version = _d["__version__"]
-    release = _d["__version__"]
+_version_file = root.joinpath("src", "hypothesis", "version.py")
+exec(_version_file.read_text(encoding="utf-8"), _d)
+version = _d["__version__"]
+release = _d["__version__"]
 
 
 def setup(app):
-    if os.path.isfile(os.path.join(os.path.dirname(__file__), "..", "RELEASE.rst")):
+    if root.joinpath("RELEASE.rst").is_file():
         app.tags.add("has_release_file")
 
     # patch in mock array_api namespace so we can autodoc it

--- a/hypothesis-python/scripts/basic-test.sh
+++ b/hypothesis-python/scripts/basic-test.sh
@@ -54,7 +54,7 @@ if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel ==
     pip install "$(grep 'numpy==' ../requirements/coverage.txt)"
   fi
 
-  pip install "$(grep 'black==' ../requirements/coverage.txt)"
+  pip install "$(grep -E 'black(==| @)' ../requirements/coverage.txt)"
   $PYTEST tests/ghostwriter/
   pip uninstall -y black numpy
 fi

--- a/hypothesis-python/scripts/other-tests.sh
+++ b/hypothesis-python/scripts/other-tests.sh
@@ -43,7 +43,7 @@ pip uninstall -y lark
 if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel == \'final\' and platform.python_implementation() not in ("PyPy", "GraalVM"))')" = "True" ] ; then
   pip install ".[codemods,cli]"
   $PYTEST tests/codemods/
-  pip install "$(grep 'black==' ../requirements/coverage.txt)"
+  pip install "$(grep -E 'black(==| @)' ../requirements/coverage.txt)"
   if [ "$(python -c 'import sys; print(sys.version_info[:2] >= (3, 9))')" = "True" ] ; then
     $PYTEST tests/patching/
   fi

--- a/hypothesis-python/scripts/validate_branch_check.py
+++ b/hypothesis-python/scripts/validate_branch_check.py
@@ -13,7 +13,7 @@ import sys
 from collections import defaultdict
 
 if __name__ == "__main__":
-    with open("branch-check") as i:
+    with open("branch-check", encoding="utf-8") as i:
         data = [json.loads(l) for l in i]
 
     checks = defaultdict(set)

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -8,9 +8,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import os
 import sys
 import warnings
+from pathlib import Path
 
 import setuptools
 
@@ -25,11 +25,10 @@ if sys.version_info[:2] < (3, 8):
 
 
 def local_file(name):
-    return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
+    return Path(__file__).parent.joinpath(name).relative_to(Path.cwd())
 
 
-SOURCE = local_file("src")
-README = local_file("README.rst")
+SOURCE = str(local_file("src"))
 
 setuptools_version = tuple(map(int, setuptools.__version__.split(".")[:1]))
 
@@ -44,10 +43,7 @@ if setuptools_version < (42,):
 
 # Assignment to placate pyflakes. The actual version is from the exec that follows.
 __version__ = None
-
-with open(local_file("src/hypothesis/version.py")) as o:
-    exec(o.read())
-
+exec(local_file("src/hypothesis/version.py").read_text(encoding="utf-8"))
 assert __version__ is not None
 
 
@@ -131,7 +127,7 @@ setuptools.setup(
         "pytest11": ["hypothesispytest = _hypothesis_pytestplugin"],
         "console_scripts": ["hypothesis = hypothesis.extra.cli:main"],
     },
-    long_description=open(README).read(),
+    long_description=local_file("README.rst").read_text(encoding="utf-8"),
     long_description_content_type="text/x-rst",
     keywords="python testing fuzzing property-based-testing",
 )

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -161,14 +161,14 @@ else:
 
     def _refactor(func, fname):
         try:
-            with open(fname) as f:
+            with open(fname, encoding="utf-8") as f:
                 oldcode = f.read()
         except (OSError, UnicodeError) as err:
             # Permissions or encoding issue, or file deleted, etc.
             return f"skipping {fname!r} due to {err}"
         newcode = func(oldcode)
         if newcode != oldcode:
-            with open(fname, mode="w") as f:
+            with open(fname, mode="w", encoding="utf-8") as f:
                 f.write(newcode)
 
     @main.command()  # type: ignore  # Click adds the .command attribute

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/dfas.py
@@ -8,19 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import hashlib
-import math
-from itertools import islice
-
-from hypothesis import HealthCheck, settings
-from hypothesis.errors import HypothesisException
-from hypothesis.internal.conjecture.data import ConjectureResult, Status
-from hypothesis.internal.conjecture.dfa.lstar import LStar
-from hypothesis.internal.conjecture.shrinking.learned_dfas import (
-    SHRINKING_DFAS,
-    __file__ as learned_dfa_file,
-)
-
 """
 This is a module for learning new DFAs that help normalize test
 functions. That is, given a test function that sometimes shrinks
@@ -28,6 +15,22 @@ to one thing and sometimes another, this module is designed to
 help learn new DFA-based shrink passes that will cause it to
 always shrink to the same thing.
 """
+
+import hashlib
+import math
+from itertools import islice
+from pathlib import Path
+
+from hypothesis import HealthCheck, settings
+from hypothesis.errors import HypothesisException
+from hypothesis.internal.conjecture.data import ConjectureResult, Status
+from hypothesis.internal.conjecture.dfa.lstar import LStar
+from hypothesis.internal.conjecture.shrinking.learned_dfas import (
+    SHRINKING_DFAS,
+    __file__ as _learned_dfa_file,
+)
+
+learned_dfa_file = Path(_learned_dfa_file)
 
 
 class FailedToNormalise(HypothesisException):
@@ -38,8 +41,7 @@ def update_learned_dfas():
     """Write any modifications to the SHRINKING_DFAS dictionary
     back to the learned DFAs file."""
 
-    with open(learned_dfa_file) as i:
-        source = i.read()
+    source = learned_dfa_file.read_text(encoding="utf-8")
 
     lines = source.splitlines()
 
@@ -60,8 +62,7 @@ def update_learned_dfas():
     new_source = "\n".join(lines) + "\n"
 
     if new_source != source:
-        with open(learned_dfa_file, "w") as o:
-            o.write(new_source)
+        learned_dfa_file.write_text(new_source, encoding="utf-8")
 
 
 def learn_a_new_dfa(runner, u, v, predicate):

--- a/hypothesis-python/src/hypothesis/internal/coverage.py
+++ b/hypothesis-python/src/hypothesis/internal/coverage.py
@@ -61,7 +61,7 @@ if IN_COVERAGE_TESTS:
         if key in written:
             return
         written.add(key)
-        with open("branch-check", "a") as log:
+        with open("branch-check", mode="a", encoding="utf-8") as log:
             log.write(json.dumps({"name": name, "value": value}) + "\n")
 
     description_stack = []

--- a/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
+++ b/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
@@ -36,41 +36,35 @@ def preserving_dfas():
         dfas.SHRINKING_DFAS.update(original)
         dfas.update_learned_dfas()
     assert TEST_DFA_NAME not in dfas.SHRINKING_DFAS
-    with open(dfas.learned_dfa_file) as i:
-        assert TEST_DFA_NAME not in i.read()
+    assert TEST_DFA_NAME not in dfas.learned_dfa_file.read_text(encoding="utf-8")
 
 
 def test_updating_the_file_makes_no_changes_normally():
-    with open(dfas.learned_dfa_file) as i:
-        source1 = i.read()
+    source1 = dfas.learned_dfa_file.read_text(encoding="utf-8")
 
     dfas.update_learned_dfas()
 
-    with open(dfas.learned_dfa_file) as i:
-        source2 = i.read()
+    source2 = dfas.learned_dfa_file.read_text(encoding="utf-8")
 
     assert source1 == source2
 
 
 def test_updating_the_file_include_new_shrinkers():
     with preserving_dfas():
-        with open(dfas.learned_dfa_file) as i:
-            source1 = i.read()
+        source1 = dfas.learned_dfa_file.read_text(encoding="utf-8")
 
         dfas.SHRINKING_DFAS[TEST_DFA_NAME] = "hello"
 
         dfas.update_learned_dfas()
 
-        with open(dfas.learned_dfa_file) as i:
-            source2 = i.read()
+        source2 = dfas.learned_dfa_file.read_text(encoding="utf-8")
 
         assert source1 != source2
         assert repr(TEST_DFA_NAME) in source2
 
     assert TEST_DFA_NAME not in dfas.SHRINKING_DFAS
 
-    with open(dfas.learned_dfa_file) as i:
-        assert "test name" not in i.read()
+    assert "test name" not in dfas.learned_dfa_file.read_text(encoding="utf-8")
 
 
 def called_by_shrinker():

--- a/hypothesis-python/tests/ghostwriter/test_expected_output.py
+++ b/hypothesis-python/tests/ghostwriter/test_expected_output.py
@@ -45,8 +45,8 @@ def update_recorded_outputs(request):
 def get_recorded(name, actual=""):
     file_ = pathlib.Path(__file__).parent / "recorded" / f"{name}.txt"
     if actual:
-        file_.write_text(actual)
-    return file_.read_text()
+        file_.write_text(actual, encoding="utf-8")
+    return file_.read_text(encoding="utf-8")
 
 
 def timsort(seq: Sequence[int]) -> Sequence[int]:

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -463,7 +463,8 @@ def temp_script_file():
             def say_hello():
                 print("Hello world!")
             """
-        )
+        ),
+        encoding="utf-8",
     )
     yield p
     p.unlink()
@@ -483,7 +484,8 @@ def temp_script_file_with_py_function():
             def py():
                 print('A function named "py" has been called')
             """
-        )
+        ),
+        encoding="utf-8",
     )
     yield p
     p.unlink()

--- a/hypothesis-python/tests/numpy/__init__.py
+++ b/hypothesis-python/tests/numpy/__init__.py
@@ -7,3 +7,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
+
+try:
+    EncodingWarning
+except NameError:
+    pass
+else:
+    # Work around https://github.com/numpy/numpy/issues/24115
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", EncodingWarning)
+        import numpy.testing  # noqa

--- a/hypothesis-python/tests/patching/test_patching.py
+++ b/hypothesis-python/tests/patching/test_patching.py
@@ -199,6 +199,6 @@ def test_pytest_reports_patch_file_location(pytester):
     print(f"{pattern=}")
     print(f"result.stdout=\n{indent(str(result.stdout), '    ')}")
     fname = re.search(pattern, str(result.stdout)).group(1)
-    patch = Path(pytester.path).joinpath(fname).read_text()
+    patch = Path(pytester.path).joinpath(fname).read_text(encoding="utf-8")
     print(patch)
     assert ADDED_LINES in patch

--- a/hypothesis-python/tests/pytest/test_seeding.py
+++ b/hypothesis-python/tests/pytest/test_seeding.py
@@ -67,10 +67,10 @@ RECORD_EXAMPLES = <file>
 
 if os.path.exists(RECORD_EXAMPLES):
     target = None
-    with open(RECORD_EXAMPLES, 'r') as i:
+    with open(RECORD_EXAMPLES, "r", encoding="utf-8") as i:
         seen = set(map(int, i.read().strip().split("\\n")))
 else:
-    target = open(RECORD_EXAMPLES, 'w')
+    target = open(RECORD_EXAMPLES, "w", encoding="utf-8")
 
 @given(st.integers())
 def test_failure(i):

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -15,7 +15,7 @@ passenv=
     # Allow CI builds (or user builds) to force coloured terminal output.
     PY_COLORS
 setenv=
-    # PYTHONWARNDEFAULTENCODING=1  # TODO: enable this
+    PYTHONWARNDEFAULTENCODING=1
     brief: HYPOTHESIS_PROFILE=speedy
 commands =
     full: bash scripts/basic-test.sh
@@ -97,6 +97,8 @@ commands =
 deps =
     -r../requirements/test.txt
     pandas~=2.0.0
+setenv=
+    PYTHONWARNDEFAULTENCODING=1
 commands =
     python -bb -X dev -m pytest tests/pandas -n auto
 # Adding a new pandas?  See comment above!
@@ -113,6 +115,8 @@ commands =
     python -bb -X dev -m tests.django.manage test tests.django
 
 [testenv:django42]
+setenv=
+    PYTHONWARNDEFAULTENCODING=1
 commands =
     pip install django~=4.2.0
     python -bb -X dev -m tests.django.manage test tests.django
@@ -140,6 +144,8 @@ commands=
 [testenv:pytest62]
 deps =
     -r../requirements/test.txt
+setenv=
+    PYTHONWARNDEFAULTENCODING=0
 commands=
     pip install pytest==6.2.5 pytest-xdist
     python -bb -X dev -m pytest tests/pytest tests/cover/test_testdecorators.py
@@ -157,6 +163,7 @@ deps =
 allowlist_externals =
     rm
 setenv=
+    PYTHONWARNDEFAULTENCODING=1
     HYPOTHESIS_INTERNAL_COVERAGE=true
 commands_pre =
     rm -f branch-check
@@ -180,6 +187,7 @@ commands =
 deps =
     -r../requirements/coverage.txt
 setenv=
+    PYTHONWARNDEFAULTENCODING=1
     HYPOTHESIS_INTERNAL_COVERAGE=true
 commands_pre =
     python -m coverage erase

--- a/requirements/coverage.in
+++ b/requirements/coverage.in
@@ -1,4 +1,4 @@
-black
+git+https://github.com/psf/black.git@eedfc3832290b3a32825b3c0f2dfa3f3d7ee9d1c
 click
 coverage
 dpcontracts

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -8,7 +8,7 @@ async-timeout==4.0.2
     # via redis
 attrs==23.1.0
     # via hypothesis (hypothesis-python/setup.py)
-black==23.3.0
+black @ git+https://github.com/psf/black.git@eedfc3832290b3a32825b3c0f2dfa3f3d7ee9d1c
     # via -r requirements/coverage.in
 click==8.1.3
     # via
@@ -22,8 +22,10 @@ exceptiongroup==1.1.2 ; python_version < "3.11"
     # via
     #   hypothesis (hypothesis-python/setup.py)
     #   pytest
-execnet==1.9.0
-    # via pytest-xdist
+execnet @ git+https://github.com/pytest-dev/execnet.git@870891d5b853808a050993f397f4e3ed06f61152
+    # via
+    #   -r requirements/test.in
+    #   pytest-xdist
 fakeredis==2.15.0
     # via -r requirements/coverage.in
 iniconfig==2.0.0

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,3 +1,4 @@
 pexpect
 pytest
 pytest-xdist
+git+https://github.com/pytest-dev/execnet.git@870891d5b853808a050993f397f4e3ed06f61152

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,8 +10,10 @@ exceptiongroup==1.1.2 ; python_version < "3.11"
     # via
     #   hypothesis (hypothesis-python/setup.py)
     #   pytest
-execnet==1.9.0
-    # via pytest-xdist
+execnet @ git+https://github.com/pytest-dev/execnet.git@870891d5b853808a050993f397f4e3ed06f61152
+    # via
+    #   -r requirements/test.in
+    #   pytest-xdist
 iniconfig==2.0.0
     # via pytest
 packaging==23.1

--- a/tooling/src/hypothesistooling/__init__.py
+++ b/tooling/src/hypothesistooling/__init__.py
@@ -11,6 +11,7 @@
 import os
 import shlex
 import subprocess
+from pathlib import Path
 
 
 def current_branch():
@@ -29,16 +30,14 @@ def tags():
     return set(result)
 
 
-ROOT = (
+ROOT = Path(
     subprocess.check_output(
         ["git", "-C", os.path.dirname(__file__), "rev-parse", "--show-toplevel"]
     )
     .decode("ascii")
     .strip()
 )
-
-
-REPO_TESTS = os.path.join(ROOT, "whole-repo-tests")
+REPO_TESTS = ROOT / "whole-repo-tests"
 
 
 def hash_for_name(name):

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -33,7 +33,7 @@ BUILD_FILES = tuple(
 
 
 def task(if_changed=()):
-    if isinstance(if_changed, str):
+    if not isinstance(if_changed, tuple):
         if_changed = (if_changed,)
 
     def accept(fn):
@@ -341,7 +341,7 @@ def upgrade_requirements():
     subprocess.call(["./build.sh", "format"], cwd=tools.ROOT)  # exits 1 if changed
     if has_diff(hp.PYTHON_SRC) and not os.path.isfile(hp.RELEASE_FILE):
         msg = hp.get_autoupdate_message(domainlist_changed=has_diff(hp.DOMAINS_LIST))
-        with open(hp.RELEASE_FILE, mode="w") as f:
+        with open(hp.RELEASE_FILE, mode="w", encoding="utf-8") as f:
             f.write(f"RELEASE_TYPE: patch\n\n{msg}")
     update_python_versions()
     subprocess.call(["git", "add", "."], cwd=tools.ROOT)

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -260,8 +260,8 @@ def compile_requirements(upgrade=False):
             },
         )
         # Check that we haven't added anything to output files without adding to inputs
-        out_pkgs = out_file.read_text()
-        for p in f.read_text().splitlines():
+        out_pkgs = out_file.read_text(encoding="utf-8")
+        for p in f.read_text(encoding="utf-8").splitlines():
             p = p.lower().replace("_", "-")
             if re.fullmatch(r"[a-z-]+", p):
                 assert p + "==" in out_pkgs, f"Package `{p}` deleted from {out_file}"
@@ -276,7 +276,7 @@ def update_python_versions():
     stable = re.compile(r".*3\.\d+.\d+$")
     min_minor_version = re.search(
         r'python_requires=">= ?3.(\d+)"',
-        Path("hypothesis-python/setup.py").read_text(),
+        Path("hypothesis-python/setup.py").read_text(encoding="utf-8"),
     ).group(1)
     best = {}
     for line in map(str.strip, result.splitlines()):
@@ -291,18 +291,18 @@ def update_python_versions():
 
     # Write the new mapping back to this file
     thisfile = pathlib.Path(__file__)
-    before = thisfile.read_text()
+    before = thisfile.read_text(encoding="utf-8")
     after = re.sub(r"\nPYTHONS = \{[^{}]+\}", f"\nPYTHONS = {best}", before)
-    thisfile.write_text(after)
+    thisfile.write_text(after, encoding="utf-8")
     pip_tool("shed", str(thisfile))
 
     # Automatically sync ci_version with the version in build.sh
     build_sh = pathlib.Path(tools.ROOT) / "build.sh"
-    sh_before = build_sh.read_text()
+    sh_before = build_sh.read_text(encoding="utf-8")
     sh_after = re.sub(r"3\.\d\d?\.\d\d?", best[ci_version], sh_before)
     if sh_before != sh_after:
         build_sh.unlink()  # so bash doesn't reload a modified file
-        build_sh.write_text(sh_after)
+        build_sh.write_text(sh_after, encoding="utf-8")
         build_sh.chmod(0o755)
 
 
@@ -321,8 +321,12 @@ def update_vendored_files():
     tz_url = "https://pypi.org/pypi/tzdata/json"
     tzdata_version = requests.get(tz_url).json()["info"]["version"]
     setup = pathlib.Path(hp.BASE_DIR, "setup.py")
-    new = re.sub(r"tzdata>=(.+?) ", f"tzdata>={tzdata_version} ", setup.read_text())
-    setup.write_text(new)
+    new = re.sub(
+        r"tzdata>=(.+?) ",
+        f"tzdata>={tzdata_version} ",
+        setup.read_text(encoding="utf-8"),
+    )
+    setup.write_text(new, encoding="utf-8")
 
 
 def has_diff(file_or_directory):

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -21,21 +21,19 @@ from hypothesistooling import releasemanagement as rm
 
 PACKAGE_NAME = "hypothesis-python"
 
-HYPOTHESIS_PYTHON = os.path.join(tools.ROOT, PACKAGE_NAME)
+HYPOTHESIS_PYTHON = tools.ROOT / PACKAGE_NAME
 PYTHON_TAG_PREFIX = "hypothesis-python-"
 
 
 BASE_DIR = HYPOTHESIS_PYTHON
 
-PYTHON_SRC = os.path.join(HYPOTHESIS_PYTHON, "src")
-PYTHON_TESTS = os.path.join(HYPOTHESIS_PYTHON, "tests")
-DOMAINS_LIST = os.path.join(
-    PYTHON_SRC, "hypothesis", "vendor", "tlds-alpha-by-domain.txt"
-)
+PYTHON_SRC = HYPOTHESIS_PYTHON / "src"
+PYTHON_TESTS = HYPOTHESIS_PYTHON / "tests"
+DOMAINS_LIST = PYTHON_SRC / "hypothesis" / "vendor" / "tlds-alpha-by-domain.txt"
 
-RELEASE_FILE = os.path.join(HYPOTHESIS_PYTHON, "RELEASE.rst")
+RELEASE_FILE = HYPOTHESIS_PYTHON / "RELEASE.rst"
 
-assert os.path.exists(PYTHON_SRC)
+assert PYTHON_SRC.exists()
 
 
 __version__ = None
@@ -43,7 +41,7 @@ __version_info__ = None
 
 VERSION_FILE = os.path.join(PYTHON_SRC, "hypothesis/version.py")
 
-with open(VERSION_FILE) as o:
+with open(VERSION_FILE, encoding="utf-8") as o:
     exec(o.read())
 
 assert __version__ is not None
@@ -51,7 +49,7 @@ assert __version_info__ is not None
 
 
 def has_release():
-    return os.path.exists(RELEASE_FILE)
+    return RELEASE_FILE.exists()
 
 
 def parse_release_file():
@@ -139,8 +137,7 @@ def update_changelog_and_version():
         rest,
     ]
 
-    with open(CHANGELOG_FILE, "w") as o:
-        o.write("\n".join(new_changelog_parts))
+    CHANGELOG_FILE.write_text("\n".join(new_changelog_parts), encoding="utf-8")
 
     # Replace the `since="RELEASEDAY"` argument to `note_deprecation`
     # with today's date, to record it for future reference.
@@ -148,20 +145,19 @@ def update_changelog_and_version():
     after = before.replace("RELEASEDAY", rm.release_date_string())
     for root, _, files in os.walk(PYTHON_SRC):
         for fname in (os.path.join(root, f) for f in files if f.endswith(".py")):
-            with open(fname) as f:
+            with open(fname, encoding="utf-8") as f:
                 contents = f.read()
             if before in contents:
-                with open(fname, "w") as f:
+                with open(fname, "w", encoding="utf-8") as f:
                     f.write(contents.replace(before, after))
 
 
-CHANGELOG_FILE = os.path.join(HYPOTHESIS_PYTHON, "docs", "changes.rst")
-DIST = os.path.join(HYPOTHESIS_PYTHON, "dist")
+CHANGELOG_FILE = HYPOTHESIS_PYTHON / "docs" / "changes.rst"
+DIST = HYPOTHESIS_PYTHON / "dist"
 
 
 def changelog():
-    with open(CHANGELOG_FILE) as i:
-        return i.read()
+    return CHANGELOG_FILE.read_text(encoding="utf-8")
 
 
 def build_distribution():
@@ -191,7 +187,7 @@ def upload_distribution():
     # with link to canonical source.
     build_docs(builder="text")
     textfile = os.path.join(HYPOTHESIS_PYTHON, "docs", "_build", "text", "changes.txt")
-    with open(textfile) as f:
+    with open(textfile, encoding="utf-8") as f:
         lines = f.readlines()
     entries = [i for i, l in enumerate(lines) if CHANGELOG_HEADER.match(l)]
     anchor = current_version().replace(".", "-")

--- a/tooling/src/hypothesistooling/releasemanagement.py
+++ b/tooling/src/hypothesistooling/releasemanagement.py
@@ -60,7 +60,7 @@ def extract_assignment_from_string(contents, name):
 
 
 def extract_assignment(filename, name):
-    with open(filename) as i:
+    with open(filename, encoding="utf-8") as i:
         return extract_assignment_from_string(i.read(), name)
 
 
@@ -93,10 +93,10 @@ def replace_assignment(filename, name, value):
     the file format. The existing value is simply the rest of the line after
     the last space after the equals.
     """
-    with open(filename) as i:
+    with open(filename, encoding="utf-8") as i:
         contents = i.read()
     result = replace_assignment_in_string(contents, name, value)
-    with open(filename, "w") as o:
+    with open(filename, "w", encoding="utf-8") as o:
         o.write(result)
 
 
@@ -112,7 +112,7 @@ VALID_RELEASE_TYPES = (MAJOR, MINOR, PATCH)
 
 
 def parse_release_file(filename):
-    with open(filename) as i:
+    with open(filename, encoding="utf-8") as i:
         return parse_release_file_contents(i.read(), filename)
 
 
@@ -150,12 +150,12 @@ def bump_version_info(version_info, release_type):
 
 
 def update_markdown_changelog(changelog, name, version, entry):
-    with open(changelog) as i:
+    with open(changelog, encoding="utf-8") as i:
         prev_contents = i.read()
 
     title = f"# {name} {version} ({release_date_string()})\n\n"
 
-    with open(changelog, "w") as o:
+    with open(changelog, "w", encoding="utf-8") as o:
         o.write(title)
         o.write(entry.strip())
         o.write("\n\n")

--- a/tooling/src/hypothesistooling/scripts.py
+++ b/tooling/src/hypothesistooling/scripts.py
@@ -40,15 +40,14 @@ def run_script(script, *args, **kwargs):
     return subprocess.check_call([os.path.join(SCRIPTS, script), *args], **kwargs)
 
 
-SCRIPTS = os.path.join(ROOT, "tooling", "scripts")
-COMMON = os.path.join(SCRIPTS, "common.sh")
+SCRIPTS = ROOT / "tooling" / "scripts"
+COMMON = SCRIPTS / "common.sh"
 
 
 def __calc_script_variables():
     exports = re.compile(r"^export ([A-Z_]+)(=|$)", flags=re.MULTILINE)
 
-    with open(COMMON) as i:
-        common = i.read()
+    common = COMMON.read_text(encoding="utf-8")
 
     for name, _ in exports.findall(common):
         globals()[name] = os.environ[name]

--- a/whole-repo-tests/test_ci_config.py
+++ b/whole-repo-tests/test_ci_config.py
@@ -16,7 +16,9 @@ from hypothesistooling.__main__ import PYTHONS
 
 ci_checks = "    ".join(
     line.strip()
-    for line in Path(".github/workflows/main.yml").read_text().splitlines()
+    for line in Path(".github/workflows/main.yml")
+    .read_text(encoding="utf-8")
+    .splitlines()
     if "- check-py" in line
 )
 

--- a/whole-repo-tests/test_deploy.py
+++ b/whole-repo-tests/test_deploy.py
@@ -32,7 +32,7 @@ def test_release_file_exists_and_is_valid(project, monkeypatch):
     try:
         main.do_release(project)
 
-        with open(project.CHANGELOG_FILE) as i:
+        with open(project.CHANGELOG_FILE, encoding="utf-8") as i:
             changelog = i.read()
         assert project.current_version() in changelog
         assert rm.release_date_string() in changelog

--- a/whole-repo-tests/test_mypy.py
+++ b/whole-repo-tests/test_mypy.py
@@ -20,7 +20,7 @@ PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 
 def test_mypy_passes_on_hypothesis():
-    pip_tool("mypy", PYTHON_SRC)
+    pip_tool("mypy", str(PYTHON_SRC))
 
 
 @pytest.mark.skip(
@@ -28,7 +28,7 @@ def test_mypy_passes_on_hypothesis():
     "but strict checks for our internals would be a net drag on productivity."
 )
 def test_mypy_passes_on_hypothesis_strict():
-    pip_tool("mypy", "--strict", PYTHON_SRC)
+    pip_tool("mypy", "--strict", str(PYTHON_SRC))
 
 
 def get_mypy_output(fname, *extra_args):

--- a/whole-repo-tests/test_pyright.py
+++ b/whole-repo-tests/test_pyright.py
@@ -52,7 +52,8 @@ def test_pyright_passes_on_basic_test(tmp_path: Path, python_version: str):
             def test_bar(x: str):
                 assert x == x
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(
         tmp_path, {"typeCheckingMode": "strict", "pythonVersion": python_version}
@@ -72,7 +73,8 @@ def test_given_only_allows_strategies(tmp_path: Path, python_version: str):
             def f():
                 pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(
         tmp_path, {"typeCheckingMode": "strict", "pythonVersion": python_version}
@@ -97,7 +99,8 @@ def test_pyright_issue_3296(tmp_path: Path):
 
             lists(integers()).map(sorted)
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(tmp_path, {"typeCheckingMode": "strict"})
     assert _get_pyright_errors(file) == []
@@ -115,7 +118,8 @@ def test_pyright_raises_for_mixed_pos_kwargs_in_given(tmp_path: Path):
             def test_bar(x: str):
                 pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(tmp_path, {"typeCheckingMode": "strict"})
     assert (
@@ -141,7 +145,8 @@ def test_pyright_issue_3348(tmp_path: Path):
             st.one_of([st.integers(), st.floats()])  # sequence of strats should be OK
             st.sampled_from([1, 2])
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(tmp_path, {"typeCheckingMode": "strict"})
     assert _get_pyright_errors(file) == []
@@ -157,7 +162,8 @@ def test_pyright_tuples_pos_args_only(tmp_path: Path):
             st.tuples(a1=st.integers())
             st.tuples(a1=st.integers(), a2=st.integers())
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(tmp_path, {"typeCheckingMode": "strict"})
     assert (
@@ -181,7 +187,8 @@ def test_pyright_one_of_pos_args_only(tmp_path: Path):
             st.one_of(a1=st.integers())
             st.one_of(a1=st.integers(), a2=st.integers())
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(tmp_path, {"typeCheckingMode": "strict"})
     assert (
@@ -213,7 +220,8 @@ def test_register_random_protocol(tmp_path: Path):
             register_random(MyRandom())
             register_random(None)  # type: ignore
             """
-        )
+        ),
+        encoding="utf-8",
     )
     _write_config(tmp_path, {"reportUnnecessaryTypeIgnoreComment": True})
     assert _get_pyright_errors(file) == []
@@ -243,4 +251,4 @@ def _get_pyright_errors(file: Path) -> list[dict[str, Any]]:
 
 def _write_config(config_dir: Path, data: dict[str, Any] | None = None):
     config = {"extraPaths": [PYTHON_SRC], **(data or {})}
-    (config_dir / "pyrightconfig.json").write_text(json.dumps(config))
+    (config_dir / "pyrightconfig.json").write_text(json.dumps(config), encoding="utf-8")

--- a/whole-repo-tests/test_pyright.py
+++ b/whole-repo-tests/test_pyright.py
@@ -250,5 +250,5 @@ def _get_pyright_errors(file: Path) -> list[dict[str, Any]]:
 
 
 def _write_config(config_dir: Path, data: dict[str, Any] | None = None):
-    config = {"extraPaths": [PYTHON_SRC], **(data or {})}
+    config = {"extraPaths": [str(PYTHON_SRC)], **(data or {})}
     (config_dir / "pyrightconfig.json").write_text(json.dumps(config), encoding="utf-8")

--- a/whole-repo-tests/test_validate_branch_check.py
+++ b/whole-repo-tests/test_validate_branch_check.py
@@ -20,7 +20,7 @@ VALIDATE_BRANCH_CHECK = os.path.join(BASE_DIR, "scripts", "validate_branch_check
 
 
 def write_entries(tmp_path, entries):
-    with open(tmp_path / BRANCH_CHECK, "w") as f:
+    with open(tmp_path / BRANCH_CHECK, "w", encoding="utf-8") as f:
         f.writelines([json.dumps(entry) + "\n" for entry in entries])
 
 


### PR DESCRIPTION
Follows https://github.com/HypothesisWorks/hypothesis/pull/3619.  Requires:

- [x] https://github.com/pytest-dev/pytest/pull/10935 released
- [ ] https://github.com/pytest-dev/execnet/pull/196 fixed but not yet released
- [ ] https://github.com/psf/black/issues/3696 fixed but not yet released
- [ ] https://github.com/numpy/numpy/issues/24115 going to work around this for now
- [ ] https://github.com/pypa/pip/issues/12070 annoying but doesn't make CI fail

I'm planning to depend on the fixed git commits for CI, and switch back after the fixes are released.