### PR TITLE
Consider reduced precision candidates for float shrinking

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Improve shrinking of floats in narrow regions that don't cross an integer
+boundary. Closes :issue:`3357`.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -65,13 +65,8 @@ class Float(Shrinker):
         # change that would require shifting the exponent while not changing
         # the float value much.
 
-        if self.consider(int(self.current)):
-            self.debug("Just an integer now")
-            self.delegate(Integer, convert_to=int, convert_from=float)
-            return
-
-        # Try dropping precision bits by rounding the scaled value. We try
-        # values ordered from least-precise (integer) to more precise, ie.
+        # First, try dropping precision bits by rounding the scaled value. We
+        # try values ordered from least-precise (integer) to more precise, ie.
         # approximate lexicographical order. Once we find an acceptable shrink,
         # self.consider discards the remaining attempts early and skips test
         # invocation. The loop count sets max fractional bits to keep, and is a
@@ -81,6 +76,11 @@ class Float(Shrinker):
             scaled = self.current * 2**p  # note: self.current may change in loop
             for truncate in [math.floor, math.ceil]:
                 self.consider(truncate(scaled) / 2**p)
+
+        if self.consider(int(self.current)):
+            self.debug("Just an integer now")
+            self.delegate(Integer, convert_to=int, convert_from=float)
+            return
 
         # Now try to minimize the top part of the fraction as an integer. This
         # basically splits the float as k + x with 0 <= x < 1 and minimizes

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -41,6 +41,10 @@ class Float(Shrinker):
         return lex1 < lex2
 
     def short_circuit(self):
+        # We check for a bunch of standard "large" floats. If we're currently
+        # worse than them and the shrink downwards doesn't help, abort early
+        # because there's not much useful we can do here.
+
         for g in [sys.float_info.max, math.inf, math.nan]:
             self.consider(g)
 
@@ -53,10 +57,6 @@ class Float(Shrinker):
         return self.current >= MAX_PRECISE_INTEGER
 
     def run_step(self):
-        # We check for a bunch of standard "large" floats. If we're currently
-        # worse than them and the shrink downwards doesn't help, abort early
-        # because there's not much useful we can do here.
-
         # Finally we get to the important bit: Each of these is a small change
         # to the floating point number that corresponds to a large change in
         # the lexical representation. Trying these ensures that our floating
@@ -65,18 +65,13 @@ class Float(Shrinker):
         # change that would require shifting the exponent while not changing
         # the float value much.
 
-        for g in [math.floor(self.current), math.ceil(self.current)]:
-            self.consider(g)
-
         if self.consider(int(self.current)):
             self.debug("Just an integer now")
             self.delegate(Integer, convert_to=int, convert_from=float)
             return
 
-        m, n = self.current.as_integer_ratio()
-        i, r = divmod(m, n)
+        # Try dropping precision bits
 
-        # Now try to minimize the top part of the fraction as an integer. This
-        # basically splits the float as k + x with 0 <= x < 1 and minimizes
-        # k as an integer, but without the precision issues that would have.
-        self.call_shrinker(Integer, i, lambda k: self.consider((i * n + r) / n))
+        for p in range(5):
+            for truncate in [math.floor, math.ceil]:
+                self.consider(truncate(self.current * 2**p) / 2**p)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -81,3 +81,10 @@ class Float(Shrinker):
             scaled = self.current * 2**p  # note: self.current may change in loop
             for truncate in [math.floor, math.ceil]:
                 self.consider(truncate(scaled) / 2**p)
+
+        # Now try to minimize the top part of the fraction as an integer. This
+        # basically splits the float as k + x with 0 <= x < 1 and minimizes
+        # k as an integer, but without the precision issues that would have.
+        m, n = self.current.as_integer_ratio()
+        i, r = divmod(m, n)
+        self.call_shrinker(Integer, i, lambda k: self.consider((k * n + r) / n))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -70,8 +70,14 @@ class Float(Shrinker):
             self.delegate(Integer, convert_to=int, convert_from=float)
             return
 
-        # Try dropping precision bits
+        # Try dropping precision bits by rounding the scaled value. We try
+        # values ordered from least-precise (integer) to more precise, ie.
+        # approximate lexicographical order. Once we find an acceptable shrink,
+        # self.consider discards the remaining attempts early and skips test
+        # invocation. The loop count sets max fractional bits to keep, and is a
+        # compromise between completeness and performance.
 
-        for p in range(5):
+        for p in range(10):
+            scaled = self.current * 2**p  # note: self.current may change in loop
             for truncate in [math.floor, math.ceil]:
-                self.consider(truncate(self.current * 2**p) / 2**p)
+                self.consider(truncate(scaled) / 2**p)

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -209,6 +209,10 @@ def test_shrink_down_to_half():
     assert minimal_from(0.75, lambda x: 0 < x < 1) == 0.5
 
 
+def test_shrink_fractional_part():
+    assert minimal_from(2.5, lambda x: divmod(x, 1)[1] == 0.5) == 1.5
+
+
 def test_does_not_shrink_across_one():
     # This is something of an odd special case. Because of our encoding we
     # prefer all numbers >= 1 to all numbers in 0 < x < 1. For the most part

--- a/hypothesis-python/tests/nocover/test_simple_numbers.py
+++ b/hypothesis-python/tests/nocover/test_simple_numbers.py
@@ -101,7 +101,7 @@ def test_minimal_float_is_zero():
 
 
 def test_minimal_asymetric_bounded_float():
-    assert minimal(floats(min_value=1.1, max_value=1.9), lambda x: True) == 1.5
+    assert minimal(floats(min_value=1.1, max_value=1.6), lambda x: True) == 1.5
 
 
 def test_negative_floats_simplify_to_zero():


### PR DESCRIPTION
Ref #3357.

Adds nearby reduced-precision shrink candidates in `Float` shrinker.