### PR TITLE
MAINT: Remove `np.int_`

### DIFF
--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -943,7 +943,7 @@ def integer_array_indices(
     shape: Shape,
     *,
     result_shape: st.SearchStrategy[Shape] = array_shapes(),
-    dtype: D = np.int_,
+    dtype: D = np.dtype(int),
 ) -> "st.SearchStrategy[Tuple[NDArray[D], ...]]":
     """Return a search strategy for tuples of integer-arrays that, when used
     to index into an array of shape ``shape``, given an array whose shape


### PR DESCRIPTION
Hi!
This PR addresses changes that will be shipped in https://github.com/numpy/numpy/pull/24794 - deprecation of `np.int_` and `np.uint`.

Additionally, I see that in the codebase you use `np.lib.function_base._parse_gufunc_signature`. It's a private function and it will raise an attribute error for NumPy 2.0:
```
AttributeError: `np.lib.function_base` is now private. If you are using a public function, it should be available in the main numpy namespace, otherwise check the NumPy 2.0 migration guide.
```

I think there are two options:
1. The call to the private function could be removed from the codebase (e.g. by vendoring implementation - I think it's just a couple lines long).
2. NumPy could potentially make this function part of the public API.

What is your opinion?

