### PR TITLE
Rewrite length filters for diverse collection types

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,6 @@
 RELEASE_TYPE: patch
 
 This patch implements filter-rewriting for most length filters on some
-additional collection types (:issue:`3795`).
+additional collection types (:issue:`3795`), and fixes several latent
+bugs where unsatisfiable or partially-infeasible rewrites could trigger
+internal errors.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch implements filter-rewriting for most length filters on some
+additional collection types (:issue:`3795`).

--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -122,7 +122,7 @@ from hypothesis.strategies._internal.flatmapped import FlatMapStrategy
 from hypothesis.strategies._internal.lazy import LazyStrategy, unwrap_strategies
 from hypothesis.strategies._internal.strategies import (
     FilteredStrategy,
-    MappedSearchStrategy,
+    MappedStrategy,
     OneOfStrategy,
     SampledFromStrategy,
 )
@@ -627,7 +627,7 @@ def _imports_for_strategy(strategy):
         strategy = unwrap_strategies(strategy)
 
     # Get imports for s.map(f), s.filter(f), s.flatmap(f), including both s and f
-    if isinstance(strategy, MappedSearchStrategy):
+    if isinstance(strategy, MappedStrategy):
         imports |= _imports_for_strategy(strategy.mapped_strategy)
         imports |= _imports_for_object(strategy.pack)
     if isinstance(strategy, FilteredStrategy):

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -50,7 +50,7 @@ from hypothesis.strategies._internal.lazy import unwrap_strategies
 from hypothesis.strategies._internal.numbers import Real
 from hypothesis.strategies._internal.strategies import (
     Ex,
-    MappedSearchStrategy,
+    MappedStrategy,
     T,
     check_strategy,
 )
