### PR TITLE
Filter-rewriting for length filters

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This introduces the rewriting of length filters in :func:`text` strategies, 
+utilizing ``partial`` and ``lambda`` functions for efficient handling of length constraints.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-This introduces the rewriting of length filters in :func:`~hypothesis.strategies.text` strategies, utilizing ``partial`` and ``lambda`` functions for efficient handling of length constraints (:issue:`3791`).
+This introduces the rewriting of length filters on some collection strategies (:issue:`3791`).
 
 Thanks to Reagan Lee for implementing this feature!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: minor
 
-This introduces the rewriting of length filters in :func:`text` strategies, 
+This introduces the rewriting of length filters in ``text`` strategies, 
 utilizing ``partial`` and ``lambda`` functions for efficient handling of length constraints.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,5 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This introduces the rewriting of length filters in ``text`` strategies, 
-utilizing ``partial`` and ``lambda`` functions for efficient handling of length constraints.
+This introduces the rewriting of length filters in :func:`~hypothesis.strategies.text` strategies, utilizing ``partial`` and ``lambda`` functions for efficient handling of length constraints (:issue:`3791`).
+
+Thanks to Reagan Lee for implementing this feature!

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -29,7 +29,7 @@ import operator
 from decimal import Decimal
 from fractions import Fraction
 from functools import partial
-from typing import Any, Callable, Collection, Dict, NamedTuple, Optional, TypeVar
+from typing import Any, Callable, Collection, Dict, NamedTuple, Optional, TypeVar, Union
 
 from hypothesis.internal.compat import ceil, floor
 from hypothesis.internal.floats import next_down, next_up
@@ -74,7 +74,8 @@ def convert(node: ast.AST, argname: str) -> object:
             raise ValueError("Non-local variable")
         return ARG
     if isinstance(node, ast.Call):
-        if node.func.id == "len":
+        # if node.func.id == "len":
+        if isinstance(node.func, ast.Name) and node.func.id == "len":
             return ARG
     return ast.literal_eval(node)
 
@@ -89,7 +90,7 @@ def comp_to_kwargs(x: ast.AST, op: ast.AST, y: ast.AST, *, argname: str) -> dict
         # (and we can't even do `arg == arg`, because what if it's NaN?)
         raise ValueError("Can't analyse this comparison")
 
-    kwargs = {}
+    kwargs: Dict[str, Union[Any, bool]] = {}
     if isinstance(x, ast.Call) and x.func.id == "len":
         kwargs["len_func"] = True
     if isinstance(y, ast.Call) and y.func.id == "len":

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -91,9 +91,9 @@ def comp_to_kwargs(x: ast.AST, op: ast.AST, y: ast.AST, *, argname: str) -> dict
         raise ValueError("Can't analyse this comparison")
 
     kwargs: Dict[str, Union[Any, bool]] = {}
-    if isinstance(x, ast.Call) and x.func.id == "len":
+    if isinstance(x, ast.Call) and isinstance(x.func, ast.Name) and x.func.id == "len":
         kwargs["len_func"] = True
-    if isinstance(y, ast.Call) and y.func.id == "len":
+    if isinstance(y, ast.Call) and isinstance(y.func, ast.Name) and y.func.id == "len":
         kwargs["len_func"] = True
 
     if isinstance(op, ast.Lt):

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -29,7 +29,7 @@ import operator
 from decimal import Decimal
 from fractions import Fraction
 from functools import partial
-from typing import Any, Callable, Collection, Dict, NamedTuple, Optional, TypeVar, Union
+from typing import Any, Callable, Collection, Dict, NamedTuple, Optional, TypeVar
 
 from hypothesis.internal.compat import ceil, floor
 from hypothesis.internal.floats import next_down, next_up

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -19,7 +19,7 @@ import re
 import sys
 import textwrap
 import types
-from functools import wraps
+from functools import partial, wraps
 from io import StringIO
 from keyword import iskeyword
 from tokenize import COMMENT, detect_encoding, generate_tokens, untokenize
