### PR TITLE
Various core and test changes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch refactors some internals, continuing our work on supporting alternative backends (:issue:`3086`). There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -30,6 +30,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -87,6 +88,8 @@ InterestingOrigin = Tuple[
     Type[BaseException], str, int, Tuple[Any, ...], Tuple[Tuple[Any, ...], ...]
 ]
 TargetObservations = Dict[Optional[str], Union[int, float]]
+
+T = TypeVar("T")
 
 
 class ExtraInformation:
@@ -1718,6 +1721,11 @@ class ConjectureData:
 
         self.buffer = bytes(self.buffer)
         self.observer.conclude_test(self.status, self.interesting_origin)
+
+    def choice(self, values: Sequence[T], *, forced: Optional[T] = None) -> T:
+        forced_i = None if forced is None else values.index(forced)
+        i = self.draw_integer(0, len(values) - 1, forced=forced_i)
+        return values[i]
 
     def draw_bits(self, n: int, *, forced: Optional[int] = None) -> int:
         """Return an ``n``-bit integer from the underlying source of

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -81,14 +81,6 @@ def check_sample(
     return tuple(values)
 
 
-def choice(
-    data: "ConjectureData", values: Sequence[T], *, forced: Optional[T] = None
-) -> T:
-    forced_i = None if forced is None else values.index(forced)
-    i = data.draw_integer(0, len(values) - 1, forced=forced_i)
-    return values[i]
-
-
 class Sampler:
     """Sampler based on Vose's algorithm for the alias method. See
     http://www.keithschwarz.com/darts-dice-coins/ for a good explanation.
@@ -182,8 +174,8 @@ class Sampler:
             if forced is None
             else next((b, a, a_c) for (b, a, a_c) in self.table if forced in (b, a))
         )