@@ -516,7 +516,7 @@ def arrays(
     # If there's a redundant cast to the requested dtype, remove it.  This unlocks
     # optimizations such as fast unique sampled_from, and saves some time directly too.
     unwrapped = unwrap_strategies(elements)
-    if isinstance(unwrapped, MappedSearchStrategy) and unwrapped.pack == dtype.type:
+    if isinstance(unwrapped, MappedStrategy) and unwrapped.pack == dtype.type:
         elements = unwrapped.mapped_strategy
     if isinstance(shape, int):
         shape = (shape,)

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -33,7 +33,10 @@ from typing import Any, Callable, Collection, Dict, NamedTuple, Optional, TypeVa
 
 from hypothesis.internal.compat import ceil, floor
 from hypothesis.internal.floats import next_down, next_up
-from hypothesis.internal.reflection import extract_lambda_source
+from hypothesis.internal.reflection import (
+    extract_lambda_source,
+    get_pretty_function_description,
+)
 
 Ex = TypeVar("Ex")
 Predicate = Callable[[Ex], bool]
@@ -63,6 +66,10 @@ class ConstructivePredicate(NamedTuple):
     @classmethod
     def unchanged(cls, predicate: Predicate) -> "ConstructivePredicate":
         return cls({}, predicate)
+
+    def __repr__(self) -> str:
+        fn = get_pretty_function_description(self.predicate)
+        return f"{self.__class__.__name__}(kwargs={self.kwargs!r}, predicate={fn})"
 
 
 ARG = object()
@@ -147,8 +154,8 @@ def merge_preds(*con_predicates: ConstructivePredicate) -> ConstructivePredicate
             elif kw["max_value"] == base["max_value"]:
                 base["exclude_max"] |= kw.get("exclude_max", False)
 
-    has_len = {"len" in kw for kw, _ in con_predicates}
-    assert len(has_len) == 1, "can't mix numeric with length constraints"
+    has_len = {"len" in kw for kw, _ in con_predicates if kw}
+    assert len(has_len) <= 1, "can't mix numeric with length constraints"
     if has_len == {True}:
         base["len"] = True
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -23,7 +23,7 @@ from hypothesis.strategies._internal.strategies import (
     T4,
     T5,
     Ex,
-    MappedSearchStrategy,
+    MappedStrategy,
     SearchStrategy,
     T,
     check_strategy,
@@ -302,7 +302,7 @@ class UniqueSampledListStrategy(UniqueListStrategy):
         return result
 
 
-class FixedKeysDictStrategy(MappedSearchStrategy):
+class FixedKeysDictStrategy(MappedStrategy):
     """A strategy which produces dicts with a fixed set of keys, given a
     strategy for each of their equivalent values.
 
@@ -311,18 +311,18 @@ class FixedKeysDictStrategy(MappedSearchStrategy):
     """
 
     def __init__(self, strategy_dict):
-        self.dict_type = type(strategy_dict)
+        dict_type = type(strategy_dict)
         self.keys = tuple(strategy_dict.keys())
-        super().__init__(strategy=TupleStrategy(strategy_dict[k] for k in self.keys))
+        super().__init__(
+            strategy=TupleStrategy(strategy_dict[k] for k in self.keys),
+            pack=lambda value: dict_type(zip(self.keys, value)),
+        )
 
     def calc_is_empty(self, recur):
         return recur(self.mapped_strategy)
 
     def __repr__(self):
         return f"FixedKeysDictStrategy({self.keys!r}, {self.mapped_strategy!r})"
-
-    def pack(self, value):
-        return self.dict_type(zip(self.keys, value))
 
 
 class FixedAndOptionalKeysDictStrategy(SearchStrategy):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -211,6 +211,9 @@ class ListStrategy(SearchStrategy):
             new = copy.copy(self)
             new.min_size = max(self.min_size, kwargs.get("min_value", self.min_size))
             new.max_size = min(self.max_size, kwargs.get("max_value", self.max_size))
+            # Unsatisfiable filters are easiest to understand without rewriting.
+            if new.min_size > new.max_size:
+                return SearchStrategy.filter(self, condition)
             # Recompute average size; this is cheaper than making it into a property.
             new.average_size = min(
                 max(new.min_size * 2, new.min_size + 5),

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -519,7 +519,10 @@ class SampledFromStrategy(SearchStrategy):
         # Used in UniqueSampledListStrategy
         for name, f in self._transformations:
             if name == "map":
-                element = f(element)
+                result = f(element)
+                if build_context := _current_build_context.value:
+                    build_context.record_call(result, f, [element], {})
+                element = result
             else:
                 assert name == "filter"
                 if not f(element):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -852,7 +852,7 @@ class MappedStrategy(SearchStrategy[Ex]):
         ListStrategy = _list_strategy_type()
         if not isinstance(self.mapped_strategy, ListStrategy) or not (
             (isinstance(self.pack, type) and issubclass(self.pack, abc.Collection))
-            or self.pack is sorted
+            or self.pack in _collection_ish_functions()
         ):
             return super().filter(condition)
 
@@ -872,6 +872,36 @@ def _list_strategy_type():
     from hypothesis.strategies._internal.collections import ListStrategy
 
     return ListStrategy
+
+
+def _collection_ish_functions():
+    funcs = [sorted]
+    if np := sys.modules.get("numpy"):
+        # c.f. https://numpy.org/doc/stable/reference/routines.array-creation.html
+        # Probably only `np.array` and `np.asarray` will be used in practice,
+        # but why should that stop us when we've already gone this far?
+        funcs += [
+            np.empty_like,
+            np.eye,
+            np.identity,
+            np.ones_like,
+            np.zeros_like,
+            np.array,
+            np.asarray,
+            np.asanyarray,
+            np.ascontiguousarray,
+            np.asmatrix,
+            np.copy,
+            np.rec.array,
+            np.rec.fromarrays,
+            np.rec.fromrecords,
+            np.diag,
+            # bonus undocumented functions from tab-completion:
+            np.asarray_chkfinite,
+            np.asfarray,
+            np.asfortranarray,
+        ]
+    return funcs
 
 
 filter_not_satisfied = UniqueIdentifier("filter not satisfied")

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -347,7 +347,7 @@ def test_can_override_label():
 def test_will_mark_too_deep_examples_as_invalid():
     d = ConjectureData.for_buffer(bytes(0))
 
-    s = st.none()
+    s = st.integers()
     for _ in range(MAX_DEPTH + 1):
         s = s.map(lambda x: None)
 

--- a/hypothesis-python/tests/cover/test_custom_reprs.py
+++ b/hypothesis-python/tests/cover/test_custom_reprs.py
@@ -79,7 +79,7 @@ class Bar(Foo):
 
 def test_reprs_as_created():
     @given(foo=st.builds(Foo), bar=st.from_type(Bar), baz=st.none().map(Foo))
-    @settings(print_blob=False, max_examples=10_000)
+    @settings(print_blob=False, max_examples=10_000, derandomize=True)
     def inner(foo, bar, baz):
         assert baz.x is None
         assert foo.x <= 0 or bar.x >= 0

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -504,6 +504,9 @@ def test_filter_rewriting_text_lambda_len(data, strategy, predicate, start, end)
     assert predicate(value)
 
 
+two = 2
+
+
 @pytest.mark.parametrize(
     "predicate, start, end",
     [
@@ -525,6 +528,9 @@ def test_filter_rewriting_text_lambda_len(data, strategy, predicate, start, end)
         (lambda x: len(x) < 1 and len(x) < 1, 0, 0),
         (lambda x: len(x) > 1 and len(x) > 0, 2, 3),  # input max element_count=3
         (lambda x: len(x) < 1 and len(x) < 2, 0, 0),
+        # Comparisons involving one literal and one variable
+        (lambda x: 1 <= len(x) <= two, 1, 3),
+        (lambda x: two <= len(x) <= 4, 0, 3),
     ],
     ids=get_pretty_function_description,
 )
@@ -536,7 +542,7 @@ def test_filter_rewriting_text_lambda_len(data, strategy, predicate, start, end)
     ids=get_pretty_function_description,
 )
 @given(data=st.data())
-def test_filter_rewriting_text_lambda_len_unique_elements(
+def test_filter_rewriting_lambda_len_unique_elements(
     data, strategy, predicate, start, end
 ):
     s = strategy.filter(predicate)
@@ -550,3 +556,20 @@ def test_filter_rewriting_text_lambda_len_unique_elements(
     assert unwrapped.filtered_strategy.max_size == end
     value = data.draw(s)
     assert predicate(value)
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        (lambda x: len(x) < 3),
+        (lambda x: len(x) > 5),
+    ],
+    ids=get_pretty_function_description,
+)
+def test_does_not_rewrite_unsatisfiable_len_filter(predicate):
+    strategy = st.lists(st.none(), min_size=4, max_size=4).filter(predicate)
+    with pytest.raises(Unsatisfiable):
+        check_can_generate_examples(strategy)
+    # Rewriting to nothing() would correctly express the constraint.  However
+    # we don't want _only rewritable strategies_ to work in e.g. one_of, so:
+    assert not strategy.is_empty


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/3795; implementing rewriting for `st.lists(...).map(<some type>).filter(<length check>)` covers all the common cases with pretty reasonable code.  I suppose we'll learn from users, eventually, if there's something this doesn't cover.

The known gaps are `st.from_type(bytearray)` and `memoryview`, because they can only operate on bytestrings and therefore require a `st.lists(...).map(bytes).map(memoryview)` and this branch only sees through one layer of mapping.  We could generalize MappedStrategy to have a tuple of pack functions, analogously to FilteredStrategy?  But tbh I'm inclined to ship without them and revisit later.

let's see what CI thinks...