### PR TITLE
Avoid side effect warning when `HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY` is set

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a spurious warning about slow imports when ``HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY`` was set.

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -108,6 +108,6 @@ if (
 
     # Remove files more than a week old, to cap the size on disk
     max_age = (date.today() - timedelta(days=8)).isoformat()
-    for f in storage_directory("observed").glob("*.jsonl"):
+    for f in storage_directory("observed", intent_to_write=False).glob("*.jsonl"):
         if f.stem < max_age:  # pragma: no branch
             f.unlink(missing_ok=True)


### PR DESCRIPTION
regressed in #3837.