### PR TITLE
Improve integer weight draw and flaky error message

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improve a rare error message for flaky tests (:issue:`3940`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -30,6 +30,7 @@ from hypothesis.internal.conjecture.data import (
     Status,
     StringKWargs,
 )
+from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import (
     count_between_floats,
     float_to_int,
@@ -83,8 +84,8 @@ class Branch:
 class Conclusion:
     """Represents a transition to a finished state."""
 
-    status = attr.ib()
-    interesting_origin = attr.ib()
+    status: Status = attr.ib()
+    interesting_origin: Optional[InterestingOrigin] = attr.ib()
 
 
 # The number of max children where, beyond this, it is practically impossible
@@ -1043,8 +1044,9 @@ class TreeRecordingObserver(DataObserver):
                 or new_transition.status != Status.VALID
             ):
                 raise Flaky(
-                    f"Inconsistent test results! Test case was {node.transition!r} "
-                    f"on first run but {new_transition!r} on second"
+                    f"Inconsistent results from replaying a test case!\n"
+                    f"  last: {node.transition.status.name} from {node.transition.interesting_origin}\n"
+                    f"  this: {new_transition.status.name} from {new_transition.interesting_origin}"
                 )
         else:
             node.transition = new_transition

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -133,9 +133,10 @@ class ParetoFront:
         """Attempts to add ``data`` to the pareto front. Returns True if
         ``data`` is now in the front, including if data is already in the
         collection, and False otherwise"""
-        data = data.as_result()
         if data.status < Status.VALID:
             return False
+
+        data = data.as_result()
 
         if not self.front:
             self.front.add(data)

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -175,11 +175,6 @@ def test_center_in_middle_above():
     assert data.draw_integer(0, 10, shrink_towards=5) == 5
 
 
-def test_restricted_bits():
-    data = ConjectureData.for_buffer([1, 0, 0, 0, 0])
-    assert data.draw_integer(0, 2**64 - 1) == 0
-
-
 @pytest.mark.parametrize(
     "lo,hi,to",
     [(1, None, 1), (1, None, 2), (None, 2, 1), (None, 1, 1), (-1, 1, 0)],

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -27,4 +27,4 @@ def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():
     # uniformly the rest.  So we should get some very large but not too many.
     huge = sum(x > 1e97 for x in values)
     assert huge != 0 or len(values) < 800
-    assert huge <= 0.3 * len(values)  # expected ~1/8
+    assert huge <= 0.5 * len(values)  # expected ~1/8


### PR DESCRIPTION
This fixes https://github.com/HypothesisWorks/hypothesis/issues/3921#issuecomment-2008569274 by always drawing the integer value from the full range.

Also closes https://github.com/HypothesisWorks/hypothesis/issues/3940 by improving the error message.

(worked on irl with @Zac-HD 😄)