### PR TITLE
compatibility with `numpy>=2.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
           # - check-crosshair-nocover
           # - check-crosshair-niche
           - check-py38-oldestnumpy
+          - check-numpy-nightly
       fail-fast: false
     steps:
     - uses: actions/checkout@v3

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -96,6 +96,7 @@ their individual contributions.
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)
 * `Joshua Boone <https://www.github.com/patchedwork>`_ (joshuaboone4190@gmail.com)
 * `jmhsi <https://www.github.com/jmhsi>`_
+* `Justus Magin <https://github.com/keewis>`_
 * `jwg4 <https://www.github.com/jwg4>`_
 * `Kai Chen <https://www.github.com/kx-chen>`_ (kaichen120@gmail.com)
 * `Karthikeyan Singaravelan <https://www.github.com/tirkarthi>`_ (tir.karthi@gmail.com)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Explicitly cast `finfo.smallest_normal` to builtin `float` in preparation for the `numpy=2.0` release (:issue:`3950`)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,4 @@
 RELEASE_TYPE: patch
 
-Explicitly cast `finfo.smallest_normal` to builtin `float` in preparation for the `numpy=2.0` release (:issue:`3950`)
+Explicitly cast :obj:`numpy.finfo.smallest_normal` to builtin `float` in
+preparation for the :pypi:`numpy==2.0 <numpy>` release (:issue:`3950`)

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -282,7 +282,7 @@ def _from_dtype(
         if allow_subnormal is not None:
             kw["allow_subnormal"] = allow_subnormal
         else:
-            subnormal = next_down(finfo.smallest_normal, width=finfo.bits)
+            subnormal = next_down(float(finfo.smallest_normal), width=finfo.bits)
             ftz = bool(xp.asarray(subnormal, dtype=dtype) == 0)
             if ftz:
                 kw["allow_subnormal"] = False
@@ -303,7 +303,7 @@ def _from_dtype(
         # complex array, in case complex arrays have different FTZ behaviour
         # than arrays of the respective composite float.
         if allow_subnormal is None:
-            subnormal = next_down(finfo.smallest_normal, width=finfo.bits)
+            subnormal = next_down(float(finfo.smallest_normal), width=finfo.bits)
             x = xp.asarray(complex(subnormal, subnormal), dtype=dtype)
             builtin_x = complex(x)
             allow_subnormal = builtin_x.real != 0 and builtin_x.imag != 0

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -910,8 +910,9 @@ def _collection_ish_functions():
             np.asarray_chkfinite,
             np.asfortranarray,
         ]
-        np_version = tuple(np.__version__.split(".", maxsplit=2)[:2])
+        np_version = tuple(int(_) for _ in np.__version__.split(".", maxsplit=2)[:2])
         if np_version < (2, 0):
+            # removed in numpy>=2.0
             funcs += [np.asfarray]
 
     return funcs

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -910,10 +910,6 @@ def _collection_ish_functions():
             np.asarray_chkfinite,
             np.asfortranarray,
         ]
-        np_version = tuple(int(_) for _ in np.__version__.split(".", maxsplit=2)[:2])
-        if np_version < (2, 0):
-            # removed in numpy>=2.0
-            funcs += [np.asfarray]
 
     return funcs
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -908,9 +908,12 @@ def _collection_ish_functions():
             np.diag,
             # bonus undocumented functions from tab-completion:
             np.asarray_chkfinite,
-            np.asfarray,
             np.asfortranarray,
         ]
+        np_version = tuple(np.__version__.split(".", maxsplit=2)[:2])
+        if np_version < (2, 0):
+            funcs += [np.asfarray]
+
     return funcs
 
 

--- a/hypothesis-python/tests/array_api/conftest.py
+++ b/hypothesis-python/tests/array_api/conftest.py
@@ -35,9 +35,10 @@ if test_version_option != "default" and test_version_option not in NOMINAL_VERSI
         f"HYPOTHESIS_TEST_ARRAY_API_VERSION='{test_version_option}' is not "
         f"'default' or a valid api_version {NOMINAL_VERSIONS}."
     )
-# with pytest.warns(HypothesisWarning):
-mock_version = "draft" if test_version_option == "default" else test_version_option
-mock_xps = make_strategies_namespace(mock_xp, api_version=mock_version)
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=HypothesisWarning)
+    mock_version = "draft" if test_version_option == "default" else test_version_option
+    mock_xps = make_strategies_namespace(mock_xp, api_version=mock_version)
 api_version = None if test_version_option == "default" else test_version_option
 
 

