### PR TITLE
add status reason to UnsatisfiedAssumption rejections

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds a note when an ``UnsatisfiedAssumption`` is raised (e.g. via :func:`assume <hypothesis.assume>` in user code), for use in both :ref:`test statistics <statistics>` and :doc:`observability <observability>`.
+
+See also :issue:`3827`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch adds a note when an ``UnsatisfiedAssumption`` is raised (e.g. via :func:`assume <hypothesis.assume>` in user code), for use in both :ref:`test statistics <statistics>` and :doc:`observability <observability>`.
+This patch adds a :ref:`test statistics <statistics>` event when a generated example is rejected via :func:`assume <hypothesis.assume>` or :func:`reject <hypothesis.reject>`.
 
-See also :issue:`3827`.
+This may also help with distinguishing ``gave_up`` examples in :doc:`observability <observability>` (:issue:`3827`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch adds a :ref:`test statistics <statistics>` event when a generated example is rejected via :func:`assume <hypothesis.assume>` or :func:`reject <hypothesis.reject>`.
+This patch adds a :ref:`test statistics <statistics>` event when a generated example is rejected via :func:`assume <hypothesis.assume>`.
 
 This may also help with distinguishing ``gave_up`` examples in :doc:`observability <observability>` (:issue:`3827`).

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -26,6 +26,10 @@ from hypothesis.utils.dynamicvariables import DynamicVariable
 from hypothesis.vendor.pretty import IDKey
 
 
+def _get_calling_function_name():
+    return inspect.currentframe().f_back.f_code.co_name
+
+
 def reject() -> NoReturn:
     if _current_build_context.value is None:
         note_deprecation(
@@ -33,7 +37,7 @@ def reject() -> NoReturn:
             since="2023-09-25",
             has_codemod=False,
         )
-    f = inspect.stack()[1].function
+    f = _get_calling_function_name()
     raise UnsatisfiedAssumption(f"reject() in {f}")
 
 
@@ -50,8 +54,8 @@ def assume(condition: object) -> bool:
             since="2023-09-25",
             has_codemod=False,
         )
-    f = inspect.stack()[1].function
     if not condition:
+        f = _get_calling_function_name()
         raise UnsatisfiedAssumption(f"failed to satisfy assume() in {f}")
     return True
 

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -26,8 +26,8 @@ from hypothesis.utils.dynamicvariables import DynamicVariable
 from hypothesis.vendor.pretty import IDKey
 
 
-def _get_calling_function_name():
-    return inspect.currentframe().f_back.f_code.co_name
+def _calling_function_name(frame):
+    return frame.f_back.f_code.co_name
 
 
 def reject() -> NoReturn:
@@ -37,7 +37,7 @@ def reject() -> NoReturn:
             since="2023-09-25",
             has_codemod=False,
         )
-    f = _get_calling_function_name()
+    f = _calling_function_name(inspect.currentframe())
     raise UnsatisfiedAssumption(f"reject() in {f}")
 
 
@@ -55,7 +55,7 @@ def assume(condition: object) -> bool:
             has_codemod=False,
         )
     if not condition:
-        f = _get_calling_function_name()
+        f = _calling_function_name(inspect.currentframe())
         raise UnsatisfiedAssumption(f"failed to satisfy assume() in {f}")
     return True
 

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -34,7 +34,7 @@ def reject() -> NoReturn:
             has_codemod=False,
         )
     f = inspect.stack()[1].function
-    raise UnsatisfiedAssumption(reason=f"reject() in {f}")
+    raise UnsatisfiedAssumption(f"reject() in {f}")
 
 
 def assume(condition: object) -> bool:
@@ -52,7 +52,7 @@ def assume(condition: object) -> bool:
         )
     f = inspect.stack()[1].function
     if not condition:
-        raise UnsatisfiedAssumption(reason=f"failed to satisfy assume() in {f}")
+        raise UnsatisfiedAssumption(f"failed to satisfy assume() in {f}")
     return True
 
 

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import inspect
 import math
 from collections import defaultdict
 from typing import NoReturn, Union
@@ -32,7 +33,8 @@ def reject() -> NoReturn:
             since="2023-09-25",
             has_codemod=False,
         )
-    raise UnsatisfiedAssumption
+    f = inspect.stack()[1].function
+    raise UnsatisfiedAssumption(reason=f"reject() in {f}")
 
 
 def assume(condition: object) -> bool:
@@ -48,8 +50,9 @@ def assume(condition: object) -> bool:
             since="2023-09-25",
             has_codemod=False,
         )
+    f = inspect.stack()[1].function
     if not condition:
-        raise UnsatisfiedAssumption
+        raise UnsatisfiedAssumption(reason=f"failed to satisfy assume() in {f}")
     return True
 
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -993,10 +993,10 @@ class StateForActualGivenExecution:
                     f"{self.test.__name__} returned {result!r} instead.",
                     HealthCheck.return_value,
                 )
-        except UnsatisfiedAssumption:
+        except UnsatisfiedAssumption as e:
             # An "assume" check failed, so instead we inform the engine that
             # this test run was invalid.
-            data.mark_invalid("failed to satisfy assume()")
+            data.mark_invalid(e.reason)
         except StopTest:
             # The engine knows how to handle this control exception, so it's
             # OK to re-raise it.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -996,7 +996,7 @@ class StateForActualGivenExecution:
         except UnsatisfiedAssumption:
             # An "assume" check failed, so instead we inform the engine that
             # this test run was invalid.
