### PR TITLE
Directly use `ConjectureData.draw_boolean()` in `booleans()`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch refactors some internals. There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -242,6 +242,7 @@ def all_children(ir_type, kwargs):
         max_size = kwargs["max_size"]
         intervals = kwargs["intervals"]
 
+        # written unidiomatically in order to handle the case of max_size=inf.
         size = min_size
         while size <= max_size:
             for ords in itertools.product(intervals, repeat=size):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -117,7 +117,7 @@ from hypothesis.strategies._internal.collections import (
 from hypothesis.strategies._internal.deferred import DeferredStrategy
 from hypothesis.strategies._internal.functions import FunctionStrategy
 from hypothesis.strategies._internal.lazy import LazyStrategy, unwrap_strategies
-from hypothesis.strategies._internal.misc import just, none, nothing
+from hypothesis.strategies._internal.misc import BooleansStrategy, just, none, nothing
 from hypothesis.strategies._internal.numbers import (
     IntegersStrategy,
     Real,
@@ -158,14 +158,14 @@ else:
 
 
 @cacheable
-@defines_strategy()
+@defines_strategy(force_reusable_values=True)
 def booleans() -> SearchStrategy[bool]:
     """Returns a strategy which generates instances of :class:`python:bool`.
 
     Examples from this strategy will shrink towards ``False`` (i.e.
     shrinking will replace ``True`` with ``False`` where possible).
     """
-    return SampledFromStrategy([False, True], repr_="booleans()")
+    return BooleansStrategy()
 
 
 @overload

--- a/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
@@ -116,3 +116,11 @@ def nothing() -> SearchStrategy:
     Examples from this strategy do not shrink (because there are none).
     """
     return NOTHING
+
+
+class BooleansStrategy(SearchStrategy):
+    def do_draw(self, data):
+        return data.draw_boolean()
+
+    def __repr__(self):
+        return "booleans()"


### PR DESCRIPTION
I don't think this has a meaningful impact yet, but directly interfacing with the IR will provide benefits in the future (e.g. better/faster shrinking). Also shamelessly snuck in a comment about the IR, since I missed doing it before we merged #3818.

A general question: is there a difference between `@defines_strategy(force_reusable_values=True)` and stating so at the strategy level?
```python
class BooleansStrategy(SearchStrategy):
    ...
    def calc_has_reusable_values(self, recur):
        return True
```

Both seemed to work; I used the former here in order to match existing strategies, even though the latter seems more explicit.