--- a/hypothesis-python/tests/array_api/conftest.py
+++ b/hypothesis-python/tests/array_api/conftest.py
@@ -35,9 +35,9 @@ if test_version_option != "default" and test_version_option not in NOMINAL_VERSI
         f"HYPOTHESIS_TEST_ARRAY_API_VERSION='{test_version_option}' is not "
         f"'default' or a valid api_version {NOMINAL_VERSIONS}."
     )
-with pytest.warns(HypothesisWarning):
-    mock_version = "draft" if test_version_option == "default" else test_version_option
-    mock_xps = make_strategies_namespace(mock_xp, api_version=mock_version)
+# with pytest.warns(HypothesisWarning):
+mock_version = "draft" if test_version_option == "default" else test_version_option
+mock_xps = make_strategies_namespace(mock_xp, api_version=mock_version)
 api_version = None if test_version_option == "default" else test_version_option
 
 

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -7,6 +7,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
+import sys
 
 import pytest
 
@@ -296,6 +297,7 @@ def test_may_not_fill_unique_array_with_non_nan(xp, xps):
         check_can_generate_examples(strat)
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 9), reason="no complex")
 def test_floating_point_array():
     import warnings
     from hypothesis.extra.array_api import make_strategies_namespace

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -297,7 +297,7 @@ def test_may_not_fill_unique_array_with_non_nan(xp, xps):
         check_can_generate_examples(strat)
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 9), reason="no complex")
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 8), reason="no complex")
 def test_floating_point_array():
     import warnings
     from hypothesis.extra.array_api import make_strategies_namespace

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -309,14 +309,12 @@ def test_floating_point_array():
     except ModuleNotFoundError:
         import numpy as nxp
     xps = make_strategies_namespace(nxp)
-    dtypes= xps.floating_dtypes() | xps.complex_dtypes()
+    dtypes = xps.floating_dtypes() | xps.complex_dtypes()
 
-    strat = xps.arrays(
-        dtype=dtypes,
-        shape=10
-    )
+    strat = xps.arrays(dtype=dtypes, shape=10)
 
     check_can_generate_examples(strat)
