### PR TITLE
Warn when generating overly large repr

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -2,4 +2,6 @@ RELEASE_TYPE: minor
 
 Warns when constructing a `repr` that is overly long. This can
 happen by accident if stringifying arbitrary strategies, and
-is expensive in time and memory.
+is expensive in time and memory. The associated deferring of
+these long strings in :func:`~hypothesis.strategies.sampled_from`
+should also lead to improved performance.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Warns when constructing a `repr` that is overly long. This can
+happen by accident if stringifying arbitrary strategies, and
+is expensive in time and memory.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -920,7 +920,9 @@ class StateForActualGivenExecution:
             except TypeError as e:
                 # If we sampled from a sequence of strategies, AND failed with a
                 # TypeError, *AND that exception mentions SearchStrategy*, add a note:
-                if "SearchStrategy" in str(e) and hasattr(data, "_sampled_from_all_strategies_elements_message"):
+                if "SearchStrategy" in str(e) and hasattr(
+                    data, "_sampled_from_all_strategies_elements_message"
+                ):
                     msg, format_arg = data._sampled_from_all_strategies_elements_message
                     add_note(e, msg.format(format_arg))
                 raise

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -920,11 +920,9 @@ class StateForActualGivenExecution:
             except TypeError as e:
                 # If we sampled from a sequence of strategies, AND failed with a
                 # TypeError, *AND that exception mentions SearchStrategy*, add a note:
-                if "SearchStrategy" in str(e):
-                    try:
-                        add_note(e, data._sampled_from_all_strategies_elements_message)
-                    except AttributeError:
-                        pass
+                if "SearchStrategy" in str(e) and hasattr(data, "_sampled_from_all_strategies_elements_message"):
+                    msg, format_arg = data._sampled_from_all_strategies_elements_message
+                    add_note(e, msg.format(format_arg))
                 raise
 
         # self.test_runner can include the execute_example method, or setup/teardown

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -19,6 +19,7 @@ import re
 import sys
 import textwrap
 import types
+import warnings
 from functools import partial, wraps
 from io import StringIO
 from keyword import iskeyword
@@ -27,6 +28,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import _patch as PatchType
 
+from hypothesis.errors import HypothesisWarning
 from hypothesis.internal.compat import PYPY, is_typed_named_tuple
 from hypothesis.utils.conventions import not_set
 from hypothesis.vendor.pretty import pretty
@@ -478,6 +480,8 @@ def repr_call(f, args, kwargs, *, reorder=True):
     rep = nicerepr(f)
     if rep.startswith("lambda") and ":" in rep:
         rep = f"({rep})"
+    if len(rep) + sum(len(b) for b in bits) > 10000:
+        warnings.warn("Generating overly large repr", HypothesisWarning, stacklevel=2)
     return rep + "(" + ", ".join(bits) + ")"
 
 

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -480,8 +480,15 @@ def repr_call(f, args, kwargs, *, reorder=True):
     rep = nicerepr(f)
     if rep.startswith("lambda") and ":" in rep:
         rep = f"({rep})"
-    if len(rep) + sum(len(b) for b in bits) > 10000:
-        warnings.warn("Generating overly large repr", HypothesisWarning, stacklevel=2)
+    repr_len = len(rep) + sum(len(b) for b in bits)  # approx
+    if repr_len > 30000:
+        warnings.warn(
+            "Generating overly large repr. This is an expensive operation, and with "
+            f"a length of {repr_len//1000} kB is is unlikely to be useful. Use -Wignore "
+            "to ignore the warning, or -Werror to get a traceback.",
+            HypothesisWarning,
+            stacklevel=2,
+        )
     return rep + "(" + ", ".join(bits) + ")"
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -531,18 +531,9 @@ class SampledFromStrategy(SearchStrategy):
         if isinstance(result, SearchStrategy) and all(
             isinstance(x, SearchStrategy) for x in self.elements
         ):
