### PR TITLE
Add hypothesis-rdkit to list of extensions in docs

### DIFF
--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -30,6 +30,7 @@ Some packages provide strategies directly:
 * :pypi:`hypothesis-csv` - strategy to generate CSV files.
 * :pypi:`hypothesis-networkx` - strategy to generate :pypi:`networkx` graphs.
 * :pypi:`hypothesis-bio` - strategies for bioinformatics data, such as DNA, codons, FASTA, and FASTQ formats.
+* :pypi:`hypothesis-rdkit` - strategies to generate RDKit molecules and representations such as SMILES and mol blocks
 * :pypi:`hypothesmith` - strategy to generate syntatically-valid Python code.
 
 Others provide a function to infer a strategy from some other schema:


### PR DESCRIPTION
Hello!

I implemented strategies to generate random molecules based on hypothesis and I would be super happy if it was listed on the extensions page of the hypothesis docs! :)

Best,
Steffen