+
 
 @pytest.mark.parametrize(
     "kwargs",

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -296,6 +296,23 @@ def test_may_not_fill_unique_array_with_non_nan(xp, xps):
         check_can_generate_examples(strat)
 
 
+def test_floating_point_array():
+    from hypothesis.extra.array_api import make_strategies_namespace
+
+    try:
+        import numpy.array_api as nxp
+    except ModuleNotFoundError:
+        import numpy as np
+    xps = make_strategies_namespace(np)
+    dtypes= xps.floating_dtypes()
+
+    strat = xps.arrays(
+        dtype=dtypes,
+        shape=10
+    )
+
+    check_can_generate_examples(strat)
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -307,7 +307,7 @@ def test_floating_point_array():
     except ModuleNotFoundError:
         import numpy as nxp
     xps = make_strategies_namespace(nxp)
-    dtypes= xps.floating_dtypes()
+    dtypes= xps.floating_dtypes() | xps.complex_dtypes()
 
     strat = xps.arrays(
         dtype=dtypes,

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -297,13 +297,16 @@ def test_may_not_fill_unique_array_with_non_nan(xp, xps):
 
 
 def test_floating_point_array():
+    import warnings
     from hypothesis.extra.array_api import make_strategies_namespace
 
     try:
-        import numpy.array_api as nxp
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            import numpy.array_api as nxp
     except ModuleNotFoundError:
-        import numpy as np
-    xps = make_strategies_namespace(np)
+        import numpy as nxp
+    xps = make_strategies_namespace(nxp)
     dtypes= xps.floating_dtypes()
 
     strat = xps.arrays(

--- a/hypothesis-python/tests/array_api/test_arrays.py
+++ b/hypothesis-python/tests/array_api/test_arrays.py
@@ -7,6 +7,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
+
 import sys
 
 import pytest

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -38,11 +38,11 @@ class MockedArray:
         self.wrapped = wrapped
         self.exclude = exclude
 
-    def __getattribute__(self, name):
+    def __getattr__(self, name):
         if name in self.exclude:
             raise AttributeError(f"removed on the mock: {name}")
 
-        return object.__getattribute__(self, name)
+        return object.__getattr__(self, name)
 
 
 def wrap_array(func: callable, exclude: Tuple[str, ...] = ()) -> callable:

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -64,7 +64,7 @@ def test_error_on_missing_attr(stratname, args, attr):
 
 dtypeless_xp = make_mock_xp(exclude=tuple(DTYPE_NAMES))
 with warnings.catch_warnings():
-    warnings.filterwarning("ignore", category=HypothesisWarning)
+    warnings.filterwarnings("ignore", category=HypothesisWarning)
     dtypeless_xps = make_strategies_namespace(dtypeless_xp, api_version="draft")
 
 

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -11,6 +11,7 @@
 from copy import copy
 from types import SimpleNamespace
 from typing import Tuple
+import warnings
 
 import pytest
 
@@ -62,8 +63,9 @@ def test_error_on_missing_attr(stratname, args, attr):
 
 
 dtypeless_xp = make_mock_xp(exclude=tuple(DTYPE_NAMES))
-# with pytest.warns(HypothesisWarning):
-dtypeless_xps = make_strategies_namespace(dtypeless_xp, api_version="draft")
+with warnings.catch_warnings():
+    warnings.filterwarning("ignore", category=HypothesisWarning)
+    dtypeless_xps = make_strategies_namespace(dtypeless_xp, api_version="draft")
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -78,7 +78,7 @@ def make_mock_xp(*, exclude: Tuple[str, ...] = (), exclude_methods: Tuple[str, .
 
 def test_warning_on_noncompliant_xp():
     """Using non-compliant array modules raises helpful warning"""
-    xp = make_mock_xp()
+    xp = make_mock_xp(exclude_methods=("__array_namespace__",))
     with pytest.warns(HypothesisWarning, match=MOCK_WARN_MSG):
         make_strategies_namespace(xp, api_version="draft")
 

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -62,8 +62,8 @@ def test_error_on_missing_attr(stratname, args, attr):
 
 
 dtypeless_xp = make_mock_xp(exclude=tuple(DTYPE_NAMES))
-with pytest.warns(HypothesisWarning):
-    dtypeless_xps = make_strategies_namespace(dtypeless_xp, api_version="draft")
+# with pytest.warns(HypothesisWarning):
+dtypeless_xps = make_strategies_namespace(dtypeless_xp, api_version="draft")
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -45,7 +45,7 @@ class MockedArray:
         return super().__getattribute__(self, name)
 
 
-def wrap_array(func: callable, exclude: Tuple[str, ...] =()) -> callable:
+def wrap_array(func: callable, exclude: Tuple[str, ...] = ()) -> callable:
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         result = func(*args, **kwargs)
@@ -57,14 +57,35 @@ def wrap_array(func: callable, exclude: Tuple[str, ...] =()) -> callable:
 
     return wrapped
 
-def make_mock_xp(*, exclude: Tuple[str, ...] = (), exclude_methods: Tuple[str, ...] = ()) -> SimpleNamespace:
+
+def make_mock_xp(
+    *, exclude: Tuple[str, ...] = (), exclude_methods: Tuple[str, ...] = ()
+) -> SimpleNamespace:
     xp = copy(mock_xp)
     assert isinstance(exclude, tuple)  # sanity check
     assert isinstance(exclude_methods, tuple)  # sanity check
     for attr in exclude:
         delattr(xp, attr)
 
-    array_returning_funcs = ("astype", "broadcast_arrays", "arange", "asarray", "empty", "zeros", "ones", "reshape", "isnan", "isfinite", "logical_or", "sum", "nonzero", "sort", "unique_values", "any", "all")
+    array_returning_funcs = (
+        "astype",
+        "broadcast_arrays",
+        "arange",
+        "asarray",
+        "empty",
+        "zeros",
+        "ones",
+        "reshape",
+        "isnan",
+        "isfinite",
+        "logical_or",
+        "sum",
+        "nonzero",
+        "sort",
+        "unique_values",
+        "any",
+        "all",
+    )
 
     for name in array_returning_funcs:
         func = getattr(xp, name, None)

--- a/hypothesis-python/tests/array_api/test_partial_adoptors.py
+++ b/hypothesis-python/tests/array_api/test_partial_adoptors.py
@@ -42,7 +42,7 @@ class MockedArray:
         if name in self.exclude:
             raise AttributeError(f"removed on the mock: {name}")
 
-        return super().__getattribute__(self, name)
+        return object.__getattribute__(self, name)
 
 
 def wrap_array(func: callable, exclude: Tuple[str, ...] = ()) -> callable:

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -128,18 +128,11 @@ def test_byte_string_dtypes_generate_unicode_strings(data):
     assert isinstance(result, bytes)
 
 
+skipif_np2 = pytest.mark.skipif(np_version >= (2, 0), reason="removed in new version")
+
 @pytest.mark.parametrize(
     "dtype",
-    [
-        "U",
-        "S",
-        pytest.param(
-            "a",
-            marks=pytest.mark.skipif(
-                np_version >= (2, 0), reason="not supported on `numpy>=2.0`"
-            ),
-        ),
-    ],
+    ["U", "S", pytest.param("a", marks=skipif_np2)],
 )
 def test_unsized_strings_length_gt_one(dtype):
     # See https://github.com/HypothesisWorks/hypothesis/issues/2229

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -10,6 +10,8 @@
 
 import sys
 
+from packaging import Version
+
 import numpy as np
 import pytest
 
@@ -126,7 +128,16 @@ def test_byte_string_dtypes_generate_unicode_strings(data):
     assert isinstance(result, bytes)
 
 
-@pytest.mark.parametrize("dtype", ["U", "S", "a"])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "U",
+        "S",
+        pytest.param(
+            "a", marks=pytest.mark.skipif(Version(np.__version__) >= Version("2.0"))
+        ),
+    ],
+)
 def test_unsized_strings_length_gt_one(dtype):
     # See https://github.com/HypothesisWorks/hypothesis/issues/2229
     find_any(nps.arrays(dtype=dtype, shape=1), lambda arr: len(arr[0]) >= 2)

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -133,7 +133,7 @@ def test_byte_string_dtypes_generate_unicode_strings(data):
     [
         "U",
         "S",
-        pytest.param("a", marks=pytest.mark.skipif(np_version >= (2, 0))),
+        pytest.param("a", marks=pytest.mark.skipif(np_version >= (2, 0), reason="not supported on `numpy>=2.0`")),
     ],
 )
 def test_unsized_strings_length_gt_one(dtype):

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -10,8 +10,6 @@
 
 import sys
 
-from packaging import Version
-
 import numpy as np
 import pytest
 
@@ -22,6 +20,8 @@ from hypothesis.internal.floats import width_smallest_normals
 from hypothesis.strategies._internal import SearchStrategy
 
 from tests.common.debug import assert_no_examples, check_can_generate_examples, find_any
+
+np_version = tuple(int(x) for x in np.__version__.split(".")[:2])
 
 STANDARD_TYPES = [
     np.dtype(t)
@@ -133,9 +133,7 @@ def test_byte_string_dtypes_generate_unicode_strings(data):
     [
         "U",
         "S",
-        pytest.param(
-            "a", marks=pytest.mark.skipif(Version(np.__version__) >= Version("2.0"))
-        ),
+        pytest.param("a", marks=pytest.mark.skipif(np_version >= (2, 0))),
     ],
 )
 def test_unsized_strings_length_gt_one(dtype):

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -133,7 +133,12 @@ def test_byte_string_dtypes_generate_unicode_strings(data):
     [
         "U",
         "S",
-        pytest.param("a", marks=pytest.mark.skipif(np_version >= (2, 0), reason="not supported on `numpy>=2.0`")),
+        pytest.param(
+            "a",
+            marks=pytest.mark.skipif(
+                np_version >= (2, 0), reason="not supported on `numpy>=2.0`"
+            ),
+        ),
     ],
 )
 def test_unsized_strings_length_gt_one(dtype):

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -348,7 +348,11 @@ np_version = tuple(int(x) for x in np.__version__.split(".")[:2])
 
 @pytest.mark.parametrize("fill", [False, True])
 # Overflowing elements deprecated upstream in Numpy 1.24 :-)
-@fails_with(InvalidArgument if np_version < (1, 24) else DeprecationWarning)
+@fails_with(
+    InvalidArgument
+    if np_version < (1, 24)
+    else (DeprecationWarning if np_version < (2, 0) else OverflowError)
+)
 @given(st.data())
 def test_overflowing_integers_are_deprecated(fill, data):
     kw = {"elements": st.just(300)}

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -63,7 +63,11 @@ allowlist_externals =
     bash
 commands=
     bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-    python -bb -X dev -m pytest tests/ -n auto
+    python -bb -X dev -m pytest tests/numpy/ -n auto
+    python -bb -X dev -m pytest tests/array_api/ -n auto
+    python -bb -X dev -m pytest tests/pandas/ -n auto
+    python -bb -X dev -m pytest tests/ghostwriter/ -n auto
+    python -bb -X dev -m pytest tests/conjecture/ -n auto
 
 # Note: when adding or removing tested Pandas versions, make sure to update the
 # docs in numpy.rst too.  To see current download rates of each minor version:

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -59,11 +59,13 @@ commands=
 [testenv:numpy-nightly]
 deps=
     -r../requirements/test.txt
+    pandas
+    black
+    click
 allowlist_externals =
     bash
 commands=
     bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-    bash -c "pip install pandas black click"
     python -bb -X dev -m pytest tests/numpy/ tests/array_api/ tests/pandas/ tests/ghostwriter/ tests/conjecture/ -n auto
 
 # Note: when adding or removing tested Pandas versions, make sure to update the

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -63,7 +63,7 @@ allowlist_externals =
     bash
 commands=
     bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-    python -bb -X dev -m pytest tests/numpy/ -n auto
+    python -bb -X dev -m pytest tests/ -n auto
 
 # Note: when adding or removing tested Pandas versions, make sure to update the
 # docs in numpy.rst too.  To see current download rates of each minor version:

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -63,11 +63,7 @@ allowlist_externals =
     bash
 commands=
     bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-    python -bb -X dev -m pytest tests/numpy/ -n auto
-    python -bb -X dev -m pytest tests/array_api/ -n auto
-    python -bb -X dev -m pytest tests/pandas/ -n auto
-    python -bb -X dev -m pytest tests/ghostwriter/ -n auto
-    python -bb -X dev -m pytest tests/conjecture/ -n auto
+    python -bb -X dev -m pytest tests/numpy/ tests/array_api/ tests/pandas/ tests/ghostwriter/ tests/conjecture/ -n auto
 
 # Note: when adding or removing tested Pandas versions, make sure to update the
 # docs in numpy.rst too.  To see current download rates of each minor version:

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -63,6 +63,7 @@ allowlist_externals =
     bash
 commands=
     bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+    bash -c "pip install pandas black click"
     python -bb -X dev -m pytest tests/numpy/ tests/array_api/ tests/pandas/ tests/ghostwriter/ tests/conjecture/ -n auto
 
 # Note: when adding or removing tested Pandas versions, make sure to update the

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -55,6 +55,16 @@ commands=
     bash -c "pip install --only-binary=:all: numpy==$(grep 'numpy>=' setup.py | grep -oE '[0-9.]+')"
     python -bb -X dev -m pytest tests/numpy/ -n auto
 
+# This test job runs against the nightly version of `numpy`
+[testenv:numpy-nightly]
+deps=
+    -r../requirements/test.txt
+allowlist_externals =
+    bash
+commands=
+    bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+    python -bb -X dev -m pytest tests/numpy/ -n auto
+
 # Note: when adding or removing tested Pandas versions, make sure to update the
 # docs in numpy.rst too.  To see current download rates of each minor version:
 # https://pepy.tech/project/pandas?versions=1.1.*&versions=1.2.*&versions=1.3.*&versions=1.4.*&versions=1.5.*&versions=2.0.*

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -66,7 +66,7 @@ allowlist_externals =
     bash
 commands=
     bash -c "pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-    python -bb -X dev -m pytest tests/numpy/ tests/array_api/ tests/pandas/ tests/ghostwriter/ tests/conjecture/ -n auto
+    python -bb -X dev -m pytest tests/numpy/ tests/array_api/ tests/pandas/ tests/ghostwriter/ tests/conjecture/ tests/cover -n auto
 
 # Note: when adding or removing tested Pandas versions, make sure to update the
 # docs in numpy.rst too.  To see current download rates of each minor version:

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -502,6 +502,7 @@ for kind in ("cover", "nocover", "niche"):
     standard_tox_task(f"crosshair-{kind}")
 
 standard_tox_task("py38-oldestnumpy", py="3.8")
+standard_tox_task("numpy-nightly")
 
 standard_tox_task("coverage")
 standard_tox_task("conjecture-coverage")

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -502,7 +502,7 @@ for kind in ("cover", "nocover", "niche"):
     standard_tox_task(f"crosshair-{kind}")
 
 standard_tox_task("py38-oldestnumpy", py="3.8")
-standard_tox_task("numpy-nightly")
+standard_tox_task("numpy-nightly", py="3.12")
 
 standard_tox_task("coverage")
 standard_tox_task("conjecture-coverage")


### PR DESCRIPTION
- [x] closes #3950

This also replaces a couple of top-level `pytest.warns` with ignores, which was the simplest way I found to silence the errors caused by the change in behavior of `numpy>=2`.

Still missing: a way to actually test this with a nightly build of `numpy`, but since I don't know your CI well enough I'll need help with that.

With `numpy>=2`, I'm getting a bunch of other failures locally, mostly concerning the removal of `numpy.asfarray`.