### PR TITLE
Fix fuzzing artifact saving

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -64,12 +64,11 @@ jobs:
       continue-on-error: true
       # The timeout ensures that we finish all steps within the six-hour
       # maximum runtime for Github Actions.
-      # Then run the fuzzer on everything, as for our Windows CI.
+      # Then run the fuzzer on everything, as for our Windows CI; avoiding
+      # the --no-dashboard option because that also disables .patch writing.
       run: |
         timeout --preserve-status 5.5h \
-          hypothesis fuzz --no-dashboard -- \
-            hypothesis-python/tests/ \
-            -k "not keyboardinterrupt" \
+          hypothesis fuzz -- hypothesis-python/tests/ \
             --ignore=hypothesis-python/tests/quality/ \
             --ignore=hypothesis-python/tests/ghostwriter/
 

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release further improves our ``.patch``-file support from
+:ref:`version 6.75 <v6.75.0>`, skipping duplicates, tests which use
+:func:`~hypothesis.strategies.data` (and don't support
+:obj:`@example() <hypothesis.example>`\ ), and various broken edge-cases.
+
+Because :pypi:`libCST` has released version 1.0 which uses the native parser
+by default, we no longer set the ``LIBCST_PARSER_TYPE=native`` environment
+variable.  If you are using an older version, you may need to upgrade or
+set this envvar for yourself.

--- a/hypothesis-python/src/hypothesis/extra/_patching.py
+++ b/hypothesis-python/src/hypothesis/extra/_patching.py
@@ -33,7 +33,6 @@ from libcst import matchers as m
 from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
 
 from hypothesis.configuration import storage_directory
-from hypothesis.extra.codemods import _native_parser
 from hypothesis.version import __version__
 
 try:
@@ -77,11 +76,9 @@ class AddExamplesCodemod(VisitorBasedCodemodCommand):
         """
         assert not isinstance(strip_via, str), "expected a collection of strings"
         dedented, prefix = dedent(code)
-        with _native_parser():
-            mod = cst.parse_module(dedented)
         modded = (
             cls(CodemodContext(), fn_examples, prefix, strip_via, dec)
-            .transform_module(mod)
+            .transform_module(cst.parse_module(dedented))
             .code
         )
         return indent(modded, prefix=prefix)

--- a/hypothesis-python/src/hypothesis/extra/_patching.py
+++ b/hypothesis-python/src/hypothesis/extra/_patching.py
@@ -155,7 +155,7 @@ def get_patch_for(func, failing_examples, *, strip_via=()):
     # The printed examples might include object reprs which are invalid syntax,
     # so we parse here and skip over those.  If _none_ are valid, there's no patch.
     call_nodes = []
-    for ex, via in failing_examples:
+    for ex, via in set(failing_examples):
         with suppress(Exception):
             node = cst.parse_expression(ex)
             assert isinstance(node, cst.Call), node

--- a/hypothesis-python/src/hypothesis/extra/_patching.py
+++ b/hypothesis-python/src/hypothesis/extra/_patching.py
@@ -159,6 +159,10 @@ def get_patch_for(func, failing_examples, *, strip_via=()):
         with suppress(Exception):
             node = cst.parse_expression(ex)
             assert isinstance(node, cst.Call), node
+            # Check for st.data(), which doesn't support explicit examples
+            data = m.Arg(m.Call(m.Name("data"), args=[m.Arg(m.Ellipsis())]))
+            if m.matches(node, m.Call(args=[m.ZeroOrMore(), data, m.ZeroOrMore()])):
+                return None
             call_nodes.append((node, via))
     if not call_nodes:
         return None

--- a/hypothesis-python/src/hypothesis/extra/codemods.py
+++ b/hypothesis-python/src/hypothesis/extra/codemods.py
@@ -47,28 +47,12 @@ at the cost of additional configuration (adding ``'hypothesis.extra'`` to the
 
 import functools
 import importlib
-import os
-from contextlib import contextmanager
 from inspect import Parameter, signature
 from typing import List
 
 import libcst as cst
 import libcst.matchers as m
 from libcst.codemod import VisitorBasedCodemodCommand
-
-
-@contextmanager
-def _native_parser():
-    # Only the native parser supports Python 3.9 and later, but for now it's
-    # only active if you set an environment variable.  Very well then:
-    var = os.environ.get("LIBCST_PARSER_TYPE")
-    try:
-        os.environ["LIBCST_PARSER_TYPE"] = "native"
-        yield
-    finally:
-        os.environ.pop("LIBCST_PARSER_TYPE")
-        if var is not None:  # pragma: no cover
-            os.environ["LIBCST_PARSER_TYPE"] = var
 
 
 def refactor(code: str) -> str:
@@ -80,8 +64,7 @@ def refactor(code: str) -> str:
     We recommend using the CLI, but if you want a Python function here it is.
     """
     context = cst.codemod.CodemodContext()
