### PR TITLE
Use Literal type annotations

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch switches some of our type annotations to use :obj:`typing.Literal`
+when only a few specific values are allowed, such as UUID or IP address versions.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -13,6 +13,7 @@ import sys
 from numbers import Real
 from types import SimpleNamespace
 from typing import (
+    TYPE_CHECKING,
     Any,
     Iterable,
     Iterator,
@@ -59,6 +60,9 @@ from hypothesis.internal.validation import (
 )
 from hypothesis.strategies._internal.strategies import check_strategy
 from hypothesis.strategies._internal.utils import defines_strategy
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
 
 __all__ = [
     "make_strategies_namespace",
@@ -654,8 +658,13 @@ def numeric_dtype_names(base_name: str, sizes: Sequence[int]) -> Iterator[str]:
         yield f"{base_name}{size}"
 
 
+IntSize: "TypeAlias" = Literal[8, 16, 32, 64]
+FltSize: "TypeAlias" = Literal[32, 64]
+CpxSize: "TypeAlias" = Literal[64, 128]
+
+
 def _integer_dtypes(
-    xp: Any, *, sizes: Union[int, Sequence[int]] = (8, 16, 32, 64)
+    xp: Any, *, sizes: Union[IntSize, Sequence[IntSize]] = (8, 16, 32, 64)
 ) -> st.SearchStrategy[DataType]:
     """Return a strategy for signed integer dtype objects.
 
@@ -673,7 +682,7 @@ def _integer_dtypes(
 
 
 def _unsigned_integer_dtypes(
-    xp: Any, *, sizes: Union[int, Sequence[int]] = (8, 16, 32, 64)
+    xp: Any, *, sizes: Union[IntSize, Sequence[IntSize]] = (8, 16, 32, 64)
 ) -> st.SearchStrategy[DataType]:
     """Return a strategy for unsigned integer dtype objects.
 
@@ -693,7 +702,7 @@ def _unsigned_integer_dtypes(
 
 
 def _floating_dtypes(
-    xp: Any, *, sizes: Union[int, Sequence[int]] = (32, 64)
+    xp: Any, *, sizes: Union[FltSize, Sequence[FltSize]] = (32, 64)
 ) -> st.SearchStrategy[DataType]:
     """Return a strategy for real-valued floating-point dtype objects.
 
@@ -711,7 +720,7 @@ def _floating_dtypes(
 
 
 def _complex_dtypes(
-    xp: Any, *, sizes: Union[int, Sequence[int]] = (64, 128)
+    xp: Any, *, sizes: Union[CpxSize, Sequence[CpxSize]] = (64, 128)
 ) -> st.SearchStrategy[DataType]:
     """Return a strategy for complex dtype objects.
 
@@ -984,19 +993,19 @@ def make_strategies_namespace(
 
     @defines_strategy()
     def integer_dtypes(
-        *, sizes: Union[int, Sequence[int]] = (8, 16, 32, 64)
+        *, sizes: Union[IntSize, Sequence[IntSize]] = (8, 16, 32, 64)
     ) -> st.SearchStrategy[DataType]:
         return _integer_dtypes(xp, sizes=sizes)
 
     @defines_strategy()
     def unsigned_integer_dtypes(
-        *, sizes: Union[int, Sequence[int]] = (8, 16, 32, 64)
+        *, sizes: Union[IntSize, Sequence[IntSize]] = (8, 16, 32, 64)
     ) -> st.SearchStrategy[DataType]:
         return _unsigned_integer_dtypes(xp, sizes=sizes)
 
     @defines_strategy()
     def floating_dtypes(
-        *, sizes: Union[int, Sequence[int]] = (32, 64)
+        *, sizes: Union[FltSize, Sequence[FltSize]] = (32, 64)
     ) -> st.SearchStrategy[DataType]:
         return _floating_dtypes(xp, sizes=sizes)
 
@@ -1057,7 +1066,7 @@ def make_strategies_namespace(
 
         @defines_strategy()
         def complex_dtypes(
-            *, sizes: Union[int, Sequence[int]] = (64, 128)
+            *, sizes: Union[CpxSize, Sequence[CpxSize]] = (64, 128)
         ) -> st.SearchStrategy[DataType]:
             return _complex_dtypes(xp, sizes=sizes)
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -13,6 +13,7 @@ import math
 from typing import (
     TYPE_CHECKING,
     Any,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -578,7 +579,9 @@ def dtype_factory(kind, sizes, valid_sizes, endianness):
 
 @defines_dtype_strategy
 def unsigned_integer_dtypes(
-    *, endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
+    *,
+    endianness: str = "?",
+    sizes: Sequence[Literal[8, 16, 32, 64]] = (8, 16, 32, 64),
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for unsigned integer dtypes.
 
@@ -594,7 +597,9 @@ def unsigned_integer_dtypes(
 
 @defines_dtype_strategy
 def integer_dtypes(
-    *, endianness: str = "?", sizes: Sequence[int] = (8, 16, 32, 64)
+    *,
+    endianness: str = "?",
+    sizes: Sequence[Literal[8, 16, 32, 64]] = (8, 16, 32, 64),
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for signed integer dtypes.
 
@@ -606,7 +611,9 @@ def integer_dtypes(
 
 @defines_dtype_strategy
 def floating_dtypes(
-    *, endianness: str = "?", sizes: Sequence[int] = (16, 32, 64)
+    *,
+    endianness: str = "?",
+    sizes: Sequence[Literal[16, 32, 64, 96, 128]] = (16, 32, 64),
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for floating-point dtypes.
 
@@ -622,7 +629,9 @@ def floating_dtypes(
 
 @defines_dtype_strategy
 def complex_number_dtypes(
-    *, endianness: str = "?", sizes: Sequence[int] = (64, 128)
+    *,
+    endianness: str = "?",
+    sizes: Sequence[Literal[64, 128, 192, 256]] = (64, 128),
 ) -> st.SearchStrategy[np.dtype]:
     """Return a strategy for complex-number dtypes.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -34,6 +34,7 @@ from typing import (
     Hashable,
     Iterable,
     List,
+    Literal,
     Optional,
     Pattern,
     Protocol,
@@ -136,8 +137,11 @@ from hypothesis.vendor.pretty import RepresentationPrinter
 
 if sys.version_info >= (3, 10):
     from types import EllipsisType as EllipsisType
+    from typing import TypeAlias as TypeAlias
 elif typing.TYPE_CHECKING:  # pragma: no cover
     from builtins import ellipsis as EllipsisType
+
+    from typing_extensions import TypeAlias
 else:
     EllipsisType = type(Ellipsis)  # pragma: no cover
 
@@ -524,6 +528,48 @@ def dictionaries(
     ).map(dict_class)
 
 
+# See https://en.wikipedia.org/wiki/Unicode_character_property#General_Category
+CategoryName: "TypeAlias" = Literal[
+    "L",  #  Letter
+    "Lu",  # Letter, uppercase
+    "Ll",  # Letter, lowercase
+    "Lt",  # Letter, titlecase
+    "Lm",  # Letter, modifier
+    "Lo",  # Letter, other
+    "M",  #  Mark
+    "Mn",  # Mark, nonspacing
+    "Mc",  # Mark, spacing combining
+    "Me",  # Mark, enclosing
+    "N",  #  Number
+    "Nd",  # Number, decimal digit
+    "Nl",  # Number, letter
+    "No",  # Number, other
+    "P",  #  Punctuation
+    "Pc",  # Punctuation, connector
+    "Pd",  # Punctuation, dash
+    "Ps",  # Punctuation, open
+    "Pe",  # Punctuation, close
+    "Pi",  # Punctuation, initial quote
+    "Pf",  # Punctuation, final quote
+    "Po",  # Punctuation, other
+    "S",  #  Symbol
+    "Sm",  # Symbol, math
+    "Sc",  # Symbol, currency
+    "Sk",  # Symbol, modifier
+    "So",  # Symbol, other
+    "Z",  #  Separator
+    "Zs",  # Separator, space
+    "Zl",  # Separator, line
+    "Zp",  # Separator, paragraph
+    "C",  #  Other
+    "Cc",  # Other, control
+    "Cf",  # Other, format
+    "Cs",  # Other, surrogate
+    "Co",  # Other, private use
+    "Cn",  # Other, not assigned
+]
+
+
 @cacheable
 @defines_strategy(force_reusable_values=True)
 def characters(
@@ -531,13 +577,13 @@ def characters(
     codec: Optional[str] = None,
     min_codepoint: Optional[int] = None,
     max_codepoint: Optional[int] = None,
-    categories: Optional[Collection[str]] = None,
-    exclude_categories: Optional[Collection[str]] = None,
+    categories: Optional[Collection[CategoryName]] = None,
+    exclude_categories: Optional[Collection[CategoryName]] = None,
     exclude_characters: Optional[Collection[str]] = None,
     include_characters: Optional[Collection[str]] = None,
     # Note: these arguments are deprecated aliases for backwards compatibility
-    blacklist_categories: Optional[Collection[str]] = None,
-    whitelist_categories: Optional[Collection[str]] = None,
+    blacklist_categories: Optional[Collection[CategoryName]] = None,
+    whitelist_categories: Optional[Collection[CategoryName]] = None,
     blacklist_characters: Optional[Collection[str]] = None,
     whitelist_characters: Optional[Collection[str]] = None,
 ) -> SearchStrategy[str]:
@@ -1791,7 +1837,7 @@ def complex_numbers(
     allow_infinity: Optional[bool] = None,
     allow_nan: Optional[bool] = None,
     allow_subnormal: bool = True,
-    width: int = 128,
+    width: Literal[32, 64, 128] = 128,
 ) -> SearchStrategy[complex]:
     """Returns a strategy that generates :class:`~python:complex`
     numbers.
@@ -1944,7 +1990,7 @@ def _maybe_nil_uuids(draw, uuid):
 @cacheable
 @defines_strategy(force_reusable_values=True)
 def uuids(
-    *, version: Optional[int] = None, allow_nil: bool = False
+    *, version: Optional[Literal[1, 2, 3, 4, 5]] = None, allow_nil: bool = False
 ) -> SearchStrategy[UUID]:
     """Returns a strategy that generates :class:`UUIDs <uuid.UUID>`.
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/ipaddress.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.validation import check_type
@@ -73,7 +73,7 @@ SPECIAL_IPv6_RANGES = (
 @defines_strategy(force_reusable_values=True)
 def ip_addresses(
     *,
-    v: Optional[int] = None,
+    v: Optional[Literal[4, 6]] = None,
     network: Optional[Union[str, IPv4Network, IPv6Network]] = None,
 ) -> SearchStrategy[Union[IPv4Address, IPv6Address]]:
     r"""Generate IP addresses - ``v=4`` for :class:`~python:ipaddress.IPv4Address`\ es,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -12,7 +12,7 @@ import math
 from decimal import Decimal
 from fractions import Fraction
 from sys import float_info
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
@@ -383,7 +383,7 @@ def floats(
     allow_nan: Optional[bool] = None,
     allow_infinity: Optional[bool] = None,
     allow_subnormal: Optional[bool] = None,
-    width: int = 64,
+    width: Literal[16, 32, 64] = 64,
     exclude_min: bool = False,
     exclude_max: bool = False,
 ) -> SearchStrategy[float]:

--- a/hypothesis-python/tests/array_api/common.py
+++ b/hypothesis-python/tests/array_api/common.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from importlib.metadata import EntryPoint, entry_points  # type: ignore
-from typing import Dict
+from typing import Dict, Literal
 
 import pytest
 
@@ -52,7 +52,7 @@ def installed_array_modules() -> Dict[str, EntryPoint]:
     return {ep.name: ep for ep in eps}
 
 
-def flushes_to_zero(xp, width: int) -> bool:
+def flushes_to_zero(xp, width: Literal[32, 64]) -> bool:
     """Infer whether build of array module has its float dtype of the specified
     width flush subnormals to zero
 

--- a/hypothesis-python/tests/cover/test_charmap.py
+++ b/hypothesis-python/tests/cover/test_charmap.py
@@ -13,10 +13,12 @@ import sys
 import tempfile
 import time
 import unicodedata
+from typing import get_args
 
 from hypothesis import given, strategies as st
 from hypothesis.internal import charmap as cm
 from hypothesis.internal.intervalsets import IntervalSet
+from hypothesis.strategies._internal.core import CategoryName
 
 
 def test_charmap_contains_all_unicode():
@@ -184,3 +186,9 @@ def test_error_writing_charmap_file_is_suppressed(monkeypatch):
         cm.charmap()
     finally:
         cm._charmap = saved
+
+
+def test_categoryname_literal_is_correct():
+    minor_categories = set(cm.categories())
+    major_categories = {c[0] for c in minor_categories}
+    assert set(get_args(CategoryName)) == minor_categories | major_categories


### PR DESCRIPTION
I happened to think of category names while working on #3742, and it turns out that we have several APIs which can be more precisely typed with `Literal`.