### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           - check-py39-nose
           - check-py39-pytest46
           - check-py39-pytest54
-          # - check-pytest62
+          - check-pytest62
           - check-django42
           - check-django41
           - check-django32

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -54,7 +54,7 @@ def test_resolves_unspecified_array_type(atype):
 
 def workaround(dtype):
     # Total hack to work around https://github.com/numpy/numpy/issues/24043
-    if np.__version__.startswith("1.25.") and dtype == np.dtype("bytes").type:
+    if np.__version__ == "1.25.0" and dtype == np.dtype("bytes").type:
         return pytest.param(dtype, marks=[pytest.mark.xfail(strict=False)])
     return dtype
 

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -145,7 +145,7 @@ commands=
 deps =
     -r../requirements/test.txt
 setenv=
-    PYTHONWARNDEFAULTENCODING=0
+    PYTHONWARNDEFAULTENCODING=
 commands=
     pip install pytest==6.2.5 pytest-xdist
     python -bb -X dev -m pytest tests/pytest tests/cover/test_testdecorators.py


### PR DESCRIPTION
https://github.com/numpy/numpy/issues/24043 will be fixed in Numpy 1.25.1, so we can tweak the xfail, and we need to unset the env var rather than setting it to `0`.