### PR TITLE
Create parent dir in `_deliver_to_file`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes an error when writing :doc:`observability <observability>` reports without a pre-existing ``.hypothesis`` directory.

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -76,7 +76,7 @@ _WROTE_TO = set()
 def _deliver_to_file(value):  # pragma: no cover
     kind = "testcases" if value["type"] == "test_case" else "info"
     fname = storage_directory("observed", f"{date.today().isoformat()}_{kind}.jsonl")
-    fname.parent.mkdir(exist_ok=True)
+    fname.parent.mkdir(exist_ok=True, parents=True)
     _WROTE_TO.add(fname)
     with fname.open(mode="a") as f:
         f.write(json.dumps(value) + "\n")


### PR DESCRIPTION
Fixes an error when using observability without a .hypothesis dir. To reproduce, delete `.hypothesis` and run pytest with `HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1`.

This matches how we do things elsewhere: https://github.com/HypothesisWorks/hypothesis/blob/6da7c6f9b7f8b838fcc83e3c4274cc4b1a56896b/hypothesis-python/src/hypothesis/internal/charmap.py#L72-L73

To be honest, this seems like a bit of a footgun with `storage_directory`. Maybe we should have a `mkdir: bool` param?

I didn't write a regression test for this because it seemed slightly annoying and not that useful. I'm happy to write one on request 🙂 