### PR TITLE
Adding `codec=` option to `st.characters()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+Adds a new ``codec=`` option in :func:`~hypothesis.strategies.characters`, making it
+convenient to produce only characters which can be encoded as ``ascii`` or ``utf-8``
+bytestrings.
+
+Support for other codecs will be added in a future release.

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -150,56 +150,22 @@ def test_non_executed_tests_raise_skipped(test_fn):
     [
         ("ascii", None, None, None),
         ("ascii", 128, None, None),
+        ("ascii", 100, None, None),
         ("utf-8", None, None, None),
         ("utf-8", None, ["Cs"], None),
         ("utf-8", None, ["N"], None),
-        ("utf-8", None, None, ["Cs"]),
         ("utf-8", None, None, ["N"]),
-        ("something", None, None, None),
     ],
 )
 @given(s.data())
 def test_characters_codec(
     codec, max_codepoint, blacklist_categories, whitelist_categories, data
 ):
-    if codec == "something":
-        with pytest.raises(InvalidArgument) as excinfo:
-            example = data.draw(
-                s.characters(
-                    codec=codec,
-                    max_codepoint=max_codepoint,
-                    blacklist_categories=blacklist_categories,
-                    whitelist_categories=whitelist_categories,
-                )
-            )
-            assert (
-                "'codec' can only accept 'ascii', 'utf-8' or None as valid values."
-                in str(excinfo.value)
-            )
-    elif (
-        codec == "utf-8"
-        and whitelist_categories is not None
-        and "Cs" in whitelist_categories
-    ):
-        with pytest.raises(InvalidArgument) as excinfo:
-            example = data.draw(
-                s.characters(
-                    codec=codec,
-                    max_codepoint=max_codepoint,
-                    blacklist_categories=blacklist_categories,
-                    whitelist_categories=whitelist_categories,
-                )
-            )
-            assert "Cannot allow 'Cs' categories in 'utf-8' codec encodings." in str(
-                excinfo.value
-            )
-    else:
-        example = data.draw(
-            s.characters(
-                codec=codec,
-                max_codepoint=max_codepoint,
-                blacklist_categories=blacklist_categories,
-                whitelist_categories=whitelist_categories,
-            )
-        )
-        assert example.encode(encoding=codec).decode(encoding=codec) == example
+    strategy = s.characters(
+        codec=codec,
+        max_codepoint=max_codepoint,
+        blacklist_categories=blacklist_categories,
+        whitelist_categories=whitelist_categories,
+    )
+    example = data.draw(strategy)
+    assert example.encode(encoding=codec).decode(encoding=codec) == example

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -180,6 +180,11 @@ def fn_ktest(*fnkwargs):
     (ds.characters, {"max_codepoint": "1"}),
     (ds.characters, {"whitelist_categories": []}),
     (ds.characters, {"whitelist_categories": ["Nd"], "blacklist_categories": ["Nd"]}),
+    (ds.characters, {"codec": 100}),
+    (ds.characters, {"codec": "cp861"}),  # not yet implemented
+    (ds.characters, {"codec": "this is not a valid codec name"}),
+    (ds.characters, {"codec": "ascii", "whitelist_characters": "é"}),
+    (ds.characters, {"codec": "utf-8", "whitelist_categories": "Cs"}),
     (ds.slices, {"size": None}),
     (ds.slices, {"size": "chips"}),
     (ds.slices, {"size": -1}),


### PR DESCRIPTION
Attempt to add two options of `codec=`: `ascii` and `utf-8` to `st.characters()` to limit the character generated.

See #1664