### PR TITLE
Implement pretty-printing of combined `enum.Flag` instances

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes pretty-printing of combinations of :class:`enum.Flag`
+values, which was previously an error (:issue:`3709`).

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -25,7 +25,7 @@ if sys.version_info[:2] < (3, 8):
 
 
 def local_file(name):
-    return Path(__file__).parent.joinpath(name).relative_to(Path.cwd())
+    return Path(__file__).absolute().parent.joinpath(name).relative_to(Path.cwd())
 
 
 SOURCE = str(local_file("src"))

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -69,6 +69,7 @@ import types
 import warnings
 from collections import defaultdict, deque
 from contextlib import contextmanager
+from enum import Flag
 from io import StringIO
 from math import copysign, isnan
 
@@ -801,7 +802,11 @@ def _repr_dataframe(obj, p, cycle):  # pragma: no cover
 
 
 def _repr_enum(obj, p, cycle):
-    p.text(type(obj).__name__ + "." + obj.name)
+    tname = type(obj).__name__
+    if isinstance(obj, Flag):
+        p.text(" | ".join(f"{tname}.{x.name}" for x in type(obj) if x & obj == x))
+    else:
+        p.text(f"{tname}.{obj.name}")
 
 
 for_type_by_name("collections", "defaultdict", _defaultdict_pprint)

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -50,7 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import re
 import warnings
 from collections import Counter, OrderedDict, defaultdict, deque
-from enum import Enum
+from enum import Enum, Flag
 
 import pytest
 
@@ -628,5 +628,40 @@ class AnEnum(Enum):
     SOME_MEMBER = 1
 
 
-def test_pretty_prints_enums_as_code():
-    assert pretty.pretty(AnEnum.SOME_MEMBER) == "AnEnum.SOME_MEMBER"
+class Options(Flag):
+    A = 1
+    B = 2
+    C = 4
+
+
+class EvilReprOptions(Flag):
+    A = 1
+    B = 2
+
+    def __repr__(self):
+        return "can't parse this nonsense"
+
+
+class LyingReprOptions(Flag):
+    A = 1
+    B = 2
+
+    def __repr__(self):
+        return "LyingReprOptions.A|B|C"
+
+
+@pytest.mark.parametrize(
+    "rep",
+    [
+        "AnEnum.SOME_MEMBER",
+        "Options.A",
+        "Options.A | Options.B",
+        "Options.A | Options.B | Options.C",
+        "EvilReprOptions.A",
+        "LyingReprOptions.A",
+        "EvilReprOptions.A | EvilReprOptions.B",
+        "LyingReprOptions.A | LyingReprOptions.B",
+    ],
+)
+def test_pretty_prints_enums_as_code(rep):
+    assert pretty.pretty(eval(rep)) == rep


### PR DESCRIPTION
Closes #3709.

And since I was pushing some commits, also fixes #3707. 