### PR TITLE
Env var to skip loading of entrypoints.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,10 @@
 RELEASE_TYPE: patch
 
-Read environment variable HYPOTHESIS_NO_ENTRYPOINTS to
-optionally skip loading of third-party plugin entrypoints.
+If the :envvar:`HYPOTHESIS_NO_PLUGINS` environment variable is set, we'll avoid 
+:ref:`loading plugins <>` such as `the old Pydantic integration 
+<https://docs.pydantic.dev/latest/integrations/hypothesis/>`__ or 
+`HypoFuzz' CLI options <https://hypofuzz.com/docs/quickstart.html#running-hypothesis-fuzz>`__.
+
+This is probably only useful for our own self-tests, but documented in case it might
+help narrow down any particularly weird bugs in complex environments.
 

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Read environment variable HYPOTHESIS_NO_ENTRYPOINTS to
+optionally skip loading of third-party plugin entrypoints.
+

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,7 @@
 RELEASE_TYPE: patch
 
 If the :envvar:`HYPOTHESIS_NO_PLUGINS` environment variable is set, we'll avoid 
-:ref:`loading plugins <>` such as `the old Pydantic integration 
+:ref:`loading plugins <entry-points>` such as `the old Pydantic integration
 <https://docs.pydantic.dev/latest/integrations/hypothesis/>`__ or 
 `HypoFuzz' CLI options <https://hypofuzz.com/docs/quickstart.html#running-hypothesis-fuzz>`__.
 

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -182,6 +182,12 @@ and then tell ``setuptools`` that this is your ``"hypothesis"`` entry point:
 
 And that's all it takes!
 
+.. envvar:: HYPOTHESIS_NO_PLUGINS
+
+   If set, disables automatic loading of all hypothesis plugins. This is probably only
+   useful for our own self-tests, but documented in case it might help narrow down
+   any particularly weird bugs in complex environments.
+
 
 Interaction with :pypi:`pytest-cov`
 -----------------------------------

--- a/hypothesis-python/src/hypothesis/entry_points.py
+++ b/hypothesis-python/src/hypothesis/entry_points.py
@@ -30,7 +30,7 @@ def get_entry_points():
 
 
 def run():
-    if not os.environ.get("HYPOTHESIS_NO_ENTRYPOINTS"):
+    if not os.environ.get("HYPOTHESIS_NO_PLUGINS"):
         for entry in get_entry_points():  # pragma: no cover
             hook = entry.load()
             if callable(hook):

--- a/hypothesis-python/src/hypothesis/entry_points.py
+++ b/hypothesis-python/src/hypothesis/entry_points.py
@@ -16,6 +16,7 @@ your package.
 """
 
 import importlib.metadata
+import os
 
 
 def get_entry_points():
@@ -29,7 +30,8 @@ def get_entry_points():
 
 
 def run():
-    for entry in get_entry_points():  # pragma: no cover
-        hook = entry.load()
-        if callable(hook):
-            hook()
+    if not os.environ.get("HYPOTHESIS_NO_ENTRYPOINTS"):
+        for entry in get_entry_points():  # pragma: no cover
+            hook = entry.load()
+            if callable(hook):
+                hook()

--- a/hypothesis-python/tests/cover/test_lazy_import.py
+++ b/hypothesis-python/tests/cover/test_lazy_import.py
@@ -47,5 +47,5 @@ def test_hypothesis_does_not_import_test_runners(tmp_path):
     fname.write_text(SHOULD_NOT_IMPORT_TEST_RUNNERS, encoding="utf-8")
     subprocess.check_call(
         [sys.executable, str(fname)],
-        env=os.environ | {"HYPOTHESIS_NO_ENTRYPOINTS": "1"},
+        env={**os.environ, **{"HYPOTHESIS_NO_ENTRYPOINTS": "1"}},
     )

--- a/hypothesis-python/tests/cover/test_lazy_import.py
+++ b/hypothesis-python/tests/cover/test_lazy_import.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import os
 import subprocess
 import sys
 
@@ -44,4 +45,7 @@ def test_hypothesis_does_not_import_test_runners(tmp_path):
     # See https://github.com/HypothesisWorks/hypothesis/pull/2204
     fname = tmp_path / "test.py"
     fname.write_text(SHOULD_NOT_IMPORT_TEST_RUNNERS, encoding="utf-8")
-    subprocess.check_call([sys.executable, str(fname)])
+    subprocess.check_call(
+        [sys.executable, str(fname)],
+        env=os.environ | {"HYPOTHESIS_NO_ENTRYPOINTS": "1"},
+    )

--- a/hypothesis-python/tests/cover/test_lazy_import.py
+++ b/hypothesis-python/tests/cover/test_lazy_import.py
@@ -47,5 +47,5 @@ def test_hypothesis_does_not_import_test_runners(tmp_path):
     fname.write_text(SHOULD_NOT_IMPORT_TEST_RUNNERS, encoding="utf-8")
     subprocess.check_call(
         [sys.executable, str(fname)],
-        env={**os.environ, **{"HYPOTHESIS_NO_ENTRYPOINTS": "1"}},
+        env={**os.environ, **{"HYPOTHESIS_NO_PLUGINS": "1"}},
     )


### PR DESCRIPTION
Closes #3686. The test_lazy_import test would fail depending on which other packages happened to be installed.

Trivial code change, but you may have an opinion on the env var name.
