### PR TITLE
Migrate `pass_to_descendant` and `redistribute_block_pairs` shrinker passes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch continues our work on refactoring the shrinker (:issue:`3921`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -325,6 +325,11 @@ class Example:
         return self.end - self.start
 
     @property
+    def ir_length(self) -> int:
+        """The number of ir nodes in this example."""
+        return self.ir_end - self.ir_start
+
+    @property
     def children(self) -> "List[Example]":
         """The list of all examples with this as a parent, in increasing index
         order."""

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -470,7 +470,11 @@ class ExampleRecord:
     def record_ir_draw(self, ir_type, value, *, kwargs, was_forced):
         self.trail.append(IR_NODE_RECORD)
         node = IRNode(
-            ir_type=ir_type, value=value, kwargs=kwargs, was_forced=was_forced
+            ir_type=ir_type,
+            value=value,
+            kwargs=kwargs,
+            was_forced=was_forced,
+            index=len(self.ir_nodes),
         )
         self.ir_nodes.append(node)
 
@@ -955,11 +959,15 @@ class IRNode:
     value: IRType = attr.ib()
     kwargs: IRKWargsType = attr.ib()
     was_forced: bool = attr.ib()
+    index: Optional[int] = attr.ib(default=None)
 
     def copy(self, *, with_value: IRType) -> "IRNode":
         # we may want to allow this combination in the future, but for now it's
         # a footgun.
         assert not self.was_forced, "modifying a forced node doesn't make sense"
+        # explicitly not copying index. node indices are only assigned via
+        # ExampleRecord. This prevents footguns with relying on stale indices
+        # after copying.
         return IRNode(
             ir_type=self.ir_type,
             value=with_value,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1270,6 +1270,12 @@ class Shrinker:
         else:
             return
 
+        if next_node.was_forced:
+            # avoid modifying a forced node! Note that it's fine for next_node
+            # to be trivial, because we're going to explicitly make it *not*
+            # trivial by adding to its value.
+            return
+
         m = node.value
         n = next_node.value
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1218,7 +1218,6 @@ class Shrinker:
             and not is_simple(node.value),
         )
 
-        i = self.nodes.index(node)
         # the Float shrinker was only built to handle positive floats. We'll
         # shrink the positive portion and reapply the sign after, which is
         # equivalent to this shrinker's previous behavior. We'll want to refactor
@@ -1228,9 +1227,9 @@ class Shrinker:
         Float.shrink(
             abs(node.value),
             lambda val: self.consider_new_tree(
-                self.nodes[:i]
+                self.nodes[: node.index]
                 + [node.copy(with_value=sign * val)]
-                + self.nodes[i + 1 :]
+                + self.nodes[node.index + 1 :]
             ),
             random=self.random,
             node=node,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1271,7 +1271,7 @@ class Shrinker:
             return
 
         if next_node.was_forced:
-            # avoid modifying a forced node! Note that it's fine for next_node
+            # avoid modifying a forced node. Note that it's fine for next_node
             # to be trivial, because we're going to explicitly make it *not*
             # trivial by adding to its value.
             return

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -377,7 +377,6 @@ class Shrinker:
 
     def consider_new_tree(self, tree):
         data = self.engine.ir_tree_to_data(tree)
-
         return self.consider_new_buffer(data.buffer)
 
     def consider_new_buffer(self, buffer):
@@ -825,12 +824,10 @@ class Shrinker:
         )
 
         ls = self.examples_by_label[label]
-
         i = chooser.choose(range(len(ls) - 1))
-
         ancestor = ls[i]
 
-        if i + 1 == len(ls) or ls[i + 1].start >= ancestor.end:
+        if i + 1 == len(ls) or ls[i + 1].ir_start >= ancestor.ir_end:
             return
 
         @self.cached(label, i)
@@ -839,22 +836,22 @@ class Shrinker:
             hi = len(ls)
             while lo + 1 < hi:
                 mid = (lo + hi) // 2
-                if ls[mid].start >= ancestor.end:
+                if ls[mid].ir_start >= ancestor.ir_end:
                     hi = mid
                 else:
                     lo = mid
-            return [t for t in ls[i + 1 : hi] if t.length < ancestor.length]
+            return [t for t in ls[i + 1 : hi] if t.ir_length < ancestor.ir_length]
 
-        descendant = chooser.choose(descendants, lambda ex: ex.length > 0)
+        descendant = chooser.choose(descendants, lambda ex: ex.ir_length > 0)
 
-        assert ancestor.start <= descendant.start
-        assert ancestor.end >= descendant.end
-        assert descendant.length < ancestor.length
+        assert ancestor.ir_start <= descendant.ir_start
+        assert ancestor.ir_end >= descendant.ir_end
+        assert descendant.ir_length < ancestor.ir_length
 
-        self.incorporate_new_buffer(
-            self.buffer[: ancestor.start]
-            + self.buffer[descendant.start : descendant.end]
-            + self.buffer[ancestor.end :]
+        self.consider_new_tree(
+            self.nodes[: ancestor.ir_start]
+            + self.nodes[descendant.ir_start : descendant.ir_end]
+            + self.nodes[ancestor.ir_end :]
         )
 
     def lower_common_block_offset(self):

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -683,6 +683,17 @@ def test_forced_nodes_are_trivial(node):
             },
             was_forced=False,
         ),
