### PR TITLE
Fix #3765 (Random.sample errors with empty sequences)

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+When :func:`~hypothesis.strategies.randoms` was called with `use_true_randoms=False`,
+calling `sample` on it with an empty sequence and 0 elements would result in an error,
+when it should have returned an empty sequence to agree with the normal behaviour of
+`random.Random`. This fixes that discrepancy.
+
+Fixes :issue:`3765``

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -296,14 +296,17 @@ class ArtificialRandom(HypothesisRandom):
                     f"Sample size {k} not in expected range 0 <= k <= {len(seq)}"
                 )
 
-            result = self.__data.draw(
-                lists(
-                    sampled_from(range(len(seq))),
-                    min_size=k,
-                    max_size=k,
-                    unique=True,
+            if k == 0:
+                result = []
+            else:
+                result = self.__data.draw(
+                    lists(
+                        sampled_from(range(len(seq))),
+                        min_size=k,
+                        max_size=k,
+                        unique=True,
+                    )
                 )
-            )
 
         elif method == "getrandbits":
             result = self.__data.draw_bits(kwargs["n"])

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -381,3 +381,8 @@ def test_can_sample_from_large_subset(rnd):
     ys = rnd.sample(xs, n)
     assert set(ys).issubset(set(xs))
     assert len(ys) == len(set(ys)) == n
+
+
+@given(st.randoms(use_true_random=False))
+def test_can_draw_empty_from_empty_sequence(rnd):
+    assert rnd.sample([], 0) == []


### PR DESCRIPTION
This special cases the case where we request `0` elements from a sequence so as to not error even if the sequence is empty.

Arguably this could be fixed at the `st.sampled_from` level, which I think is something we've gone back and forth on (i.e. should `st.sampled_from([])` be equivalent to `st.nothing()` - it's arguably correct behaviour, but it's likely to silently cover errors), so I went for the minimal change that would get the correct behaviour. 