### PR TITLE
More small IR-related improvements

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch slightly refactors some internals. There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1093,12 +1093,12 @@ class PrimitiveProvider:
                 if clamped != result and not (math.isnan(result) and allow_nan):
                     self._cd.stop_example(discard=True)
                     self._cd.start_example(DRAW_FLOAT_LABEL)
-                    self._write_float(clamped)
+                    self._draw_float(forced=clamped)
                     result = clamped
             else:
                 result = nasty_floats[i - 1]
 
-                self._write_float(result)
+                self._draw_float(forced=result)
 
             self._cd.stop_example()  # (DRAW_FLOAT_LABEL)
             self._cd.stop_example()  # (FLOAT_STRATEGY_DO_DRAW_LABEL)
@@ -1182,11 +1182,6 @@ class PrimitiveProvider:
             return -f if is_negative else f
         finally:
             self._cd.stop_example()
-
-    def _write_float(self, f: float) -> None:
-        sign = float_to_int(f) >> 63
-        self._cd.draw_bits(1, forced=sign)
-        self._cd.draw_bits(64, forced=float_to_lex(abs(f)))
 
     def _draw_unbounded_integer(self, *, forced: Optional[int] = None) -> int:
         forced_i = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1170,18 +1170,13 @@ class PrimitiveProvider:
             # sign_aware_lte(forced, -0.0) does not correctly handle the
             # math.nan case here.
             forced_sign_bit = math.copysign(1, forced) == -1
-
-        self._cd.start_example(DRAW_FLOAT_LABEL)
-        try:
-            is_negative = self._cd.draw_bits(1, forced=forced_sign_bit)
-            f = lex_to_float(
-                self._cd.draw_bits(
-                    64, forced=None if forced is None else float_to_lex(abs(forced))
-                )
+        is_negative = self._cd.draw_bits(1, forced=forced_sign_bit)
+        f = lex_to_float(
+            self._cd.draw_bits(
+                64, forced=None if forced is None else float_to_lex(abs(forced))
             )
-            return -f if is_negative else f
-        finally:
-            self._cd.stop_example()
+        )
+        return -f if is_negative else f
 
     def _draw_unbounded_integer(self, *, forced: Optional[int] = None) -> int:
         forced_i = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/floats.py
@@ -99,7 +99,7 @@ del i, b
 
 
 def decode_exponent(e: int) -> int:
-    """Take draw_bits(11) and turn it into a suitable floating point exponent
+    """Take an integer and turn it into a suitable floating point exponent
     such that lexicographically simpler leads to simpler floats."""
     assert 0 <= e <= MAX_EXPONENT
     return ENCODING_TABLE[e]

--- a/hypothesis-python/src/hypothesis/internal/intervalsets.py
+++ b/hypothesis-python/src/hypothesis/internal/intervalsets.py
@@ -99,6 +99,9 @@ class IntervalSet:
     def __and__(self, other):
         return self.intersection(other)
 
+    def __eq__(self, other):
+        return isinstance(other, IntervalSet) and (other.intervals == self.intervals)
+
     def union(self, other):
         """Merge two sequences of intervals into a single tuple of intervals.
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -442,8 +442,8 @@ def test_can_shrink_variable_draws(n_large):
 
     @run_to_data
     def data(data):
-        n = data.draw_bits(4)
-        b = [data.draw_bits(8) for _ in range(n)]
+        n = data.draw_integer(0, 15)
+        b = [data.draw_integer(0, 255) for _ in range(n)]
         if sum(b) >= target:
             data.mark_interesting()
 

--- a/hypothesis-python/tests/cover/test_intervalset.py
+++ b/hypothesis-python/tests/cover/test_intervalset.py
@@ -99,3 +99,18 @@ def test_char_in_shrink_order():
     rewritten = [ord(xs.char_in_shrink_order(i)) for i in range(256)]
     assert rewritten != list(range(256))
     assert sorted(rewritten) == sorted(range(256))
+
+
+def test_index_from_char_in_shrink_order():
+    xs = IntervalSet([(0, 256)])
+    for i in xs:
+        assert xs.index_from_char_in_shrink_order(xs.char_in_shrink_order(i)) == i
+
+
+def test_intervalset_equal():
+    xs1 = IntervalSet([(0, 256)])
+    xs2 = IntervalSet([(0, 256)])
+    assert xs1 == xs2
+
+    xs3 = IntervalSet([(0, 255)])
+    assert xs2 != xs3

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -98,7 +98,7 @@ def test_regression_1():
         if v >= 512 or v == 254:
             data.mark_interesting()
 
-    assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0]
+    assert list(x)[:-2] == [1, 2, 1, 0, 0, 0, 0, 0, 0]
 
     assert int_from_bytes(x[-2:]) in (254, 512)
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -85,11 +85,16 @@ def test_regression_1():
     # specific exception inside one of the shrink passes. It's unclear how
     # useful this regression test really is, but nothing else caught the
     # problem.
+    #
+    # update 2024-01-15: we've since changed generation and are about to
+    # change shrinking, so it's unclear if the failure case this test was aimed
+    # at (1) is still being covered or (2) even exists anymore.
+    # we can probably safely remove this once the shrinker is rebuilt.
     @run_to_buffer
     def x(data):
         data.draw_bytes(2, forced=b"\x01\x02")
         data.draw_bytes(2, forced=b"\x01\x00")