@@ -432,6 +432,8 @@ def extract_lambda_source(f):
 
 
 def get_pretty_function_description(f):
+    if isinstance(f, partial):
+        return pretty(f)
     if not hasattr(f, "__name__"):
         return repr(f)
     name = f.__name__

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -9,8 +9,8 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import copy
-from typing import Any, Iterable, Tuple, overload
 from functools import partial
+from typing import Any, Iterable, Tuple, overload
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
@@ -223,7 +223,7 @@ class ListStrategy(SearchStrategy):
             "max_size": max_value,
         }
         if type(self) in (UniqueListStrategy, UniqueSampledListStrategy):
-            strat_keywords["keys"] = self.unique_by
+            strat_keywords["keys"] = self.keys
             strat_keywords["tuple_suffixes"] = self.tuple_suffixes
         modified_strat = type(self)(**strat_keywords)
         if isinstance(condition, partial):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -206,6 +206,11 @@ class ListStrategy(SearchStrategy):
             new = copy.copy(self)
             new.min_size = max(self.min_size, kwargs.get("min_value", self.min_size))
             new.max_size = min(self.max_size, kwargs.get("max_value", self.max_size))
+            # Recompute average size; this is cheaper than making it into a property.
+            new.average_size = min(
+                max(new.min_size * 2, new.min_size + 5),
+                0.5 * (new.min_size + new.max_size),
+            )
             # Note that it's possible for `len` to be redefined in the enclosing scope,
             # so we *always* have to apply the condition as a filter, in addition to
             # our filter-rewriting tricks (which are *usually* all we need).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -201,7 +201,7 @@ class ListStrategy(SearchStrategy):
             new.min_size = 1
             return new
 
-        kwargs, _ = get_integer_predicate_bounds(condition)
+        kwargs, pred = get_integer_predicate_bounds(condition)
         if kwargs.get("len") and ("min_value" in kwargs or "max_value" in kwargs):
             new = copy.copy(self)
             new.min_size = max(self.min_size, kwargs.get("min_value", self.min_size))
@@ -211,9 +211,8 @@ class ListStrategy(SearchStrategy):
                 max(new.min_size * 2, new.min_size + 5),
                 0.5 * (new.min_size + new.max_size),
             )
-            # Note that it's possible for `len` to be redefined in the enclosing scope,
-            # so we *always* have to apply the condition as a filter, in addition to
-            # our filter-rewriting tricks (which are *usually* all we need).
+            if pred is None:
+                return new
             return SearchStrategy.filter(new, condition)
 
         return SearchStrategy.filter(self, condition)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
@@ -143,7 +143,6 @@ class TextStrategy(ListStrategy):
                 stacklevel=2,
             )
         elems = unwrap_strategies(self.element_strategy)
-
         if (
             condition is str.isidentifier
             and self.max_size >= 1

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
@@ -11,11 +11,10 @@
 import copy
 import re
 import warnings
-from functools import lru_cache, partial
+from functools import lru_cache
 
 from hypothesis.errors import HypothesisWarning, InvalidArgument
 from hypothesis.internal import charmap
-from hypothesis.internal.filtering import get_integer_predicate_bounds, max_len, min_len
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.strategies._internal.collections import ListStrategy
 from hypothesis.strategies._internal.lazy import unwrap_strategies
@@ -143,31 +142,7 @@ class TextStrategy(ListStrategy):
                 HypothesisWarning,
                 stacklevel=2,
             )
-
         elems = unwrap_strategies(self.element_strategy)
