### PR TITLE
Observability features to support deeper understanding + future Tyche integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
-# Engine changes need to be approved by DRMacIver, as per
+# Engine changes need to be approved by Zac-HD, as per
 # https://github.com/HypothesisWorks/hypothesis/blob/master/guides/review.rst#engine-changes
-/hypothesis-python/src/hypothesis/internal/conjecture/ @DRMacIver @Zac-HD
+/hypothesis-python/src/hypothesis/internal/conjecture/ @Zac-HD
 
-# Changes to the paper also need to be approved by DRMacIver
-/paper.md @DRMacIver
-/paper.bib @DRMacIver
+# Changes to the paper also need to be approved by DRMacIver or Zac, as authors
+/paper.md @DRMacIver @Zac-HD
+/paper.bib @DRMacIver @Zac-HD

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release adds an experimental :wikipedia:`observability <Observability_(software)>`
+mode.  :doc:`You can read the docs about it here <observability>`.

--- a/hypothesis-python/docs/_static/wrap-in-tables.css
+++ b/hypothesis-python/docs/_static/wrap-in-tables.css
@@ -1,0 +1,15 @@
+/* override table width restrictions */
+/* thanks to https://github.com/readthedocs/sphinx_rtd_theme/issues/117#issuecomment-153083280 */
+@media screen and (min-width: 767px) {
+
+    .wy-table-responsive table td {
+        /* !important prevents the common CSS stylesheets from
+            overriding this as on RTD they are loaded after this stylesheet */
+        white-space: normal !important;
+    }
+
+    .wy-table-responsive {
+        overflow: visible !important;
+    }
+
+}

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -2362,7 +2362,7 @@ Did you know that of the 2\ :superscript:`64` possible floating-point numbers,
 
 While nans *usually* have all zeros in the sign bit and mantissa, this
 `isn't always true <https://wingolog.org/archives/2011/05/18/value-representation-in-javascript-implementations>`__,
-and :wikipedia:`'signaling' nans might trap or error <https://en.wikipedia.org/wiki/NaN#Signaling_NaN>`.
+and :wikipedia:`'signaling' nans might trap or error <NaN#Signaling_NaN>`.
 To help distinguish such errors in e.g. CI logs, Hypothesis now prints ``-nan`` for
 negative nans, and adds a comment like ``# Saw 3 signaling NaNs`` if applicable.
 

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "hoverxref.extension",
     "sphinx_codeautolink",
     "sphinx_selective_exclude.eager_only",
+    "sphinx-jsonschema",
 ]
 
 templates_path = ["_templates"]
@@ -146,6 +147,8 @@ html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_static_path = ["_static"]
+
+html_css_files = ["wrap-in-tables.css"]
 
 htmlhelp_basename = "Hypothesisdoc"
 

--- a/hypothesis-python/docs/index.rst
+++ b/hypothesis-python/docs/index.rst
@@ -80,3 +80,4 @@ check out some of the
   support
   packaging
   reproducing
+  observability

