### PR TITLE
Avoid pointless discards during the `reuse` and `target` phases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch slightly changes how we replay examples from
+:doc:`the database <database>`: if the behavior of the saved example has
+changed, we now keep running the test case instead of aborting at the size
+of the saved example.  While we know it's not the *same* example, we might
+as well continue running the test!
+
+Because we now finish running a few more examples for affected tests, this
+might be a slight slowdown - but correspondingly more likely to find a bug.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -8,3 +8,6 @@ as well continue running the test!
 
 Because we now finish running a few more examples for affected tests, this
 might be a slight slowdown - but correspondingly more likely to find a bug.
+
+We've also applied similar tricks to the :ref:`target phase <phases>`, where
+they are a pure performance improvement for affected tests.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1054,6 +1054,8 @@ class StateForActualGivenExecution:
             if TESTCASE_CALLBACKS:
                 if self.failed_normally or self.failed_due_to_deadline:
                     phase = "shrink"
+                elif runner := getattr(self, "_runner", None):
+                    phase = runner._current_phase
                 else:
                     phase = "unknown"
                 tc = make_testcase(
@@ -1084,7 +1086,7 @@ class StateForActualGivenExecution:
             else:
                 database_key = None
 
-        runner = ConjectureRunner(
+        runner = self._runner = ConjectureRunner(
             self._execute_once_for_engine,
             settings=self.settings,
             random=self.random,

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1510,8 +1510,7 @@ def given(
                 except UnsatisfiedAssumption:
                     raise DidNotReproduce(
                         "The test data failed to satisfy an assumption in the "
-                        "test. Have you added it since this blob was "
-                        "generated?"
+                        "test. Have you added it since this blob was generated?"
                     ) from None
 
             # There was no @reproduce_failure, so start by running any explicit

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1056,7 +1056,7 @@ class StateForActualGivenExecution:
                     phase = "shrink"
                 elif runner := getattr(self, "_runner", None):
                     phase = runner._current_phase
-                else:
+                else:  # pragma: no cover  # in case of messing with internals
                     phase = "unknown"
                 tc = make_testcase(
                     start_timestamp=self._start_timestamp,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -175,6 +175,7 @@ class ConjectureRunner:
         self.stats_per_test_case.clear()
         start_time = time.perf_counter()
         try:
+            self._current_phase = phase
             yield
         finally:
             self.statistics[phase + "-phase"] = {
@@ -693,6 +694,7 @@ class ConjectureRunner:
         ran_optimisations = False
 
         while self.should_generate_more():
+            self._current_phase = "generate"
             prefix = self.generate_novel_prefix()
             assert len(prefix) <= BUFFER_SIZE
             if (
@@ -763,6 +765,7 @@ class ConjectureRunner:
                 and not ran_optimisations
             ):
                 ran_optimisations = True
+                self._current_phase = "target"
                 self.optimise_targets()
 
     def generate_mutations_from(self, data):
@@ -902,6 +905,7 @@ class ConjectureRunner:
             # but if we've been asked to run it but not generation then we have to
             # run it explciitly on its own here.
             if Phase.generate not in self.settings.phases:
+                self._current_phase = "target"
                 self.optimise_targets()
         with self._log_phase_statistics("shrink"):
             self.shrink_interesting_examples()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -554,7 +554,7 @@ class ConjectureRunner:
                 corpus.extend(extra)
 
             for existing in corpus:
-                data = self.cached_test_function(existing)
+                data = self.cached_test_function(existing, extend=BUFFER_SIZE)
                 if data.status != Status.INTERESTING:
                     self.settings.database.delete(self.database_key, existing)
                     self.settings.database.delete(self.secondary_key, existing)
@@ -569,7 +569,7 @@ class ConjectureRunner:
                 pareto_corpus.sort(key=sort_key)
 
                 for existing in pareto_corpus:
-                    data = self.cached_test_function(existing)
+                    data = self.cached_test_function(existing, extend=BUFFER_SIZE)
                     if data not in self.pareto_front:
                         self.settings.database.delete(self.pareto_key, existing)
                     if data.status == Status.INTERESTING:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -129,6 +129,7 @@ class ConjectureRunner:
 
         # Global dict of per-phase statistics, and a list of per-call stats
         # which transfer to the global dict at the end of each phase.
+        self._current_phase = "(not a phase)"
         self.statistics = {}
         self.stats_per_test_case = []
 
@@ -887,7 +888,8 @@ class ConjectureRunner:
             if any_improvements:
                 continue
 
-            self.pareto_optimise()
+            if self.best_observed_targets:
+                self.pareto_optimise()
 
             if prev_calls == self.call_count:
                 break
@@ -1015,6 +1017,7 @@ class ConjectureRunner:
             predicate,
             allow_transition=allow_transition,
             explain=Phase.explain in self.settings.phases,
+            in_target_phase=self._current_phase == "target",
         )
 
     def cached_test_function(self, buffer, *, error_on_discard=False, extend=0):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -317,7 +317,7 @@ class ParetoOptimiser:
                     # If ``destination`` dominates ``source`` then ``source``
                     # must be dominated in the front - either ``destination`` is in
                     # the front, or it was not added to it because it was
-                    # dominated by something in it.,
+                    # dominated by something in it.
                     try:
                         self.front.front.remove(source)
                     except ValueError:


### PR DESCRIPTION
*This problem was jointly identified in discussion of #3827 with @tybug  and @hgoldstein95.  Finding this kind of performance issue without knowing to look for it is a great illustration of the value of observability!*

It turns out that we're spuriously aborting many test cases with status=Overrun, due to `ConjectureData.from_buffer()` limiting the max length to the length of the provided bytestring unless `extend=...` is passed.  This makes sense in the `shrink` phase - any longer buffer cannot be a successful shrink, so we may as well abort early - but *not* in the `reuse` or `target` phases.

- The `reuse` phase is easy to fix: simply add the relevant argument to allow extending buffers replayed from the database - we'll get different behaviour, but get a performance gain (and maybe avoid `HealthCheck.filter_too_much`) by finishing this test case rather than retrying in the `generate` phase.
- The `target` phase is a little more complicated, and ... it turns out that by the time I worked out how we'd need to thread state through to the shrinker I had 80% of a fix, so this is now a PR rather than an issue 😅 

Tests tbd when I have some more time.