### PR TITLE
Generate empty flag enums

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+Changes the distribution of :func:`~hypothesis.strategies.sampled_from` when
+sampling from a :func:`~python:enum.Flag`. Previously, no-flags-set values would
+never be generated, and all-flags-set values would be unlikely for large enums.
+With this change, the distribution is more uniform in the number of flags set.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: minor
 
 Changes the distribution of :func:`~hypothesis.strategies.sampled_from` when
-sampling from a :func:`~python:enum.Flag`. Previously, no-flags-set values would
+sampling from a :class:`~python:enum.Flag`. Previously, no-flags-set values would
 never be generated, and all-flags-set values would be unlikely for large enums.
 With this change, the distribution is more uniform in the number of flags set.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -196,7 +196,7 @@ def extract_bits(x: int, /, width: Optional[int] = None) -> List[int]:
 try:
     bit_count = int.bit_count
 except AttributeError:  # pragma: no cover
-    bit_count = lambda x: sum(extract_bits(abs(x)))
+    bit_count = lambda self: sum(extract_bits(abs(self)))
 
 
 def bad_django_TestCase(runner):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -181,6 +181,7 @@ def ceil(x):
 
 
 def extract_bits(x: int, /, width: Optional[int] = None) -> List[int]:
+    assert x >= 0
     result = []
     while x:
         result.append(x & 1)
@@ -192,7 +193,10 @@ def extract_bits(x: int, /, width: Optional[int] = None) -> List[int]:
 
 
 # int.bit_count was added sometime around python 3.9
-bit_count = getattr(int, "bit_count", lambda x: sum(extract_bits(x)))
+try:
+    bit_count = int.bit_count
+except AttributeError:  # pragma: no cover
+    bit_count = lambda x: sum(extract_bits(abs(x)))
 
 
 def bad_django_TestCase(runner):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -16,7 +16,7 @@ import platform
 import sys
 import typing
 from functools import partial
-from typing import Any, ForwardRef, get_args
+from typing import Any, ForwardRef, List, Optional, get_args
 
 try:
     BaseExceptionGroup = BaseExceptionGroup
@@ -178,6 +178,21 @@ def ceil(x):
     if y != x and x > 0:
         return y + 1
     return y