-        v = data.draw_bits(41)
+        v = data.draw_integer(0, 2**41 - 1)
         if v >= 512 or v == 254:
             data.mark_interesting()
 

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -40,9 +40,9 @@ class PoisonedTree(SearchStrategy):
             # single block. If it did, the heuristics that allow us to move
             # blocks around would fire and it would move right, which would
             # then allow us to shrink it more easily.
-            n = (data.draw_integer(0, 2**16 - 1) << 16) | data.draw_integer(
-                0, 2**16 - 1
-            )
+            n1 = data.draw_integer(0, 2**16 - 1) << 16
+            n2 = data.draw_integer(0, 2**16 - 1)
+            n = n1 | n2
             if n == MAX_INT:
                 return (POISON,)
             else:

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -21,19 +21,20 @@ from hypothesis import (
     settings,
     strategies as st,
 )
-from hypothesis.internal.compat import ceil, int_from_bytes
+from hypothesis.internal.compat import ceil
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
+from tests.conjecture.common import run_to_buffer
+
 
 @st.composite
-def problem(draw):
-    b = draw(st.binary(min_size=1, max_size=8))
-    m = int_from_bytes(b) * 256
+def problems(draw):
+    m = draw(st.integers(256, 2**64 - 1))
     assume(m > 0)
     marker = draw(st.binary(max_size=8))
     bound = draw(st.integers(0, m - 1))
-    return (b, marker, bound)
+    return (m, marker, bound)
 
 
 base_settings = settings(
@@ -46,17 +47,17 @@ base_settings = settings(
 )
 
 
-@example((b"\x10\x00\x00\x00\x00\x00", b"", 2861143707951135))
-@example((b"\x05Cn", b"%\x1b\xa0\xfa", 12394667))
-@example((b"\x179 f", b"\xf5|", 24300326997))
-@example((b"\x05*\xf5\xe5\nh", b"", 1076887621690235))
-@example((b"=", b"", 2508))
-@example((b"\x01\x00", b"", 20048))
-@example((b"\x01", b"", 0))
-@example((b"\x02", b"", 258))
-@example((b"\x08", b"", 1792))
-@example((b"\x0c", b"", 0))
-@example((b"\x01", b"", 1))
+@example((4503599627370496, b"", 2861143707951135))
+@example((88305152, b"%\x1b\xa0\xfa", 12394667))
+@example((99742672384, b"\xf5|", 24300326997))
+@example((1454610481571840, b"", 1076887621690235))
+@example((15616, b"", 2508))
+@example((65536, b"", 20048))
+@example((256, b"", 0))
+@example((512, b"", 258))
+@example((2048, b"", 1792))
+@example((3072, b"", 0))
+@example((256, b"", 1))
 @settings(
     base_settings,
     verbosity=Verbosity.normal,
@@ -68,17 +69,23 @@ base_settings = settings(
     ),
     max_examples=20,
 )
-@given(problem())
+@given(problems())
 def test_avoids_zig_zag_trap(p):
-    b, marker, lower_bound = p
+    m, marker, lower_bound = p
+    n_bits = m.bit_length() + 1
 
-    n_bits = 8 * (len(b) + 1)
+    @run_to_buffer
+    def buf(data):
+        _m = data.draw_integer(0, 2**n_bits - 1, forced=m)
+        _n = data.draw_integer(0, 2**n_bits - 1, forced=m + 1)
+        _marker = data.draw_bytes(len(marker), forced=marker)
+        data.mark_interesting()
 
     def test_function(data):
-        m = data.draw_bits(n_bits)
+        m = data.draw_integer(0, 2**n_bits - 1)
         if m < lower_bound:
             data.mark_invalid()
-        n = data.draw_bits(n_bits)
+        n = data.draw_integer(0, 2**n_bits - 1)
         if data.draw_bytes(len(marker)) != marker:
             data.mark_invalid()
         if abs(m - n) == 1:
@@ -91,18 +98,14 @@ def test_avoids_zig_zag_trap(p):
         random=Random(0),
     )
 
-    runner.cached_test_function(b + bytes([0]) + b + bytes([1]) + marker)
-
+    runner.cached_test_function(buf)
     assert runner.interesting_examples
-
     runner.run()
-
     (v,) = runner.interesting_examples.values()
-
     data = ConjectureData.for_buffer(v.buffer)
 
-    m = data.draw_bits(n_bits)
-    n = data.draw_bits(n_bits)
+    m = data.draw_integer(0, 2**n_bits - 1)
+    n = data.draw_integer(0, 2**n_bits - 1)
     assert m == lower_bound
     if m == 0:
         assert n == 1
@@ -110,5 +113,4 @@ def test_avoids_zig_zag_trap(p):
         assert n == m - 1
 
     budget = 2 * n_bits * ceil(log(n_bits, 2)) + 2
-
     assert runner.shrinks <= budget


### PR DESCRIPTION
The last simple bits I could squeeze out of #3818.

The last remaining test I'd like to migrate off `draw_bits` is `test_avoids_zig_zag_trap`. But I spent a fair amount of time trying to make that work, and wasn't able to get it to cooperate, likely because I don't fully understand when `lower_common_block_offset` fires. Any changes to `draw_bits` I made in the zigzag test caused `lower_common_block_offset` to be passed over as a result of this conditional being false: https://github.com/HypothesisWorks/hypothesis/blob/775ed9125f8429b6a92912c723d0cefee8b664cf/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py#L1011-L1013

but I don't really understand why this conditional is there or the circumstances that cause it to be true.