### PR TITLE
Deprecate use of `assume` or `reject` outside of tests

### DIFF
--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -28,7 +28,7 @@ def reject() -> NoReturn:
     if context is None:
         note_deprecation(
             "Using `reject` outside a test is deprecated",
-            since="2023-09-18",
+            since="RELEASEDAY",
             has_codemod=False,
         )
     raise UnsatisfiedAssumption

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -24,6 +24,13 @@ from hypothesis.vendor.pretty import IDKey
 
 
 def reject() -> NoReturn:
+    context = _current_build_context.value
+    if context is None:
+        note_deprecation(
+            "Using `reject` outside a test is deprecated",
+            since="2023-09-18",
+            has_codemod=False,
+        )
     raise UnsatisfiedAssumption
 
 
@@ -34,6 +41,13 @@ def assume(condition: object) -> bool:
     This allows you to specify properties that you *assume* will be
     true, and let Hypothesis try to avoid similar examples in future.
     """
+    context = _current_build_context.value
+    if context is None:
+        note_deprecation(
+            "Using `assume` outside a test is deprecated",
+            since="2023-09-18",
+            has_codemod=False,
+        )
     if not condition:
         raise UnsatisfiedAssumption
     return True


### PR DESCRIPTION
If some code outside a test (e.g. `execute_example`) calls `assume` or `reject`, they raise `UnsatisfiedAssumption`, which is an internal exception that should generally not seen by user code. This commit provides a warning deprecating such use cases, which helps clarify to the user that they are getting the exception because they have called these functions from the wrong places.