### PR TITLE
Fix `trivial` computation for floats

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release improves an internal invariant.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1216,7 +1216,7 @@ class Shrinker:
 
         node = chooser.choose(
             self.nodes,
-            lambda node: node.ir_type == "float" and not node.was_forced
+            lambda node: node.ir_type == "float" and not node.trivial
             # avoid shrinking integer-valued floats. In our current ordering, these
             # are already simpler than all other floats, so it's better to shrink
             # them in other passes.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1194,7 +1194,6 @@ class Shrinker:
             block,
             lambda b: self.try_shrinking_blocks(targets, b),
             random=self.random,
-            full=False,
         )
 
     @defines_shrink_pass()
@@ -1364,7 +1363,6 @@ class Shrinker:
             self.shrink_target.buffer[u:v],
             lambda b: self.try_shrinking_blocks((i,), b),
             random=self.random,
-            full=False,
         )
 
         if self.shrink_target is not initial:


### PR DESCRIPTION
Forgot that float shrinking is more complicated than just "closest to 0". 

Full disclosure, I'm hoping to defer some of this work to later because it would substantially complicate things for probably little benefit (maybe we save one or two shrink calls here and there). I just got it to a point where it's not *wrong* anymore.

When we redefine ordering for the ir, we can probably simplify this function to "is first in ordering", like we do for buffers (first in ordering == zero buffer)