### PR TITLE
Remove stale target tests

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch removes some stale internal tests for :func:`~hypothesis.control.target`.

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -102,21 +102,3 @@ def test_cannot_target_default_label_twice(_):
     target(0.0)
     with pytest.raises(InvalidArgument):
         target(1.0)
-
-
-@given(st.lists(st.integers()), st.none())
-def test_targeting_with_following_empty(ls, n):
-    # This exercises some logic in the optimiser that prevents it from trying
-    # to mutate empty examples at the end of the test case.
-    target(float(len(ls)))
-
-
-@given(
-    st.tuples(
-        *([st.none()] * 10 + [st.integers()] + [st.none()] * 10 + [st.integers()])
-    )
-)
-def test_targeting_with_many_empty(_):
-    # This exercises some logic in the optimiser that prevents it from trying
-    # to mutate empty examples in the middle of the test case.
-    target(1.0)


### PR DESCRIPTION
I'm taking a look at improving `cover` test times. `test_targeting_with_following_empty` takes 3-5 seconds to run - `target(len(lst))` is dangerous, as my observation is hypothesis occasionally tries doubling the length of the list, which can quickly get out of hand and cause slow generations when unbounded.

I was going to simply improve the runtime. However, I don't think the test (and the related `test_targeting_with_many_empty`) is needed anymore. They were introduced in https://github.com/HypothesisWorks/hypothesis/pull/2137, back when there was special-case handling for empty vs non-empty examples in `Optimiser`. This logic was changed in https://github.com/HypothesisWorks/hypothesis/pull/2289, and I don't *think* there's a distinction between empty and non-empty anymore, but please correct me if there is.