### PR TITLE
Pull out timing observations, more jsonable arguments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,8 @@
 # version of Python, then hand over to the actual Hypothesis build runner (which
 # is written in Python instead of bash).
 
+if [ -n "${CI:-}" ] ; then echo "::group::Build setup" ; fi
+
 set -o xtrace
 set -o errexit
 set -o nounset
@@ -43,5 +45,7 @@ if ! "$TOOL_PYTHON" -m hypothesistooling check-installed ; then
   "$PYTHON" -m virtualenv "$TOOL_VIRTUALENV"
   "$TOOL_PYTHON" -m pip install --no-warn-script-location -r requirements/tools.txt
 fi
+
+if [ -n "${CI:-}" ] ; then echo "::endgroup::" ; fi
 
 "$TOOL_PYTHON" -m hypothesistooling "$@"

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -4,3 +4,12 @@ This patch improves :doc:`observability <observability>` reports by moving
 timing information from ``metadata`` to a new ``timing`` key, and supporting
 conversion of additional argument types to json rather than string reprs
 via a ``.to_json()`` method (including e.g. Pandas dataframes).
+
+Additionally, the :obj:`~hypothesis.HealthCheck.too_slow` health check will
+now report *which* strategies were slow, e.g. for strategies a, b, c, ...::
+
+        count | fraction |    slowest draws (seconds)
+    a |    3  |     65%  |      --      --      --   0.357,  2.000
+    b |    8  |     16%  |   0.100,  0.100,  0.100,  0.111,  0.123
+    c |    3  |      8%  |      --      --   0.030,  0.050,  0.200
+    (skipped 2 rows of fast draws)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves :doc:`observability <observability>` reports by moving
+timing information from ``metadata`` to a new ``timing`` key, and supporting
+conversion of additional argument types to json rather than string reprs
+via a ``.to_json()`` method (including e.g. Pandas dataframes).

--- a/hypothesis-python/docs/schema_observations.json
+++ b/hypothesis-python/docs/schema_observations.json
@@ -33,7 +33,7 @@
                 },
                 "features": {
                     "type": "object",
-                    "description": "Runtime observations which might help explain what this test case did.  Hypothesis includes target() scores, tags from event(), time spent generating data and running user code, and so on."
+                    "description": "Runtime observations which might help explain what this test case did.  Hypothesis includes target() scores, tags from event(), and so on."
                 },
                 "coverage": {
                     "type": ["object", "null"],
@@ -42,6 +42,14 @@
                         "type": "array",
                         "items": {"type": "integer", "minimum": 1},
                         "uniqueItems": true
+                    }
+                },
+                "timing": {
+                    "type": "object",
+                    "description": "The time in seconds taken by non-overlapping parts of this test case.  Hypothesis reports execute_test, and generate:{argname} for each argument.",
+                    "additionalProperties": {
+                        "type": "number",
+                        "minimum": 0
                     }
                 },
                 "metadata": {
@@ -57,7 +65,7 @@
                     "description": "unix timestamp at which we started running this test function, so that later analysis can group test cases by run."
                 }
             },
-            "required": ["type", "status", "status_reason", "representation", "arguments", "how_generated", "features", "coverage", "metadata", "property", "run_start"],
+            "required": ["type", "status", "status_reason", "representation", "arguments", "how_generated", "features", "coverage", "timing", "metadata", "property", "run_start"],
             "additionalProperties": false
         },
         {

--- a/hypothesis-python/docs/schema_observations.json
+++ b/hypothesis-python/docs/schema_observations.json
@@ -25,7 +25,7 @@
                 },
                 "arguments": {
                     "type": "object",
-                    "description": "A structured json-encoded representation of the input.  Hypothesis always provides a dictionary of argument names to json-ified values, including interactive draws from the :func:`~hypothesis.strategies.data` strategy.  In other libraries this can be any object."
+                    "description": "A structured json-encoded representation of the input.  Hypothesis provides a dictionary of argument names to json-ified values, including interactive draws from the :func:`~hypothesis.strategies.data` strategy.  If 'status' is 'gave_up', this may be absent or incomplete.  In other libraries this can be any object."
                 },
                 "how_generated": {
                     "type": ["string", "null"],

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -105,16 +105,13 @@ class BuildContext:
             )
         )
 