+
+
+def extract_bits(x: int, /, width: Optional[int] = None) -> List[int]:
+    result = []
+    while x:
+        result.append(x & 1)
+        x >>= 1
+    if width is not None:
+        result = (result + [0] * width)[:width]
+    result.reverse()
+    return result
+
+
+# int.bit_count was added sometime around python 3.9
+bit_count = getattr(int, "bit_count", lambda x: sum(extract_bits(x)))
 
 
 def bad_django_TestCase(runner):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -228,8 +228,8 @@ def sampled_from(
         # Combinations of enum.Flag members are also members.  We generate
         # these dynamically, because static allocation takes O(2^n) memory.
         # LazyStrategy is used for the ease of force_repr.
-        inner = sets(sampled_from(list(values)), min_size=1).map(
-            lambda s: reduce(operator.or_, s)
+        inner = sets(sampled_from(list(values))).map(
+            lambda s: reduce(operator.or_, s, elements(0))
         )
         return LazyStrategy(lambda: inner, args=[], kwargs={}, force_repr=repr_)
     return SampledFromStrategy(values, repr_)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -227,7 +227,7 @@ def sampled_from(
         if not flags or flags[0].value != 0:
             try:
                 flags_with_empty = [*flags, elements(0)]
-            except TypeError:
+            except TypeError:  # pragma: no cover
                 # Happens on some python versions (at least 3.12) when there are no named values
                 pass
         inner = [

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -13,7 +13,7 @@ import sys
 import pytest
 
 from hypothesis import HealthCheck, assume, example, given, settings, strategies as st
-from hypothesis.internal.compat import ceil, floor, int_to_bytes
+from hypothesis.internal.compat import ceil, extract_bits, floor, int_to_bytes
 from hypothesis.internal.conjecture import floats as flt
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
@@ -115,16 +115,8 @@ def test_fractional_floats_are_worse_than_one(f):
 
 
 def test_reverse_bits_table_reverses_bits():
-    def bits(x):
-        result = []
-        for _ in range(8):
-            result.append(x & 1)
-            x >>= 1
-        result.reverse()
-        return result
-
     for i, b in enumerate(flt.REVERSE_BITS_TABLE):
-        assert bits(i) == list(reversed(bits(b)))
+        assert extract_bits(i, width=8) == list(reversed(extract_bits(b, width=8)))
 
 
 def test_reverse_bits_table_has_right_elements():

--- a/hypothesis-python/tests/cover/test_compat.py
+++ b/hypothesis-python/tests/cover/test_compat.py
@@ -17,7 +17,13 @@ from typing import ForwardRef, Optional, Union
 
 import pytest
 
-from hypothesis.internal.compat import ceil, dataclass_asdict, floor, get_type_hints
+from hypothesis.internal.compat import (
+    ceil,
+    dataclass_asdict,
+    extract_bits,
+    floor,
+    get_type_hints,
+)
 
 floor_ceil_values = [
     -10.7,
@@ -128,3 +134,12 @@ def test_dataclass_asdict():
         "d": {4: 5},
         "e": {},
     }
+
+
+@pytest.mark.parametrize("width", [None, 8])
+@pytest.mark.parametrize("x", [0, 2, 123])
+def test_extract_bits_roundtrip(width, x):
+    bits = extract_bits(x, width=width)
+    if width is not None:
+        assert len(bits) == width
+    assert x == sum(v << p for p, v in enumerate(reversed(bits)))

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -12,7 +12,7 @@ import sys
 
 import pytest
 
-from hypothesis import assume, given, strategies as st
+from hypothesis import HealthCheck, assume, given, settings, strategies as st
 from hypothesis.errors import (
     HypothesisDeprecationWarning,
     HypothesisWarning,
@@ -47,6 +47,7 @@ def draw_ordered_with_assume(draw):
 
 
 @given(draw_ordered_with_assume())
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
 def test_can_assume_in_draw(xy):
     assert xy[0] < xy[1]
 

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -522,9 +522,9 @@ def test_resolves_flag_enum(resolver):
     # Storing all combinations takes O(2^n) memory.  Using an enum of 52
     # members in this test ensures that we won't try!
     F = enum.Flag("F", " ".join(string.ascii_letters))
-    # Filter to check that we can generate compound members of enum.Flags
 
-    @given(resolver(F).filter(lambda ex: ex not in tuple(F)))
+    # Checks for combination coverage are found in nocover/test_sampled_from
+    @given(resolver(F))
     def inner(ex):
         assert isinstance(ex, F)
 

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -10,6 +10,7 @@
 
 import collections
 import enum
+import sys
 
 import pytest
 
@@ -32,7 +33,7 @@ from tests.common.utils import fails_with
 
 an_enum = enum.Enum("A", "a b c")
 a_flag = enum.Flag("A", "a b c")
-an_empty_flag = enum.Flag("EmptyFlag", {})
+an_empty_flag = enum.Flag("EmptyFlag", {"a": 0})
 
 an_ordereddict = collections.OrderedDict([("a", 1), ("b", 2), ("c", 3)])
 
@@ -57,6 +58,13 @@ def test_can_sample_enums(enum_class):
         assert isinstance(member, enum_class)
 
     test_it()
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 12), reason="behaviour change")
+def test_invalid_enum():
+    not_constructible_enum = enum.Flag("invalid", ())
+    with pytest.raises(InvalidArgument):
+        st.sampled_from(not_constructible_enum).example()
 
 
 @fails_with(FailedHealthCheck)

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -28,11 +28,13 @@ from hypothesis.strategies._internal.strategies import (
     filter_not_satisfied,
 )
 
+from tests.common.debug import assert_all_examples
 from tests.common.utils import fails_with
 
 an_enum = enum.Enum("A", "a b c")
 a_flag = enum.Flag("A", "a b c")
 an_empty_flag = enum.Flag("EmptyFlag", {"a": 0})
+empty_unnamed_flag = enum.Flag("EmptyUnnamed", "")
 
 an_ordereddict = collections.OrderedDict([("a", 1), ("b", 2), ("c", 3)])
 
@@ -50,13 +52,11 @@ def test_can_sample_ordereddict_without_warning():
     sampled_from(an_ordereddict).example()
 
 
-@pytest.mark.parametrize("enum_class", [an_enum, a_flag, an_empty_flag])
+@pytest.mark.parametrize(
+    "enum_class", [an_enum, a_flag, an_empty_flag, empty_unnamed_flag]
+)
 def test_can_sample_enums(enum_class):
-    @given(sampled_from(enum_class))
-    def test_it(member):
-        assert isinstance(member, enum_class)
-
-    test_it()
+    assert_all_examples(sampled_from(enum_class), lambda x: isinstance(x, enum_class))
 
 
 @fails_with(FailedHealthCheck)

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -60,13 +60,6 @@ def test_can_sample_enums(enum_class):
     test_it()
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 12), reason="behaviour change")
-def test_invalid_enum():
-    not_constructible_enum = enum.Flag("invalid", ())
-    with pytest.raises(InvalidArgument):
-        st.sampled_from(not_constructible_enum).example()
-
-
 @fails_with(FailedHealthCheck)
 @given(sampled_from(range(10)).filter(lambda x: x < 0))
 def test_unsat_filtered_sampling(x):

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -33,8 +33,8 @@ from tests.common.utils import fails_with
 
 an_enum = enum.Enum("A", "a b c")
 a_flag = enum.Flag("A", "a b c")
+# named zero state is required for empty flags from around py3.11/3.12
 an_empty_flag = enum.Flag("EmptyFlag", {"a": 0})
-empty_unnamed_flag = enum.Flag("EmptyUnnamed", "")
 
 an_ordereddict = collections.OrderedDict([("a", 1), ("b", 2), ("c", 3)])
 
@@ -52,9 +52,7 @@ def test_can_sample_ordereddict_without_warning():
     sampled_from(an_ordereddict).example()
 
 
-@pytest.mark.parametrize(
-    "enum_class", [an_enum, a_flag, an_empty_flag, empty_unnamed_flag]
-)
+@pytest.mark.parametrize("enum_class", [an_enum, a_flag, an_empty_flag])
 def test_can_sample_enums(enum_class):
     assert_all_examples(sampled_from(enum_class), lambda x: isinstance(x, enum_class))
 

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -10,7 +10,6 @@
 
 import collections
 import enum
-import sys
 
 import pytest
 

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -31,6 +31,8 @@ from hypothesis.strategies._internal.strategies import (
 from tests.common.utils import fails_with
 
 an_enum = enum.Enum("A", "a b c")
+a_flag = enum.Flag("A", "a b c")
+an_empty_flag = enum.Flag("EmptyFlag", {})
 
 an_ordereddict = collections.OrderedDict([("a", 1), ("b", 2), ("c", 3)])
 
@@ -48,9 +50,13 @@ def test_can_sample_ordereddict_without_warning():
     sampled_from(an_ordereddict).example()
 
 
-@given(sampled_from(an_enum))
-def test_can_sample_enums(member):
-    assert isinstance(member, an_enum)
+@pytest.mark.parametrize("enum_class", [an_enum, a_flag, an_empty_flag])
+def test_can_sample_enums(enum_class):
+    @given(sampled_from(enum_class))
+    def test_it(member):
+        assert isinstance(member, enum_class)
+
+    test_it()
 
 
 @fails_with(FailedHealthCheck)

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -15,7 +15,7 @@ import operator
 
 import pytest
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies._internal.strategies import SampledFromStrategy
 

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -12,6 +12,7 @@ import enum
 import functools
 import itertools
 import operator
+import sys
 
 import pytest
 
@@ -80,16 +81,13 @@ def test_enum_repr_uses_class_not_a_list():
     assert lazy_repr == "sampled_from(tests.nocover.test_sampled_from.AnEnum)"
 
 
-class EmptyFlag(enum.Flag):
-    pass
-
-
 class AFlag(enum.Flag):
     a = enum.auto()
     b = enum.auto()
     c = enum.auto()
 
 
+EmptyFlag = enum.Flag("EmptyFlag", {})
 LargeFlag = enum.Flag("LargeFlag", {f"bit{i}": enum.auto() for i in range(64)})
 
 
@@ -125,6 +123,7 @@ def test_flags_minimize_to_first_named_flag():
     assert minimal(st.sampled_from(LargeFlag)) == LargeFlag.bit0
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 9), reason="bit_count")
 def test_flags_minimizes_bit_count():
     shrunk = minimal(st.sampled_from(LargeFlag), lambda f: f.value.bit_count() > 1)
     # Ideal would be (bit0 | bit1), but:

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -12,12 +12,12 @@ import enum
 import functools
 import itertools
 import operator
