### PR TITLE
Fix unimplemented default TypeVar argument in 3.13a4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,9 @@ jobs:
           - check-py312-cover
           - check-py312-nocover
           - check-py312-niche
-          # - check-py313-cover
+          - check-py313-cover
+          - check-py313-nocover
+          - check-py313-niche
           - check-quality
           ## Skip all the (inactive/old) Rust and Ruby tests pending fixes
           # - lint-ruby

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Fix regression caused by using :pep:`696` default in TypeVar with Python 3.13a4.
+Fix regression caused by using :pep:`696` default in TypeVar with Python 3.13.0a3.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix regression caused by using :pep:`696` default in TypeVar with Python 3.13a4.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -58,7 +58,7 @@ if sys.version_info >= (3, 13, 0, "final"):
 elif TYPE_CHECKING:
     from typing_extensions import TypeVar  # type: ignore[assignment]
 
-    Ex = TypeVar("Ex", covariant=True, default=Any)
+    Ex = TypeVar("Ex", covariant=True, default=Any)  # type: ignore[call-arg,misc]
 else:
     Ex = TypeVar("Ex", covariant=True)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -52,7 +52,8 @@ from hypothesis.internal.reflection import (
 from hypothesis.strategies._internal.utils import defines_strategy
 from hypothesis.utils.conventions import UniqueIdentifier
 
-if sys.version_info >= (3, 13):
+# TODO: Use `(3, 13)` once Python 3.13 is released.
+if sys.version_info >= (3, 13, 0, "final"):
     Ex = TypeVar("Ex", covariant=True, default=Any)
 elif TYPE_CHECKING:
     from typing_extensions import TypeVar  # type: ignore[assignment]

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -519,16 +519,13 @@ def test_can_generate_hard_values():
         data.draw_integer(min_value, max_value)
         data.freeze()
 
-    @run_to_buffer
-    def expected_buf(data):
-        data.draw_integer(min_value, max_value, forced=max_value)
-        data.mark_interesting()
-
     # this test doubles as conjecture coverage for using our child cache, so
     # ensure we don't miss that logic by getting lucky and drawing the correct
     # value once or twice.
     for _ in range(20):
-        assert tree.generate_novel_prefix(Random()) == expected_buf
+        prefix = tree.generate_novel_prefix(Random())
+        data = ConjectureData.for_buffer(prefix)
+        assert data.draw_integer(min_value, max_value) == 1000
 
 
 def test_can_generate_hard_floats():

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -12,6 +12,7 @@ import decimal
 import math
 import operator
 import re
+import sys
 from fractions import Fraction
 from functools import partial
 from sys import float_info
@@ -33,6 +34,10 @@ from tests.common.debug import check_can_generate_examples
 from tests.common.utils import fails_with
 
 A_FEW = 15  # speed up massively-parametrized tests
+
+# FIXME-3.13: something about get_lambda_source not working with pytest-xdist?
+if sys.version_info[:2] == (3, 13) and sys.version_info.releaselevel < "final":
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -8,6 +8,10 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
+
+import pytest
+
 from hypothesis.internal.reflection import get_pretty_function_description
 
 
@@ -15,6 +19,7 @@ def test_bracket_whitespace_is_striped():
     assert get_pretty_function_description(lambda x: (x + 1)) == "lambda x: (x + 1)"
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="FIXME-3.13")
 def test_no_whitespace_before_colon_with_no_args():
     assert get_pretty_function_description(eval("lambda: None")) == "lambda: <unknown>"
 
@@ -58,6 +63,7 @@ def test_variable_names_are_not_pretty():
     assert get_pretty_function_description(t) == "lambda x: True"
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="FIXME-3.13")
 def test_does_not_error_on_dynamically_defined_functions():
     x = eval("lambda t: 1")
     get_pretty_function_description(x)


### PR DESCRIPTION
- Fix #3916
- The regression was introduced by #3915
- PEP 696 was accepted but is not currently implemented python/cpython#116129

also closes #3918 by cherry-picking