### PR TITLE
use `get_origin` when looking up type registration

### DIFF
--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1311,7 +1311,7 @@ def _from_type(thing: Type[Ex]) -> SearchStrategy[Ex]:
     # lookup may be a strategy or a function from type -> strategy; and we
     # convert empty results into an explicit error.
     try:
-        if thing in types._global_type_lookup:
+        if get_origin(thing) in types._global_type_lookup:
             return as_strategy(types._global_type_lookup[thing], thing)
     except TypeError:  # pragma: no cover
         # This is due to a bizarre divergence in behaviour under Python 3.9.0:


### PR DESCRIPTION
This is only an RFC, this will break tests and is used to demonstrate which tests will break if we make this oversimplistic change