-
-        kwargs, pred = get_integer_predicate_bounds(condition)
-
-        min_value, max_value = None, None
-        if "len_func" in kwargs and kwargs["len_func"]:
-            min_value = kwargs.get("min_value")
-            max_value = kwargs.get("max_value")
-        if isinstance(condition, partial) and len(condition.args) == 1:
-            min_value = condition.args[0] if condition.func is min_len else None
-            max_value = condition.args[0] if condition.func is max_len else None
-        if min_value is not None or max_value is not None:
-            self.min_size = (
-                max(self.min_size, min_value)
-                if min_value is not None
-                else self.min_size
-            )
-            self.max_size = (
-                min(self.max_size, max_value)
-                if max_value is not None
-                else self.max_size
-            )
-            if isinstance(condition, partial):
-                return self
 
         if (
             condition is str.isidentifier

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -480,29 +480,19 @@ def test_filter_rewriting_text_lambda_len(data, strategy, predicate, start, end)
         (lambda x: len(x) < 3, 0, 2),
         (lambda x: len(x) <= 3, 0, 3),
         (lambda x: len(x) == 3, 3, 3),
-        (lambda x: len(x) >= 3, 3, 3),  # Due to set size
-        # (
-        #     lambda x: len(x) > 3,
-        #     4,
-        #     3,
-        # ),  # Due to set size, output nothing()? or just take this out
+        (lambda x: len(x) >= 3, 3, 3),  # max element_count=3
         # Simple lambdas, reverse comparison
         (lambda x: 3 > len(x), 0, 2),
         (lambda x: 3 >= len(x), 0, 3),
         (lambda x: 3 == len(x), 3, 3),
-        (lambda x: 3 <= len(x), 3, 3),  # Due to set size
-        # (
-        #     lambda x: 3 < len(x),
-        #     4,
-        #     3,
-        # ),  # Due to set size, output nothing()? or just take this out
+        (lambda x: 3 <= len(x), 3, 3),  # max element_count=3
         # More complicated lambdas
-        (lambda x: 0 < len(x) < 5, 1, 3),  # Due to set size
-        (lambda x: 0 < len(x) >= 1, 1, 3),  # Due to set size
+        (lambda x: 0 < len(x) < 5, 1, 3),  # max element_count=3
+        (lambda x: 0 < len(x) >= 1, 1, 3),  # max element_count=3
         (lambda x: 1 > len(x) <= 0, 0, 0),
-        (lambda x: len(x) > 0 and len(x) > 0, 1, 3),  # Due to set size
+        (lambda x: len(x) > 0 and len(x) > 0, 1, 3),  # max element_count=3
         (lambda x: len(x) < 1 and len(x) < 1, 0, 0),
-        (lambda x: len(x) > 1 and len(x) > 0, 2, 3),  # Due to set size
+        (lambda x: len(x) > 1 and len(x) > 0, 2, 3),  # max element_count=3
         (lambda x: len(x) < 1 and len(x) < 2, 0, 0),
     ],
     ids=get_pretty_function_description,

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -402,51 +402,68 @@ def test_filter_floats_can_skip_subnormals(op, attr, value, expected):
         (st.text(), partial(min_len, 3), 3, math.inf),
         (st.text(), partial(max_len, 3), 0, 3),
     ],
+    ids=get_pretty_function_description,
 )
 @given(data=st.data())
 def test_filter_rewriting_text_partial_len(data, strategy, predicate, start, end):
     s = strategy.filter(predicate)
 
     assert isinstance(s, LazyStrategy)
