### PR TITLE
Vendor `dataclasses.asdict`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug introduced in :ref:`version 6.92.0 <v6.92.0>`, where using :func:`~python:dataclasses.dataclass` with a :class:`~python:collections.defaultdict` field as a strategy argument would error.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -192,21 +192,22 @@ def bad_django_TestCase(runner):
         return not isinstance(runner, HypothesisTestCase)
 
 
-def dataclass_asdict(obj, *, dict_factory=dict):
-    """
-    A vendored variant of dataclasses.asdict. Includes the bugfix for
-    defaultdicts (cpython/32056) for all versions. See also issues/3812.
+# see issue #3812
+if sys.version_info[:2] < (3, 12):
 
-    This should be removed whenever we drop support for 3.11. We can use the
-    standard dataclasses.asdict after that point.
-    """
-    if not dataclasses._is_dataclass_instance(obj):  # pragma: no cover
-        raise TypeError("asdict() should be called on dataclass instances")
-    return _asdict_inner(obj, dict_factory)
+    def dataclass_asdict(obj, *, dict_factory=dict):
+        """
+        A vendored variant of dataclasses.asdict. Includes the bugfix for
+        defaultdicts (cpython/32056) for all versions. See also issues/3812.
 
+        This should be removed whenever we drop support for 3.11. We can use the
+        standard dataclasses.asdict after that point.
+        """
+        if not dataclasses._is_dataclass_instance(obj):  # pragma: no cover
+            raise TypeError("asdict() should be called on dataclass instances")
+        return _asdict_inner(obj, dict_factory)
 
-if sys.version_info[:2] >= (3, 12):
-    # see issue #3812
+else:
     dataclass_asdict = dataclasses.asdict
 
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -212,17 +212,10 @@ if sys.version_info[:2] >= (3, 12):
 
 def _asdict_inner(obj, dict_factory):
     if dataclasses._is_dataclass_instance(obj):
-        if dict_factory is dict:
-            return {
-                f.name: _asdict_inner(getattr(obj, f.name), dict)
-                for f in dataclasses.fields(obj)
-            }
-        else:  # pragma: no cover
-            result = []
-            for f in dataclasses.fields(obj):
-                value = _asdict_inner(getattr(obj, f.name), dict_factory)
-                result.append((f.name, value))
-            return dict_factory(result)
+        return dict_factory(
+            (f.name, _asdict_inner(getattr(obj, f.name), dict_factory))
+            for f in dataclasses.fields(obj)
+        )
     elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
         return type(obj)(*[_asdict_inner(v, dict_factory) for v in obj])
     elif isinstance(obj, (list, tuple)):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -205,6 +205,11 @@ def dataclass_asdict(obj, *, dict_factory=dict):
     return _asdict_inner(obj, dict_factory)
 
 
+if sys.version_info[:2] >= (3, 12):
+    # see issue #3812
+    dataclass_asdict = dataclasses.asdict
+
+
 def _asdict_inner(obj, dict_factory):
     if dataclasses._is_dataclass_instance(obj):
         if dict_factory is dict:

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -220,7 +220,7 @@ def dataclass_asdict(obj, *, dict_factory=dict):
     A vendored variant of dataclasses.asdict. Includes the bugfix for
     defaultdicts (cpython/32056) for all versions. See also issues/3812.
     """
-    if not dataclasses._is_dataclass_instance(obj):
+    if not dataclasses._is_dataclass_instance(obj):  # pragma: no cover
         raise TypeError("asdict() should be called on dataclass instances")
     return _asdict_inner(obj, dict_factory)
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -212,7 +212,7 @@ def _asdict_inner(obj, dict_factory):
                 f.name: _asdict_inner(getattr(obj, f.name), dict)
                 for f in dataclasses.fields(obj)
             }
-        else:
+        else:  # pragma: no cover
             result = []
             for f in dataclasses.fields(obj):
                 value = _asdict_inner(getattr(obj, f.name), dict_factory)

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -14,7 +14,6 @@ import dataclasses
 import inspect
 import platform
 import sys
-import types
 import typing
 from functools import partial
 from typing import Any, ForwardRef, get_args
@@ -193,28 +192,6 @@ def bad_django_TestCase(runner):
         return not isinstance(runner, HypothesisTestCase)
 
 
-# _ATOMIC_TYPES was introduced as an optimization in 3.12's dataclasses.
-_ATOMIC_TYPES = frozenset(
-    {
-        types.NoneType,
-        bool,
-        int,
-        float,
-        str,
-        complex,
-        bytes,
-        types.EllipsisType,
-        types.NotImplementedType,
-        types.CodeType,
-        types.BuiltinFunctionType,
-        types.FunctionType,
-        type,
-        range,
-        property,
-    }
-)
-
-
 def dataclass_asdict(obj, *, dict_factory=dict):
     """
     A vendored variant of dataclasses.asdict. Includes the bugfix for
