### PR TITLE
Improve error message for missin `[cli]` extra

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Fixes the error message for missing ``[cli]]`` extra.
+Fixes the error message for missing ``[cli]`` extra.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes the error message for missing ``[cli]]`` extra.

--- a/hypothesis-python/src/hypothesis/extra/cli.py
+++ b/hypothesis-python/src/hypothesis/extra/cli.py
@@ -53,7 +53,7 @@ MESSAGE = """
 The Hypothesis command-line interface requires the `{}` package,
 which you do not have installed.  Run:
 
-    python -m pip install --upgrade hypothesis[cli]
+    python -m pip install --upgrade 'hypothesis[cli]'
 
 and try again.
 """


### PR DESCRIPTION
If you copy paste the current message in bash / zsh it will error out with:

```
» pip install --upgrade hypothesis[cli]
zsh: no matches found: hypothesis[cli]
```