### PR TITLE
Migrate `reorder_examples` to the IR

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch continues our work on refactoring shrinker internals (:issue:`3921`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -2186,7 +2186,7 @@ class ConjectureData:
         # that is allowed by the expected kwargs, then we can coerce this node
         # into an aligned one by using its value. It's unclear how useful this is.
         if not ir_value_permitted(node.value, node.ir_type, kwargs):
-            self.mark_invalid()  # pragma: no cover  # FIXME @tybug
+            self.mark_invalid()
 
         return node
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -290,6 +290,14 @@ class Example:
         return self.owner.ends[self.index]
 
     @property
+    def ir_start(self) -> int:
+        return self.owner.ir_starts[self.index]
+
+    @property
+    def ir_end(self) -> int:
+        return self.owner.ir_ends[self.index]
+
+    @property
     def depth(self):
         """Depth of this example in the example tree. The top-level example has a
         depth of 0."""
@@ -528,6 +536,32 @@ class Examples:
     @property
     def ends(self) -> IntList:
         return self.starts_and_ends[1]
+
+    class _ir_starts_and_ends(ExampleProperty):
+        def begin(self):
+            self.starts = IntList.of_length(len(self.examples))
+            self.ends = IntList.of_length(len(self.examples))
+
+        def start_example(self, i: int, label_index: int) -> None:
+            self.starts[i] = self.ir_node_count
+
+        def stop_example(self, i: int, *, discarded: bool) -> None:
+            self.ends[i] = self.ir_node_count
+
+        def finish(self) -> Tuple[IntList, IntList]:
+            return (self.starts, self.ends)
+
+    ir_starts_and_ends: "Tuple[IntList, IntList]" = calculated_example_property(
+        _ir_starts_and_ends
+    )
+
+    @property
+    def ir_starts(self) -> IntList:
+        return self.ir_starts_and_ends[0]
+
+    @property
+    def ir_ends(self) -> IntList:
+        return self.ir_starts_and_ends[1]
 
     class _discarded(ExampleProperty):
         def begin(self) -> None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -910,7 +910,7 @@ class DataObserver:
         pass
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, repr=False)
 class IRNode:
     ir_type: IRTypeName = attr.ib()
     value: IRType = attr.ib()
@@ -927,6 +927,11 @@ class IRNode:
             kwargs=self.kwargs,
             was_forced=self.was_forced,
         )
+
+    def __repr__(self):
+        # repr to avoid "BytesWarning: str() on a bytes instance" for bytes nodes
+        forced_marker = " [forced]" if self.was_forced else ""
+        return f"{self.ir_type} {self.value!r}{forced_marker} {self.kwargs!r}"
 
 
 def ir_value_permitted(value, ir_type, kwargs):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -239,6 +239,11 @@ class ConjectureRunner:
                     # correct engine.
                     raise
 
+    def ir_tree_to_data(self, ir_tree_nodes):
+        data = ConjectureData.for_ir_tree(ir_tree_nodes)
+        self.__stoppable_test_function(data)
+        return data
+
     def test_function(self, data):
         if self.__pending_call_explanation is not None:
             self.debug(self.__pending_call_explanation)
@@ -316,8 +321,7 @@ class ConjectureRunner:
 
                 # drive the ir tree through the test function to convert it
                 # to a buffer
-                data = ConjectureData.for_ir_tree(data.examples.ir_tree_nodes)
-                self.__stoppable_test_function(data)
+                data = self.ir_tree_to_data(data.examples.ir_tree_nodes)
                 self.__data_cache[data.buffer] = data.as_result()
 
             key = data.interesting_origin

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -35,6 +35,8 @@ from hypothesis.errors import HypothesisWarning
 
 ARRAY_CODES = ["B", "H", "I", "L", "Q", "O"]
 