-            max_num_strats = 3
-            preamble = (
-                f"(first {max_num_strats}) "
-                if len(self.elements) > max_num_strats
-                else ""
-            )
-            strat_reprs = ", ".join(
-                map(get_pretty_function_description, self.elements[:max_num_strats])
-            )
             data._sampled_from_all_strategies_elements_message = (
                 "sample_from was given a collection of strategies: "
-                f"{preamble}{strat_reprs}. Was one_of intended?"
+                "{!r}. Was one_of intended?", self.elements
             )
         if result is filter_not_satisfied:
             data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -533,7 +533,8 @@ class SampledFromStrategy(SearchStrategy):
         ):
             data._sampled_from_all_strategies_elements_message = (
                 "sample_from was given a collection of strategies: "
-                "{!r}. Was one_of intended?", self.elements
+                "{!r}. Was one_of intended?",
+                self.elements,
             )
         if result is filter_not_satisfied:
             data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -20,6 +20,7 @@ import pytest
 from pytest import raises
 
 from hypothesis import given, strategies as st
+from hypothesis.errors import HypothesisWarning
 from hypothesis.internal import reflection
 from hypothesis.internal.reflection import (
     convert_keyword_arguments,
@@ -35,6 +36,7 @@ from hypothesis.internal.reflection import (
     required_args,
     source_exec_as_module,
 )
+from hypothesis.strategies._internal.lazy import LazyStrategy
 
 
 def do_conversion_test(f, args, kwargs):
@@ -710,3 +712,8 @@ def _prep_source(*pairs):
 )
 def test_clean_source(src, clean):
     assert reflection._clean_source(src).splitlines() == clean.splitlines()
+
+
+def test_overlong_repr_warns():
+    with pytest.warns(HypothesisWarning, match="overly large"):
+        repr(LazyStrategy(st.one_of, [st.none()] * 10000, {}))

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -19,7 +19,6 @@ from hypothesis.errors import (
     HypothesisWarning,
     InvalidArgument,
 )
-from hypothesis.strategies._internal.types import _global_type_lookup
 from hypothesis.strategies._internal.lazy import LazyStrategy
 
 
@@ -124,4 +123,4 @@ def test_sampled_transform_reprs(r):
 
 def test_overlong_repr_warns():
     with pytest.warns(HypothesisWarning, match="overly large"):
-        repr(LazyStrategy(st.one_of, _global_type_lookup.values(), {}))
+        repr(LazyStrategy(st.one_of, [st.none()] * 10000, {}))

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -14,10 +14,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.control import reject
-from hypothesis.errors import (
-    HypothesisDeprecationWarning,
-    InvalidArgument,
-)
+from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
 
 
 def foo(x):

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -16,10 +16,8 @@ from hypothesis import given, strategies as st
 from hypothesis.control import reject
 from hypothesis.errors import (
     HypothesisDeprecationWarning,
-    HypothesisWarning,
     InvalidArgument,
 )
-from hypothesis.strategies._internal.lazy import LazyStrategy
 
 
 def foo(x):
@@ -119,8 +117,3 @@ def test_repr_evals_to_thing_with_same_repr(strategy):
 )
 def test_sampled_transform_reprs(r):
     assert repr(eval(r, strategy_globals)) == r
-
-
-def test_overlong_repr_warns():
-    with pytest.warns(HypothesisWarning, match="overly large"):
-        repr(LazyStrategy(st.one_of, [st.none()] * 10000, {}))

--- a/hypothesis-python/tests/nocover/test_pretty_repr.py
+++ b/hypothesis-python/tests/nocover/test_pretty_repr.py
@@ -14,7 +14,13 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.control import reject
-from hypothesis.errors import HypothesisDeprecationWarning, InvalidArgument
+from hypothesis.errors import (
+    HypothesisDeprecationWarning,
+    HypothesisWarning,
+    InvalidArgument,
+)
+from hypothesis.strategies._internal.types import _global_type_lookup
+from hypothesis.strategies._internal.lazy import LazyStrategy
 
 
 def foo(x):
@@ -114,3 +120,8 @@ def test_repr_evals_to_thing_with_same_repr(strategy):
 )
 def test_sampled_transform_reprs(r):
     assert repr(eval(r, strategy_globals)) == r
+
+
+def test_overlong_repr_warns():
+    with pytest.warns(HypothesisWarning, match="overly large"):
+        repr(LazyStrategy(st.one_of, _global_type_lookup.values(), {}))


### PR DESCRIPTION
For consideration, and submitted for the test runs.

A warning like this would have saved some development time lately, on #3820 and #3837.