### PR TITLE
De-flake `non_normalized_test_function` (again)

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes one of our internal flaky tests.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,0 @@
-RELEASE_TYPE: patch
-
-This patch fixes one of our internal flaky tests.

--- a/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
+++ b/hypothesis-python/tests/conjecture/test_shrinking_dfas.py
@@ -16,7 +16,6 @@ from itertools import islice
 import pytest
 
 from hypothesis import settings
-from hypothesis.internal import charmap
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinking import dfas
@@ -132,16 +131,14 @@ def non_normalized_test_function(data):
     is hard to move between. It's basically unreasonable for
     our shrinker to be able to transform from one to the other
     because of how different they are."""
-    data.draw_integer(0, 2**8 - 1)
     if data.draw_boolean():
         n = data.draw_integer(0, 2**10 - 1)
         if 100 < n < 1000:
             data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
     else:
-        # ascii
-        s = data.draw_string(charmap.query(min_codepoint=0, max_codepoint=127))
-        if "\n" in s:
+        n = data.draw_integer(0, 2**10 - 1)
+        if n > 500:
             data.draw_integer(0, 2**8 - 1)
             data.mark_interesting()
 


### PR DESCRIPTION
follow-up to https://github.com/HypothesisWorks/hypothesis/pull/3839#issuecomment-1890255785.

We have a fine line to walk here. Here's my understanding. `normalize` has a budget of 100 calls, and at least once within those 100 calls, the following needs to happen:

- We run into some failure A.
- While shrinking A, we run into a different failure B.

These two items are in contention. We explore generation *upwards* towards larger examples, so we are likely to run into the minimal counterexample first. But we explore shrinking *downwards* towards smaller examples, so shrinking the minimal counterexample is unlikely to find a new counterexample (or that would have been the one found during generation).

Of course, these are heuristics, and the very need for dfa normalization is proof of that. But any test function that exploits this weakness will be very sensitive to the internals of both generation and shrinking. I fully expect this test to flake again in the future.

---

You'll notice I haven't given a justification for the changes here. That's because I don't have one. This is what happened to work; everything else I tried either had failure B too hard to discover, or both failures A and B satisfied the criteria above, but required multiple dfas to learn instead of just one.

This version hasn't flaked in n ~= 200 calls and running, so I'm fairly confident this will bring back consistency for the time being.