### PR TITLE
Update Arch Linux package URL in packaging.rst

### DIFF
--- a/hypothesis-python/docs/packaging.rst
+++ b/hypothesis-python/docs/packaging.rst
@@ -76,6 +76,6 @@ The organisation of the tests is described in the :gh-file:`hypothesis-python/te
 Examples
 --------
 
-* `arch linux <https://archlinux.org/packages/community/any/python-hypothesis/>`_
+* `arch linux <https://archlinux.org/packages/extra/any/python-hypothesis/>`_
 * `fedora <https://src.fedoraproject.org/rpms/python-hypothesis>`_
 * `gentoo <https://packages.gentoo.org/packages/dev-python/hypothesis>`_

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -40,7 +40,7 @@ def task(if_changed=()):
         def wrapped(*args, **kwargs):
             if if_changed and tools.IS_PULL_REQUEST:
                 if not tools.has_changes(if_changed + BUILD_FILES):
-                    changed = ", ".join(if_changed)
+                    changed = ", ".join(map(str, if_changed))
                     print(f"Skipping task due to no changes in {changed}")
                     return
             fn(*args, **kwargs)


### PR DESCRIPTION
The old URL returns 404 now.