### PR TITLE
Observability - count sat/unsat calls to `assume()` and stateful `@precondition()`s

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch adds some :doc:`observability information <observability>`
+about how many times predicates in :func:`~hypothesis.assume` or
+:func:`~hypothesis.stateful.precondition` were satisfied, so that
+downstream tools can warn you if some were *never* satisfied by
+any test case.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1195,7 +1195,10 @@ class StateForActualGivenExecution:
                     },
                     "timing": self._timing_features,
                     "coverage": None,  # Not recorded when we're replaying the MFE
-                    "metadata": {"traceback": tb},
+                    "metadata": {
+                        "traceback": tb,
+                        "predicates": ran_example._observability_predicates,
+                    },
                 }
                 deliver_json_blob(tc)
                 # Whether or not replay actually raised the exception again, we want

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -91,6 +91,7 @@ from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.internal.observability import (
     OBSERVABILITY_COLLECT_COVERAGE,
     TESTCASE_CALLBACKS,
+    _system_metadata,
     deliver_json_blob,
     make_testcase,
 )
@@ -1066,7 +1067,6 @@ class StateForActualGivenExecution:
                     string_repr=self._string_repr,
                     arguments={**self._jsonable_arguments, **data._observability_args},
                     timing=self._timing_features,
-                    metadata={},
                     coverage=tractable_coverage_report(trace) or None,
                 )
                 deliver_json_blob(tc)
@@ -1198,6 +1198,7 @@ class StateForActualGivenExecution:
                     "metadata": {
                         "traceback": tb,
                         "predicates": ran_example._observability_predicates,
+                        **_system_metadata(),
                     },
                 }
                 deliver_json_blob(tc)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1450,6 +1450,9 @@ class ConjectureData:
         self.arg_slices: Set[Tuple[int, int]] = set()
         self.slice_comments: Dict[Tuple[int, int], str] = {}
         self._observability_args: Dict[str, Any] = {}
+        self._observability_predicates: defaultdict = defaultdict(
+            lambda: {"satisfied": 0, "unsatisfied": 0}
+        )
 
         self.extra_information = ExtraInformation()
 

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -70,6 +70,7 @@ def make_testcase(
         "metadata": {
             **(metadata or {}),
             "traceback": getattr(data.extra_information, "_expected_traceback", None),
+            "predicates": data._observability_predicates,
         },
         "coverage": coverage,
     }

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -13,8 +13,10 @@
 import json
 import os
 import sys
+import time
 import warnings
 from datetime import date, timedelta
+from functools import lru_cache
 from typing import Callable, Dict, List, Optional
 
 from hypothesis.configuration import storage_directory
@@ -38,7 +40,6 @@ def make_testcase(
     string_repr: str = "<unknown>",
     arguments: Optional[dict] = None,
     timing: Dict[str, float],
-    metadata: Optional[dict] = None,
     coverage: Optional[Dict[str, List[int]]] = None,
 ) -> dict:
     if data.interesting_origin:
@@ -68,9 +69,9 @@ def make_testcase(
         },
         "timing": timing,
         "metadata": {
-            **(metadata or {}),
             "traceback": getattr(data.extra_information, "_expected_traceback", None),
             "predicates": data._observability_predicates,
+            **_system_metadata(),
         },
         "coverage": coverage,
     }
@@ -86,6 +87,18 @@ def _deliver_to_file(value):  # pragma: no cover
     _WROTE_TO.add(fname)
     with fname.open(mode="a") as f:
         f.write(json.dumps(value) + "\n")
+
+
+_imported_at = time.time()
+
+
+@lru_cache
+def _system_metadata():
+    return {
+        "sys.argv": sys.argv,
+        "os.getpid()": os.getpid(),
+        "imported_at": _imported_at,
+    }
 
 
 OBSERVABILITY_COLLECT_COVERAGE = (

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -83,4 +83,4 @@ def test_assume_has_status_reason():
 
     gave_ups = [t for t in ls if t["type"] == "test_case" and t["status"] == "gave_up"]
     for gave_up in gave_ups:
-        assert gave_up["status_reason"] == "failed to satisfy assume() in f"
+        assert gave_up["status_reason"].startswith("failed to satisfy assume() in f")


### PR DESCRIPTION
This is part of #3845, which will enable downstream tools to resolve #213 for good.  Also includes some extra metadata to fix #3861, since it looked easy.

@hgoldstein95, let me know what you think - will this be useful for Tyche?