-            data.mark_invalid()
+            data.mark_invalid("failed to satisfy assume()")
         except StopTest:
             # The engine knows how to handle this control exception, so it's
             # OK to re-raise it.

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -23,6 +23,9 @@ class UnsatisfiedAssumption(HypothesisException):
     If you're seeing this error something has gone wrong.
     """
 
+    def __init__(self, *, reason=None):
+        self.reason = reason
+
 
 class NoSuchExample(HypothesisException):
     """The condition we have been asked to satisfy appears to be always false.

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -23,7 +23,7 @@ class UnsatisfiedAssumption(HypothesisException):
     If you're seeing this error something has gone wrong.
     """
 
-    def __init__(self, *, reason=None):
+    def __init__(self, reason=None):
         self.reason = reason
 
 

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -27,7 +27,7 @@ from hypothesis.errors import (
     UnsatisfiedAssumption,
 )
 from hypothesis.internal.compat import ExceptionGroup
-from hypothesis.internal.conjecture.data import ConjectureData as TD
+from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.stateful import RuleBasedStateMachine, rule
 from hypothesis.strategies import integers
 
@@ -35,7 +35,7 @@ from tests.common.utils import capture_out
 
 
 def bc():
-    return BuildContext(TD.for_buffer(b""))
+    return BuildContext(ConjectureData.for_buffer(b""))
 
 
 def test_cannot_cleanup_with_no_context():

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -65,3 +65,16 @@ def test_observability():
     assert {t["property"] for t in testcases} == {do_it_all.__name__}
     assert len({t["run_start"] for t in testcases}) == 2
     assert {t["status"] for t in testcases} == {"gave_up", "passed", "failed"}
+
+
+def test_assume_has_status_reason():
+    @given(st.booleans())
+    def f(b):
+        assume(b)
+
+    with capture_observations() as ls:
+        f()
+
+    gave_ups = [t for t in ls if t["type"] == "test_case" and t["status"] == "gave_up"]
+    for gave_up in gave_ups:
+        assert gave_up["status_reason"] == "failed to satisfy assume()"

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -77,4 +77,4 @@ def test_assume_has_status_reason():
 
     gave_ups = [t for t in ls if t["type"] == "test_case" and t["status"] == "gave_up"]
     for gave_up in gave_ups:
-        assert gave_up["status_reason"] == "failed to satisfy assume()"
+        assert gave_up["status_reason"] == "failed to satisfy assume() in f"

--- a/hypothesis-python/tests/cover/test_regressions.py
+++ b/hypothesis-python/tests/cover/test_regressions.py
@@ -129,6 +129,7 @@ exc_instances = [
         runtime=timedelta(seconds=1.5), deadline=timedelta(seconds=1.0)
     ),
     errors.RewindRecursive(int),
+    errors.UnsatisfiedAssumption("reason for unsatisfied"),
 ]
 
 

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -20,6 +20,7 @@ from hypothesis import (
     event,
     example,
     given,
+    reject,
     settings,
     stateful,
     strategies as st,
@@ -260,3 +261,28 @@ def test_statistics_with_events_and_target():
 @given(st.booleans())
 def test_event_with_non_weakrefable_keys(b):
     event((b,))
+
+
+def test_assume_adds_event_with_function_origin():
+    @given(st.integers())
+    def very_distinguishable_name(n):
+        assume(n > 100)
+
+    stats = call_for_statistics(very_distinguishable_name)
+
+    for tc in stats["generate-phase"]["test-cases"]:
+        for event in tc["events"]:
+            assert "failed to satisfy assume() in very_distinguishable_name" in event
+
+
+def test_reject_adds_event_with_function_origin():
+    @given(st.integers())
+    def very_distinguishable_name(n):
+        if n > 100:
+            reject()
+
+    stats = call_for_statistics(very_distinguishable_name)
+
+    for tc in stats["generate-phase"]["test-cases"]:
+        for event in tc["events"]:
+            assert "reject() in very_distinguishable_name" in event

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -271,8 +271,8 @@ def test_assume_adds_event_with_function_origin():
     stats = call_for_statistics(very_distinguishable_name)
 
     for tc in stats["generate-phase"]["test-cases"]:
-        for event in tc["events"]:
-            assert "failed to satisfy assume() in very_distinguishable_name" in event
+        for e in tc["events"]:
+            assert "failed to satisfy assume() in very_distinguishable_name" in e
 
 
 def test_reject_adds_event_with_function_origin():
@@ -284,5 +284,5 @@ def test_reject_adds_event_with_function_origin():
     stats = call_for_statistics(very_distinguishable_name)
 
     for tc in stats["generate-phase"]["test-cases"]:
-        for event in tc["events"]:
-            assert "reject() in very_distinguishable_name" in event
+        for e in tc["events"]:
+            assert "reject() in very_distinguishable_name" in e


### PR DESCRIPTION
closes https://github.com/HypothesisWorks/hypothesis/issues/3827.

Note that what we originally discussed in the issue has the knock-on effect of adding to the events of that test case, which shows up in e.g. [statistics mode](https://hypothesis.readthedocs.io/en/latest/details.html#test-statistics) reporting:

```
from hypothesis import *
from hypothesis.strategies import *

@given(integers())
def test_f(n):
    assume(n > 2)
```
```
sandbox.py::test_f:

  - during reuse phase (0.00 seconds):
    - Typical runtimes: < 1ms, of which < 1ms in data generation
    - 1 passing examples, 0 failing examples, 0 invalid examples

  - during generate phase (0.04 seconds):
    - Typical runtimes: < 1ms, of which < 1ms in data generation
    - 99 passing examples, 0 failing examples, 96 invalid examples
    - Events:
      * 49.23%, invalid because: failed to satisfy assume()

  - Stopped because settings.max_examples=100
```

I'd call this desirable, though perhaps a tad confusing as it doesn't state which assume statement was unsatisfied. But I wonder if there was a good reason this hasn't been done yet.

cc @hgoldstein95