### PR TITLE
Support attrs `alias` and private attributes in `st.builds`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes an issue where :func:`~hypothesis.strategies.builds` could not be used with :pypi:`attrs` objects that defined private attributes (i.e. attributes with a leading underscore). See also :issue:`3791`.
+
+This patch also adds support more generally for using :func:`~hypothesis.strategies.builds` with attrs' ``alias`` parameter, which was previously unsupported.
+
+This patch increases the minimum required version of attrs to 22.2.0.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -96,7 +96,7 @@ setuptools.setup(
     zip_safe=False,
     extras_require=extras,
     install_requires=[
-        "attrs>=19.2.0",
+        "attrs>=22.2.0",
         "exceptiongroup>=1.0.0 ; python_version<'3.11'",
         "sortedcontainers>=2.1.0,<3.0.0",
     ],

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -89,3 +89,37 @@ def test_cannot_infer(c):
 def test_cannot_infer_takes_self():
     with pytest.raises(ResolutionFailed):
         st.builds(Inferrables, has_default_factory_takes_self=...).example()
+
+
+@attr.s
+class HasPrivateAttribute:
+    _x: int = attr.ib()
+
+
+@pytest.mark.parametrize("s", [st.just(42), ...])
+def test_private_attribute(s):
+    st.builds(HasPrivateAttribute, x=s).example()
+
+
+def test_private_attribute_underscore_fails():
+    with pytest.raises(TypeError, match="unexpected keyword argument '_x'"):
+        st.builds(HasPrivateAttribute, _x=st.just(42)).example()
+
+
+def test_private_attribute_underscore_infer_fails():
+    # this has a slightly different failure case, because it goes through
+    # attrs-specific resolution logic.
+    with pytest.raises(
+        TypeError, match="Unexpected keyword argument _x for attrs class"
+    ):
+        st.builds(HasPrivateAttribute, _x=...).example()
+
+
+@attr.s
+class HasAliasedAttribute:
+    x: int = attr.ib(alias="crazyname")
+
+
+@pytest.mark.parametrize("s", [st.just(42), ...])
+def test_aliased_attribute(s):
+    st.builds(HasAliasedAttribute, crazyname=s).example()


### PR DESCRIPTION
Closes #3791.

More generally, adds support for attr's [alias parameter](https://www.attrs.org/en/stable/api-attr.html#attr.ib). On master, the following errors, for instance:

```python
@attr.s
class HasAliasedAttribute:
    x: int = attr.ib(alias="crazyname")

st.builds(HasAliasedAttribute)
```

Attrs also helpfully fills in `alias` with the correctly-stripped version of private attributes, which is why this fixes the linked issue.

attrs only [added `alias`](https://github.com/python-attrs/attrs/pull/950) in `22.2.0`. I probably could have thrown a `if attrs.__version__` in here and made things backwards compatible, but it would have complicated things, so I've taken the easier option of bumping the dependency. [There is precedence for this](https://github.com/HypothesisWorks/hypothesis/pull/2111), but if this is a tough sell I can work on continuing to support previous versions.

P.S. I thought I would take a small break from IR pulls to do some good ol' bug fixing. I'm continuing to work on migrating the datatree to the IR, though! 🙂 