### PR TITLE
Support `2023.12` version of the array API

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -2,5 +2,7 @@ RELEASE_TYPE: patch
 
 This release adds support for the Array API's `2023.12 release
 <https://data-apis.org/array-api/2023.12/>`_ via the ``api_version`` argument in
-:func:`~hypothesis.extra.array_api.make_strategies_namespace`. There is no
-distinction between a ``2012.12`` and ``2023.12`` strategies namespace.
+:func:`~hypothesis.extra.array_api.make_strategies_namespace`. The API additions
+and modifications in the ``2023.12`` spec do not necessitate any changes in the
+Hypothesis strategies, hence there is no distinction between a ``2022.12`` and
+``2023.12`` strategies namespace.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release adds support for the Array API's `2023.12 release
+<https://data-apis.org/array-api/2023.12/>`_ via the ``api_version`` argument in
+:func:`~hypothesis.extra.array_api.make_strategies_namespace`. There is no
+distinction between a ``2012.12`` and ``2023.12`` strategies namespace.

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -63,7 +63,7 @@ Hypothesis offers strategies for `Array API <https://data-apis.org/>`_ adopting
 libraries in the ``hypothesis.extra.array_api`` package. See :issue:`3037` for
 more details.  If you want to test with :pypi:`CuPy`, :pypi:`Dask`, :pypi:`JAX`,
 :pypi:`MXNet`, :pypi:`PyTorch <torch>`, :pypi:`TensorFlow`, or :pypi:`Xarray` -
-or just ``numpy.array_api`` - this is the extension for you!
+or just :pypi:`NumPy` - this is the extension for you!
 
 .. autofunction:: hypothesis.extra.array_api.make_strategies_namespace
 

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -69,10 +69,10 @@ __all__ = [
 ]
 
 
-RELEASED_VERSIONS = ("2021.12", "2022.12")
+RELEASED_VERSIONS = ("2021.12", "2022.12", "2023.12")
 NOMINAL_VERSIONS = (*RELEASED_VERSIONS, "draft")
 assert sorted(NOMINAL_VERSIONS) == list(NOMINAL_VERSIONS)  # sanity check
-NominalVersion = Literal["2021.12", "2022.12", "draft"]
+NominalVersion = Literal["2021.12", "2022.12", "2023.12", "draft"]
 assert get_args(NominalVersion) == NOMINAL_VERSIONS  # sanity check
 
 

--- a/hypothesis-python/tests/array_api/README.md
+++ b/hypothesis-python/tests/array_api/README.md
@@ -3,7 +3,7 @@ This folder contains tests for `hypothesis.extra.array_api`.
 ## Mocked array module
 
 A mock of the Array API namespace exists as `mock_xp` in `extra.array_api`. This
-wraps NumPy-proper to conform it to the *draft* spec, where `numpy.array_api`
+wraps NumPy-proper to conform it to the *draft* spec, where `array_api_strict`
 might not. This is not a fully compliant wrapper, but conforms enough for the
 purposes of testing.
 
@@ -21,7 +21,7 @@ If neither of these, the test suite will then try resolve the variable like so:
 1. If the variable matches a name of an available entry point, load said entry point.
 2. If the variables matches a valid import path, import said path.
 
-For example, to specify NumPy's Array API implementation, you could use its
+For example, to specify NumPy's Array API implementation[^1], you could use its
 entry point (**1.**),
 
     HYPOTHESIS_TEST_ARRAY_API=numpy pytest tests/array_api
@@ -48,3 +48,6 @@ Otherwise the test suite will use the variable as the `api_version` argument for
 In the future we intend to support running tests against multiple API versioned
 namespaces, likely with an additional recognized option that infers all
 supported versions.
+
+[^1]: Note NumPy will likely remove `numpy.array_api` in the future ([NEP 56](https://github.com/numpy/numpy/pull/25542))
+in favour of the third-party [`array-api-strict`](https://github.com/data-apis/array-api-strict) library.


### PR DESCRIPTION
The array API has just had its `2023.12` release (https://github.com/data-apis/array-api/pull/755)... in Feb 2024 :sweat_smile: This PR simply accepts `api_version="2023.12"` for `extra.array_api.make_strategies_namespace()`.

---

I believe there aren't any changes that should necessitate what the strategies namespace is doing for `2023.12`! I assume this will be an on-going trend, as I can't think of any existing discussions that would either shake-up the existing strategies or want us to add news ones.

I did have the idea to maybe just warn instead of erroring when `api_version` is greater than the last item of `RELEASED_VERSIONS` (and not `draft`), so we don't "annoy" libraries by asking them to use an older `api_version` kwarg for `make_strategies_namespace()` whilst they wait on us to update one variable upstream for a very trivial change :thinking: I'm really not sure and might be something to just see how future array API iterations play out first.

---

It's also worth noting that `numpy.array_api` will most likely be removed at some point (https://github.com/numpy/numpy/pull/25542) and superseded by the new [`array-api-strict`](https://github.com/data-apis/array-api-strict) third-party package. As that library is "official" and pretty stable (esp. for the purposes of what `extra.array_api` does), is that something we'd want for CI @Zac-HD? If so, I can try work out how to do CI things with some direction.

There's also [`array-api-compat`](https://github.com/data-apis/array-api-compat) which could be a good start in covering libraries other than NumPy (CuPy, PyTorch, Dask, possibly more in the future). I'll be having a think on it generally for the array API test suite (https://github.com/data-apis/array-api-tests/issues/235) anywho.