### PR TITLE
Fix `PermissionError` on inaccessible paths 

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release resolves :py:exc:`PermissionError` that come from creating databases on inaccessible paths.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -69,7 +69,7 @@ def _db_for_path(path=None):
                 stacklevel=3,
             )
             return InMemoryExampleDatabase()
-    if path in (None, ":memory:"):
+    if path in (None, ":memory:") or not os.access(path, os.R_OK | os.W_OK | os.X_OK):
         return InMemoryExampleDatabase()
     return DirectoryBasedExampleDatabase(str(path))
 

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -8,12 +8,15 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import pytest
+
 from hypothesis import assume, core, find, given, settings, strategies as st
 from hypothesis.database import (
     ExampleDatabase,
     GitHubArtifactDatabase,
     InMemoryExampleDatabase,
     ReadOnlyDatabase,
+    DirectoryBasedExampleDatabase,
 )
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -132,6 +135,16 @@ def test_respects_max_examples_in_database_usage():
     counter[0] = 0
     stuff()
     assert counter == [10]
+
+
+@pytest.mark.parametrize("db_cls", [ExampleDatabase, DirectoryBasedExampleDatabase])
+def test_database_handles_permissions_correctly(db_cls, tmp_path):
+    tmp_path.chmod(0o000)
+    try:
+        database = db_cls(tmp_path)
+        database.save(b"fizz", b"buzz")
+    finally:
+        tmp_path.chmod(0o777)
 
 
 def test_does_not_use_database_when_seed_is_forced(monkeypatch):

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -177,7 +177,6 @@ SELF_REF = st.recursive(
 )
 
 
-@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
 @given(SELF_REF)
 def test_self_ref_regression(_):
     # See https://github.com/HypothesisWorks/hypothesis/issues/2794


### PR DESCRIPTION
Resolves part of #3764

I believe the error [previous line suggestion](https://github.com/HypothesisWorks/hypothesis/issues/3764#issuecomment-1752100694) wouldn't be reached since that's only when the path is not set, but correct me if I'm wrong. 

Also noticed that some of the other databases can have inaccessible paths as well, or I can't find the checks that [this comment](https://github.com/HypothesisWorks/hypothesis/blob/6a6c1cf553a99d82af5baf6eeed848d0968600e8/hypothesis-python/src/hypothesis/database.py#L221C63-L222) is refers to. Added one of these database types into the test, but let me know what the desired behavior on this is 
