### PR TITLE
Pretty-print objects in `note()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds the ability to pass any object to :func:`~hypothesis.note`, instead of just strings. The pretty-printed representation of the object will be used.
+
+See also :issue:`3843`.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -23,7 +23,7 @@ from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.internal.validation import check_type
 from hypothesis.reporting import report, verbose_report
 from hypothesis.utils.dynamicvariables import DynamicVariable
-from hypothesis.vendor.pretty import IDKey
+from hypothesis.vendor.pretty import IDKey, pretty
 
 
 def _calling_function_name(frame):
@@ -170,9 +170,11 @@ def should_note():
     return context.is_final or settings.default.verbosity >= Verbosity.verbose
 
 
-def note(value: str) -> None:
+def note(value: object) -> None:
     """Report this value for the minimal failing example."""
     if should_note():
+        if not isinstance(value, str):
+            value = pretty(value)
         report(value)
 
 

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+from dataclasses import dataclass
+
 import pytest
 
 from hypothesis import Verbosity, assume, given, reject, reporting, settings
@@ -174,6 +176,26 @@ def test_prints_all_notes_in_verbose_mode():
     v = out.getvalue()
     for x in sorted(messages):
         assert x in v
+
+
+@dataclass
+class CanBePrettyPrinted:
+    n: int
+
+
+def test_note_pretty_prints():
+    reports = []
+
+    @given(integers(1, 10))
+    def test(n):
+        with reporting.with_reporter(reports.append):
+            note(CanBePrettyPrinted(n))
+        assert n != 5
+
+    with pytest.raises(AssertionError):
+        test()
+
+    assert reports == ["CanBePrettyPrinted(n=5)"]
 
 
 def test_not_currently_in_hypothesis():

--- a/hypothesis-python/tests/ghostwriter/recorded/hypothesis_module_magic.txt
+++ b/hypothesis-python/tests/ghostwriter/recorded/hypothesis_module_magic.txt
@@ -42,8 +42,8 @@ def test_fuzz_find(
     )
 
 
-@given(value=st.text())
-def test_fuzz_note(value: str) -> None:
+@given(value=st.from_type(object))
+def test_fuzz_note(value: object) -> None:
     hypothesis.note(value=value)
 
 


### PR DESCRIPTION
closes #3843.