@@ -226,9 +203,7 @@ def dataclass_asdict(obj, *, dict_factory=dict):
 
 
 def _asdict_inner(obj, dict_factory):
-    if type(obj) in _ATOMIC_TYPES:
-        return obj
-    elif dataclasses._is_dataclass_instance(obj):
+    if dataclasses._is_dataclass_instance(obj):
         if dict_factory is dict:
             return {
                 f.name: _asdict_inner(getattr(obj, f.name), dict)

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -207,7 +207,7 @@ if sys.version_info[:2] < (3, 12):
             raise TypeError("asdict() should be called on dataclass instances")
         return _asdict_inner(obj, dict_factory)
 
-else:
+else:  # pragma: no cover
     dataclass_asdict = dataclasses.asdict
 
 

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -196,6 +196,9 @@ def dataclass_asdict(obj, *, dict_factory=dict):
     """
     A vendored variant of dataclasses.asdict. Includes the bugfix for
     defaultdicts (cpython/32056) for all versions. See also issues/3812.
+
+    This should be removed whenever we drop support for 3.11. We can use the
+    standard dataclasses.asdict after that point.
     """
     if not dataclasses._is_dataclass_instance(obj):  # pragma: no cover
         raise TypeError("asdict() should be called on dataclass instances")

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -77,6 +77,7 @@ from hypothesis.internal.compat import (
 from hypothesis.internal.conjecture.utils import calc_label_from_cls, check_sample
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.floats import float_of
+from hypothesis.internal.observability import TESTCASE_CALLBACKS
 from hypothesis.internal.reflection import (
     define_function_signature,
     get_pretty_function_description,
@@ -2103,7 +2104,9 @@ class DataObject:
         self.count += 1
         printer = RepresentationPrinter(context=current_build_context())
         desc = f"Draw {self.count}{'' if label is None else f' ({label})'}: "
-        self.conjecture_data._observability_args[desc] = to_jsonable(result)
+        if TESTCASE_CALLBACKS:
+            self.conjecture_data._observability_args[desc] = to_jsonable(result)
+
         printer.text(desc)
         printer.pretty(result)
         note(printer.getvalue())

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Callable, Dict
 import attr
 
 from hypothesis.internal.cache import LRUReusedCache
+from hypothesis.internal.compat import dataclass_asdict
 from hypothesis.internal.floats import float_to_int
 from hypothesis.internal.reflection import proxies
 from hypothesis.vendor.pretty import pretty
@@ -177,7 +178,7 @@ def to_jsonable(obj: object) -> object:
         and dcs.is_dataclass(obj)
         and not isinstance(obj, type)
     ):
-        return to_jsonable(dcs.asdict(obj))
+        return to_jsonable(dataclass_asdict(obj))
     if attr.has(type(obj)):
         return to_jsonable(attr.asdict(obj, recurse=False))  # type: ignore
     if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -178,11 +178,7 @@ def to_jsonable(obj: object) -> object:
         and dcs.is_dataclass(obj)
         and not isinstance(obj, type)
     ):
-        if sys.version_info[:2] < (3, 12):
-            # see issue #3812
-            return to_jsonable(dataclass_asdict(obj))
-        else:  # pragma: no cover
-            return to_jsonable(dcs.asdict(obj))
+        return to_jsonable(dataclass_asdict(obj))
     if attr.has(type(obj)):
         return to_jsonable(attr.asdict(obj, recurse=False))  # type: ignore
     if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -181,7 +181,7 @@ def to_jsonable(obj: object) -> object:
         if sys.version_info[:2] < (3, 12):
             # see issue #3812
             return to_jsonable(dataclass_asdict(obj))
-        else:
+        else:  # pragma: no cover
             return to_jsonable(dcs.asdict(obj))
     if attr.has(type(obj)):
         return to_jsonable(attr.asdict(obj, recurse=False))  # type: ignore

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -178,7 +178,11 @@ def to_jsonable(obj: object) -> object:
         and dcs.is_dataclass(obj)
         and not isinstance(obj, type)
     ):
