### PR TITLE
Fix explain-mode bug

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Hotfix for :issue:`3747`, a bug in explain mode which is so rare that
+we missed it in six months of dogfooding.  Thanks to :pypi:`mygrad`
+for discovering and promptly reporting this!

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -547,7 +547,7 @@ class Shrinker:
 
                 # Turns out this was a variable-length part, so grab the infix...
                 if result.status == Status.OVERRUN:
-                    continue  # pragma: no cover
+                    continue  # pragma: no cover  # flakily covered
                 if not (
                     len(buf_attempt_fixed) == len(result.buffer)
                     and result.buffer.endswith(buffer[end:])
@@ -568,11 +568,13 @@ class Shrinker:
                     chunks[(start, end)].append(result.buffer[start:res_end])
                     result = self.engine.cached_test_function(buf_attempt_fixed)
 
-                    if (
-                        result.status == Status.OVERRUN
-                        or len(buf_attempt_fixed) != len(result.buffer)
-                        or not result.buffer.endswith(buffer[end:])
-                    ):
+                    if result.status == Status.OVERRUN:
+                        continue  # pragma: no cover  # flakily covered
+
+                    if not (
+                        len(buf_attempt_fixed) == len(result.buffer)
+                        and result.buffer.endswith(buffer[end:])
+                    ):  # pragma: no cover
                         raise NotImplementedError("This should never happen")
                 else:
                     chunks[(start, end)].append(result.buffer[start:end])


### PR DESCRIPTION
Closes #3747.  @rsokl I've checked locally that this fixes the `mygrad` failure and and so I'm shipping this asap, but please do confirm the fix at your leisure.