### PR TITLE
RFC: Allow registration of tuples

### DIFF
--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -118,6 +118,14 @@ def test_lookup_overrides_defaults(typ):
     assert st.from_type(typ).example() is not sentinel
 
 
+def test_lookup_registered_tuple():
+    sentinel = object()
+    typ = tuple[int]
+    with temp_registered(tuple, st.just(sentinel)):
+        assert st.from_type(typ).example() is sentinel
+    assert st.from_type(typ).example() is not sentinel
+
+
 class ParentUnknownType:
     pass
 
@@ -329,9 +337,11 @@ def test_generic_origin_with_type_args(generic, strategy):
         Callable,
         List,
         Sequence,
+        tuple,
         # you can register types with all generic parameters
         List[T],
         Sequence[T],
+        tuple[T],
         # User-defined generics should also work
         MyGeneric,
         MyGeneric[T],


### PR DESCRIPTION
Previously, if `tuple` was registered, the registered strategy would be ignored. Now it is actually used. Note that `tuple[...]` cannot be registered because genericized types are not allowed to be registered in general, so a user must register `tuple` with a function that takes the type args and returns a strategy appropriate to the particular genericized type at hand.