-    assert isinstance(s.wrapped_strategy, TextStrategy)
-    assert s.wrapped_strategy.min_size == start
-    assert s.wrapped_strategy.max_size == end
+    assert isinstance(inner := unwrap_strategies(s), TextStrategy)
+    assert inner.min_size == start
+    assert inner.max_size == end
     value = data.draw(s)
     assert predicate(value)
 
 
 @pytest.mark.parametrize(
-    "strategy, predicate, start, end",
+    "predicate, start, end",
     [
         # Simple lambdas
-        (st.text(), lambda x: len(x) < 3, 0, 2),
-        (st.text(), lambda x: len(x) <= 3, 0, 3),
-        (st.text(), lambda x: len(x) == 3, 3, 3),
-        (st.text(), lambda x: len(x) >= 3, 3, math.inf),
-        (st.text(), lambda x: len(x) > 3, 4, math.inf),
+        (lambda x: len(x) < 3, 0, 2),
+        (lambda x: len(x) <= 3, 0, 3),
+        (lambda x: len(x) == 3, 3, 3),
+        (lambda x: len(x) >= 3, 3, math.inf),
+        (lambda x: len(x) > 3, 4, math.inf),
         # Simple lambdas, reverse comparison
-        (st.text(), lambda x: 3 > len(x), 0, 2),
-        (st.text(), lambda x: 3 >= len(x), 0, 3),
-        (st.text(), lambda x: 3 == len(x), 3, 3),
-        (st.text(), lambda x: 3 <= len(x), 3, math.inf),
-        (st.text(), lambda x: 3 < len(x), 4, math.inf),
+        (lambda x: 3 > len(x), 0, 2),
+        (lambda x: 3 >= len(x), 0, 3),
+        (lambda x: 3 == len(x), 3, 3),
+        (lambda x: 3 <= len(x), 3, math.inf),
+        (lambda x: 3 < len(x), 4, math.inf),
         # More complicated lambdas
-        (st.text(), lambda x: 0 < len(x) < 5, 1, 4),
-        (st.text(), lambda x: 0 < len(x) >= 1, 1, math.inf),
-        (st.text(), lambda x: 1 > len(x) <= 0, 0, 0),
-        (st.text(), lambda x: len(x) > 0 and len(x) > 0, 1, math.inf),
-        (st.text(), lambda x: len(x) < 1 and len(x) < 1, 0, 0),
-        (st.text(), lambda x: len(x) > 1 and len(x) > 0, 2, math.inf),
-        (st.text(), lambda x: len(x) < 1 and len(x) < 2, 0, 0),
+        (lambda x: 0 < len(x) < 5, 1, 4),
+        (lambda x: 0 < len(x) >= 1, 1, math.inf),
+        (lambda x: 1 > len(x) <= 0, 0, 0),
+        (lambda x: len(x) > 0 and len(x) > 0, 1, math.inf),
+        (lambda x: len(x) < 1 and len(x) < 1, 0, 0),
+        (lambda x: len(x) > 1 and len(x) > 0, 2, math.inf),
+        (lambda x: len(x) < 1 and len(x) < 2, 0, 0),
+    ],
+    ids=get_pretty_function_description,
+)
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        st.text(),
+        st.lists(st.integers()),
+        st.lists(st.integers(), unique=True),
+        st.lists(st.sampled_from([1, 2, 3]), unique=True),
+        # TODO: support more collection types.  Might require messing around with
+        #       strategy internals, e.g. in MappedStrategy/FilteredStrategy.
+        # st.binary(),
+        # st.binary.map(bytearray),
+        # st.sets(st.integers()),
+        # st.dictionaries(st.integers(), st.none()),
     ],
     ids=get_pretty_function_description,
 )
 @given(data=st.data())
 def test_filter_rewriting_text_lambda_len(data, strategy, predicate, start, end):
     s = strategy.filter(predicate)
-    unwrapped = s.wrapped_strategy
+    unwrapped = unwrap_strategies(s)
     assert isinstance(unwrapped, FilteredStrategy)
-    assert isinstance(unwrapped.filtered_strategy, TextStrategy)
+    assert isinstance(unwrapped.filtered_strategy, type(unwrap_strategies(strategy)))
     for pred in unwrapped.flat_conditions:
         assert pred.__name__ == "<lambda>"
 

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -480,19 +480,19 @@ def test_filter_rewriting_text_lambda_len(data, strategy, predicate, start, end)
         (lambda x: len(x) < 3, 0, 2),
         (lambda x: len(x) <= 3, 0, 3),
         (lambda x: len(x) == 3, 3, 3),