-import sys
 
 import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
+from hypothesis.internal.compat import bit_count
 from hypothesis.strategies._internal.strategies import SampledFromStrategy
 
 from tests.common.debug import find_any, minimal
@@ -123,9 +123,8 @@ def test_flags_minimize_to_first_named_flag():
     assert minimal(st.sampled_from(LargeFlag)) == LargeFlag.bit0
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 9), reason="bit_count")
 def test_flags_minimizes_bit_count():
-    shrunk = minimal(st.sampled_from(LargeFlag), lambda f: f.value.bit_count() > 1)
+    shrunk = minimal(st.sampled_from(LargeFlag), lambda f: bit_count(f.value) > 1)
     # Ideal would be (bit0 | bit1), but:
     # minimal(st.sets(st.sampled_from(range(10)), min_size=3)) == {0, 8, 9}  # not {0, 1, 2}
     assert shrunk == LargeFlag.bit0 | LargeFlag.bit63  # documents actual behaviour

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -87,7 +87,6 @@ class AFlag(enum.Flag):
     c = enum.auto()
 
 
-EmptyFlag = enum.Flag("EmptyFlag", {})
 LargeFlag = enum.Flag("LargeFlag", {f"bit{i}": enum.auto() for i in range(64)})
 
 
@@ -112,11 +111,6 @@ def test_exhaustive_flags():
     accept()
 
     assert not unseen_flags
