### PR TITLE
Add note to errors from strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch :pep:`adds a note <678>` to errors which occur while drawing from
+a strategy, to make it easier to tell why your test failed in such cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -40,7 +40,7 @@ import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
 from hypothesis.internal.cache import LRUReusedCache
-from hypothesis.internal.compat import floor, int_from_bytes, int_to_bytes
+from hypothesis.internal.compat import add_note, floor, int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
 from hypothesis.internal.conjecture.junkdrawer import IntList, uniform
 from hypothesis.internal.conjecture.utils import (
@@ -1748,14 +1748,17 @@ class ConjectureData:
         try:
             if not at_top_level:
                 return strategy.do_draw(self)
-            else:
-                assert start_time is not None
+            assert start_time is not None
+            key = observe_as or f"generate:unlabeled_{len(self.draw_times)}"
+            try:
                 strategy.validate()
                 try:
                     return strategy.do_draw(self)
                 finally:
-                    key = observe_as or f"generate:unlabeled_{len(self.draw_times)}"
                     self.draw_times[key] = time.perf_counter() - start_time
+            except Exception as err:
+                add_note(err, f"while generating {key[9:]!r} from {strategy!r}")
+                raise
         finally:
             self.stop_example()
 

--- a/hypothesis-python/tests/cover/test_error_in_draw.py
+++ b/hypothesis-python/tests/cover/test_error_in_draw.py
@@ -8,10 +8,13 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import re
+
 import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import HypothesisWarning
+from hypothesis.stateful import RuleBasedStateMachine, rule, run_state_machine_as_test
 
 
 def test_error_is_in_finally():
@@ -36,3 +39,31 @@ def test_warns_on_bool_strategy(data):
     ):
         if st.booleans():  # 'forgot' to draw from the strategy
             pass
+
+
+def test_adds_note_showing_which_strategy():
+    class X:
+        def __init__(self, y: int) -> None:
+            assert y == 7
+
+    @given(...)
+    def inner(value: X):
+        assert isinstance(value, X)
+
+    rep = re.escape(repr(st.from_type(X)))
+    with pytest.raises(AssertionError, match=f".*while generating 'value' from {rep}"):
+        inner()
+
+
+def test_adds_note_showing_which_strategy_stateful():
+    strategy = st.integers().map(lambda x: x / 0)
+
+    class Machine(RuleBasedStateMachine):
+        @rule(value=strategy)
+        def take_a_step(self, value):
+            assert value
+
+    msg = f"while generating 'value' from {strategy!r} for rule take_a_step"
+    print(msg)
+    with pytest.raises(ZeroDivisionError, match=f".*{re.escape(msg)}"):
+        run_state_machine_as_test(Machine)

--- a/hypothesis-python/tests/test_annotated_types.py
+++ b/hypothesis-python/tests/test_annotated_types.py
@@ -37,9 +37,10 @@ def test_strategy_priority_over_constraints():
 
 
 def test_invalid_annotated_type():
-    with pytest.raises(ResolutionFailed):
+    msg = re.escape("Did you mean `Annotated[str | int, 'dummy']`?")
+    with pytest.raises(ResolutionFailed, match=f".*{msg}$"):
         check_can_generate_examples(
-            st.from_type(Annotated[None, "dummy", Annotated[int, "dummy"]])
+            st.from_type(Annotated[str, "dummy", Annotated[int, "dummy"]])
         )
 
 


### PR DESCRIPTION
First commit inspired by https://github.com/HypothesisWorks/hypothesis/issues/3739#issuecomment-1954952599.  Second fixes https://github.com/HypothesisWorks/hypothesis/issues/3891 (along with https://github.com/annotated-types/annotated-types/pull/62 upstream).

I sometimes wonder what the world would be like if everyone cared this much about error messages...