-        (lambda x: len(x) >= 3, 3, 3),  # max element_count=3
+        (lambda x: len(x) >= 3, 3, 3),  # input max element_count=3
         # Simple lambdas, reverse comparison
         (lambda x: 3 > len(x), 0, 2),
         (lambda x: 3 >= len(x), 0, 3),
         (lambda x: 3 == len(x), 3, 3),
-        (lambda x: 3 <= len(x), 3, 3),  # max element_count=3
+        (lambda x: 3 <= len(x), 3, 3),  # input max element_count=3
         # More complicated lambdas
-        (lambda x: 0 < len(x) < 5, 1, 3),  # max element_count=3
-        (lambda x: 0 < len(x) >= 1, 1, 3),  # max element_count=3
+        (lambda x: 0 < len(x) < 5, 1, 3),  # input max element_count=3
+        (lambda x: 0 < len(x) >= 1, 1, 3),  # input max element_count=3
         (lambda x: 1 > len(x) <= 0, 0, 0),
-        (lambda x: len(x) > 0 and len(x) > 0, 1, 3),  # max element_count=3
+        (lambda x: len(x) > 0 and len(x) > 0, 1, 3),  # input max element_count=3
         (lambda x: len(x) < 1 and len(x) < 1, 0, 0),
-        (lambda x: len(x) > 1 and len(x) > 0, 2, 3),  # max element_count=3
+        (lambda x: len(x) > 1 and len(x) > 0, 2, 3),  # input max element_count=3
         (lambda x: len(x) < 1 and len(x) < 2, 0, 0),
     ],
     ids=get_pretty_function_description,

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -416,6 +416,23 @@ def test_filter_rewriting_text_partial_len(data, strategy, predicate, start, end
     assert predicate(value)
 
 
+@given(data=st.data())
+def test_can_rewrite_multiple_length_filters_if_not_lambdas(data):
+    # This is a key capability for efficient rewriting using the `annotated-types`
+    # package, although unfortunately we can't do it for lambdas.
+    s = (
+        st.text(min_size=1, max_size=5)
+        .filter(partial(min_len, 2))
+        .filter(partial(max_len, 4))
+    )
+    assert isinstance(s, LazyStrategy)
+    assert isinstance(inner := unwrap_strategies(s), TextStrategy)
+    assert inner.min_size == 2
+    assert inner.max_size == 4
+    value = data.draw(s)
+    assert 2 <= len(value) <= 4
+
+
 @pytest.mark.parametrize(
     "predicate, start, end",
     [

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -13,11 +13,11 @@ import functools
 from collections import defaultdict, namedtuple
 
 import attr
-from hypothesis.internal.reflection import get_pretty_function_description
 import pytest
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies import booleans, integers, just, none, tuples
 from hypothesis.strategies._internal.utils import to_jsonable
 

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -13,6 +13,7 @@ import functools
 from collections import defaultdict, namedtuple
 
 import attr
+from hypothesis.internal.reflection import get_pretty_function_description
 import pytest
 
 from hypothesis.errors import InvalidArgument
@@ -77,12 +78,12 @@ def nameless_const(x):
 
 def test_can_map_nameless():
     f = nameless_const(2)
-    assert repr(f) in repr(integers().map(f))
+    assert get_pretty_function_description(f) in repr(integers().map(f))
 
 
 def test_can_flatmap_nameless():
     f = nameless_const(just(3))
-    assert repr(f) in repr(integers().flatmap(f))
+    assert get_pretty_function_description(f) in repr(integers().flatmap(f))
 
 
 def test_flatmap_with_invalid_expand():


### PR DESCRIPTION
Resolves part of #3795

> in this case we'll want to apply the rewrite for efficiency, and apply the predicate as a filter in case the name len has been rebound in the enclosing scope

So we take the components of the lambda and re-write with them. However, how would we keep in mind the case that the `len` function has been rebound/redefined? Or do you mean falling back to rejection sampling in this case?