### PR TITLE
migrate `Float` shrinker to the ir

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch starts work on refactoring our shrinker internals. There is no user-visible change.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1991,8 +1991,8 @@ class ConjectureData:
         p: float = 0.5,
         *,
         forced: Optional[bool] = None,
-        observe: bool = True,
         fake_forced: bool = False,
+        observe: bool = True,
     ) -> bool:
         # Internally, we treat probabilities lower than 1 / 2**64 as
         # unconditionally false.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Dict, Optional
 
@@ -19,14 +20,9 @@ from hypothesis.internal.conjecture.choicetree import (
     prefix_selection_order,
     random_selection_order,
 )
-from hypothesis.internal.conjecture.data import (
-    DRAW_FLOAT_LABEL,
-    ConjectureData,
-    ConjectureResult,
-    Status,
-)
+from hypothesis.internal.conjecture.data import ConjectureData, ConjectureResult, Status
 from hypothesis.internal.conjecture.dfa import ConcreteDFA
-from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
+from hypothesis.internal.conjecture.floats import is_simple
 from hypothesis.internal.conjecture.junkdrawer import (
     binary_search,
     find_integer,
@@ -378,6 +374,12 @@ class Shrinker:
         """Return the number of calls that have been made to the underlying
         test function."""
         return self.engine.call_count
+
+    def consider_new_tree(self, tree):
+        data = ConjectureData.for_ir_tree(tree)
+        self.engine.test_function(data)
+
+        return self.consider_new_buffer(data.buffer)
 
     def consider_new_buffer(self, buffer):
         """Returns True if after running this buffer the result would be
@@ -773,6 +775,10 @@ class Shrinker:
     @property
     def blocks(self):
         return self.shrink_target.blocks
+
+    @property
+    def nodes(self):
+        return self.shrink_target.examples.ir_tree_nodes
 
     @property
     def examples(self):
@@ -1207,31 +1213,32 @@ class Shrinker:
         anything particularly meaningful for non-float values.
         """
 
-        ex = chooser.choose(
-            self.examples,
-            lambda ex: (
-                ex.label == DRAW_FLOAT_LABEL
-                and len(ex.children) == 2
-                and ex.children[1].length == 8
-            ),
+        node = chooser.choose(
+            self.nodes, lambda node: node.ir_type == "float" and not node.was_forced
         )
+        # avoid shrinking integer-valued floats. In our current ordering, these
+        # are already simpler than all other floats, so it's better to shrink
+        # them in other passes.
+        if is_simple(node.value):
+            return
 
-        u = ex.children[1].start
-        v = ex.children[1].end
-        buf = self.shrink_target.buffer
-        b = buf[u:v]
-        f = lex_to_float(int_from_bytes(b))
-        b2 = int_to_bytes(float_to_lex(f), 8)
-        if b == b2 or self.consider_new_buffer(buf[:u] + b2 + buf[v:]):
-            Float.shrink(
-                f,
-                lambda x: self.consider_new_buffer(
-                    self.shrink_target.buffer[:u]
-                    + int_to_bytes(float_to_lex(x), 8)
-                    + self.shrink_target.buffer[v:]
-                ),
-                random=self.random,
-            )
+        i = self.nodes.index(node)
+        # the Float shrinker was only built to handle positive floats. We'll
+        # shrink the positive portion and reapply the sign after, which is
+        # equivalent to this shrinker's previous behavior. We'll want to refactor
+        # Float to handle negative floats natively in the future. (likely a pure
+        # code quality change, with no shrinking impact.)
+        sign = math.copysign(1.0, node.value)
+        Float.shrink(
+            abs(node.value),
+            lambda val: self.consider_new_tree(
+                self.nodes[:i]
+                + [node.copy(with_value=sign * val)]
+                + self.nodes[i + 1 :]
+            ),
+            random=self.random,
+            node=node,
+        )
 
     @defines_shrink_pass()
     def redistribute_block_pairs(self, chooser):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1214,13 +1214,13 @@ class Shrinker:
         """
 
         node = chooser.choose(
-            self.nodes, lambda node: node.ir_type == "float" and not node.was_forced
+            self.nodes,
+            lambda node: node.ir_type == "float" and not node.was_forced
+            # avoid shrinking integer-valued floats. In our current ordering, these
+            # are already simpler than all other floats, so it's better to shrink
+            # them in other passes.
+            and not is_simple(node.value),
         )
-        # avoid shrinking integer-valued floats. In our current ordering, these
-        # are already simpler than all other floats, so it's better to shrink
-        # them in other passes.
-        if is_simple(node.value):
-            return
 
         i = self.nodes.index(node)
         # the Float shrinker was only built to handle positive floats. We'll

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -133,6 +133,7 @@ class Shrinker:
     def consider(self, value):
         """Returns True if make_immutable(value) == self.current after calling
         self.incorporate(value)."""
+        self.debug(f"considering {value}")
         value = self.make_immutable(value)
         if value == self.current:
             return True

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -11,10 +11,10 @@
 import math
 import sys
 
+from hypothesis.internal.conjecture.data import ir_value_permitted
 from hypothesis.internal.conjecture.floats import float_to_lex
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
-from hypothesis.internal.floats import sign_aware_lte
 
 MAX_PRECISE_INTEGER = 2**53
 
@@ -28,9 +28,7 @@ class Float(Shrinker):
     def consider(self, value):
         min_value = self.node.kwargs["min_value"]
         max_value = self.node.kwargs["max_value"]
-        if not math.isnan(value) and not (
-            sign_aware_lte(min_value, value) and sign_aware_lte(value, max_value)
-        ):
+        if not ir_value_permitted(value, "float", self.node.kwargs):
             self.debug(
                 f"rejecting {value} as out of bounds for [{min_value}, {max_value}]"
             )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -14,14 +14,28 @@ import sys
 from hypothesis.internal.conjecture.floats import float_to_lex
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
+from hypothesis.internal.floats import sign_aware_lte
 
 MAX_PRECISE_INTEGER = 2**53
 
 
 class Float(Shrinker):
-    def setup(self):
+    def setup(self, node):
         self.NAN = math.nan
         self.debugging_enabled = True
+        self.node = node
+
+    def consider(self, value):
+        min_value = self.node.kwargs["min_value"]
+        max_value = self.node.kwargs["max_value"]
+        if not math.isnan(value) and not (
+            sign_aware_lte(min_value, value) and sign_aware_lte(value, max_value)
+        ):
+            self.debug(
+                f"rejecting {value} as out of bounds for [{min_value}, {max_value}]"
+            )
+            return False
+        return super().consider(value)
 
     def make_immutable(self, f):
         f = float(f)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -26,12 +26,8 @@ class Float(Shrinker):
         self.node = node
 
     def consider(self, value):
-        min_value = self.node.kwargs["min_value"]
-        max_value = self.node.kwargs["max_value"]
         if not ir_value_permitted(value, "float", self.node.kwargs):
-            self.debug(
-                f"rejecting {value} as out of bounds for [{min_value}, {max_value}]"
-            )
+            self.debug(f"rejecting {value} as disallowed for {self.node.kwargs}")
             return False
         return super().consider(value)
 

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+from math import isnan
+
 import pytest
 
 from hypothesis import assume, example, given, strategies as st
@@ -222,7 +224,8 @@ def test_copy_ir_node(node):
 
     assume(not node.was_forced)
     new_value = draw_value(node.ir_type, node.kwargs)
-    # if we drew the same value as before, the node should still be equal.
+    # if we drew the same value as before, the node should still be equal (unless nan)
+    assume(node.ir_type != "float" or not (isnan(new_value) or isnan(node.value)))
     assert (node.copy(with_value=new_value) == node) is (new_value == node.value)
 
 

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -359,7 +359,7 @@ def test_data_with_empty_ir_tree_is_overrun():
 
 
 @given(st.data())
-def test_data_with_misaligned_ir_tree_is_overrun(data):
+def test_data_with_misaligned_ir_tree_is_invalid(data):
     node = data.draw(ir_nodes())
     (ir_type, kwargs) = data.draw(ir_types_and_kwargs())
 
@@ -375,7 +375,7 @@ def test_data_with_misaligned_ir_tree_is_overrun(data):
     with pytest.raises(StopTest):
         draw_func(**kwargs)
 
-    assert data.status is Status.OVERRUN
+    assert data.status is Status.INVALID
 
 
 @given(ir_types_and_kwargs())


### PR DESCRIPTION
I had originally tried writing a `shrinker_v2.py` from scratch...and quickly abandoned it as infeasible. I think my current plan is to convert shrinking passes one by one (where possible, which may or may not be all of them). `minimize_floats` is one of the more directly applicable ones. 

Definitely open to feedback on the details of the migration approach here. 

There is overlap in the `IRTree` definition with #3806, though it's not exactly the same. Either is fine to merge before the other; I'll handle conflict resolution whichever way.