### PR TITLE
Improve given position-only strategy arguments type annotations

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
-This release resolves :py:exc:`PermissionError` that come from
-creating databases on inaccessible paths.
+Improve type annotations of :func:`~hypothesis.given` when using positional-only strategy arguments.
+Type-checkers will now detect the given strategies do not match the test function signature.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -70,6 +70,8 @@ from hypothesis.errors import (
 from hypothesis.internal.compat import (
     PYPY,
     BaseExceptionGroup,
+    Concatenate,
+    ParamSpec,
     add_note,
     bad_django_TestCase,
     get_type_hints,
@@ -1337,13 +1339,194 @@ class HypothesisHandle:
             return self.__cached_target
 
 
+P = ParamSpec("P")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
+T7 = TypeVar("T7")
+T8 = TypeVar("T8")
+T9 = TypeVar("T9")
+T10 = TypeVar("T10")
+
+
 @overload
 def given(
     _: EllipsisType, /
 ) -> Callable[
     [Callable[..., Optional[Coroutine[Any, Any, None]]]], Callable[[], None]
-]:  # pragma: no cover
-    ...
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    /,
+) -> Callable[
+    [Callable[Concatenate[T1, P], Optional[Coroutine[Any, Any, None]]]],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    /,
+) -> Callable[
+    [Callable[Concatenate[T1, T2, P], Optional[Coroutine[Any, Any, None]]]],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    /,
+) -> Callable[
+    [Callable[Concatenate[T1, T2, T3, P], Optional[Coroutine[Any, Any, None]]]],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    /,
+) -> Callable[
+    [Callable[Concatenate[T1, T2, T3, T4, P], Optional[Coroutine[Any, Any, None]]]],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    _given_argument5: SearchStrategy[T5],
+    /,
+) -> Callable[
+    [Callable[Concatenate[T1, T2, T3, T4, T5, P], Optional[Coroutine[Any, Any, None]]]],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    _given_argument5: SearchStrategy[T5],
+    _given_argument6: SearchStrategy[T6],
+    /,
+) -> Callable[
+    [
+        Callable[
+            Concatenate[T1, T2, T3, T4, T5, T6, P], Optional[Coroutine[Any, Any, None]]
+        ]
+    ],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    _given_argument5: SearchStrategy[T5],
+    _given_argument6: SearchStrategy[T6],
+    _given_argument7: SearchStrategy[T7],
+    /,
+) -> Callable[
+    [
+        Callable[
+            Concatenate[T1, T2, T3, T4, T5, T6, T7, P],
+            Optional[Coroutine[Any, Any, None]],
+        ]
+    ],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    _given_argument5: SearchStrategy[T5],
+    _given_argument6: SearchStrategy[T6],
+    _given_argument7: SearchStrategy[T7],
+    _given_argument8: SearchStrategy[T8],
+    /,
+) -> Callable[
+    [
+        Callable[
+            Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, P],
+            Optional[Coroutine[Any, Any, None]],
+        ]
+    ],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    _given_argument5: SearchStrategy[T5],
+    _given_argument6: SearchStrategy[T6],
+    _given_argument7: SearchStrategy[T7],
+    _given_argument8: SearchStrategy[T8],
+    _given_argument9: SearchStrategy[T9],
+    /,
+) -> Callable[
+    [
+        Callable[
+            Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, P],
+            Optional[Coroutine[Any, Any, None]],
+        ]
+    ],
+    Callable[..., None],
+]: ...
+
+
+@overload
+def given(
+    _given_argument1: SearchStrategy[T1],
+    _given_argument2: SearchStrategy[T2],
+    _given_argument3: SearchStrategy[T3],
+    _given_argument4: SearchStrategy[T4],
+    _given_argument5: SearchStrategy[T5],
+    _given_argument6: SearchStrategy[T6],
+    _given_argument7: SearchStrategy[T7],
+    _given_argument8: SearchStrategy[T8],
+    _given_argument9: SearchStrategy[T9],
+    _given_argument10: SearchStrategy[T10],
+    /,
+) -> Callable[
+    [
+        Callable[
+            Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P],
+            Optional[Coroutine[Any, Any, None]],
+        ]
+    ],
+    Callable[..., None],
+]: ...
 
 
 @overload
