### PR TITLE
deflake `test_can_generate_hard_values`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch deflakes one of our internal tests.

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -519,16 +519,13 @@ def test_can_generate_hard_values():
         data.draw_integer(min_value, max_value)
         data.freeze()
 
-    @run_to_buffer
-    def expected_buf(data):
-        data.draw_integer(min_value, max_value, forced=max_value)
-        data.mark_interesting()
-
     # this test doubles as conjecture coverage for using our child cache, so
     # ensure we don't miss that logic by getting lucky and drawing the correct
     # value once or twice.
     for _ in range(20):
-        assert tree.generate_novel_prefix(Random()) == expected_buf
+        prefix = tree.generate_novel_prefix(Random())
+        data = ConjectureData.for_buffer(prefix)
+        assert data.draw_integer(min_value, max_value) == 1000
 
 
 def test_can_generate_hard_floats():


### PR DESCRIPTION
[Saw this fail again](https://github.com/HypothesisWorks/hypothesis/actions/runs/8230099344/job/22504897853) and figured I'd better pay up my IOU here. I think rejection sampling was the culprit of changing buffers here.