### PR TITLE
Fix error with very large ints in `to_jsonable`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes an error when generating :doc:`observability <observability>` reports involving large (``n > 1e308``) integers.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -243,7 +243,7 @@ class LazySequenceCopy:
         return i
 
 
-def clamp(lower: int, value: int, upper: int) -> int:
+def clamp(lower: float, value: float, upper: float) -> float:
     """Given a value and lower/upper bounds, 'clamp' the value so that
     it satisfies lower <= value <= upper."""
     return max(lower, min(value, upper))

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -17,6 +17,7 @@ import attr
 
 from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.compat import dataclass_asdict
+from hypothesis.internal.conjecture.junkdrawer import clamp
 from hypothesis.internal.floats import float_to_int
 from hypothesis.internal.reflection import proxies
 from hypothesis.vendor.pretty import pretty
@@ -160,6 +161,9 @@ def to_jsonable(obj: object) -> object:
     """
     if isinstance(obj, (str, int, float, bool, type(None))):
         if isinstance(obj, int) and abs(obj) >= 2**63:
+            # Silently clamp very large ints to max_float, to avoid
+            # OverflowError when casting to float.
+            obj = clamp(-sys.float_info.max, obj, sys.float_info.max)
             return float(obj)
         return obj
     if isinstance(obj, (list, tuple, set, frozenset)):

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -527,7 +527,7 @@ def test_can_generate_hard_values():
     # this test doubles as conjecture coverage for using our child cache, so
     # ensure we don't miss that logic by getting lucky and drawing the correct
     # value once or twice.
-    for _ in range(5):
+    for _ in range(20):
         assert tree.generate_novel_prefix(Random()) == expected_buf
 
 
@@ -565,7 +565,7 @@ def test_can_generate_hard_floats():
     # this test doubles as conjecture coverage for drawing floats from the
     # children cache. Draw a few times to ensure we hit that logic (as opposed
     # to getting lucky and drawing the correct value the first time).
-    for _ in range(5):
+    for _ in range(20):
         expected_value = next_up_n(min_value, 100)
         prefix = tree.generate_novel_prefix(Random())
         data = ConjectureData.for_buffer(prefix)

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -11,6 +11,7 @@
 import dataclasses
 import functools
 import random
+import sys
 from collections import defaultdict, namedtuple
 
 import attr
@@ -153,3 +154,9 @@ def test_jsonable_large_ints_are_floats():
     n = 2**63
     assert isinstance(to_jsonable(n), float)
     assert to_jsonable(n) == float(n)
+
+
+def test_jsonable_very_large_ints():
+    # previously caused OverflowError when casting to float.
+    n = 2**1024
+    assert to_jsonable(n) == sys.float_info.max


### PR DESCRIPTION
Noticed when investigating https://github.com/HypothesisWorks/hypothesis/issues/3874.

Can reproduce with:

```python
@given(st.integers(0, 1<<10000))
def test_f(n):
    pass
test_f()
```

```
...
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/strategies/_internal/utils.py", line 163, in to_jsonable
    return float(obj)
           ^^^^^^^^^^
OverflowError: int too large to convert to float
```