### PR TITLE
Disable health check during replay.

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Disable health checks during database replay, to avoid spurious
+errors when wrong examples are used due to database key collissions.


### PR DESCRIPTION
Disable health check during replay of database examples, to avoid spurious failures due to database key collissions.

Ref https://github.com/HypothesisWorks/hypothesis/pull/3720#pullrequestreview-1597084792, closes #3446.