+        IRNode(
+            ir_type="integer",
+            value=0,
+            kwargs={
+                "min_value": None,
+                "max_value": None,
+                "weights": None,
+                "shrink_towards": 0,
+            },
+            was_forced=False,
+        ),
     ],
 )
 def test_trivial_nodes(node):
@@ -750,6 +761,17 @@ def test_trivial_nodes(node):
             kwargs={
                 "min_value": -10,
                 "max_value": 10,
+                "weights": None,
+                "shrink_towards": 0,
+            },
+            was_forced=False,
+        ),
+        IRNode(
+            ir_type="integer",
+            value=42,
+            kwargs={
+                "min_value": None,
+                "max_value": None,
                 "weights": None,
                 "shrink_towards": 0,
             },

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -563,3 +563,61 @@ def test_all_children_are_permitted_values(ir_type_and_kwargs):
 )
 def test_ir_value_permitted(value, ir_type, kwargs, permitted):
     assert ir_value_permitted(value, ir_type, kwargs) == permitted
+
+
+@given(ir_nodes(was_forced=True))
+def test_forced_nodes_are_trivial(node):
+    assert node.trivial
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        IRNode(
+            ir_type="float",
+            value=5.0,
+            kwargs={
+                "min_value": 5.0,
+                "max_value": 10.0,
+                "allow_nan": True,
+                "smallest_nonzero_magnitude": SMALLEST_SUBNORMAL,
+            },
+            was_forced=False,
+        ),
+        IRNode(
+            ir_type="boolean",
+            value=False,
+            kwargs={"p": 0.5},
+            was_forced=False,
+        ),
+        IRNode(
+            ir_type="string",
+            value="",
+            kwargs={
+                "intervals": IntervalSet.from_string("abcd"),
+                "min_size": 0,
+                "max_size": None,
+            },
+            was_forced=False,
+        ),
+        IRNode(
+            ir_type="bytes",
+            value=bytes(8),
+            kwargs={"size": 8},
+            was_forced=False,
+        ),
+        IRNode(
+            ir_type="integer",
+            value=50,
+            kwargs={
+                "min_value": 50,
+                "max_value": 100,
+                "weights": None,
+                "shrink_towards": 0,
+            },
+            was_forced=False,
+        ),
+    ],
+)
+def test_trivial_nodes(node):
+    assert node.trivial


### PR DESCRIPTION
I think these are the last remaining directly translatable passes. The remaining two groups are "block programs" (roughly corresponding to new "node programs" with a single instruction `X`, no `-`) and "everything else".