-        return to_jsonable(dataclass_asdict(obj))
+        if sys.version_info[:2] < (3, 12):
+            # see issue #3812
+            return to_jsonable(dataclass_asdict(obj))
+        else:
+            return to_jsonable(dcs.asdict(obj))
     if attr.has(type(obj)):
         return to_jsonable(attr.asdict(obj, recurse=False))  # type: ignore
     if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):

--- a/hypothesis-python/tests/cover/test_compat.py
+++ b/hypothesis-python/tests/cover/test_compat.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
+from collections import defaultdict, namedtuple
 from dataclasses import dataclass
 from functools import partial
 from inspect import Parameter, Signature, signature
@@ -16,7 +17,7 @@ from typing import ForwardRef, Optional, Union
 
 import pytest
 
-from hypothesis.internal.compat import ceil, floor, get_type_hints
+from hypothesis.internal.compat import ceil, dataclass_asdict, floor, get_type_hints
 
 floor_ceil_values = [
     -10.7,
@@ -106,3 +107,24 @@ def func(a, b: int, *c: str, d: Optional[int] = None):
 )
 def test_get_hints_through_partial(pf, names):
     assert set(get_type_hints(pf)) == set(names.split())
+
+
+@dataclass
+class FilledWithStuff:
+    a: list
+    b: tuple
+    c: namedtuple
+    d: dict
+    e: defaultdict
+
+
+def test_dataclass_asdict():
+    ANamedTuple = namedtuple("ANamedTuple", ("with_some_field"))
+    obj = FilledWithStuff(a=[1], b=(2), c=ANamedTuple(3), d={4: 5}, e=defaultdict(list))
+    assert dataclass_asdict(obj) == {
+        "a": [1],
+        "b": (2),
+        "c": ANamedTuple(3),
+        "d": {4: 5},
+        "e": {},
+    }

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -98,18 +98,22 @@ def test_jsonable():
 class HasDefaultDict:
     x: defaultdict
 
+
 @attr.s
 class AttrsClass:
     n = attr.ib()
+
 
 def test_jsonable_defaultdict():
     obj = HasDefaultDict(defaultdict(list))
     obj.x["a"] = [42]
     assert to_jsonable(obj) == {"x": {"a": [42]}}
 
+
 def test_jsonable_attrs():
     obj = AttrsClass(n=10)
     assert to_jsonable(obj) == {"n": 10}
+
 
 def test_jsonable_namedtuple():
     Obj = namedtuple("Obj", ("x"))

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -8,8 +8,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import dataclasses
 import functools
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 
 import pytest
 
@@ -90,3 +91,15 @@ def test_flatmap_with_invalid_expand():
 
 def test_jsonable():
     assert isinstance(to_jsonable(object()), str)
+
+
+@dataclasses.dataclass()
+class HasDefaultDict:
+    x: defaultdict
+
+
+def test_jsonable_defaultdict():
+    obj = HasDefaultDict(defaultdict(list))
+    obj.x["a"] = [42]
+    json = to_jsonable(obj)
+    assert json == {"x": {"a": [42]}}

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -12,6 +12,7 @@ import dataclasses
 import functools
 from collections import defaultdict, namedtuple
 
+import attr
 import pytest
 
 from hypothesis.errors import InvalidArgument
@@ -97,9 +98,20 @@ def test_jsonable():
 class HasDefaultDict:
     x: defaultdict
 
+@attr.s
+class AttrsClass:
+    n = attr.ib()
 
 def test_jsonable_defaultdict():
     obj = HasDefaultDict(defaultdict(list))
     obj.x["a"] = [42]
-    json = to_jsonable(obj)
-    assert json == {"x": {"a": [42]}}
+    assert to_jsonable(obj) == {"x": {"a": [42]}}
+
+def test_jsonable_attrs():
+    obj = AttrsClass(n=10)
+    assert to_jsonable(obj) == {"n": 10}
+
+def test_jsonable_namedtuple():
+    Obj = namedtuple("Obj", ("x"))
+    obj = Obj(10)
+    assert to_jsonable(obj) == {"x": 10}


### PR DESCRIPTION
closes #3812.

A pair of related questions: how heavily should this vendored implementation be tested, and how much (if any) of it can be `# pragma: no cover`'d? There are currently a number of uncovered lines in `_asdict_inner`.