+T = TypeVar("T")
+
 
 def array_or_list(
     code: str, contents: Iterable[int]
@@ -45,25 +47,25 @@ def array_or_list(
 
 
 def replace_all(
-    buffer: Sequence[int],
-    replacements: Iterable[Tuple[int, int, Sequence[int]]],
-) -> bytes:
-    """Substitute multiple replacement values into a buffer.
+    ls: Sequence[T],
+    replacements: Iterable[Tuple[int, int, Sequence[T]]],
+) -> List[T]:
+    """Substitute multiple replacement values into a list.
 
     Replacements is a list of (start, end, value) triples.
     """
 
-    result = bytearray()
+    result: List[T] = []
     prev = 0
     offset = 0
     for u, v, r in replacements:
-        result.extend(buffer[prev:u])
+        result.extend(ls[prev:u])
         result.extend(r)
         prev = v
         offset += len(r) - (v - u)
-    result.extend(buffer[prev:])
-    assert len(result) == len(buffer) + offset
-    return bytes(result)
+    result.extend(ls[prev:])
+    assert len(result) == len(ls) + offset
+    return result
 
 
 NEXT_ARRAY_CODE = dict(zip(ARRAY_CODES, ARRAY_CODES[1:]))
@@ -188,9 +190,6 @@ def binary_search(lo: int, hi: int, f: Callable[[int], bool]) -> int:
 def uniform(random: Random, n: int) -> bytes:
     """Returns a bytestring of length n, distributed uniformly at random."""
     return random.getrandbits(n * 8).to_bytes(n, "big")
-
-
-T = TypeVar("T")
 
 
 class LazySequenceCopy:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1412,20 +1412,31 @@ class Shrinker:
         ex = chooser.choose(self.examples)
         label = chooser.choose(ex.children).label
 
-        group = [c for c in ex.children if c.label == label]
-        if len(group) <= 1:
+        examples = [c for c in ex.children if c.label == label]
+        if len(examples) <= 1:
             return
-
         st = self.shrink_target
-        pieces = [st.buffer[ex.start : ex.end] for ex in group]
-        endpoints = [(ex.start, ex.end) for ex in group]
+        endpoints = [(ex.ir_start, ex.ir_end) for ex in examples]
 
         Ordering.shrink(
-            pieces,
-            lambda ls: self.consider_new_buffer(
-                replace_all(st.buffer, [(u, v, r) for (u, v), r in zip(endpoints, ls)])
+            range(len(examples)),
+            lambda indices: self.consider_new_tree(
+                replace_all(
+                    st.examples.ir_nodes,
+                    [
+                        (
+                            u,
+                            v,
+                            st.examples.ir_nodes[
+                                examples[i].ir_start : examples[i].ir_end
+                            ],
+                        )
+                        for (u, v), i in zip(endpoints, indices)
+                    ],
+                )
             ),
             random=self.random,
+            key=lambda i: st.buffer[examples[i].start : examples[i].end],
         )
 
     def run_block_program(self, i, description, original, repeats=1):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -376,8 +376,7 @@ class Shrinker:
         return self.engine.call_count
 
     def consider_new_tree(self, tree):
-        data = ConjectureData.for_ir_tree(tree)
-        self.engine.test_function(data)
+        data = self.engine.ir_tree_to_data(tree)
 
         return self.consider_new_buffer(data.buffer)
 

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -277,12 +277,18 @@ def draw_boolean_kwargs(draw, *, use_forced=False):
     return {"p": p, "forced": forced}
 
 
+def kwargs_strategy(ir_type):
+    return {
+        "boolean": draw_boolean_kwargs(),
+        "integer": draw_integer_kwargs(),
+        "float": draw_float_kwargs(),
+        "bytes": draw_bytes_kwargs(),
+        "string": draw_string_kwargs(),
+    }[ir_type]
+
+
 def ir_types_and_kwargs():
-    options = [
-        ("boolean", draw_boolean_kwargs()),
-        ("integer", draw_integer_kwargs()),
-        ("float", draw_float_kwargs()),
-        ("bytes", draw_bytes_kwargs()),
-        ("string", draw_string_kwargs()),
-    ]
-    return st.one_of(st.tuples(st.just(name), kws) for name, kws in options)
+    options = ["boolean", "integer", "float", "bytes", "string"]
+    return st.one_of(
+        st.tuples(st.just(name), kwargs_strategy(name)) for name in options
+    )

--- a/hypothesis-python/tests/conjecture/test_dfa.py
+++ b/hypothesis-python/tests/conjecture/test_dfa.py
@@ -14,7 +14,16 @@ from math import inf
 
 import pytest
 
-from hypothesis import assume, example, given, note, reject, settings, strategies as st
+from hypothesis import (
+    HealthCheck,
+    assume,
+    example,
+    given,
+    note,
+    reject,
+    settings,
+    strategies as st,
+)
 from hypothesis.internal.conjecture.dfa import DEAD, ConcreteDFA
 
 
@@ -112,7 +121,8 @@ def test_canonicalised_matches_same_strings(dfa, via_repr):
     )
 
 
-@settings(max_examples=20)
+# filters about 80% of examples. should potentially improve at some point.
+@settings(max_examples=20, suppress_health_check=[HealthCheck.filter_too_much])
 @given(dfas())
 def test_has_string_of_max_length(dfa):
     length = dfa.max_length(dfa.start)

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -365,6 +365,10 @@ def test_data_with_empty_ir_tree_is_overrun():
     assert data.status is Status.OVERRUN
 
 
+# root cause of too_slow is filtering too much via assume in kwargs strategies.
+# exacerbated in this test because we draw kwargs twice.
+# TODO revisit and improve the kwargs strategies at some point, once the ir
+# is further along we can maybe remove e.g. a string assumption.
 @given(st.data())
 @settings(suppress_health_check=[HealthCheck.too_slow])
 def test_node_with_different_ir_type_is_invalid(data):

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -107,8 +107,8 @@ def test_assignment():
 
 
 def test_replacement():
-    result = replace_all(bytes([1, 1, 1, 1]), [(1, 3, bytes([3, 4]))])
-    assert result == bytes([1, 3, 4, 1])
+    result = replace_all([1, 1, 1, 1], [(1, 3, [3, 4])])
+    assert result == [1, 3, 4, 1]
 
 
 def test_int_list_cannot_contain_negative():

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -193,6 +193,7 @@ def test_handle_empty_draws():
 
 
 def test_can_reorder_examples():
+    # grouped by iteration: (1, 0, 1) (1, 0, 1) (0) (0) (0)
     @shrinking_from([1, 0, 1, 1, 0, 1, 0, 0, 0])
     def shrinker(data):
         total = 0

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -443,7 +443,7 @@ def test_non_float_decimal():
 
 def test_produces_dictionaries_of_at_least_minimum_size():
     t = minimal(
-        ds.dictionaries(ds.booleans(), ds.integers(), min_size=2), lambda x: True
+        ds.dictionaries(ds.booleans(), ds.integers(), min_size=2),
     )
     assert t == {False: 0, True: 0}
 


### PR DESCRIPTION
Part of #3921.

There's a failure on `test_optimises_the_pareto_front`:
```
...
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/tests/conjecture/test_pareto.py", line 206, in test_optimises_the_pareto_front
    assert len(runner.pareto_front) == 6
AssertionError: assert 26 == 6
 +  where 26 = len(<hypothesis.internal.conjecture.pareto.ParetoFront object at 0x13b9c68d0>)
 +    where <hypothesis.internal.conjecture.pareto.ParetoFront object at 0x13b9c68d0> = <hypothesis.internal.conjecture.engine.ConjectureRunner object at 0x13b9c6bd0>.pareto_front
```

I am still fuzzy on the purpose of the pareto front for cases when `target()` is not involved. With `target()`, it's clear to me that we want to keep the pareto front of all distinct target keys. But what metric are we optimizing over when there are no `target` calls?

But I'm even less clear why my changes broke it beyond "ParetoFront uses shrinker and this pull changes the shrinker". If I'm lucky you'll immediately have an idea what the problem is 😄 but otherwise I'll pick up here again tomorrow.