-    with _native_parser():
-        mod = cst.parse_module(code)
+    mod = cst.parse_module(code)
     transforms: List[VisitorBasedCodemodCommand] = [
         HypothesisFixPositionalKeywonlyArgs(context),
         HypothesisFixComplexMinMagnitude(context),

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -83,7 +83,7 @@ import types
 import warnings
 from collections import OrderedDict, defaultdict
 from itertools import permutations, zip_longest
-from keyword import iskeyword
+from keyword import iskeyword as _iskeyword
 from string import ascii_lowercase
 from textwrap import dedent, indent
 from typing import (
@@ -482,7 +482,7 @@ def _get_params(func: Callable) -> Dict[str, inspect.Parameter]:
                 if arg.startswith("*") or arg == "...":
                     kind = inspect.Parameter.KEYWORD_ONLY
                     continue  # we omit *varargs, if there are any
-                if iskeyword(arg.lstrip("*")) or not arg.lstrip("*").isidentifier():
+                if _iskeyword(arg.lstrip("*")) or not arg.lstrip("*").isidentifier():
                     print(repr(args))
                     break  # skip all subsequent params if this name is invalid
                 params.append(inspect.Parameter(name=arg, kind=kind))

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -9,14 +9,11 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import os
-from tempfile import mkdtemp
 from warnings import filterwarnings
 
 from hypothesis import Phase, Verbosity, settings
 from hypothesis._settings import not_set
-from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.errors import NonInteractiveExampleWarning
-from hypothesis.internal import charmap
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
@@ -41,16 +38,6 @@ def run():
 
     # User-facing warning which does not apply to our own tests
     filterwarnings("ignore", category=NonInteractiveExampleWarning)
-
-    new_home = mkdtemp()
-    set_hypothesis_home_dir(new_home)
-    assert settings.default.database.path.startswith(new_home)
-
-    # Remove the cache because we might have saved this before setting the new home dir
-    charmap._charmap = None
-    charmap.charmap()
-    assert os.path.exists(charmap.charmap_file()), charmap.charmap_file()
-    assert isinstance(settings, type)
 
     # We do a smoke test here before we mess around with settings.
     x = settings()

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -87,14 +87,6 @@ def test_interactive_example_does_not_emit_warning():
     child.sendline("quit(code=0)")
 
 
-@fails_with(KeyboardInterrupt)
-@example(1)
-@example(2)
-@given(st.none())
-def test_raises_keyboardinterrupt_immediately(_):
-    raise KeyboardInterrupt
-
-
 def identity(decorator):
     # The "identity function hack" from https://peps.python.org/pep-0614/
     # Method-chaining decorators are otherwise a syntax error in Python <= 3.8

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -592,7 +592,7 @@ def test_inline_given_handles_self():
 def logged(f):
     @wraps(f)
     def wrapper(*a, **kw):
-        print("I was called")
+        # print("I was called")
         return f(*a, **kw)
 
     return wrapper

--- a/hypothesis-python/tests/patching/test_patching.py
+++ b/hypothesis-python/tests/patching/test_patching.py
@@ -161,6 +161,14 @@ def test_invalid_syntax_cases_dropped(n):
     assert after.count(expected.lstrip("+")) == n
 
 
+def test_no_example_for_data_strategy():
+    assert get_patch_for(fn, [("fn(data=data(...))", "msg")]) is None
+    assert get_patch_for(fn, [("fn(123, data(...))", "msg")]) is None
+
+    assert get_patch_for(fn, [("fn(data='data(...)')", "msg")]) is not None
+    assert get_patch_for(fn, [("fn(Foo(data=data(...)))", "msg")]) is not None
+
+
 def test_irretrievable_callable():
     # Check that we return None instead of raising an exception
     old_module = fn.__module__


### PR DESCRIPTION
- The `.patch` files weren't showing up because the dashboard process is responsible for writing them (since that's where all the examples are reported); fixed by removing `--no-dashboard`.
- The database _also_ wasn't showing up, because eight years ago we set that to a random location (in such a way that it only sometimes took effect).  Removed this so we'll use the default location from now on.