--- a/hypothesis-python/docs/observability.rst
+++ b/hypothesis-python/docs/observability.rst
@@ -1,0 +1,76 @@
+===================
+Observability tools
+===================
+
+.. warning::
+
+    This feature is experimental, and could have breaking changes or even be removed
+    without notice.  Try it out, let us know what you think, but don't rely on it
+    just yet!
+
+
+Motivation
+==========
+
+Understanding what your code is doing - for example, why your test failed - is often
+a frustrating exercise in adding some more instrumentation or logging (or ``print()`` calls)
+and running it again.  The idea of :wikipedia:`observability <Observability_(software)>`
+is to let you answer questions you didn't think of in advance.  In slogan form,
+
+  *Debugging should be a data analysis problem.*
+
+By default, Hypothesis only reports the minimal failing example... but sometimes you might
+want to know something about *all* the examples.  Printing them to the terminal with
+:ref:`verbose output <verbose-output>` might be nice, but isn't always enough.
+This feature gives you an analysis-ready dataframe with useful columns and one row
+per test case, with columns from arguments to code coverage to pass/fail status.
+
+This is deliberately a much lighter-weight and task-specific system than e.g.
+`OpenTelemetry <https://opentelemetry.io/>`__.  It's also less detailed than time-travel
+debuggers such as `rr <https://rr-project.org/>`__ or `pytrace <https://pytrace.com/>`__,
+because there's no good way to compare multiple traces from these tools and their
+Python support is relatively immature.
+
+
+Configuration
+=============
+
+If you set the ``HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY`` environment variable,
+Hypothesis will log various observations to jsonlines files in the
+``.hypothesis/observed/`` directory.  You can load and explore these with e.g.
+:func:`pd.read_json(".hypothesis/observed/*_testcases.jsonl", lines=True) <pandas.read_json>`,
+or by using the :pypi:`sqlite-utils` and :pypi:`datasette` libraries::
+
+    sqlite-utils insert testcases.db testcases .hypothesis/observed/*_testcases.jsonl --nl --flatten
+    datasette serve testcases.db
+
+
+Collecting more information
+---------------------------
+
+If you want to record more information about your test cases than the arguments and
+outcome - for example, was ``x`` a binary tree?  what was the difference between the
+expected and the actual value?  how many queries did it take to find a solution? -
+Hypothesis makes this easy.
+
+:func:`~hypothesis.event` accepts a string label, and optionally a string or int or
+float observation associated with it.  All events are collected and summarized in
+:ref:`statistics`, as well as included on a per-test-case basis in our observations.
+
+:func:`~hypothesis.target` is a special case of numeric-valued events: as well as
+recording them in observations, Hypothesis will try to maximize the targeted value.
+Knowing that, you can use this to guide the search for failing inputs.
+
+
+Data Format
+===========
+
+We dump observations in `json lines format <https://jsonlines.org/>`__, with each line
+describing either a test case or an information message.  The tables below are derived
+from :download:`this machine-readable JSON schema <schema_observations.json>`, to
+provide both readable and verifiable specifications.
+
+.. jsonschema:: ./schema_observations.json#/oneOf/0
+   :hide_key: /additionalProperties, /type
+.. jsonschema:: ./schema_observations.json#/oneOf/1
+   :hide_key: /additionalProperties, /type

--- a/hypothesis-python/docs/schema_observations.json
+++ b/hypothesis-python/docs/schema_observations.json
@@ -1,0 +1,93 @@
+{
+    "title": "PBT Observations",
+    "description": "PBT Observations define a standard way to communicate what happened when property-based tests were run.  They describe test cases, or general notifications classified as info, alert, or error messages.",
+    "oneOf": [
+        {
+            "title": "Test case",
+            "description": "Describes the inputs to and result of running some test function on a particular input.  The test might have passed, failed, or been abandoned part way through (e.g. because we failed a ``.filter()`` condition).",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "test_case",
+                    "description": "A tag which labels this observation as data about a specific test case."
+                },
+                "status": {
+                    "enum": ["passed", "failed", "gave_up"],
+                    "description": "Whether the test passed, failed, or was aborted before completion (e.g. due to use of ``.filter()``).  Note that if we gave_up partway, values such as arguments and features may be incomplete."
+                },
+                "status_reason": {
+                    "type": "string",
+                    "description": "If non-empty, the reason for which the test failed or was abandoned.  For Hypothesis, this is usually the exception type and location."
+                },
+                "representation": {
+                    "type": "string",
+                    "description": "The string representation of the input."
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "A structured json-encoded representation of the input.  Hypothesis always provides a dictionary of argument names to json-ified values, including interactive draws from the :func:`~hypothesis.strategies.data` strategy.  In other libraries this can be any object."
+                },
+                "how_generated": {
+                    "type": ["string", "null"],
+                    "description": "How the input was generated, if known.  In Hypothesis this might be an explicit example, generated during a particular phase with some backend, or by replaying the minimal failing example."
+                },
+                "features": {
+                    "type": "object",
+                    "description": "Runtime observations which might help explain what this test case did.  Hypothesis includes target() scores, tags from event(), time spent generating data and running user code, and so on."
+                },
+                "coverage": {
+                    "type": ["object", "null"],
+                    "description": "Mapping of filename to list of covered line numbers, if coverage information is available, or None if not.  Hypothesis deliberately omits stdlib and site-packages code.",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {"type": "integer", "minimum": 1},
+                        "uniqueItems": true
+                    }
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Arbitrary metadata which might be of interest, but does not semantically fit in 'features'.  For example, Hypothesis includes the traceback for failing tests here."
+                },
+                "property": {
+                    "type": "string",
+                    "description": "The name or representation of the test function we're running."
+                },
+                "run_start": {
+                    "type": "number",
+                    "description": "unix timestamp at which we started running this test function, so that later analysis can group test cases by run."
+                }
+            },
+            "required": ["type", "status", "status_reason", "representation", "arguments", "how_generated", "features", "coverage", "metadata", "property", "run_start"],
+            "additionalProperties": false
+        },
+        {
+            "title": "Information message",
+            "description": "Info, alert, and error messages correspond to a group of test cases or the overall run, and are intended for humans rather than machine analysis.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": [ "info", "alert", "error"],
+                    "description": "A tag which labels this observation as general information to show the user.  Hypothesis uses info messages to report statistics; alert or error messages can be provided by plugins."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "The title of this message"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The body of the message.  May use markdown."
+                },
+                "property": {
+                    "type": "string",
+                    "description": "The name or representation of the test function we're running.  For Hypothesis, usually the Pytest nodeid."
+                },
+                "run_start": {
+                    "type": "number",
+                    "description": "unix timestamp at which we started running this test function, so that later analysis can group test cases by run."
+                }
+            },
+            "required": [ "type", "title", "content", "property", "run_start"],
+            "additionalProperties": false
+        }
+    ]
+}

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -373,6 +373,13 @@ else:
                 if fex:
                     failing_examples.append(json.loads(fex))
 
+        from hypothesis.internal.observability import _WROTE_TO
+
+        if _WROTE_TO:
+            terminalreporter.section("Hypothesis")
+            for fname in sorted(_WROTE_TO):
+                terminalreporter.write_line(f"observations written to {fname}")
+
         if failing_examples:
             # This must have been imported already to write the failing examples
             from hypothesis.extra._patching import gc_patches, make_patch, save_patch
@@ -384,7 +391,8 @@ else:
             except Exception:
                 # fail gracefully if we hit any filesystem or permissions problems
                 return
-            terminalreporter.section("Hypothesis")
+            if not _WROTE_TO:
+                terminalreporter.section("Hypothesis")
             terminalreporter.write_line(
                 f"`git apply {fname}` to add failing examples to your code."
             )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1456,6 +1456,7 @@ class ConjectureData:
         # try varying, to report if the minimal example always fails anyway.
         self.arg_slices: Set[Tuple[int, int]] = set()
         self.slice_comments: Dict[Tuple[int, int], str] = {}
+        self._observability_args: Dict[str, Any] = {}
 
         self.extra_information = ExtraInformation()
 

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -1,0 +1,92 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Observability tools to spit out analysis-ready tables, one row per test case."""
+
+import json
+import os
+from datetime import date, timedelta
+from typing import Callable, Dict, List, Optional
+
+from hypothesis.configuration import storage_directory
+from hypothesis.internal.conjecture.data import ConjectureData, Status
+
+TESTCASE_CALLBACKS: List[Callable[[dict], None]] = []
+
+
+def deliver_json_blob(value: dict) -> None:
+    for callback in TESTCASE_CALLBACKS:
+        callback(value)
+
+
+def make_testcase(
+    *,
+    start_timestamp: float,
+    test_name_or_nodeid: str,
+    data: ConjectureData,
+    how_generated: str = "unknown",
+    string_repr: str = "<unknown>",
+    arguments: Optional[dict] = None,
+    metadata: Optional[dict] = None,
+    coverage: Optional[Dict[str, List[int]]] = None,
+) -> dict:
+    if data.interesting_origin:
+        status_reason = str(data.interesting_origin)
+    else:
+        status_reason = str(data.events.pop("invalid because", ""))
+
+    return {
+        "type": "test_case",
+        "run_start": start_timestamp,
+        "property": test_name_or_nodeid,
+        "status": {
+            Status.OVERRUN: "gave_up",
+            Status.INVALID: "gave_up",
+            Status.VALID: "passed",
+            Status.INTERESTING: "failed",
+        }[data.status],
+        "status_reason": status_reason,
+        "representation": string_repr,
+        "arguments": arguments or {},
+        "how_generated": how_generated,  # iid, mutation, etc.
+        "features": {
+            **{
+                f"target:{k}".strip(":"): v for k, v in data.target_observations.items()
+            },
+            **data.events,
+        },
+        "metadata": {
+            **(metadata or {}),
+            "traceback": getattr(data.extra_information, "_expected_traceback", None),
+        },
+        "coverage": coverage,
+    }
+
+
+_WROTE_TO = set()
+
+
+def _deliver_to_file(value):  # pragma: no cover
+    kind = "testcases" if value["type"] == "test_case" else "info"
+    fname = storage_directory("observed", f"{date.today().isoformat()}_{kind}.jsonl")
+    fname.parent.mkdir(exist_ok=True)
+    _WROTE_TO.add(fname)
+    with fname.open(mode="a") as f:
+        f.write(json.dumps(value) + "\n")
+
+
+if "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY" in os.environ:  # pragma: no cover
+    TESTCASE_CALLBACKS.append(_deliver_to_file)
+
+    # Remove files more than a week old, to cap the size on disk
+    max_age = (date.today() - timedelta(days=8)).isoformat()
+    for f in storage_directory("observed").glob("*.jsonl"):
+        if f.stem < max_age:  # pragma: no branch
+            f.unlink(missing_ok=True)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -306,8 +306,12 @@ def extract_lambda_source(f):
     This is not a good function and I am sorry for it. Forgive me my
     sins, oh lord
     """
+    # You might be wondering how a lambda can have a return-type annotation?
+    # The answer is that we add this at runtime, in new_given_signature(),
+    # and we do support strange choices as applying @given() to a lambda.
     sig = inspect.signature(f)
-    assert sig.return_annotation is inspect.Parameter.empty
+    assert sig.return_annotation in (inspect.Parameter.empty, None), sig
+
     if sig.parameters:
         if_confused = f"lambda {str(sig)[1:-1]}: <unknown>"
     else:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -129,7 +129,11 @@ from hypothesis.strategies._internal.strings import (
     OneCharStringStrategy,
     TextStrategy,
 )
-from hypothesis.strategies._internal.utils import cacheable, defines_strategy
+from hypothesis.strategies._internal.utils import (
+    cacheable,
+    defines_strategy,
+    to_jsonable,
+)
 from hypothesis.utils.conventions import not_set
 from hypothesis.vendor.pretty import RepresentationPrinter
 
@@ -2098,8 +2102,9 @@ class DataObject:
         result = self.conjecture_data.draw(strategy)
         self.count += 1
         printer = RepresentationPrinter(context=current_build_context())
-        printer.text(f"Draw {self.count}")
-        printer.text(": " if label is None else f" ({label}): ")
+        desc = f"Draw {self.count}{'' if label is None else f' ({label})'}: "
+        self.conjecture_data._observability_args[desc] = to_jsonable(result)
+        printer.text(desc)
         printer.pretty(result)
         note(printer.getvalue())
         return result

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -8,13 +8,17 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
 import threading
 from inspect import signature
 from typing import TYPE_CHECKING, Callable, Dict
 
+import attr
+
 from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.floats import float_to_int
 from hypothesis.internal.reflection import proxies
+from hypothesis.vendor.pretty import pretty
 
 if TYPE_CHECKING:
     from hypothesis.strategies._internal.strategies import SearchStrategy, T
@@ -144,3 +148,40 @@ def defines_strategy(
         return accept
 
     return decorator
+
+
+def to_jsonable(obj: object) -> object:
+    """Recursively convert an object to json-encodable form.
+
+    This is not intended to round-trip, but rather provide an analysis-ready
+    format for observability.  To avoid side affects, we pretty-print all but
+    known types.
+    """
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        if isinstance(obj, int) and abs(obj) >= 2**63:
+            return float(obj)
+        return obj
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        if isinstance(obj, tuple) and hasattr(obj, "_asdict"):
+            return to_jsonable(obj._asdict())  # treat namedtuples as dicts
+        return [to_jsonable(x) for x in obj]
+    if isinstance(obj, dict):
+        return {
+            k if isinstance(k, str) else pretty(k): to_jsonable(v)
+            for k, v in obj.items()
+        }
+
+    # Special handling for dataclasses, attrs, and pydantic classes
+    if (
+        (dcs := sys.modules.get("dataclasses"))
+        and dcs.is_dataclass(obj)
+        and not isinstance(obj, type)
+    ):
+        return to_jsonable(dcs.asdict(obj))
+    if attr.has(type(obj)):
+        return to_jsonable(attr.asdict(obj, recurse=False))  # type: ignore
+    if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):
+        return to_jsonable(obj.model_dump())
+
+    # If all else fails, we'll just pretty-print as a string.
+    return pretty(obj)

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -1,0 +1,67 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import contextlib
+
+import pytest
+
+from hypothesis import (
+    assume,
+    event,
+    example,
+    given,
+    seed,
+    settings,
+    strategies as st,
+    target,
+)
+from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.internal.observability import TESTCASE_CALLBACKS
+
+
+@contextlib.contextmanager
+def capture_observations():
+    ls = []
+    TESTCASE_CALLBACKS.append(ls.append)
+    try:
+        yield ls
+    finally:
+        TESTCASE_CALLBACKS.remove(ls.append)
+
+
+@seed("deterministic so we don't miss some combination of features")
+@example(a=0, x=4, data=None)
+@settings(database=InMemoryExampleDatabase())
+@given(st.integers(), st.integers(), st.data())
+def do_it_all(a, x, data):
+    event(f"{x%2=}")
+    target(x % 5, label="x%5")
+    assume(a % 9)
+    if data:
+        data.draw(st.text("abcdef", min_size=a % 3), label="interactive")
+    1 / ((x or 1) % 7)
+
+
+def test_observability():
+    with capture_observations() as ls:
+        with pytest.raises(ZeroDivisionError):
+            do_it_all()
+        with pytest.raises(ZeroDivisionError):
+            do_it_all()
+
+    infos = [t for t in ls if t["type"] == "info"]
+    assert len(infos) == 2
+    assert {t["title"] for t in infos} == {"Hypothesis Statistics"}
+
+    testcases = [t for t in ls if t["type"] == "test_case"]
+    assert len(testcases) > 50
+    assert {t["property"] for t in testcases} == {do_it_all.__name__}
+    assert len({t["run_start"] for t in testcases}) == 2
+    assert {t["status"] for t in testcases} == {"gave_up", "passed", "failed"}

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -16,6 +16,7 @@ import pytest
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies import booleans, integers, just, none, tuples
+from hypothesis.strategies._internal.utils import to_jsonable
 
 from tests.common.debug import assert_no_examples
 
@@ -85,3 +86,7 @@ def test_can_flatmap_nameless():
 def test_flatmap_with_invalid_expand():
     with pytest.raises(InvalidArgument):
         just(100).flatmap(lambda n: "a").example()
+
+
+def test_jsonable():
+    assert isinstance(to_jsonable(object()), str)

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,5 @@ warn_no_return = True
 warn_unused_ignores = True
 warn_unused_configs = True
 warn_redundant_casts = True
+
+disable_error_code = annotation-unchecked

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -17,6 +17,7 @@ shed
 sphinx
 sphinx-codeautolink
 sphinx-hoverxref
+sphinx-jsonschema
 sphinx-rtd-theme
 sphinx-selective-exclude
 tox

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -60,6 +60,7 @@ docutils==0.20.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
+    #   sphinx-jsonschema
     #   sphinx-rtd-theme
 dpcontracts==0.6.0
     # via -r requirements/tools.in
@@ -98,6 +99,8 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
+jsonpointer==2.4
+    # via sphinx-jsonschema
 keyring==24.3.0
     # via twine
 lark==1.1.8
@@ -183,7 +186,9 @@ python-dateutil==2.8.2
 pyupgrade==3.15.0
     # via shed
 pyyaml==6.0.1
-    # via libcst
+    # via
+    #   libcst
+    #   sphinx-jsonschema
 readme-renderer==42.0
     # via twine
 requests==2.31.0
@@ -191,6 +196,7 @@ requests==2.31.0
     #   -r requirements/tools.in
     #   requests-toolbelt
     #   sphinx
+    #   sphinx-jsonschema
     #   twine
 requests-toolbelt==1.0.0
     # via twine
@@ -231,6 +237,8 @@ sphinx==7.2.6
 sphinx-codeautolink==0.15.0
     # via -r requirements/tools.in
 sphinx-hoverxref==1.3.0
+    # via -r requirements/tools.in
+sphinx-jsonschema==1.19.1
     # via -r requirements/tools.in
 sphinx-rtd-theme==2.0.0
     # via -r requirements/tools.in


### PR DESCRIPTION
I've been corresponding with @hgoldstein95 for a while now, and last week we met up in person too.  After talking about and hacking on https://github.com/tyche-pbt/ ([paper](https://harrisongoldste.in/papers/uist23.pdf)) - a neat in-editor frontend to see what Hypothesis is doing - we hit on the concept of [observability](https://en.wikipedia.org/wiki/Observability_(software)) for PBT.

As well as reporting the minimal failing example, let's log _every_ test case - including argument values, test outcome, runtimes, code coverage, events and target values, etc.  If all you need is the minimal example, great - but if you need more, you can treat (more of) debugging as a data analysis problem!

In a future version, we're aiming for automatic integration with [the Tyche vs code extension](https://marketplace.visualstudio.com/items?itemName=HarrisonGoldstein.tyche) and will encourage other editors to add support - e.g. PyCharm devs were interested in [Tarantula-style](https://faculty.cc.gatech.edu/~john.stasko/papers/icse02.pdf) coverage visualization when I mentioned the idea to them at PyCon '23.

--------

Status of this PR:  fleshed-out demo, waiting for some decisions + docs + upstream work but pretty compelling
- [x] release notes and documentation
  - [x] ship schema file
  - [x] include schema in the docs with nice typography (e.g. descriptions off to the right / in ⓘ expandos)
- [x] grep for FIXME and TODO comments
- [x] lots of tests
  - [x] `InterestingOrigin` string form
  - [x] check that our testcase json blobs work reliably
- [ ] get a release out which _doesn't_ mention or explicitly integrate with Tyche.  Then as followup:
  - [ ] detect when running in VSCode tests without Tyche and recommend it
  - [ ] include the client-side logic for Tyche in Hypothesis itself so users can _just_ install the vsc extension
  - [ ] email Pycharm devs about including their own integration