@@ -1351,8 +1534,7 @@ def given(
     *_given_arguments: SearchStrategy[Any],
 ) -> Callable[
     [Callable[..., Optional[Coroutine[Any, Any, None]]]], Callable[..., None]
-]:  # pragma: no cover
-    ...
+]: ...
 
 
 @overload
@@ -1360,8 +1542,7 @@ def given(
     **_given_kwargs: Union[SearchStrategy[Any], EllipsisType],
 ) -> Callable[
     [Callable[..., Optional[Coroutine[Any, Any, None]]]], Callable[..., None]
-]:  # pragma: no cover
-    ...
+]: ...
 
 
 def given(

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1366,7 +1366,7 @@ def given(
     _given_argument1: SearchStrategy[T1],
     /,
 ) -> Callable[
-    [Callable["Concatenate[T1, P]", Optional[Coroutine[Any, Any, None]]]],
+    ["Callable[Concatenate[T1, P], Optional[Coroutine[Any, Any, None]]]"],
     Callable[..., None],
 ]: ...
 
@@ -1377,7 +1377,7 @@ def given(
     _given_argument2: SearchStrategy[T2],
     /,
 ) -> Callable[
-    [Callable["Concatenate[T1, T2, P]", Optional[Coroutine[Any, Any, None]]]],
+    ["Callable[Concatenate[T1, T2, P], Optional[Coroutine[Any, Any, None]]]"],
     Callable[..., None],
 ]: ...
 
@@ -1389,7 +1389,7 @@ def given(
     _given_argument3: SearchStrategy[T3],
     /,
 ) -> Callable[
-    [Callable["Concatenate[T1, T2, T3, P]", Optional[Coroutine[Any, Any, None]]]],
+    ["Callable[Concatenate[T1, T2, T3, P], Optional[Coroutine[Any, Any, None]]]"],
     Callable[..., None],
 ]: ...
 
@@ -1402,7 +1402,7 @@ def given(
     _given_argument4: SearchStrategy[T4],
     /,
 ) -> Callable[
-    [Callable["Concatenate[T1, T2, T3, T4, P]", Optional[Coroutine[Any, Any, None]]]],
+    ["Callable[Concatenate[T1, T2, T3, T4, P], Optional[Coroutine[Any, Any, None]]]"],
     Callable[..., None],
 ]: ...
 
@@ -1417,9 +1417,7 @@ def given(
     /,
 ) -> Callable[
     [
-        Callable[
-            "Concatenate[T1, T2, T3, T4, T5, P]", Optional[Coroutine[Any, Any, None]]
-        ]
+        "Callable[Concatenate[T1, T2, T3, T4, T5, P], Optional[Coroutine[Any, Any, None]]]"
     ],
     Callable[..., None],
 ]: ...
@@ -1436,10 +1434,7 @@ def given(
     /,
 ) -> Callable[
     [
-        Callable[
-            "Concatenate[T1, T2, T3, T4, T5, T6, P]",
-            Optional[Coroutine[Any, Any, None]],
-        ]
+        "Callable[Concatenate[T1, T2, T3, T4, T5, T6, P], Optional[Coroutine[Any, Any, None]]]"
     ],
     Callable[..., None],
 ]: ...
@@ -1457,10 +1452,7 @@ def given(
     /,
 ) -> Callable[
     [
-        Callable[
-            "Concatenate[T1, T2, T3, T4, T5, T6, T7, P]",
-            Optional[Coroutine[Any, Any, None]],
-        ]
+        "Callable[Concatenate[T1, T2, T3, T4, T5, T6, T7, P], Optional[Coroutine[Any, Any, None]]]"
     ],
     Callable[..., None],
 ]: ...
@@ -1479,10 +1471,7 @@ def given(
     /,
 ) -> Callable[
     [
-        Callable[
-            "Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, P]",
-            Optional[Coroutine[Any, Any, None]],
-        ]
+        "Callable[Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, P], Optional[Coroutine[Any, Any, None]]]"
     ],
     Callable[..., None],
 ]: ...
@@ -1502,10 +1491,7 @@ def given(
     /,
 ) -> Callable[
     [
-        Callable[
-            "Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, P]",
-            Optional[Coroutine[Any, Any, None]],
-        ]
+        "Callable[Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, P], Optional[Coroutine[Any, Any, None]]]"
     ],
     Callable[..., None],
 ]: ...
@@ -1526,10 +1512,7 @@ def given(
     /,
 ) -> Callable[
     [
-        Callable[
-            "Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P]",
-            Optional[Coroutine[Any, Any, None]],
-        ]
+        "Callable[Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P], Optional[Coroutine[Any, Any, None]]]"
     ],
     Callable[..., None],
 ]: ...

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1339,7 +1339,8 @@ class HypothesisHandle:
             return self.__cached_target
 
 
-P = ParamSpec("P")
+if TYPE_CHECKING:
+    P = ParamSpec("P")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
@@ -1365,7 +1366,7 @@ def given(
     _given_argument1: SearchStrategy[T1],
     /,
 ) -> Callable[
-    [Callable[Concatenate[T1, P], Optional[Coroutine[Any, Any, None]]]],
+    [Callable["Concatenate[T1, P]", Optional[Coroutine[Any, Any, None]]]],
     Callable[..., None],
 ]: ...
 
@@ -1376,7 +1377,7 @@ def given(
     _given_argument2: SearchStrategy[T2],
     /,
 ) -> Callable[
-    [Callable[Concatenate[T1, T2, P], Optional[Coroutine[Any, Any, None]]]],
+    [Callable["Concatenate[T1, T2, P]", Optional[Coroutine[Any, Any, None]]]],
     Callable[..., None],
 ]: ...
 
@@ -1388,7 +1389,7 @@ def given(
     _given_argument3: SearchStrategy[T3],
     /,
 ) -> Callable[
-    [Callable[Concatenate[T1, T2, T3, P], Optional[Coroutine[Any, Any, None]]]],
+    [Callable["Concatenate[T1, T2, T3, P]", Optional[Coroutine[Any, Any, None]]]],
     Callable[..., None],
 ]: ...
 
@@ -1401,7 +1402,7 @@ def given(
     _given_argument4: SearchStrategy[T4],
     /,
 ) -> Callable[
-    [Callable[Concatenate[T1, T2, T3, T4, P], Optional[Coroutine[Any, Any, None]]]],
+    [Callable["Concatenate[T1, T2, T3, T4, P]", Optional[Coroutine[Any, Any, None]]]],
     Callable[..., None],
 ]: ...
 
@@ -1415,7 +1416,11 @@ def given(
     _given_argument5: SearchStrategy[T5],
     /,
 ) -> Callable[
-    [Callable[Concatenate[T1, T2, T3, T4, T5, P], Optional[Coroutine[Any, Any, None]]]],
+    [
+        Callable[
+            "Concatenate[T1, T2, T3, T4, T5, P]", Optional[Coroutine[Any, Any, None]]
+        ]
+    ],
     Callable[..., None],
 ]: ...
 
@@ -1432,7 +1437,8 @@ def given(
 ) -> Callable[
     [
         Callable[
-            Concatenate[T1, T2, T3, T4, T5, T6, P], Optional[Coroutine[Any, Any, None]]
+            "Concatenate[T1, T2, T3, T4, T5, T6, P]",
+            Optional[Coroutine[Any, Any, None]],
         ]
     ],
     Callable[..., None],
@@ -1452,7 +1458,7 @@ def given(
 ) -> Callable[
     [
         Callable[
-            Concatenate[T1, T2, T3, T4, T5, T6, T7, P],
+            "Concatenate[T1, T2, T3, T4, T5, T6, T7, P]",
             Optional[Coroutine[Any, Any, None]],
         ]
     ],
@@ -1474,7 +1480,7 @@ def given(
 ) -> Callable[
     [
         Callable[
-            Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, P],
+            "Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, P]",
             Optional[Coroutine[Any, Any, None]],
         ]
     ],
@@ -1497,7 +1503,7 @@ def given(
 ) -> Callable[
     [
         Callable[
-            Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, P],
+            "Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, P]",
             Optional[Coroutine[Any, Any, None]],
         ]
     ],
@@ -1521,7 +1527,7 @@ def given(
 ) -> Callable[
     [
         Callable[
-            Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P],
+            "Concatenate[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P]",
             Optional[Coroutine[Any, Any, None]],
         ]
     ],


### PR DESCRIPTION
I tested with MyPy and Pyright that positional-only strategy arguments up to 10 will check if the strategies given match the test function type annotations.
```python
from pathlib import Path
from hypothesis import given, strategies as st


@given(st.floats(), st.integers())
def good(a: float, b: int, tmp_path: Path) -> None:
    assert True

@given(st.floats(), st.text())
def bad(a: float, b: int, tmp_path: Path) -> None:
    assert True
```