### PR TITLE
Improve compatibility with `IPython.lib.pretty` for pretty-printing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,10 @@ jobs:
         restore-keys: |
           deps-${{ runner.os }}-${{ matrix.python-architecture }}-${{ hashFiles('requirements/*.txt') }}
           deps-${{ runner.os }}-${{ matrix.python-architecture }}
+    - name: Use old pandas on win32
+      if: matrix.python-architecture
+      # See https://github.com/pandas-dev/pandas/issues/54979
+      run: (Get-Content .\requirements\coverage.txt) -replace 'pandas==[0-9.]+', 'pandas==2.0.3' | Out-File .\requirements\coverage.txt
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip wheel

--- a/hypothesis-python/.coveragerc
+++ b/hypothesis-python/.coveragerc
@@ -27,4 +27,4 @@ exclude_lines =
     if PYPY:
     if TYPE_CHECKING:
     if sys\.version_info
-    if "\w+" in sys\.modules:
+    if "[\w\.]+" in sys\.modules:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+Pretty-printing of failing examples can now use functions registered with
+:func:`IPython.lib.pretty.for_type` or :func:`~IPython.lib.pretty.for_type_by_name`,
+as well as restoring compatibility with ``_repr_pretty_`` callback methods
+which were accidentally broken in :ref:`version 6.61.2 <v6.61.2>` (:issue:`3721`).

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -111,6 +111,7 @@ intersphinx_mapping = {
     "redis": ("https://redis-py.readthedocs.io/en/stable/", None),
     "attrs": ("https://www.attrs.org/en/stable/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "IPython": ("https://ipython.readthedocs.io/en/stable/", None),
 }
 
 autodoc_mock_imports = ["numpy", "pandas", "redis", "django", "pytz"]

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -158,7 +158,6 @@ except {exceptions}:
 
 Except = Union[Type[Exception], Tuple[Type[Exception], ...]]
 ImportSet = Set[Union[str, Tuple[str, str]]]
-RE_TYPES = (type(re.compile(".")), type(re.match(".", "abc")))
 _quietly_settings = settings(
     database=None,
     deadline=None,
@@ -587,7 +586,7 @@ def _assert_eq(style: str, a: str, b: str) -> str:
 
 def _imports_for_object(obj):
     """Return the imports for `obj`, which may be empty for e.g. lambdas"""
-    if isinstance(obj, RE_TYPES):
+    if isinstance(obj, (re.Pattern, re.Match)):
         return {"re"}
     try:
         if is_generic_type(obj):

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -35,16 +35,6 @@ from hypothesis.strategies._internal.strategies import Ex, check_strategy
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 
 try:
-    from pandas.api.types import is_categorical_dtype
-except ImportError:
-
-    def is_categorical_dtype(dt):
-        if isinstance(dt, np.dtype):
-            return False
-        return dt == "category"
-
-
-try:
     from pandas.core.arrays.integer import IntegerDtype
 except ImportError:
     IntegerDtype = ()
@@ -79,8 +69,8 @@ def elements_and_dtype(elements, dtype, source=None):
                     f"At least one of {prefix}elements or {prefix}dtype must be provided."
                 )
 
-    with check("is_categorical_dtype"):
-        if is_categorical_dtype(dtype):
+    with check("isinstance(dtype, CategoricalDtype)"):
+        if pandas.api.types.CategoricalDtype.is_dtype(dtype):
             raise InvalidArgument(
                 f"{prefix}dtype is categorical, which is currently unsupported"
             )

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -142,7 +142,7 @@ def _get_exceptioninfo():
         with contextlib.suppress(Exception):
             # From Pytest 7, __init__ warns on direct calls.
             return sys.modules["pytest"].ExceptionInfo.from_exc_info
-    if "_pytest._code" in sys.modules:  # pragma: no cover  # old versions only
+    if "_pytest._code" in sys.modules:  # old versions only
         with contextlib.suppress(Exception):
             return sys.modules["_pytest._code"].ExceptionInfo
     return None  # pragma: no cover  # coverage tests always use pytest

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -81,9 +81,6 @@ __all__ = [
 ]
 
 
-_re_pattern_type = type(re.compile(""))
-
-
 def _safe_getattr(obj, attr, default=None):
     """Safe version of getattr.
 
@@ -746,7 +743,7 @@ _type_pprinters = {
     set: _set_pprinter_factory("{", "}", set),
     frozenset: _set_pprinter_factory("frozenset({", "})", frozenset),
     super: _super_pprint,
-    _re_pattern_type: _re_pattern_pprint,
+    re.Pattern: _re_pattern_pprint,
     type: _type_pprint,
     types.FunctionType: _function_pprint,
     types.BuiltinFunctionType: _function_pprint,

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -12,6 +12,7 @@ import gc
 import random
 import sys
 import time as time_module
+from functools import wraps
 
 import pytest
 
@@ -81,10 +82,13 @@ def _consistently_increment_time(monkeypatch):
     def freeze():
         frozen[0] = True
 
-    monkeypatch.setattr(time_module, "time", time)
-    monkeypatch.setattr(time_module, "monotonic", time)
-    monkeypatch.setattr(time_module, "perf_counter", time)
-    monkeypatch.setattr(time_module, "sleep", sleep)
+    def _patch(name, fn):
+        monkeypatch.setattr(time_module, name, wraps(getattr(time_module, name))(fn))
+
+    _patch("time", time)
+    _patch("monotonic", time)
+    _patch("perf_counter", time)
+    _patch("sleep", sleep)
     monkeypatch.setattr(time_module, "freeze", freeze, raising=False)
 
 

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -667,3 +667,19 @@ class LyingReprOptions(Flag):
 )
 def test_pretty_prints_enums_as_code(rep):
     assert pretty.pretty(eval(rep)) == rep
+
+
+class Obj:
+    def _repr_pretty_(self, p, cycle):
+        """Exercise the IPython callback interface."""
+        assert not cycle
+        with p.indent(2):
+            p.text("abc,")
+            p.breakable(" ")
+            p.break_()
+        p.begin_group(8, "<")
+        p.end_group(8, ">")
+
+
+def test_supports_ipython_callback():
+    assert pretty.pretty(Obj()) == "abc, \n  <>"

--- a/requirements/coverage.in
+++ b/requirements/coverage.in
@@ -1,4 +1,4 @@
-git+https://github.com/psf/black.git@eedfc3832290b3a32825b3c0f2dfa3f3d7ee9d1c
+black
 click
 coverage
 dpcontracts

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -8,7 +8,7 @@ async-timeout==4.0.3
     # via redis
 attrs==23.1.0
     # via hypothesis (hypothesis-python/setup.py)
-black @ git+https://github.com/psf/black.git@eedfc3832290b3a32825b3c0f2dfa3f3d7ee9d1c
+black==23.7.0
     # via -r requirements/coverage.in
 click==8.1.7
     # via

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -44,7 +44,7 @@ packaging==23.1
     # via
     #   black
     #   pytest
-pandas==2.0.3
+pandas==2.1.0
     # via -r requirements/coverage.in
 pathspec==0.11.2
     # via black
@@ -56,7 +56,7 @@ pluggy==1.3.0
     # via pytest
 ptyprocess==0.7.0
     # via pexpect
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   -r requirements/test.in
     #   pytest-xdist

--- a/requirements/fuzzing.txt
+++ b/requirements/fuzzing.txt
@@ -31,7 +31,7 @@ coverage==7.3.0
     # via
     #   -r requirements/coverage.in
     #   hypofuzz
-dash==2.12.1
+dash==2.13.0
     # via hypofuzz
 dash-core-components==2.0.0
     # via dash
@@ -54,7 +54,7 @@ flask==2.2.5
     # via dash
 hypofuzz==23.7.1
     # via -r requirements/fuzzing.in
-hypothesis[cli]==6.82.6
+hypothesis[cli]==6.83.0
     # via hypofuzz
 idna==3.4
     # via requests
@@ -93,7 +93,7 @@ packaging==23.1
     #   black
     #   plotly
     #   pytest
-pandas==2.0.3
+pandas==2.1.0
     # via
     #   -r requirements/coverage.in
     #   hypofuzz
@@ -113,7 +113,7 @@ ptyprocess==0.7.0
     # via pexpect
 pygments==2.16.1
     # via rich
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   -r requirements/test.in
     #   hypofuzz

--- a/requirements/fuzzing.txt
+++ b/requirements/fuzzing.txt
@@ -12,7 +12,7 @@ attrs==23.1.0
     # via
     #   hypothesis
     #   hypothesis (hypothesis-python/setup.py)
-black @ git+https://github.com/psf/black.git@eedfc3832290b3a32825b3c0f2dfa3f3d7ee9d1c
+black==23.7.0
     # via
     #   -r requirements/coverage.in
     #   hypofuzz

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,7 +22,7 @@ pluggy==1.3.0
     # via pytest
 ptyprocess==0.7.0
     # via pexpect
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   -r requirements/test.in
     #   pytest-xdist

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -8,11 +8,11 @@ alabaster==0.7.13
     # via sphinx
 asgiref==3.7.2
     # via django
-asttokens==2.2.1
+asttokens==2.3.0
     # via stack-data
 attrs==23.1.0
     # via hypothesis (hypothesis-python/setup.py)
-autoflake==2.2.0
+autoflake==2.2.1
     # via shed
 babel==2.12.1
     # via sphinx
@@ -24,7 +24,7 @@ black==23.7.0
     # via shed
 bleach==6.0.0
     # via readme-renderer
-build==0.10.0
+build==1.0.0
     # via pip-tools
 cachetools==5.3.1
     # via tox
@@ -70,10 +70,11 @@ dpcontracts==0.6.0
 exceptiongroup==1.1.3 ; python_version < "3.11"
     # via
     #   hypothesis (hypothesis-python/setup.py)
+    #   ipython
     #   pytest
 executing==1.2.0
     # via stack-data
-filelock==3.12.2
+filelock==3.12.3
     # via
     #   tox
     #   virtualenv
@@ -87,7 +88,7 @@ importlib-metadata==6.8.0
     #   twine
 iniconfig==2.0.0
     # via pytest
-ipython==8.14.0
+ipython==8.15.0
     # via -r requirements/tools.in
 isort==5.12.0
     # via shed
@@ -173,13 +174,13 @@ pygments==2.16.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyproject-api==1.5.4
+pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pyright==1.1.324
+pyright==1.1.325
     # via -r requirements/tools.in
-pytest==7.4.0
+pytest==7.4.1
     # via -r requirements/tools.in
 python-dateutil==2.8.2
     # via -r requirements/tools.in
@@ -203,7 +204,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.5.2
     # via twine
-ruff==0.0.286
+ruff==0.0.287
     # via -r requirements/tools.in
 secretstorage==3.3.3
     # via keyring
@@ -218,9 +219,9 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via hypothesis (hypothesis-python/setup.py)
-soupsieve==2.4.1
+soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.3
+sphinx==7.2.5
     # via
     #   -r requirements/tools.in
     #   sphinx-codeautolink
@@ -273,7 +274,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.10.0
+tox==4.11.1
     # via -r requirements/tools.in
 traitlets==5.9.0
     # via
@@ -295,6 +296,7 @@ typing-extensions==4.7.1
     # via
     #   -r requirements/tools.in
     #   asgiref
+    #   filelock
     #   libcst
     #   mypy
     #   typing-inspect
@@ -304,7 +306,7 @@ urllib3==2.0.4
     # via
     #   requests
     #   twine
-virtualenv==20.24.3
+virtualenv==20.24.4
     # via tox
 wcwidth==0.2.6
     # via prompt-toolkit


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/3721 and adds new access to the IPython type-to-prettyprinter registry, which should be a nice enhancement to people using complicated datastructures which have been registered with IPython.  Admittedly I expect this to be rare, but so are many of the quality of life features we have - they still add up 🙂 

Also fixes https://github.com/HypothesisWorks/hypothesis/issues/3642 because I was there anyway, and closes https://github.com/HypothesisWorks/hypothesis/pull/3727 by inclusion and a tiny patch.