-    def prep_args_kwargs_from_strategies(self, arg_strategies, kwarg_strategies):
+    def prep_args_kwargs_from_strategies(self, kwarg_strategies):
         arg_labels = {}
-        all_s = [(None, s) for s in arg_strategies] + list(kwarg_strategies.items())
-        args = []
         kwargs = {}
-        for i, (k, s) in enumerate(all_s):
+        for k, s in kwarg_strategies.items():
             start_idx = self.data.index
-            obj = self.data.draw(s)
+            obj = self.data.draw(s, observe_as=f"generate:{k}")
             end_idx = self.data.index
-            assert k is not None
             kwargs[k] = obj
 
             # This high up the stack, we can't see or really do much with the conjecture
@@ -124,10 +121,10 @@ class BuildContext:
             # pass a dict of such out so that the pretty-printer knows where to place
             # the which-parts-matter comments later.
             if start_idx != end_idx:
-                arg_labels[k or i] = (start_idx, end_idx)
+                arg_labels[k] = (start_idx, end_idx)
                 self.data.arg_slices.add((start_idx, end_idx))
 
-        return args, kwargs, arg_labels
+        return kwargs, arg_labels
 
     def __enter__(self):
         self.assign_variable = _current_build_context.with_value(self)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1187,9 +1187,8 @@ class StateForActualGivenExecution:
                     "how_generated": "minimal failing example",
                     "features": {
                         **{
-                            k: v
+                            f"target:{k}".strip(":"): v
                             for k, v in ran_example.target_observations.items()
-                            if isinstance(k, str)
                         },
                         **ran_example.events,
                         **self._timing_features,

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -15,6 +15,7 @@ import contextlib
 import datetime
 import inspect
 import io
+import math
 import sys
 import time
 import types
@@ -605,6 +606,7 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs, original_s
                     data=empty_data,
                     how_generated="explicit example",
                     string_repr=state._string_repr,
+                    timing=state._timing_features,
                 )
                 deliver_json_blob(tc)
 
@@ -816,34 +818,30 @@ class StateForActualGivenExecution:
 
         self._string_repr = ""
         text_repr = None
-        if self.settings.deadline is None:
+        if self.settings.deadline is None and not TESTCASE_CALLBACKS:
             test = self.test
         else:
 
             @proxies(self.test)
             def test(*args, **kwargs):
-                arg_drawtime = sum(data.draw_times)
-                initial_draws = len(data.draw_times)
+                arg_drawtime = math.fsum(data.draw_times.values())
                 start = time.perf_counter()
                 try:
                     result = self.test(*args, **kwargs)
                 finally:
                     finish = time.perf_counter()
-                    internal_draw_time = sum(data.draw_times[initial_draws:])
-                    runtime = datetime.timedelta(
-                        seconds=finish - start - internal_draw_time
-                    )
+                    in_drawtime = math.fsum(data.draw_times.values()) - arg_drawtime
+                    runtime = datetime.timedelta(seconds=finish - start - in_drawtime)
                     self._timing_features = {
-                        "time_running_test": finish - start - internal_draw_time,
-                        "time_drawing_args": arg_drawtime,
-                        "time_interactive_draws": internal_draw_time,
+                        "execute_test": finish - start - in_drawtime,
+                        **data.draw_times,
                     }
 
