### PR TITLE
Improve `draw_float_kwargs` and internal `draw_float` assertion to account for `0.0` vs `-0.0`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves some internal assertions about how we draw floats. There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1589,7 +1589,9 @@ class ConjectureData:
 
         if forced is not None:
             assert allow_nan or not math.isnan(forced)
-            assert math.isnan(forced) or min_value <= forced <= max_value
+            assert math.isnan(forced) or (
+                sign_aware_lte(min_value, forced) and sign_aware_lte(forced, max_value)
+            )
 
         kwargs: FloatKWargs = {
             "min_value": min_value,

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -159,6 +159,30 @@ def sign_aware_lte(x: float, y: float) -> bool:
         return x <= y
 
 
+def sign_aware_max(x: float, y: float) -> float:
+    """
+    builtin max(), but strictly orders -0.0 and 0.0.
+
+    Compare max(-0.0, 0.0) == -0.0 but max(0.0, -0.0) == 0.0.
+    """
+    if x == 0.0 == y:
+        return y if math.copysign(1.0, x) <= math.copysign(1.0, y) else x
+    else:
+        return max(x, y)
+
+
+def sign_aware_min(x: float, y: float) -> float:
+    """
+    builtin min(), but strictly orders -0.0 and 0.0.
+
+    Compare min(0.0, -0.0) == 0.0 but min(-0.0, 0.0) == -0.0.
+    """
+    if x == 0.0 == y:
+        return x if math.copysign(1.0, x) <= math.copysign(1.0, y) else y
+    else:
+        return min(x, y)
+
+
 SMALLEST_SUBNORMAL = next_up(0.0)
 SIGNALING_NAN = int_to_float(0x7FF8_0000_0000_0001)  # nonzero mantissa
 assert math.isnan(SIGNALING_NAN)

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -19,6 +19,7 @@ from hypothesis.internal.conjecture.engine import BUFFER_SIZE, ConjectureRunner
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.strategies._internal.strings import OneCharStringStrategy, TextStrategy
+from hypothesis.internal.floats import sign_aware_max
 
 from tests.common.strategies import intervals
 
@@ -201,7 +202,9 @@ def draw_float_kwargs(
         min_value = draw(st.floats(max_value=pivot, allow_nan=False))
 
     if use_max_value:
-        min_val = min_value if not pivot is not None else max(min_value, pivot)
+        min_val = (
+            min_value if not pivot is not None else sign_aware_max(min_value, pivot)
+        )
         max_value = draw(st.floats(min_value=min_val, allow_nan=False))
 
     return {"min_value": min_value, "max_value": max_value, "forced": forced}

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -18,8 +18,8 @@ from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE, ConjectureRunner
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.entropy import deterministic_PRNG
-from hypothesis.strategies._internal.strings import OneCharStringStrategy, TextStrategy
 from hypothesis.internal.floats import sign_aware_max
+from hypothesis.strategies._internal.strings import OneCharStringStrategy, TextStrategy
 
 from tests.common.strategies import intervals
 

--- a/hypothesis-python/tests/cover/test_float_utils.py
+++ b/hypothesis-python/tests/cover/test_float_utils.py
@@ -16,13 +16,13 @@ import pytest
 from hypothesis import example, given, strategies as st
 from hypothesis.internal.floats import (
     count_between_floats,
+    float_to_int,
     make_float_clamper,
     next_down,
     next_up,
     sign_aware_lte,
     sign_aware_max,
     sign_aware_min,
-    float_to_int,
 )
 
 

--- a/hypothesis-python/tests/cover/test_float_utils.py
+++ b/hypothesis-python/tests/cover/test_float_utils.py
@@ -19,6 +19,10 @@ from hypothesis.internal.floats import (
     make_float_clamper,
     next_down,
     next_up,
+    sign_aware_lte,
+    sign_aware_max,
+    sign_aware_min,
+    float_to_int,
 )
 
 
@@ -81,3 +85,33 @@ def test_float_clamper_with_allowed_zeros(min_value, max_value, input_value):
         assert input_value == clamped
     else:
         assert min_value <= clamped <= max_value
+
+
+@pytest.mark.parametrize(
+    "x, y, expected",
+    [
+        (-1, 1, True),
+        (1, -1, False),
+        (0.0, 0.0, True),
+        (-0.0, 0.0, True),
+        (0.0, -0.0, False),
+    ],
+)
+def test_sign_aware_lte(x, y, expected):
+    assert sign_aware_lte(x, y) is expected
+
+
+@pytest.mark.parametrize(
+    "x, y, expected",
+    [(-1, 1, 1), (1, -1, 1), (0.0, 0.0, 0.0), (-0.0, 0.0, 0.0), (0.0, -0.0, 0.0)],
+)
+def test_sign_aware_max(x, y, expected):
+    assert float_to_int(sign_aware_max(x, y)) == float_to_int(expected)
+
+
+@pytest.mark.parametrize(
+    "x, y, expected",
+    [(-1, 1, -1), (1, -1, -1), (0.0, 0.0, 0.0), (-0.0, 0.0, -0.0), (0.0, -0.0, -0.0)],
+)
+def test_sign_aware_min(x, y, expected):
+    assert float_to_int(sign_aware_min(x, y)) == float_to_int(expected)

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -28,7 +28,7 @@ from numbers import Real
 
 import pytest
 
-from hypothesis import HealthCheck, assume, given, settings, strategies as st, Verbosity
+from hypothesis import HealthCheck, Verbosity, assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument, ResolutionFailed, SmallSearchSpaceWarning
 from hypothesis.internal.compat import PYPY, get_type_hints
 from hypothesis.internal.conjecture.junkdrawer import stack_depth_of_caller

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -28,7 +28,7 @@ from numbers import Real
 
 import pytest
 
-from hypothesis import HealthCheck, assume, given, settings, strategies as st
+from hypothesis import HealthCheck, assume, given, settings, strategies as st, Verbosity
 from hypothesis.errors import InvalidArgument, ResolutionFailed, SmallSearchSpaceWarning
 from hypothesis.internal.compat import PYPY, get_type_hints
 from hypothesis.internal.conjecture.junkdrawer import stack_depth_of_caller
@@ -944,7 +944,8 @@ def test_timezone_lookup(type_):
         typing.Dict[typing.Hashable, int],
     ],
 )
-@settings(suppress_health_check=[HealthCheck.data_too_large])
+# temporary verbosity=debug to narrow down this flake.
+@settings(suppress_health_check=[HealthCheck.data_too_large], verbosity=Verbosity.debug)
 @given(data=st.data())
 def test_generic_collections_only_use_hashable_elements(typ, data):
     data.draw(from_type(typ))


### PR DESCRIPTION
Brought up in https://github.com/HypothesisWorks/hypothesis/pull/3881#issuecomment-1944493265.

Sign-aware strikes again. Our `draw_float_kwargs` strategy was unsound: it could generate e.g. forced=0.0, min_value=max_value=-0.0. I've fixed this and improved the relevant internal assertion so it gets caught earlier.