-
-
-@given(st.sampled_from(EmptyFlag))
-def test_empty_flag(empty):
-    assert empty == EmptyFlag(0)
 
 
 def test_flags_minimize_to_first_named_flag():

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -90,6 +90,12 @@ class AFlag(enum.Flag):
 LargeFlag = enum.Flag("LargeFlag", {f"bit{i}": enum.auto() for i in range(64)})
 
 
+class UnnamedFlag(enum.Flag):
+    # Would fail under EnumCheck.NAMED_FLAGS
+    a = 0
+    b = 7
+
+
 def test_flag_enum_repr_uses_class_not_a_list():
     lazy_repr = repr(st.sampled_from(AFlag))
     assert lazy_repr == "sampled_from(tests.nocover.test_sampled_from.AFlag)"
@@ -127,3 +133,11 @@ def test_flags_minimizes_bit_count():
 
 def test_flags_finds_all_bits_set():
     assert find_any(st.sampled_from(LargeFlag), lambda f: f == ~LargeFlag(0))
+
+
+def test_sample_unnamed_alias():
+    assert find_any(st.sampled_from(UnnamedFlag), lambda f: f == UnnamedFlag.b)
+
+
+def test_shrink_to_named_empty():
+    assert minimal(st.sampled_from(UnnamedFlag)) == UnnamedFlag(0)


### PR DESCRIPTION
We should sample empty enum.Flag examples by default. They are valid instances after all, representing no flag bits set.

True, a user could opt-in by for example `one_of(sampled_from(Flags), just(Flags(0)))`. But it's better to have complete coverage by default, and if necessary opt-out by adding `.filter(bool)` or similar.

We *might* want to lessen visible impact by shrinking towards first non-empty flag instead of empty. I don't know how best to achieve this, I expected the first (opt-in) example to do exactly that but it doesn't. Anyway, I added a provisional test to modify to whatever shrinking behaviour we desire.