### PR TITLE
Remove explain-phase assertion which is in fact reachable

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Fixes :issue:`3755`, where an internal condition turns out
+to be reachable after all.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -570,12 +570,6 @@ class Shrinker:
 
                     if result.status == Status.OVERRUN:
                         continue  # pragma: no cover  # flakily covered
-
-                    if not (
-                        len(buf_attempt_fixed) == len(result.buffer)
-                        and result.buffer.endswith(buffer[end:])
-                    ):  # pragma: no cover
-                        raise NotImplementedError("This should never happen")
                 else:
                     chunks[(start, end)].append(result.buffer[start:end])
 

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -12,6 +12,8 @@ import pytest
 
 from hypothesis import given, settings, strategies as st
 
+from tests.common.utils import fails_with
+
 
 def fails_with_output(expected, error=AssertionError, **kw):
     def _inner(f):
@@ -70,3 +72,11 @@ Falsifying example: test_inquisitor_no_together_comment_if_single_argument(
 @given(st.text(), st.text())
 def test_inquisitor_no_together_comment_if_single_argument(a, b):
     assert a
+
+
+@fails_with(ZeroDivisionError)
+@settings(database=None)
+@given(start_date=st.datetimes(), data=st.data())
+def test_issue_3755_regression(start_date, data):
+    data.draw(st.datetimes(min_value=start_date))
+    raise ZeroDivisionError


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/3755, by deleting some defensive code which I wrote to defend against implementation bugs and thought was unreachable in normal use.  Obviously that turned out to be wrong!  So, how _can_ you reach that?

The relevant loop is replacing an infix of our test buffer, for example taking `AA XX BB` and trying `AA YY BB`.  However, the length can vary by contents, so the test might try to read off the end of the buffer: `AA YYB B-`.  In this case, we'll try fixing it up as `AA YYB BB` - and my incorrect assert was that we'd have exactly this buffer from the rerun.  _However_, it's possible for the infix to first overflow, and then have part of the infix dropped by the canonicalisation logic (e.g. because of a filter) - so the final buffer is actually (e.g.) `AA YB BB`.  This is in fact working as intended, so deleting the oversensitive check is a complete solution 😅 