### PR TITLE
Suppress flakiness reporting when groups differ in number of times raised

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release suppresses flakiness reporting for a very mild form of flakiness
+where two exception groups being raised in different iterations of the test
+differ only in the number of times that their constituent exceptions are
+raised. This is an essentially harmless form of flakiness that can be hard
+to avoid in certain scenarios.

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -119,6 +119,23 @@ class InterestingOrigin(NamedTuple):
     context: "InterestingOrigin | tuple[()]"
     group_elems: "tuple[InterestingOrigin, ...]"
 
+    def __eq__(self, other):
+        if not isinstance(other, InterestingOrigin):
+            return NotImplemented
+        return self.__eq_tuple() == other.__eq_tuple()
+
+    def __hash__(self):
+        return hash(self.__eq_tuple())
+
+    def __eq_tuple(self):
+        return (
+            self.exc_type,
+            self.filename,
+            self.lineno,
+            self.context,
+            frozenset(self.group_elems),
+        )
+
     def __str__(self) -> str:
         ctx = ""
         if self.context:

--- a/hypothesis-python/tests/cover/test_escalation.py
+++ b/hypothesis-python/tests/cover/test_escalation.py
@@ -97,3 +97,14 @@ def test_handles_groups():
     assert "ExceptionGroup at " in str(origin)
     assert "child exception" in str(origin)
     assert "ValueError at " in str(origin)
+
+
+def test_conflates_repeat_exceptions_for_equality():
+    errors = [ValueError(""), ValueError("")]
+
+    o1 = esc.InterestingOrigin.from_exception(BaseExceptionGroup("message", errors))
+    o2 = esc.InterestingOrigin.from_exception(BaseExceptionGroup("message", errors[:1]))
+
+    assert o1.group_elems != o2.group_elems
+    assert o1 == o2
+    assert hash(o1) == hash(o2)


### PR DESCRIPTION
This changes our `InterestingnessOrigin` class so that if two exception groups are equal except for the number of times each exception in them is raised, they are considered equal. This suppresses some flakiness reporting for a type of flakiness that doesn't really matter and is hard to avoid when testing concurrent applications (shrinkray in my case)

Fixes #3940, at least the narrowly scoped version of this I was running into. Might be worth speccing out a more general fix, but I think this is a good fix to have even if we want the more general one.