### PR TITLE
Improve `draw_string_kwargs` efficiency

### DIFF
--- a/hypothesis-python/tests/common/strategies.py
+++ b/hypothesis-python/tests/common/strategies.py
@@ -65,13 +65,22 @@ def build_intervals(intervals):
         yield batch
 
 
-def interval_lists(min_codepoint=0, max_codepoint=sys.maxunicode):
+def interval_lists(*, min_codepoint=0, max_codepoint=sys.maxunicode, min_size=0):
     return (
-        st.lists(st.integers(min_codepoint, max_codepoint), unique=True)
+        st.lists(
+            st.integers(min_codepoint, max_codepoint),
+            unique=True,
+            min_size=min_size * 2,
+        )
         .map(sorted)
         .map(build_intervals)
     )
 
 
-def intervals(min_codepoint=0, max_codepoint=sys.maxunicode):
-    return st.builds(IntervalSet, interval_lists(min_codepoint, max_codepoint))
+def intervals(*, min_codepoint=0, max_codepoint=sys.maxunicode, min_size=0):
+    return st.builds(
+        IntervalSet,
+        interval_lists(
+            min_codepoint=min_codepoint, max_codepoint=max_codepoint, min_size=min_size
+        ),
+    )

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -168,9 +168,9 @@ def draw_integer_kwargs(
 
 @st.composite
 def draw_string_kwargs(draw, *, use_min_size=True, use_max_size=True, use_forced=False):
-    interval_set = draw(intervals())
-    # TODO relax this restriction once we handle empty pseudo-choices in the ir
-    assume(len(interval_set) > 0)
+    # TODO also sample empty intervals, ie remove this min_size, once we handle empty
+    # pseudo-choices in the ir
+    interval_set = draw(intervals(min_size=1))
     forced = (
         draw(TextStrategy(OneCharStringStrategy(interval_set))) if use_forced else None
     )

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 
 import pytest
 
-from hypothesis import HealthCheck, assume, example, given, settings, strategies as st
+from hypothesis import assume, example, given, strategies as st
 from hypothesis.errors import StopTest
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
@@ -367,12 +367,7 @@ def test_data_with_empty_ir_tree_is_overrun():
     assert data.status is Status.OVERRUN
 
 
-# root cause of too_slow is filtering too much via assume in kwargs strategies.
-# exacerbated in this test because we draw kwargs twice.
-# TODO revisit and improve the kwargs strategies at some point, once the ir
-# is further along we can maybe remove e.g. a string assumption.
 @given(st.data())
-@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_node_with_different_ir_type_is_invalid(data):
     node = data.draw(ir_nodes())
     (ir_type, kwargs) = data.draw(ir_types_and_kwargs())
@@ -406,7 +401,6 @@ def test_node_with_same_ir_type_but_different_value_is_invalid(data):
 
 
 @given(st.data())
-@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_data_with_changed_was_forced(data):
     # we had a normal node and then tried to draw a different forced value from it.
     # ir tree: v1 [was_forced=False]
@@ -423,7 +417,6 @@ def test_data_with_changed_was_forced(data):
 
 
 @given(ir_nodes(was_forced=True))
-@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_data_with_changed_forced_value(node):
     # we had a forced node and then tried to draw a different forced value from it.
     # ir tree: v1 [was_forced=True]


### PR DESCRIPTION
got tired of seeing this fail 😅 https://github.com/HypothesisWorks/hypothesis/actions/runs/8946209326/job/24576465627

possibly *too* aggressive with removing `HealthCheck.too_slow`? ah well, let's run it through the ci wringer and we can revert some if necessary.