-        base, alternate, alternate_chance = choice(
-            data, self.table, forced=forced_choice
+        base, alternate, alternate_chance = data.choice(
+            self.table, forced=forced_choice
         )
         use_alternate = data.draw_boolean(
             alternate_chance, forced=None if forced is None else forced == alternate

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -586,7 +586,7 @@ class SampledFromStrategy(SearchStrategy):
         # The speculative index didn't work out, but at this point we've built
         # and can choose from the complete list of allowed indices and elements.
         if allowed:
-            i, element = cu.choice(data, allowed)
+            i, element = data.choice(allowed)
             data.draw_integer(0, len(self.elements) - 1, forced=i)
             return element
         # If there are no allowed indices, the filter couldn't be satisfied.

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1078,8 +1078,8 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
 
 def test_does_not_keep_generating_when_multiple_bugs():
     def test(data):
-        if data.draw_integer(0, 2**64 - 1) > 0:
-            data.draw_integer(0, 2**64 - 1)
+        if data.draw_integer(0, 2**20 - 1) > 0:
+            data.draw_integer(0, 2**20 - 1)
             data.mark_interesting()
 
     with deterministic_PRNG():

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -155,7 +155,7 @@ def recur(i, data):
 
 def test_recursion_error_is_not_flaky():
     def tf(data):
-        i = data.draw_bits(16)
+        i = data.draw_integer(0, 2**16 - 1)
         try:
             recur(i, data)
         except RecursionError:
@@ -248,7 +248,7 @@ def test_stops_after_max_examples_when_generating_more_bugs(examples):
     bad = [False, False]
 
     def f(data):
-        seen.append(data.draw_bits(32))
+        seen.append(data.draw_integer(0, 2**32 - 1))
         # Rare, potentially multi-error conditions
         if seen[-1] > 2**31:
             bad[0] = True
@@ -312,7 +312,7 @@ def test_reuse_phase_runs_for_max_examples_if_generation_is_disabled():
         seen = set()
 
         def test(data):
-            seen.add(data.draw_bits(8))
+            seen.add(data.draw_integer(0, 2**8 - 1))
 
         ConjectureRunner(
             test,
@@ -425,7 +425,7 @@ def test_fails_health_check_for_large_base():
 def test_fails_health_check_for_large_non_base():
     @fails_health_check(HealthCheck.data_too_large)
     def _(data):
-        if data.draw_bits(8):
+        if data.draw_integer(0, 2**8 - 1):
             data.draw_bytes(10**6)
 
 
@@ -471,7 +471,7 @@ def test_debug_data(capsys):
 
     def f(data):
         for x in bytes(buf):
-            if data.draw_bits(8) != x:
+            if data.draw_integer(0, 2**8 - 1) != x:
                 data.mark_invalid()
             data.start_example(1)
             data.stop_example()
@@ -498,7 +498,7 @@ def test_can_write_bytes_towards_the_end():
     buf = b"\1\2\3"
 
     def f(data):
-        if data.draw_bits(1):
+        if data.draw_boolean():
             data.draw_bytes(5)
             data.write(bytes(buf))
             assert bytes(data.buffer[-len(buf) :]) == buf
@@ -512,7 +512,7 @@ def test_uniqueness_is_preserved_when_writing_at_beginning():
 
     def f(data):
         data.write(bytes(1))
-        n = data.draw_bits(3)
+        n = data.draw_integer(0, 2**3 - 1)
         assert n not in seen
         seen.add(n)
 
@@ -537,7 +537,7 @@ def test_clears_out_its_database_on_shrinking(
     db = InMemoryExampleDatabase()
 
     def f(data):
-        if data.draw_bits(8) >= 127:
+        if data.draw_integer(0, 2**8 - 1) >= 127:
             data.mark_interesting()
 
     runner = ConjectureRunner(
@@ -584,7 +584,7 @@ def test_shrinks_both_interesting_examples(monkeypatch):
     )
 
     def f(data):
-        n = data.draw_bits(8)
+        n = data.draw_integer(0, 2**8 - 1)
         data.mark_interesting(n & 1)
 
     runner = ConjectureRunner(f, database_key=b"key")
@@ -606,7 +606,7 @@ def test_discarding(monkeypatch):
         count = 0
         while count < 10:
             data.start_example(SOME_LABEL)
-            b = data.draw_bits(1)
+            b = data.draw_boolean()
             if b:
                 count += 1
             data.stop_example(discard=not b)
@@ -620,7 +620,7 @@ def test_can_remove_discarded_data():
     def shrinker(data):
         while True:
             data.start_example(SOME_LABEL)
-            b = data.draw_bits(8)
+            b = data.draw_integer(0, 2**8 - 1)
             data.stop_example(discard=(b == 0))
             if b == 11:
                 break
@@ -634,9 +634,9 @@ def test_discarding_iterates_to_fixed_point():
     @shrinking_from(bytes(list(range(100, -1, -1))))
     def shrinker(data):
         data.start_example(0)
-        data.draw_bits(8)
+        data.draw_integer(0, 2**8 - 1)
         data.stop_example(discard=True)
-        while data.draw_bits(8):
+        while data.draw_integer(0, 2**8 - 1):
             pass
         data.mark_interesting()
 
@@ -647,10 +647,10 @@ def test_discarding_iterates_to_fixed_point():
 def test_discarding_is_not_fooled_by_empty_discards():
     @shrinking_from(bytes([1, 1]))
     def shrinker(data):
-        data.draw_bits(1)
+        data.draw_integer(0, 2**1 - 1)
         data.start_example(0)
         data.stop_example(discard=True)
-        data.draw_bits(1)
+        data.draw_integer(0, 2**1 - 1)
         data.mark_interesting()
 
     shrinker.remove_discarded()
@@ -661,7 +661,7 @@ def test_discarding_can_fail(monkeypatch):
     @shrinking_from(bytes([1]))
     def shrinker(data):
         data.start_example(0)
-        data.draw_bits(1)
+        data.draw_boolean()
         data.stop_example(discard=True)
         data.mark_interesting()
 
@@ -678,7 +678,7 @@ def test_shrinking_from_mostly_zero(monkeypatch):
 
     @run_to_buffer
     def x(data):
-        s = [data.draw_bits(8) for _ in range(6)]
+        s = [data.draw_integer(0, 2**8 - 1) for _ in range(6)]
         if any(s):
             data.mark_interesting()
 
@@ -697,9 +697,9 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
     def x(data):
         while True:
             data.start_example(SOME_LABEL)
-            succeeded = data.draw_bits(1)
+            succeeded = data.draw_boolean()
             data.start_example(SOME_LABEL)
-            data.draw_bits(1)
+            data.draw_boolean()
             data.stop_example(discard=not succeeded)
             data.stop_example(discard=not succeeded)
             if succeeded:
@@ -713,7 +713,7 @@ def test_database_clears_secondary_key():
     database = InMemoryExampleDatabase()
 
     def f(data):
-        if data.draw_bits(8) == 10:
+        if data.draw_integer(0, 2**8 - 1) == 10:
             data.mark_interesting()
         else:
             data.mark_invalid()
@@ -746,7 +746,7 @@ def test_database_uses_values_from_secondary_key():
     database = InMemoryExampleDatabase()
 
     def f(data):
-        if data.draw_bits(8) >= 5:
+        if data.draw_integer(0, 2**8 - 1) >= 5:
             data.mark_interesting()
         else:
             data.mark_invalid()
@@ -782,7 +782,7 @@ def test_database_uses_values_from_secondary_key():
 
 def test_exit_because_max_iterations():
     def f(data):
-        data.draw_bits(64)
+        data.draw_integer(0, 2**64 - 1)
         data.mark_invalid()
 
     runner = ConjectureRunner(
@@ -806,7 +806,7 @@ def test_exit_because_shrink_phase_timeout(monkeypatch):
         return val[0]
 
     def f(data):
-        if data.draw_bits(64) > 2**33:
+        if data.draw_integer(0, 2**64 - 1) > 2**33:
             data.mark_interesting()
 
     monkeypatch.setattr(time, "perf_counter", fast_time)
@@ -819,10 +819,10 @@ def test_exit_because_shrink_phase_timeout(monkeypatch):
 def test_dependent_block_pairs_can_lower_to_zero():
     @shrinking_from([1, 0, 1])
     def shrinker(data):
-        if data.draw_bits(1):
-            n = data.draw_bits(16)
+        if data.draw_boolean():
+            n = data.draw_integer(0, 2**16 - 1)
         else:
-            n = data.draw_bits(8)
+            n = data.draw_integer(0, 2**8 - 1)
 
         if n == 1:
             data.mark_interesting()
@@ -834,11 +834,11 @@ def test_dependent_block_pairs_can_lower_to_zero():
 def test_handle_size_too_large_during_dependent_lowering():
     @shrinking_from([1, 255, 0])
     def shrinker(data):
-        if data.draw_bits(1):
-            data.draw_bits(16)
+        if data.draw_boolean():
+            data.draw_integer(0, 2**16 - 1)
             data.mark_interesting()
         else:
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
 
     shrinker.fixate_shrink_passes(["minimize_individual_blocks"])
 
@@ -848,12 +848,12 @@ def test_block_may_grow_during_lexical_shrinking():
 
     @shrinking_from(initial)
     def shrinker(data):
-        n = data.draw_bits(8)
+        n = data.draw_integer(0, 2**8 - 1)
         if n == 2:
-            data.draw_bits(8)
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
+            data.draw_integer(0, 2**8 - 1)
         else:
-            data.draw_bits(16)
+            data.draw_integer(0, 2**16 - 1)
         data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_individual_blocks"])
@@ -863,10 +863,10 @@ def test_block_may_grow_during_lexical_shrinking():
 def test_lower_common_block_offset_does_nothing_when_changed_blocks_are_zero():
     @shrinking_from([1, 0, 1, 0])
     def shrinker(data):
-        data.draw_bits(1)
-        data.draw_bits(1)
-        data.draw_bits(1)
-        data.draw_bits(1)
+        data.draw_boolean()
+        data.draw_boolean()
+        data.draw_boolean()
+        data.draw_boolean()
         data.mark_interesting()
 
     shrinker.mark_changed(1)
@@ -878,9 +878,9 @@ def test_lower_common_block_offset_does_nothing_when_changed_blocks_are_zero():
 def test_lower_common_block_offset_ignores_zeros():
     @shrinking_from([2, 2, 0])
     def shrinker(data):
-        n = data.draw_bits(8)
-        data.draw_bits(8)
-        data.draw_bits(8)
+        n = data.draw_integer(0, 2**8 - 1)
+        data.draw_integer(0, 2**8 - 1)
+        data.draw_integer(0, 2**8 - 1)
         if n > 0:
             data.mark_interesting()
 
@@ -893,13 +893,13 @@ def test_lower_common_block_offset_ignores_zeros():
 def test_pandas_hack():
     @shrinking_from([2, 1, 1, 7])
     def shrinker(data):
-        n = data.draw_bits(8)
-        m = data.draw_bits(8)
+        n = data.draw_integer(0, 2**8 - 1)
+        m = data.draw_integer(0, 2**8 - 1)
         if n == 1:
             if m == 7:
                 data.mark_interesting()
-        data.draw_bits(8)
-        if data.draw_bits(8) == 7:
+        data.draw_integer(0, 2**8 - 1)
+        if data.draw_integer(0, 2**8 - 1) == 7:
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes([block_program("-XX")])
@@ -911,7 +911,7 @@ def test_cached_test_function_returns_right_value():
 
     def tf(data):
         count[0] += 1
-        data.draw_bits(2)
+        data.draw_integer(0, 3)
         data.mark_interesting()
 
     with deterministic_PRNG():
@@ -929,9 +929,9 @@ def test_cached_test_function_does_not_reinvoke_on_prefix():
 
     def test_function(data):
         call_count[0] += 1
-        data.draw_bits(8)
+        data.draw_integer(0, 2**8 - 1)
         data.write(bytes([7]))
-        data.draw_bits(8)
+        data.draw_integer(0, 2**8 - 1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test_function, settings=TEST_SETTINGS)
@@ -969,11 +969,11 @@ def test_branch_ending_in_write():
 
     def tf(data):
         count = 0
-        while data.draw_bits(1):
+        while data.draw_boolean():
             count += 1
 
         if count > 1:
-            data.draw_bits(1, forced=0)
+            data.draw_boolean(forced=False)
 
         b = bytes(data.buffer)
         assert b not in seen
@@ -993,7 +993,7 @@ def test_branch_ending_in_write():
 def test_exhaust_space():
     with deterministic_PRNG():
         runner = ConjectureRunner(
-            lambda data: data.draw_bits(1), settings=TEST_SETTINGS
+            lambda data: data.draw_boolean(), settings=TEST_SETTINGS
         )
         runner.run()
         assert runner.tree.is_exhausted
@@ -1012,7 +1012,7 @@ def test_discards_kill_branches():
             assert runner.call_count <= 256
             while True:
                 data.start_example(1)
-                b = data.draw_bits(8)
+                b = data.draw_integer(0, 2**8 - 1)
                 data.stop_example(discard=b != 0)
                 if len(data.buffer) == 1:
                     s = bytes(data.buffer)
@@ -1045,7 +1045,7 @@ def test_prefix_cannot_exceed_buffer_size(monkeypatch):
     with deterministic_PRNG():
 
         def test(data):
-            while data.draw_bits(1):
+            while data.draw_boolean():
                 assert len(data.buffer) <= buffer_size
             assert len(data.buffer) <= buffer_size
 
@@ -1056,8 +1056,8 @@ def test_prefix_cannot_exceed_buffer_size(monkeypatch):
 
 def test_does_not_shrink_multiple_bugs_when_told_not_to():
     def test(data):
-        m = data.draw_bits(8)
-        n = data.draw_bits(8)
+        m = data.draw_integer(0, 2**8 - 1)
+        n = data.draw_integer(0, 2**8 - 1)
 
         if m > 0:
             data.mark_interesting(1)
@@ -1078,8 +1078,8 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
 
 def test_does_not_keep_generating_when_multiple_bugs():
     def test(data):
-        if data.draw_bits(64) > 0:
-            data.draw_bits(64)
+        if data.draw_integer(0, 2**64 - 1) > 0:
+            data.draw_integer(0, 2**64 - 1)
             data.mark_interesting()
 
     with deterministic_PRNG():
@@ -1110,7 +1110,7 @@ def test_shrink_after_max_examples():
         if bad:
             post_failure_calls[0] += 1
 
-        value = data.draw_bits(8)
+        value = data.draw_integer(0, 2**8 - 1)
 
         if value in seen and value not in bad:
             return
@@ -1167,7 +1167,7 @@ def test_shrink_after_max_iterations():
         if bad:
             post_failure_calls[0] += 1
 
-        value = data.draw_bits(16)
+        value = data.draw_integer(0, 2**16 - 1)
 
         if value in invalid:
             data.mark_invalid()
@@ -1212,7 +1212,7 @@ def test_populates_the_pareto_front():
     with deterministic_PRNG():
 
         def test(data):
-            data.target_observations[""] = data.draw_bits(4)
+            data.target_observations[""] = data.draw_integer(0, 2**4 - 1)
 
         runner = ConjectureRunner(
             test,
@@ -1233,7 +1233,7 @@ def test_pareto_front_contains_smallest_valid_when_not_targeting():
     with deterministic_PRNG():
 
         def test(data):
-            data.draw_bits(4)
+            data.draw_integer(0, 2**4 - 1)
 
         runner = ConjectureRunner(
             test,
@@ -1254,7 +1254,7 @@ def test_pareto_front_contains_different_interesting_reasons():
     with deterministic_PRNG():
 
         def test(data):
-            data.mark_interesting(data.draw_bits(4))
+            data.mark_interesting(data.draw_integer(0, 2**4 - 1))
 
         runner = ConjectureRunner(
             test,
@@ -1275,8 +1275,8 @@ def test_clears_defunct_pareto_front():
     with deterministic_PRNG():
 
         def test(data):
-            data.draw_bits(8)
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
+            data.draw_integer(0, 2**8 - 1)
 
         db = InMemoryExampleDatabase()
 
@@ -1301,8 +1301,8 @@ def test_clears_defunct_pareto_front():
 
 def test_replaces_all_dominated():
     def test(data):
-        data.target_observations["m"] = 3 - data.draw_bits(2)
-        data.target_observations["n"] = 3 - data.draw_bits(2)
+        data.target_observations["m"] = 3 - data.draw_integer(0, 3)
+        data.target_observations["n"] = 3 - data.draw_integer(0, 3)
 
     runner = ConjectureRunner(
         test,
@@ -1326,7 +1326,7 @@ def test_replaces_all_dominated():
 
 def test_does_not_duplicate_elements():
     def test(data):
-        data.target_observations["m"] = data.draw_bits(8)
+        data.target_observations["m"] = data.draw_integer(0, 2**8 - 1)
 
     runner = ConjectureRunner(
         test,
@@ -1350,7 +1350,7 @@ def test_does_not_duplicate_elements():
 
 def test_includes_right_hand_side_targets_in_dominance():
     def test(data):
-        if data.draw_bits(8):
+        if data.draw_integer(0, 2**8 - 1):
             data.target_observations[""] = 10
 
     runner = ConjectureRunner(
@@ -1367,7 +1367,7 @@ def test_includes_right_hand_side_targets_in_dominance():
 
 def test_smaller_interesting_dominates_larger_valid():
     def test(data):
-        if data.draw_bits(8) == 0:
+        if data.draw_integer(0, 2**8 - 1) == 0:
             data.mark_interesting()
 
     runner = ConjectureRunner(
@@ -1383,7 +1383,7 @@ def test_smaller_interesting_dominates_larger_valid():
 
 def test_runs_full_set_of_examples():
     def test(data):
-        data.draw_bits(64)
+        data.draw_integer(0, 2**64 - 1)
 
     runner = ConjectureRunner(
         test,
@@ -1397,7 +1397,7 @@ def test_runs_full_set_of_examples():
 
 def test_runs_optimisation_even_if_not_generating():
     def test(data):
-        data.target_observations["n"] = data.draw_bits(16)
+        data.target_observations["n"] = data.draw_integer(0, 2**16 - 1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(
@@ -1413,7 +1413,7 @@ def test_runs_optimisation_even_if_not_generating():
 
 def test_runs_optimisation_once_when_generating():
     def test(data):
-        data.target_observations["n"] = data.draw_bits(16)
+        data.target_observations["n"] = data.draw_integer(0, 2**16 - 1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(
@@ -1430,7 +1430,7 @@ def test_runs_optimisation_once_when_generating():
 
 def test_does_not_run_optimisation_when_max_examples_is_small():
     def test(data):
-        data.target_observations["n"] = data.draw_bits(16)
+        data.target_observations["n"] = data.draw_integer(0, 2**16 - 1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(
@@ -1447,7 +1447,7 @@ def test_does_not_run_optimisation_when_max_examples_is_small():
 
 def test_does_not_cache_extended_prefix():
     def test(data):
-        data.draw_bits(64)
+        data.draw_bytes(8)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -1464,7 +1464,7 @@ def test_does_cache_if_extend_is_not_used():
 
     def test(data):
         calls[0] += 1
-        data.draw_bits(8)
+        data.draw_bytes(1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -1481,7 +1481,7 @@ def test_does_result_for_reuse():
 
     def test(data):
         calls[0] += 1
-        data.draw_bits(8)
+        data.draw_bytes(1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -1495,7 +1495,7 @@ def test_does_result_for_reuse():
 
 def test_does_not_cache_overrun_if_extending():
     def test(data):
-        data.draw_bits(64)
+        data.draw_bytes(8)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -1508,8 +1508,8 @@ def test_does_not_cache_overrun_if_extending():
 
 def test_does_cache_overrun_if_not_extending():
     def test(data):
-        data.draw_bits(64)
-        data.draw_bits(64)
+        data.draw_bytes(8)
+        data.draw_bytes(8)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -1522,7 +1522,7 @@ def test_does_cache_overrun_if_not_extending():
 
 def test_does_not_cache_extended_prefix_if_overrun():
     def test(data):
-        data.draw_bits(64)
+        data.draw_bytes(8)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -1535,7 +1535,7 @@ def test_does_not_cache_extended_prefix_if_overrun():
 
 def test_can_be_set_to_ignore_limits():
     def test(data):
-        data.draw_bits(8)
+        data.draw_bytes(1)
 
     with deterministic_PRNG():
         runner = ConjectureRunner(

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1271,46 +1271,6 @@ def test_pareto_front_contains_different_interesting_reasons():
         assert len(runner.pareto_front) == 2**4
 
 
-def test_database_contains_only_pareto_front():
-    with deterministic_PRNG():
-
-        def test(data):
-            data.target_observations["1"] = data.draw_bits(4)
-            data.draw_bits(64)
-            data.target_observations["2"] = data.draw_bits(8)
-
-        db = InMemoryExampleDatabase()
-
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=500, database=db, suppress_health_check=list(HealthCheck)
-            ),
-            database_key=b"stuff",
-        )
-
-        runner.run()
-
-        assert len(runner.pareto_front) <= 500
-
-        for v in runner.pareto_front:
-            assert v.status >= Status.VALID
-
-        assert len(db.data) == 1
-
-        (values,) = db.data.values()
-        values = set(values)
-
-        assert len(values) == len(runner.pareto_front)
-
-        for data in runner.pareto_front:
-            assert data.buffer in values
-            assert data in runner.pareto_front
-
-        for k in values:
-            assert runner.cached_test_function(k) in runner.pareto_front
-
-
 def test_clears_defunct_pareto_front():
     with deterministic_PRNG():
 

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -63,29 +63,6 @@ def test_double_reverse(i):
     assert flt.reverse64(j) == i
 
 
-@example(1.25)
-@example(1.0)
-@given(st.floats())
-def test_draw_write_round_trip(f):
-    d = ConjectureData.for_buffer(bytes(10))
-    pp = PrimitiveProvider(d)
-    pp._write_float(f)
-
-    d2 = ConjectureData.for_buffer(d.buffer)
-    pp2 = PrimitiveProvider(d2)
-    g = pp2._draw_float()
-
-    if f == f:
-        assert f == g
-
-    assert float_to_int(f) == float_to_int(g)
-
-    d3 = ConjectureData.for_buffer(d2.buffer)
-    pp3 = PrimitiveProvider(d3)
-    pp3._draw_float()
-    assert d3.buffer == d2.buffer
-
-
 @example(0.0)
 @example(2.5)
 @example(8.000000000000007)

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -23,7 +23,7 @@ def test_optimises_to_maximum():
     with deterministic_PRNG():
 
         def test(data):
-            data.target_observations["m"] = data.draw_bits(8)
+            data.target_observations["m"] = data.draw_integer(0, 2**8 - 1)
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
         runner.cached_test_function([0])
@@ -40,8 +40,8 @@ def test_optimises_multiple_targets():
     with deterministic_PRNG():
 
         def test(data):
-            n = data.draw_bits(8)
-            m = data.draw_bits(8)
+            n = data.draw_integer(0, 2**8 - 1)
+            m = data.draw_integer(0, 2**8 - 1)
             if n + m > 256:
                 data.mark_invalid()
             data.target_observations["m"] = m
@@ -66,7 +66,7 @@ def test_optimises_when_last_element_is_empty():
     with deterministic_PRNG():
 
         def test(data):
-            data.target_observations["n"] = data.draw_bits(8)
+            data.target_observations["n"] = data.draw_integer(0, 2**8 - 1)
             data.start_example(label=1)
             data.stop_example()
 
@@ -86,8 +86,8 @@ def test_can_optimise_last_with_following_empty():
 
         def test(data):
             for _ in range(100):
-                data.draw_bits(2)
-            data.target_observations[""] = data.draw_bits(8)
+                data.draw_integer(0, 3)
+            data.target_observations[""] = data.draw_integer(0, 2**8 - 1)
             data.start_example(1)
             data.stop_example()
 
@@ -107,7 +107,7 @@ def test_can_find_endpoints_of_a_range(lower, upper, score_up):
     with deterministic_PRNG():
 
         def test(data):
-            n = data.draw_bits(16)
+            n = data.draw_integer(0, 2**16 - 1)
             if n < lower or n > upper:
                 data.mark_invalid()
             if not score_up:
@@ -134,7 +134,10 @@ def test_targeting_can_drive_length_very_high():
 
         def test(data):
             count = 0
-            while data.draw_bits(2) == 3:
+            # TODO this test fails with data.draw_boolean(0.25). Does the hill
+            # climbing optimizer just not like the bit representation of boolean
+            # draws, or do we have a deeper bug here?
+            while data.draw_integer(0, 3) == 3:
                 count += 1
             data.target_observations[""] = min(count, 100)
 
@@ -153,10 +156,10 @@ def test_optimiser_when_test_grows_buffer_to_invalid():
     with deterministic_PRNG():
 
         def test(data):
-            m = data.draw_bits(8)
+            m = data.draw_integer(0, 2**8 - 1)
             data.target_observations["m"] = m
             if m > 100:
-                data.draw_bits(16)
+                data.draw_integer(0, 2**16 - 1)
                 data.mark_invalid()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -175,13 +178,13 @@ def test_can_patch_up_examples():
 
         def test(data):
             data.start_example(42)
-            m = data.draw_bits(6)
+            m = data.draw_integer(0, 2**6 - 1)
             data.target_observations["m"] = m
             for _ in range(m):
-                data.draw_bits(1)
+                data.draw_boolean()
             data.stop_example()
             for i in range(4):
-                if i != data.draw_bits(8):
+                if i != data.draw_integer(0, 2**8 - 1):
                     data.mark_invalid()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
@@ -201,10 +204,10 @@ def test_optimiser_when_test_grows_buffer_to_overflow():
         with buffer_size_limit(2):
 
             def test(data):
-                m = data.draw_bits(8)
+                m = data.draw_integer(0, 2**8 - 1)
                 data.target_observations["m"] = m
                 if m > 100:
-                    data.draw_bits(64)
+                    data.draw_integer(0, 2**64 - 1)
                     data.mark_invalid()
 
             runner = ConjectureRunner(test, settings=TEST_SETTINGS)

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -22,7 +22,7 @@ def test_pareto_front_contains_different_interesting_reasons():
     with deterministic_PRNG():
 
         def test(data):
-            data.mark_interesting(data.draw_bits(4))
+            data.mark_interesting(data.draw_integer(0, 2**4 - 1))
 
         runner = ConjectureRunner(
             test,
@@ -43,9 +43,9 @@ def test_database_contains_only_pareto_front():
     with deterministic_PRNG():
 
         def test(data):
-            data.target_observations["1"] = data.draw_bits(4)
-            data.draw_bits(64)
-            data.target_observations["2"] = data.draw_bits(8)
+            data.target_observations["1"] = data.draw_integer(0, 2**4 - 1)
+            data.draw_integer(0, 2**64 - 1)
+            data.target_observations["2"] = data.draw_integer(0, 2**8 - 1)
 
         db = InMemoryExampleDatabase()
 
@@ -83,8 +83,8 @@ def test_clears_defunct_pareto_front():
     with deterministic_PRNG():
 
         def test(data):
-            data.draw_bits(8)
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
+            data.draw_integer(0, 2**8 - 1)
 
         db = InMemoryExampleDatabase()
 
@@ -111,8 +111,8 @@ def test_down_samples_the_pareto_front():
     with deterministic_PRNG():
 
         def test(data):
-            data.draw_bits(8)
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
+            data.draw_integer(0, 2**8 - 1)
 
         db = InMemoryExampleDatabase()
 
@@ -140,8 +140,8 @@ def test_stops_loading_pareto_front_if_interesting():
     with deterministic_PRNG():
 
         def test(data):
-            data.draw_bits(8)
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
+            data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
 
         db = InMemoryExampleDatabase()
@@ -169,9 +169,9 @@ def test_uses_tags_in_calculating_pareto_front():
     with deterministic_PRNG():
 
         def test(data):
-            if data.draw_bits(1):
+            if data.draw_boolean():
                 data.start_example(11)
-                data.draw_bits(8)
+                data.draw_integer(0, 2**8 - 1)
                 data.stop_example()
 
         runner = ConjectureRunner(
@@ -188,7 +188,7 @@ def test_uses_tags_in_calculating_pareto_front():
 def test_optimises_the_pareto_front():
     def test(data):
         count = 0
-        while data.draw_bits(8):
+        while data.draw_integer(0, 2**8 - 1):
             count += 1
 
         data.target_observations[""] = min(count, 5)
@@ -210,7 +210,7 @@ def test_optimises_the_pareto_front():
 
 def test_does_not_optimise_the_pareto_front_if_interesting():
     def test(data):
-        n = data.draw_bits(8)
+        n = data.draw_integer(0, 2**8 - 1)
         data.target_observations[""] = n
         if n == 255:
             data.mark_interesting()
@@ -234,7 +234,7 @@ def test_stops_optimising_once_interesting():
     hi = 2**16 - 1
 
     def test(data):
-        n = data.draw_bits(16)
+        n = data.draw_integer(0, 2**16 - 1)
         data.target_observations[""] = n
         if n < hi:
             data.mark_interesting()

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -275,10 +275,10 @@ def test_dependent_block_pairs_is_up_to_shrinking_integers():
     @shrinking_from(b"\x03\x01\x00\x00\x00\x00\x00\x01\x00\x02\x01")
     def shrinker(data):
         size = sizes[distribution.sample(data)]
-        result = data.draw_integer(0, 2**size - 1)
+        result = data.draw_bits(size)
         sign = (-1) ** (result & 1)
         result = (result >> 1) * sign
-        cap = data.draw_integer(0, 2**8 - 1)
+        cap = data.draw_bits(8)
 
         if result >= 32768 and cap == 1:
             data.mark_interesting()

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -12,9 +12,6 @@ import time
 
 import pytest
 
-from hypothesis.internal.compat import int_to_bytes
-from hypothesis.internal.conjecture import floats as flt
-from hypothesis.internal.conjecture.data import PrimitiveProvider
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import (
     Shrinker,
@@ -22,18 +19,17 @@ from hypothesis.internal.conjecture.shrinker import (
     StopShrinking,
     block_program,
 )
-from hypothesis.internal.conjecture.shrinking import Float
 from hypothesis.internal.conjecture.utils import Sampler
 
 from tests.conjecture.common import SOME_LABEL, run_to_buffer, shrinking_from
 
 
 @pytest.mark.parametrize("n", [1, 5, 8, 15])
-def test_can_shrink_variable_draws_with_just_deletion(n, monkeypatch):
+def test_can_shrink_variable_draws_with_just_deletion(n):
     @shrinking_from([n] + [0] * (n - 1) + [1])
     def shrinker(data):
-        n = data.draw_bits(4)
-        b = [data.draw_bits(8) for _ in range(n)]
+        n = data.draw_integer(0, 2**4 - 1)
+        b = [data.draw_integer(0, 2**8 - 1) for _ in range(n)]
         if any(b):
             data.mark_interesting()
 
@@ -64,10 +60,20 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
 
 
 def test_duplicate_blocks_that_go_away():
-    @shrinking_from([1, 1, 1, 2] * 2 + [5] * 2)
+    # careful not to go over 24 bits (> 2**24), which triggers a more complicated
+    # interpretation of the buffer in draw_integer due to size sampling.
+    @run_to_buffer
+    def base_buf(data):
+        x = data.draw_integer(0, 2**24 - 1, forced=1234567)
+        y = data.draw_integer(0, 2**24 - 1, forced=1234567)
+        for _ in range(x & 255):
+            data.draw_bytes(1)
+        data.mark_interesting()
+
+    @shrinking_from(base_buf)
     def shrinker(data):
-        x = data.draw_bits(32)
-        y = data.draw_bits(32)
+        x = data.draw_integer(0, 2**24 - 1)
+        y = data.draw_integer(0, 2**24 - 1)
         if x != y:
             data.mark_invalid()
         b = [data.draw_bytes(1) for _ in range(x & 255)]
@@ -75,14 +81,16 @@ def test_duplicate_blocks_that_go_away():
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_duplicated_blocks"])
-    assert shrinker.shrink_target.buffer == bytes(8)
+    # 24 bits for each integer = (24 * 2) / 8 = 6 bytes, which should all get
+    # reduced to 0.
+    assert shrinker.shrink_target.buffer == bytes(6)
 
 
-def test_accidental_duplication(monkeypatch):
+def test_accidental_duplication():
     @shrinking_from([18] * 20)
     def shrinker(data):
-        x = data.draw_bits(8)
-        y = data.draw_bits(8)
+        x = data.draw_integer(0, 2**8 - 1)
+        y = data.draw_integer(0, 2**8 - 1)
         if x != y:
             data.mark_invalid()
         if x < 5:
@@ -95,15 +103,15 @@ def test_accidental_duplication(monkeypatch):
     assert list(shrinker.buffer) == [5] * 7
 
 
-def test_can_zero_subintervals(monkeypatch):
+def test_can_zero_subintervals():
     @shrinking_from(bytes([3, 0, 0, 0, 1]) * 10)
     def shrinker(data):
         for _ in range(10):
             data.start_example(SOME_LABEL)
-            n = data.draw_bits(8)
+            n = data.draw_integer(0, 2**8 - 1)
             data.draw_bytes(n)
             data.stop_example()
-            if data.draw_bits(8) != 1:
+            if data.draw_integer(0, 2**8 - 1) != 1:
                 return
         data.mark_interesting()
 
@@ -111,11 +119,11 @@ def test_can_zero_subintervals(monkeypatch):
     assert list(shrinker.buffer) == [0, 1] * 10
 
 
-def test_can_pass_to_an_indirect_descendant(monkeypatch):
+def test_can_pass_to_an_indirect_descendant():
     def tree(data):
         data.start_example(label=1)
-        n = data.draw_bits(1)
-        data.draw_bits(8)
+        n = data.draw_integer(0, 1)
+        data.draw_integer(0, 2**8 - 1)
         if n:
             tree(data)
             tree(data)
@@ -151,8 +159,8 @@ def shrink(buffer, *passes):
 def test_shrinking_blocks_from_common_offset():
     @shrinking_from([11, 10])
     def shrinker(data):
-        m = data.draw_bits(8)
-        n = data.draw_bits(8)
+        m = data.draw_integer(0, 2**8 - 1)
+        n = data.draw_integer(0, 2**8 - 1)
         if abs(m - n) <= 1 and max(m, n) > 0:
             data.mark_interesting()
 
@@ -170,7 +178,7 @@ def test_handle_empty_draws():
     def x(data):
         while True:
             data.start_example(SOME_LABEL)
-            n = data.draw_bits(1)
+            n = data.draw_integer(0, 1)
             data.start_example(SOME_LABEL)
             data.stop_example()
             data.stop_example(discard=n > 0)
@@ -187,8 +195,8 @@ def test_can_reorder_examples():
         total = 0
         for _ in range(5):
             data.start_example(label=0)
-            if data.draw_bits(8):
-                total += data.draw_bits(9)
+            if data.draw_integer(0, 2**8 - 1):
+                total += data.draw_integer(0, 2**9 - 1)
             data.stop_example()
         if total == 2:
             data.mark_interesting()
@@ -211,19 +219,19 @@ def test_permits_but_ignores_raising_order(monkeypatch):
 
     @run_to_buffer
     def x(data):
-        data.draw_bits(2)
+        data.draw_integer(0, 3)
         data.mark_interesting()
 
     assert list(x) == [1]
 
 
-def test_block_deletion_can_delete_short_ranges(monkeypatch):
+def test_block_deletion_can_delete_short_ranges():
     @shrinking_from([v for i in range(5) for _ in range(i + 1) for v in [0, i]])
     def shrinker(data):
         while True:
-            n = data.draw_bits(16)
+            n = data.draw_integer(0, 2**16 - 1)
             for _ in range(n):
-                if data.draw_bits(16) != n:
+                if data.draw_integer(0, 2**16 - 1) != n:
                     data.mark_invalid()
             if n == 4:
                 data.mark_interesting()
@@ -247,11 +255,11 @@ def test_try_shrinking_blocks_ignores_overrun_blocks(monkeypatch):
 
     @run_to_buffer
     def x(data):
-        n1 = data.draw_bits(8)
-        data.draw_bits(8)
+        n1 = data.draw_integer(0, 2**8 - 1)
+        data.draw_integer(0, 2**8 - 1)
         if n1 == 3:
-            data.draw_bits(8)
-        k = data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
+        k = data.draw_integer(0, 2**8 - 1)
         if k == 1:
             data.mark_interesting()
 
@@ -267,10 +275,10 @@ def test_dependent_block_pairs_is_up_to_shrinking_integers():
     @shrinking_from(b"\x03\x01\x00\x00\x00\x00\x00\x01\x00\x02\x01")
     def shrinker(data):
         size = sizes[distribution.sample(data)]
-        result = data.draw_bits(size)
+        result = data.draw_integer(0, 2**size - 1)
         sign = (-1) ** (result & 1)
         result = (result >> 1) * sign
-        cap = data.draw_bits(8)
+        cap = data.draw_integer(0, 2**8 - 1)
 
         if result >= 32768 and cap == 1:
             data.mark_interesting()
@@ -287,8 +295,7 @@ def test_finding_a_minimal_balanced_binary_tree():
     def tree(data):
         # Returns height of a binary tree and whether it is height balanced.
         data.start_example(label=0)
-        n = data.draw_bits(1)
-        if n == 0:
+        if not data.draw_boolean():
             result = (1, True)
         else:
             h1, b1 = tree(data)
@@ -309,16 +316,15 @@ def test_finding_a_minimal_balanced_binary_tree():
     assert list(shrinker.shrink_target.buffer) == [1, 0, 1, 0, 1, 0, 0]
 
 
-def test_float_shrink_can_run_when_canonicalisation_does_not_work(monkeypatch):
-    # This should be an error when called
-    monkeypatch.setattr(Float, "shrink", None)
-
-    base_buf = bytes(1) + int_to_bytes(flt.base_float_to_lex(1000.0), 8)
+def test_float_shrink_can_run_when_canonicalisation_does_not_work():
+    @run_to_buffer
+    def base_buf(data):
+        data.draw_float(forced=1000.0)
+        data.mark_interesting()
 
     @shrinking_from(base_buf)
     def shrinker(data):
-        pp = PrimitiveProvider(data)
-        pp._draw_float()
+        data.draw_float()
         if bytes(data.buffer) == base_buf:
             data.mark_interesting()
 
@@ -330,7 +336,7 @@ def test_float_shrink_can_run_when_canonicalisation_does_not_work(monkeypatch):
 def test_try_shrinking_blocks_out_of_bounds():
     @shrinking_from(bytes([1]))
     def shrinker(data):
-        data.draw_bits(1)
+        data.draw_boolean()
         data.mark_interesting()
 
     assert not shrinker.try_shrinking_blocks((1,), bytes([1]))
@@ -339,7 +345,7 @@ def test_try_shrinking_blocks_out_of_bounds():
 def test_block_programs_are_adaptive():
     @shrinking_from(bytes(1000) + bytes([1]))
     def shrinker(data):
-        while not data.draw_bits(1):
+        while not data.draw_boolean():
             pass
         data.mark_interesting()
 
@@ -355,7 +361,7 @@ def test_zero_examples_with_variable_min_size():
     def shrinker(data):
         any_nonzero = False
         for i in range(1, 10):
-            any_nonzero |= data.draw_bits(i * 8) > 0
+            any_nonzero |= data.draw_integer(0, 2**i - 1) > 0
         if not any_nonzero:
             data.mark_invalid()
         data.mark_interesting()
@@ -369,10 +375,10 @@ def test_zero_contained_examples():
     def shrinker(data):
         for _ in range(4):
             data.start_example(1)
-            if data.draw_bits(8) == 0:
+            if data.draw_integer(0, 2**8 - 1) == 0:
                 data.mark_invalid()
             data.start_example(1)
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
             data.stop_example()
             data.stop_example()
         data.mark_interesting()
@@ -384,8 +390,8 @@ def test_zero_contained_examples():
 def test_zig_zags_quickly():
     @shrinking_from(bytes([255]) * 4)
     def shrinker(data):
-        m = data.draw_bits(16)
-        n = data.draw_bits(16)
+        m = data.draw_integer(0, 2**16 - 1)
+        n = data.draw_integer(0, 2**16 - 1)
         if m == 0 or n == 0:
             data.mark_invalid()
         if abs(m - n) <= 1:
@@ -404,11 +410,14 @@ def test_zero_irregular_examples():
     @shrinking_from([255] * 6)
     def shrinker(data):
         data.start_example(1)
-        data.draw_bits(8)
-        data.draw_bits(16)
+        data.draw_integer(0, 2**8 - 1)
+        data.draw_integer(0, 2**16 - 1)
         data.stop_example()
         data.start_example(1)
-        interesting = data.draw_bits(8) > 0 and data.draw_bits(16) > 0
+        interesting = (
+            data.draw_integer(0, 2**8 - 1) > 0
+            and data.draw_integer(0, 2**16 - 1) > 0
+        )
         data.stop_example()
         if interesting:
             data.mark_interesting()
@@ -422,7 +431,7 @@ def test_retain_end_of_buffer():
     def shrinker(data):
         interesting = False
         while True:
-            n = data.draw_bits(8)
+            n = data.draw_integer(0, 2**8 - 1)
             if n == 6:
                 interesting = True
             if n == 0:
@@ -439,7 +448,7 @@ def test_can_expand_zeroed_region():
     def shrinker(data):
         seen_non_zero = False
         for _ in range(5):
-            if data.draw_bits(8) == 0:
+            if data.draw_integer(0, 2**8 - 1) == 0:
                 if seen_non_zero:
                     data.mark_invalid()
             else:
@@ -457,11 +466,11 @@ def test_can_expand_deleted_region():
             data.start_example(1)
 
             data.start_example(1)
-            m = data.draw_bits(8)
+            m = data.draw_integer(0, 2**8 - 1)
             data.stop_example()
 
             data.start_example(1)
-            n = data.draw_bits(8)
+            n = data.draw_integer(0, 2**8 - 1)
             data.stop_example()
 
             data.stop_example()
@@ -481,7 +490,7 @@ def test_can_expand_deleted_region():
 def test_shrink_pass_method_is_idempotent():
     @shrinking_from([255])
     def shrinker(data):
-        data.draw_bits(8)
+        data.draw_integer(0, 2**8 - 1)
         data.mark_interesting()
 
     sp = shrinker.shrink_pass(block_program("X"))
@@ -500,7 +509,7 @@ def test_will_terminate_stalled_shrinks():
         count = 0
 
         for _ in range(100):
-            if data.draw_bits(8) != 255:
+            if data.draw_integer(0, 2**8 - 1) != 255:
                 count += 1
                 if count >= 10:
                     return
@@ -514,7 +523,7 @@ def test_will_let_fixate_shrink_passes_do_a_full_run_through():
     @shrinking_from(range(50))
     def shrinker(data):
         for i in range(50):
-            if data.draw_bits(8) != i:
+            if data.draw_integer(0, 2**8 - 1) != i:
                 data.mark_invalid()
         data.mark_interesting()
 
@@ -533,12 +542,12 @@ def test_can_simultaneously_lower_non_duplicated_nearby_blocks(n_gap):
     @shrinking_from([1, 1] + [0] * n_gap + [0, 2])
     def shrinker(data):
         # Block off lowering the whole buffer
-        if data.draw_bits(1) == 0:
+        if data.draw_integer(0, 2**1 - 1) == 0:
             data.mark_invalid()
-        m = data.draw_bits(8)
+        m = data.draw_integer(0, 2**8 - 1)
         for _ in range(n_gap):
-            data.draw_bits(8)
-        n = data.draw_bits(16)
+            data.draw_integer(0, 2**8 - 1)
+        n = data.draw_integer(0, 2**16 - 1)
 
         if n == m + 1:
             data.mark_interesting()

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -65,7 +65,7 @@ def test_duplicate_blocks_that_go_away():
     @run_to_buffer
     def base_buf(data):
         x = data.draw_integer(0, 2**24 - 1, forced=1234567)
-        y = data.draw_integer(0, 2**24 - 1, forced=1234567)
+        _y = data.draw_integer(0, 2**24 - 1, forced=1234567)
         for _ in range(x & 255):
             data.draw_bytes(1)
         data.mark_interesting()

--- a/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
+++ b/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
@@ -16,6 +16,7 @@ from itertools import islice
 import pytest
 
 from hypothesis import settings
+from hypothesis.internal import charmap
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinking import dfas
@@ -138,8 +139,9 @@ def non_normalized_test_function(data):
             data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
     else:
-        n = data.draw_integer(0, 2**64 - 1)
-        if n > 10000:
+        # ascii
+        s = data.draw_string(charmap.query(min_codepoint=0, max_codepoint=127))
+        if "\n" in s:
             data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
 

--- a/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
+++ b/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
@@ -85,7 +85,7 @@ def a_bad_test_function():
     cache = {0: False}
 
     def test_function(data):
-        n = data.draw_bits(64)
+        n = data.draw_integer(0, 2**64 - 1)
         if n < 1000:
             return
 
@@ -131,16 +131,16 @@ def non_normalized_test_function(data):
     is hard to move between. It's basically unreasonable for
     our shrinker to be able to transform from one to the other
     because of how different they are."""
-    data.draw_bits(8)
-    if data.draw_bits(1):
-        n = data.draw_bits(10)
+    data.draw_integer(0, 2**8 - 1)
+    if data.draw_boolean():
+        n = data.draw_integer(0, 2**10 - 1)
         if 100 < n < 1000:
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
     else:
-        n = data.draw_bits(64)
+        n = data.draw_integer(0, 2**64 - 1)
         if n > 10000:
-            data.draw_bits(8)
+            data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
 
 
@@ -157,12 +157,12 @@ def test_can_learn_to_normalize_the_unnormalized():
 
 def test_will_error_on_uninteresting_test():
     with pytest.raises(AssertionError):
-        dfas.normalize(TEST_DFA_NAME, lambda data: data.draw_bits(64))
+        dfas.normalize(TEST_DFA_NAME, lambda data: data.draw_integer(0, 2**64 - 1))
 
 
 def test_makes_no_changes_if_already_normalized():
     def test_function(data):
-        if data.draw_bits(16) >= 1000:
+        if data.draw_integer(0, 2**16 - 1) >= 1000:
             data.mark_interesting()
 
     with preserving_dfas():
@@ -177,8 +177,8 @@ def test_makes_no_changes_if_already_normalized():
 
 def test_learns_to_bridge_only_two():
     def test_function(data):
-        m = data.draw_bits(8)
-        n = data.draw_bits(8)
+        m = data.draw_integer(0, 2**8 - 1)
+        n = data.draw_integer(0, 2**8 - 1)
 
         if (m, n) in ((10, 100), (2, 8)):
             data.mark_interesting()
@@ -205,7 +205,7 @@ def test_learns_to_bridge_only_two_with_overlap():
 
     def test_function(data):
         for i in range(len(u)):
-            c = data.draw_bits(8)
+            c = data.draw_integer(0, 2**8 - 1)
             if c != u[i]:
                 if c != v[i]:
                     return
@@ -213,7 +213,7 @@ def test_learns_to_bridge_only_two_with_overlap():
         else:
             data.mark_interesting()
         for j in range(i + 1, len(v)):
-            if data.draw_bits(8) != v[j]:
+            if data.draw_integer(0, 2**8 - 1) != v[j]:
                 return
 
         data.mark_interesting()
@@ -232,15 +232,15 @@ def test_learns_to_bridge_only_two_with_suffix():
     v = [0] * 10 + [7]
 
     def test_function(data):
-        n = data.draw_bits(8)
+        n = data.draw_integer(0, 2**8 - 1)
         if n == 7:
             data.mark_interesting()
         elif n != 0:
             return
         for _ in range(9):
-            if data.draw_bits(8) != 0:
+            if data.draw_integer(0, 2**8 - 1) != 0:
                 return
-        if data.draw_bits(8) == 7:
+        if data.draw_integer(0, 2**8 - 1) == 7:
             data.mark_interesting()
 
     runner = ConjectureRunner(

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -79,7 +79,7 @@ def test_can_mark_interesting():
 
 def test_drawing_zero_bits_is_free():
     x = ConjectureData.for_buffer(b"")
-    assert x.draw_integer(0, 0) == 0
+    assert x.draw_bits(0) == 0
 
 
 def test_can_mark_invalid():
@@ -202,11 +202,11 @@ def test_has_cached_examples_even_when_overrun():
 
 def test_can_write_empty_string():
     d = ConjectureData.for_buffer([1, 1, 1])
-    d.draw_boolean()
+    d.draw_bits(1)
     d.write(b"")
-    d.draw_boolean()
-    d.draw_boolean(forced=False)
-    d.draw_boolean()
+    d.draw_bits(1)
+    d.draw_bits(0, forced=0)
+    d.draw_bits(1)
     assert d.buffer == bytes([1, 1, 1])
 
 

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -434,10 +434,10 @@ def test_blocks_end_points():
 
 def test_blocks_lengths():
     d = ConjectureData.for_buffer(bytes(7))
-    d.draw_integer(0, 2**32 - 1)
+    d.draw_integer(0, 2**24 - 1)
     d.draw_integer(0, 2**16 - 1)
     d.draw_boolean()
-    assert [b.length for b in d.blocks] == [4, 2, 1]
+    assert [b.length for b in d.blocks] == [3, 2, 1]
 
 
 def test_child_indices():

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -313,7 +313,7 @@ def test_handles_start_indices_like_a_list():
 
 
 def test_last_block_length():
-    d = ConjectureData.for_buffer([0] * 15)
+    d = ConjectureData.for_buffer([0] * 20)
 
     with pytest.raises(IndexError):
         d.blocks.last_block_length

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -319,7 +319,7 @@ def test_last_block_length():
         d.blocks.last_block_length
 
     for n in range(1, 5 + 1):
-        d.draw_bits(n * 8)
+        d.draw_integer(0, 2 ** (n * 8) - 1)
         assert d.blocks.last_block_length == n
 
 

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -445,17 +445,17 @@ def test_child_indices():
 
     d.start_example(0)  # examples[1]
     d.start_example(0)  # examples[2]
-    d.draw_boolean()  # examples[3]
-    d.draw_boolean()  # examples[4]
+    d.draw_boolean()  # examples[3] + draw_bits (examples[4])
+    d.draw_boolean()  # examples[5] + draw_bits (examples[6])
     d.stop_example()
     d.stop_example()
-    d.draw_boolean()  # examples[5]
-    d.draw_boolean()  # examples[6]
+    d.draw_boolean()  # examples[7] + draw_bits (examples[8])
+    d.draw_boolean()  # examples[9] + draw_bits (examples[10])
     d.freeze()
 
-    assert list(d.examples.children[0]) == [1, 5, 6]
+    assert list(d.examples.children[0]) == [1, 7, 9]
     assert list(d.examples.children[1]) == [2]
-    assert list(d.examples.children[2]) == [3, 4]
+    assert list(d.examples.children[2]) == [3, 5]
 
     assert d.examples[0].parent is None
     for ex in list(d.examples)[1:]:

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -253,7 +253,7 @@ def test_valid_list_sample():
 
 
 def test_choice():
-    assert cu.choice(ConjectureData.for_buffer([1]), [1, 2, 3]) == 2
+    assert ConjectureData.for_buffer([1]).choice([1, 2, 3]) == 2
 
 
 def test_fixed_size_draw_many():

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -101,7 +101,7 @@ def test_regression_1():
 @given(st.integers(0, 255), st.integers(0, 255))
 def test_cached_with_masked_byte_agrees_with_results(byte_a, byte_b):
     def f(data):
-        data.draw_bits(2)
+        data.draw_integer(0, 3)
 
     runner = ConjectureRunner(f)
 
@@ -125,7 +125,7 @@ def test_block_programs_fail_efficiently(monkeypatch):
     def shrinker(data):
         values = set()
         for _ in range(256):
-            v = data.draw_bits(8)
+            v = data.draw_integer(0, 2**8 - 1)
             values.add(v)
         if len(values) == 256:
             data.mark_interesting()

--- a/hypothesis-python/tests/quality/test_integers.py
+++ b/hypothesis-python/tests/quality/test_integers.py
@@ -35,7 +35,7 @@ def problems(draw):
         try:
             d = ConjectureData.for_buffer(buf)
             k = d.draw(st.integers())
-            stop = d.draw_bits(8)
+            stop = d.draw_integer(0, 2**8 - 1)
         except (StopTest, IndexError):
             pass
         else:
@@ -68,7 +68,7 @@ def test_always_reduces_integers_to_smallest_suitable_sizes(problem):
     def f(data):
         k = data.draw(st.integers())
         data.output = repr(k)
-        if data.draw_bits(8) == stop and k >= n:
+        if data.draw_integer(0, 2**8 - 1) == stop and k >= n:
             data.mark_interesting()
 
     runner = ConjectureRunner(

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -40,7 +40,7 @@ class PoisonedTree(SearchStrategy):
             # single block. If it did, the heuristics that allow us to move
             # blocks around would fire and it would move right, which would
             # then allow us to shrink it more easily.
-            n = (data.draw_bits(16) << 16) | data.draw_bits(16)
+            n = (data.draw_integer(0, 2**16 - 1) << 16) | data.draw_integer(0, 2**16 - 1)
             if n == MAX_INT:
                 return (POISON,)
             else:

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -40,7 +40,9 @@ class PoisonedTree(SearchStrategy):
             # single block. If it did, the heuristics that allow us to move
             # blocks around would fire and it would move right, which would
             # then allow us to shrink it more easily.
-            n = (data.draw_integer(0, 2**16 - 1) << 16) | data.draw_integer(0, 2**16 - 1)
+            n = (data.draw_integer(0, 2**16 - 1) << 16) | data.draw_integer(
+                0, 2**16 - 1
+            )
             if n == MAX_INT:
                 return (POISON,)
             else:

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -75,10 +75,10 @@ def test_avoids_zig_zag_trap(p):
     n_bits = 8 * (len(b) + 1)
 
     def test_function(data):
-        m = data.draw_integer(0, 2**n_bits - 1)
+        m = data.draw_bits(n_bits)
         if m < lower_bound:
             data.mark_invalid()
-        n = data.draw_integer(0, 2**n_bits - 1)
+        n = data.draw_bits(n_bits)
         if data.draw_bytes(len(marker)) != marker:
             data.mark_invalid()
         if abs(m - n) == 1:
@@ -101,8 +101,8 @@ def test_avoids_zig_zag_trap(p):
 
     data = ConjectureData.for_buffer(v.buffer)
 
-    m = data.draw_integer(0, 2**n_bits - 1)
-    n = data.draw_integer(0, 2**n_bits - 1)
+    m = data.draw_bits(n_bits)
+    n = data.draw_bits(n_bits)
     assert m == lower_bound
     if m == 0:
         assert n == 1

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -75,10 +75,10 @@ def test_avoids_zig_zag_trap(p):
     n_bits = 8 * (len(b) + 1)
 
     def test_function(data):
-        m = data.draw_bits(n_bits)
+        m = data.draw_integer(0, 2**n_bits - 1)
         if m < lower_bound:
             data.mark_invalid()
-        n = data.draw_bits(n_bits)
+        n = data.draw_integer(0, 2**n_bits - 1)
         if data.draw_bytes(len(marker)) != marker:
             data.mark_invalid()
         if abs(m - n) == 1:
@@ -101,8 +101,8 @@ def test_avoids_zig_zag_trap(p):
 
     data = ConjectureData.for_buffer(v.buffer)
 
-    m = data.draw_bits(n_bits)
-    n = data.draw_bits(n_bits)
+    m = data.draw_integer(0, 2**n_bits - 1)
+    n = data.draw_integer(0, 2**n_bits - 1)
     assert m == lower_bound
     if m == 0:
         assert n == 1


### PR DESCRIPTION
Split from #3818. I could split this further if desired, with all the `draw_bits` changes in a single PR.

Changes:
* [move cu.choice to ConjectureData](https://github.com/HypothesisWorks/hypothesis/commit/0690201688cc7024ddebc70ef237791d5cbe5e1c)
* [improve minimal readability with nonlocal](https://github.com/HypothesisWorks/hypothesis/commit/f6b7349c9520b3c08baf698084541b08d9db9ebc)
* migrate away from `draw_bits` in various test files in preparation for its removal. Or at least, taking a back seat relative to the ir.

There were some test changes where the extra boolean draw from > 24 bit integers caused the test to fail.

https://github.com/HypothesisWorks/hypothesis/blob/980042e4018069cf24f6c161434378a353586a76/hypothesis-python/src/hypothesis/internal/conjecture/data.py#L1260-L1262

I mostly remedied this by reducing the bit size down to 20 for these tests. It does make me wonder if we're doing the appropriate thing by biasing the distribution in this way at the ir level, rather than at the strategy level (`integers()`).