### PR TITLE
Fix performance of `RuleBasedStateMachine` with data-hungry rules

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes a longstanding performance problem in stateful testing (:issue:`3618`),
+where state machines which generated a substantial amount of input for each step would
+hit the maximum amount of entropy and then fail with an ``Unsatisfiable`` error.
+
+We now stop taking additional steps when we're approaching the entropy limit,
+which neatly resolves the problem without touching unaffected tests.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1693,7 +1693,7 @@ class ConjectureData:
         if observer is None:
             observer = DataObserver()
         assert isinstance(observer, DataObserver)
-        self.__bytes_drawn = 0
+        self._bytes_drawn = 0
         self.observer = observer
         self.max_length = max_length
         self.is_find = False
@@ -2264,8 +2264,8 @@ class ConjectureData:
 
         if forced is not None:
             buf = int_to_bytes(forced, n_bytes)
-        elif self.__bytes_drawn < len(self.__prefix):
-            index = self.__bytes_drawn
+        elif self._bytes_drawn < len(self.__prefix):
+            index = self._bytes_drawn
             buf = self.__prefix[index : index + n_bytes]
             if len(buf) < n_bytes:
                 assert self.__random is not None
@@ -2274,7 +2274,7 @@ class ConjectureData:
             assert self.__random is not None
             buf = uniform(self.__random, n_bytes)
         buf = bytearray(buf)
-        self.__bytes_drawn += n_bytes
+        self._bytes_drawn += n_bytes
 
         assert len(buf) == n_bytes
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -49,6 +49,7 @@ from hypothesis.core import TestFunc, given
 from hypothesis.errors import InvalidArgument, InvalidDefinition
 from hypothesis.internal.compat import add_note
 from hypothesis.internal.conjecture import utils as cu
+from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.internal.observability import TESTCASE_CALLBACKS
 from hypothesis.internal.reflection import (
@@ -151,6 +152,10 @@ def run_state_machine_as_test(state_machine_factory, *, settings=None, _min_step
                     must_stop = True
                 elif steps_run <= _min_steps:
                     must_stop = False
+                elif cd._bytes_drawn > (0.8 * BUFFER_SIZE):
+                    # Better to stop after fewer steps, than always overrun and retry.
+                    # See https://github.com/HypothesisWorks/hypothesis/issues/3618
+                    must_stop = True
 
                 start_draw = perf_counter()
                 if cd.draw_boolean(p=2**-16, forced=must_stop):

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1288,3 +1288,13 @@ state.fail_fast(a1=a_5, a2=a_4, a3=a_3, a4=a_2, a5=a_1, a6=a_0, b1=b_2, b2=b_1, 
 state.teardown()
 """.strip()
     )
+
+
+class LotsOfEntropyPerStepMachine(RuleBasedStateMachine):
+    # Regression tests for https://github.com/HypothesisWorks/hypothesis/issues/3618
+    @rule(data=binary(min_size=512, max_size=512))
+    def rule1(self, data):
+        assert data
+
+
+TestLotsOfEntropyPerStepMachine = LotsOfEntropyPerStepMachine.TestCase


### PR DESCRIPTION
Fixes #3618; it turns out this wasn't about filtering at all.