### PR TITLE
Work around weird lambda issue by popping entry from `linecache`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+If you were running Python 3.13 (currently in alpha) with :pypi:`pytest-xdist`
+and then attempted to pretty-print a ``lambda`` functions which was created
+using the :func:`eval` builtin, it would have raised an AssertionError.
+Now you'll get ``"lambda ...: <unknown>"``, as expected.

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -12,7 +12,6 @@ import decimal
 import math
 import operator
 import re
-import sys
 from fractions import Fraction
 from functools import partial
 from sys import float_info
@@ -34,10 +33,6 @@ from tests.common.debug import check_can_generate_examples
 from tests.common.utils import fails_with
 
 A_FEW = 15  # speed up massively-parametrized tests
-
-# FIXME-3.13: something about get_lambda_source not working with pytest-xdist?
-if sys.version_info[:2] == (3, 13) and sys.version_info.releaselevel < "final":
-    pytest.skip(allow_module_level=True)
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -8,10 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import sys
-
-import pytest
-
 from hypothesis.internal.reflection import get_pretty_function_description
 
 
@@ -19,7 +15,6 @@ def test_bracket_whitespace_is_striped():
     assert get_pretty_function_description(lambda x: (x + 1)) == "lambda x: (x + 1)"
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="FIXME-3.13")
 def test_no_whitespace_before_colon_with_no_args():
     assert get_pretty_function_description(eval("lambda: None")) == "lambda: <unknown>"
 
@@ -63,7 +58,6 @@ def test_variable_names_are_not_pretty():
     assert get_pretty_function_description(t) == "lambda x: True"
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="FIXME-3.13")
 def test_does_not_error_on_dynamically_defined_functions():
     x = eval("lambda t: 1")
     get_pretty_function_description(x)


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/3919.  This _wasn't_ fixed upstream, but turns out to be an easy workaround, and I've reported https://github.com/python/cpython/issues/117174.