-                current_deadline = self.settings.deadline
-                if not is_final:
-                    current_deadline = (current_deadline // 4) * 5
-                if runtime >= current_deadline:
-                    raise DeadlineExceeded(runtime, self.settings.deadline)
+                if (current_deadline := self.settings.deadline) is not None:
+                    if not is_final:
+                        current_deadline = (current_deadline // 4) * 5
+                    if runtime >= current_deadline:
+                        raise DeadlineExceeded(runtime, self.settings.deadline)
                 return result
 
         def run(data):
@@ -854,10 +852,9 @@ class StateForActualGivenExecution:
             args = self.stuff.args
             kwargs = dict(self.stuff.kwargs)
             if example_kwargs is None:
-                a, kw, argslices = context.prep_args_kwargs_from_strategies(
-                    (), self.stuff.given_kwargs
+                kw, argslices = context.prep_args_kwargs_from_strategies(
+                    self.stuff.given_kwargs
                 )
-                assert not a, "strategies all moved to kwargs by now"
             else:
                 kw = example_kwargs
                 argslices = {}
@@ -944,7 +941,7 @@ class StateForActualGivenExecution:
         if expected_failure is not None:
             exception, traceback = expected_failure
             if isinstance(exception, DeadlineExceeded) and (
-                runtime_secs := self._timing_features.get("time_running_test")
+                runtime_secs := self._timing_features.get("execute_test")
             ):
                 report(
                     "Unreliable test timings! On an initial run, this "
@@ -1066,11 +1063,12 @@ class StateForActualGivenExecution:
                     how_generated=f"generated during {phase} phase",
                     string_repr=self._string_repr,
                     arguments={**self._jsonable_arguments, **data._observability_args},
-                    metadata=self._timing_features,
+                    timing=self._timing_features,
+                    metadata={},
                     coverage=tractable_coverage_report(trace) or None,
                 )
                 deliver_json_blob(tc)
-            self._timing_features.clear()
+            self._timing_features = {}
 
     def run_engine(self):
         """Run the test function many times, on database input and generated
@@ -1191,9 +1189,9 @@ class StateForActualGivenExecution:
                             for k, v in ran_example.target_observations.items()
                         },
                         **ran_example.events,
-                        **self._timing_features,
                     },
-                    "coverage": None,  # TODO: expose this?
+                    "timing": self._timing_features,
+                    "coverage": None,  # Not recorded when we're replaying the MFE
                     "metadata": {"traceback": tb},
                 }
                 deliver_json_blob(tc)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1182,6 +1182,7 @@ class StateForActualGivenExecution:
                     "status": "passed" if sys.exc_info()[0] else "failed",
                     "status_reason": str(origin or "unexpected/flaky pass"),
                     "representation": self._string_repr,
+                    "arguments": self._jsonable_arguments,
                     "how_generated": "minimal failing example",
                     "features": {
                         **{

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1429,7 +1429,7 @@ class ConjectureData:
         self.events: Dict[str, Union[str, int, float]] = {}
         self.forced_indices: "Set[int]" = set()
         self.interesting_origin: Optional[InterestingOrigin] = None
-        self.draw_times: "List[float]" = []
+        self.draw_times: "Dict[str, float]" = {}
         self.max_depth = 0
         self.has_discards = False
         self.provider = PrimitiveProvider(self)
@@ -1599,7 +1599,12 @@ class ConjectureData:
             value = repr(value)
         self.output += value
 
-    def draw(self, strategy: "SearchStrategy[Ex]", label: Optional[int] = None) -> "Ex":
+    def draw(
+        self,
+        strategy: "SearchStrategy[Ex]",
+        label: Optional[int] = None,
+        observe_as: Optional[str] = None,
+    ) -> "Ex":
         if self.is_find and not strategy.supports_find:
             raise InvalidArgument(
                 f"Cannot use strategy {strategy!r} within a call to find "
@@ -1636,7 +1641,8 @@ class ConjectureData:
                 try:
                     return strategy.do_draw(self)
                 finally:
-                    self.draw_times.append(time.perf_counter() - start_time)
+                    key = observe_as or f"unlabeled_{len(self.draw_times)}"
+                    self.draw_times[key] = time.perf_counter() - start_time
         finally:
             self.stop_example()
 

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -37,6 +37,7 @@ def make_testcase(
     how_generated: str = "unknown",
     string_repr: str = "<unknown>",
     arguments: Optional[dict] = None,
+    timing: Dict[str, float],
     metadata: Optional[dict] = None,
     coverage: Optional[Dict[str, List[int]]] = None,
 ) -> dict:
@@ -65,6 +66,7 @@ def make_testcase(
             },
             **data.events,
         },
+        "timing": timing,
         "metadata": {
             **(metadata or {}),
             "traceback": getattr(data.extra_information, "_expected_traceback", None),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2100,10 +2100,10 @@ class DataObject:
 
     def draw(self, strategy: SearchStrategy[Ex], label: Any = None) -> Ex:
         check_strategy(strategy, "strategy")
-        result = self.conjecture_data.draw(strategy)
         self.count += 1
         printer = RepresentationPrinter(context=current_build_context())
         desc = f"Draw {self.count}{'' if label is None else f' ({label})'}: "
+        result = self.conjecture_data.draw(strategy, observe_as=f"generate:{desc}")
         if TESTCASE_CALLBACKS:
             self.conjecture_data._observability_args[desc] = to_jsonable(result)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -184,5 +184,11 @@ def to_jsonable(obj: object) -> object:
     if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):
         return to_jsonable(obj.model_dump())
 
+    # Hey, might as well try this convention - it works for Pandas!
+    try:
+        return to_jsonable(obj.to_json())  # type: ignore
+    except Exception:
+        pass
+
     # If all else fails, we'll just pretty-print as a string.
     return pretty(obj)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -184,7 +184,7 @@ def to_jsonable(obj: object) -> object:
     if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):
         return to_jsonable(obj.model_dump())
 
-    # Hey, might as well try this convention - it works for Pandas!
+    # Hey, might as well try calling a .to_json() method - it works for Pandas!
     try:
         return to_jsonable(obj.to_json())  # type: ignore
     except Exception:

--- a/hypothesis-python/tests/common/strategies.py
+++ b/hypothesis-python/tests/common/strategies.py
@@ -15,7 +15,7 @@ from hypothesis.strategies._internal import SearchStrategy
 
 class _Slow(SearchStrategy):
     def do_draw(self, data):
-        time.sleep(1.0)
+        time.sleep(1.01)
         data.draw_bytes(2)
         return None
 

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -38,7 +38,7 @@ def capture_observations():
 
 @seed("deterministic so we don't miss some combination of features")
 @example(a=0, x=4, data=None)
-@settings(database=InMemoryExampleDatabase())
+@settings(database=InMemoryExampleDatabase(), deadline=None)
 @given(st.integers(), st.integers(), st.data())
 def do_it_all(a, x, data):
     event(f"{x%2=}")
@@ -65,6 +65,12 @@ def test_observability():
     assert {t["property"] for t in testcases} == {do_it_all.__name__}
     assert len({t["run_start"] for t in testcases}) == 2
     assert {t["status"] for t in testcases} == {"gave_up", "passed", "failed"}
+    for t in testcases:
+        if t["status"] != "gave_up":
+            assert t["timing"]
+            assert ("interactive" in t["arguments"]) == (
+                "generate:interactive" in t["timing"]
+            )
 
 
 def test_assume_has_status_reason():

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -100,7 +100,7 @@ def test_healthcheck_traceback_is_hidden(testdir):
     timeout_token = ": FailedHealthCheck"
     def_line = get_line_num(def_token, result)
     timeout_line = get_line_num(timeout_token, result)
-    assert timeout_line - def_line == 7
+    assert timeout_line - def_line == 9
 
 
 COMPOSITE_IS_NOT_A_TEST = """

--- a/tooling/scripts/ensure-python.sh
+++ b/tooling/scripts/ensure-python.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+if [ -n "${CI:-}" ] ; then echo "::group::Ensure Python" ; fi
+
 set -o errexit
 set -o nounset
 set -x
@@ -23,7 +25,7 @@ source "$HERE/common.sh"
 VERSION="$1"
 TARGET=$(pythonloc "$VERSION")
 
-if [ ! -e "$TARGET/bin/python" ] ; then 
+if [ ! -e "$TARGET/bin/python" ] ; then
     mkdir -p "$BASE"
 
     LOCKFILE="$BASE/.install-lockfile"
@@ -64,3 +66,5 @@ if [ ! -e "$TARGET/bin/python" ] ; then
         sleep $(( ( RANDOM % 10 )  + 1 )).$(( RANDOM % 100 ))s
     done
 fi
+
+if [ -n "${CI:-}" ] ; then echo "::endgroup::" ; fi


### PR DESCRIPTION
Plus a note in the docs inspired by discussion on https://github.com/tyche-pbt/tyche-extension/issues/3.  

Cc @hgoldstein95 for timing metadata per your email.

- [x] Report `generate:{argname}` separately for each argument (and interactive draw).  If we update the too_slow healthcheck message to include observability info (or suggest turning it on), this will fix #434!