### PR TITLE
Improve caching for misaligned `ConjectureData`s

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves our internal caching logic. We don't expect it to result in any performance improvements (yet!).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -24,6 +24,7 @@ from hypothesis.internal.conjecture.data import (
     DataObserver,
     FloatKWargs,
     IntegerKWargs,
+    InvalidAt,
     IRKWargsType,
     IRType,
     IRTypeName,
@@ -422,6 +423,8 @@ class TreeNode:
     #   be explored when generating novel prefixes)
     transition: Union[None, Branch, Conclusion, Killed] = attr.ib(default=None)
 
+    invalid_at: Optional[InvalidAt] = attr.ib(default=None)
+
     # A tree node is exhausted if every possible sequence of draws below it has
     # been explored. We only update this when performing operations that could
     # change the answer.
@@ -475,6 +478,8 @@ class TreeNode:
         del self.ir_types[i:]
         del self.values[i:]
         del self.kwargs[i:]
+        # we have a transition now, so we don't need to carry around invalid_at.
+        self.invalid_at = None
         assert len(self.values) == len(self.kwargs) == len(self.ir_types) == i
 
     def check_exhausted(self):
@@ -835,6 +840,13 @@ class DataTree:
                     t = node.transition
                     data.conclude_test(t.status, t.interesting_origin)
                 elif node.transition is None:
+                    if node.invalid_at is not None:
+                        (ir_type, kwargs) = node.invalid_at
+                        try:
+                            draw(ir_type, kwargs)
+                        except StopTest:
+                            if data.invalid_at is not None:
+                                raise
                     raise PreviouslyUnseenBehaviour
                 elif isinstance(node.transition, Branch):
                     v = draw(node.transition.ir_type, node.transition.kwargs)
@@ -979,6 +991,9 @@ class TreeRecordingObserver(DataObserver):
         self, value: bool, *, was_forced: bool, kwargs: BooleanKWargs
     ) -> None:
         self.draw_value("boolean", value, was_forced=was_forced, kwargs=kwargs)
+
+    def mark_invalid(self, invalid_at: InvalidAt) -> None:
+        self.__current_node.invalid_at = invalid_at
 
     def draw_value(
         self,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -811,6 +811,9 @@ class DataTree:
         node = self.root
 
         def draw(ir_type, kwargs, *, forced=None):
+            if ir_type == "float" and forced is not None:
+                forced = int_to_float(forced)
+
             draw_func = getattr(data, f"draw_{ir_type}")
             value = draw_func(**kwargs, forced=forced)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -254,7 +254,7 @@ class ConjectureRunner:
 
         # intentionally drop was_forced from equality here, because the was_forced
         # of node prefixes on ConjectureData has no impact on that data's result
-        key = tuple(
+        return tuple(
             (
                 node.ir_type,
                 ir_value_key(node.ir_type, node.value),
@@ -262,7 +262,6 @@ class ConjectureRunner:
             )
             for node in nodes + extension
         )
-        return key
 
     def _cache(self, data):
         result = data.as_result()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -34,6 +34,8 @@ from hypothesis.internal.conjecture.data import (
     Overrun,
     PrimitiveProvider,
     Status,
+    ir_kwargs_key,
+    ir_value_key,
 )
 from hypothesis.internal.conjecture.datatree import DataTree, PreviouslyUnseenBehaviour
 from hypothesis.internal.conjecture.junkdrawer import clamp, ensure_free_stackframes
@@ -186,6 +188,7 @@ class ConjectureRunner:
         # shrinking where we need to know about the structure of the
         # executed test case.
         self.__data_cache = LRUReusedCache(CACHE_SIZE)
+        self.__data_cache_ir = LRUReusedCache(CACHE_SIZE)
 
         self.__pending_call_explanation = None
         self._switch_to_hypothesis_provider = False
@@ -239,10 +242,71 @@ class ConjectureRunner:
                     # correct engine.
                     raise
 
-    def ir_tree_to_data(self, ir_tree_nodes):
-        data = ConjectureData.for_ir_tree(ir_tree_nodes)
-        self.__stoppable_test_function(data)
-        return data
+    def _cache_key_ir(self, *, nodes=None, data=None):
+        assert (nodes is not None) ^ (data is not None)
+        extension = []
+        if data is not None:
+            nodes = data.examples.ir_tree_nodes
+            if data.invalid_at is not None:
+                # if we're invalid then we should have at least one node left (the invalid one).
+                assert data._node_index < len(data.ir_tree_nodes)
+                extension = [data.ir_tree_nodes[data._node_index]]
+
+        # intentionally drop was_forced from equality here, because the was_forced
+        # of node prefixes on ConjectureData has no impact on that data's result
+        key = tuple(
+            (
+                node.ir_type,
+                ir_value_key(node.ir_type, node.value),
+                ir_kwargs_key(node.ir_type, node.kwargs),
+            )
+            for node in nodes + extension
+        )
+        return key
+
+    def _cache(self, data):
+        result = data.as_result()
+        # when we shrink, we try out of bounds things, which can lead to the same
+        # data.buffer having multiple outcomes. eg data.buffer=b'' is Status.OVERRUN
+        # in normal circumstances, but a data with
+        # ir_nodes=[integer -5 {min_value: 0, max_value: 10}] will also have
+        # data.buffer=b'' but will be Status.INVALID instead. We do not want to
+        # change the cached value to INVALID in this case.
+        #
+        # We handle this specially for the ir cache by keying off the misaligned node
+        # as well, but we cannot do the same for buffers as we do not know ahead of
+        # time what buffer a node maps to. I think it's largely fine that we don't
+        # write to the buffer cache here as we move more things to the ir cache.
+        if data.invalid_at is None:
+            self.__data_cache[data.buffer] = result
+        key = self._cache_key_ir(data=data)
+        self.__data_cache_ir[key] = result
+
+    def cached_test_function_ir(self, nodes):
+        key = self._cache_key_ir(nodes=nodes)
+        try:
+            return self.__data_cache_ir[key]
+        except KeyError:
+            pass
+
+        try:
+            trial_data = self.new_conjecture_data_ir(nodes)
+            self.tree.simulate_test_function(trial_data)
+        except PreviouslyUnseenBehaviour:
+            pass
+        else:
+            trial_data.freeze()
+            key = self._cache_key_ir(data=trial_data)
+            try:
+                return self.__data_cache_ir[key]
+            except KeyError:
+                pass
+
+        data = self.new_conjecture_data_ir(nodes)
+        # note that calling test_function caches `data` for us, for both an ir
+        # tree key and a buffer key.
+        self.test_function(data)
+        return data.as_result()
 
     def test_function(self, data):
         if self.__pending_call_explanation is not None:
@@ -274,7 +338,7 @@ class ConjectureRunner:
                     ),
                 }
                 self.stats_per_test_case.append(call_stats)
-                self.__data_cache[data.buffer] = data.as_result()
+                self._cache(data)
 
         self.debug_data(data)
 
@@ -321,8 +385,9 @@ class ConjectureRunner:
 
                 # drive the ir tree through the test function to convert it
                 # to a buffer
-                data = self.ir_tree_to_data(data.examples.ir_tree_nodes)
-                self.__data_cache[data.buffer] = data.as_result()
+                data = ConjectureData.for_ir_tree(data.examples.ir_tree_nodes)
+                self.__stoppable_test_function(data)
+                self._cache(data)
 
             key = data.interesting_origin
             changed = False
@@ -982,6 +1047,18 @@ class ConjectureRunner:
         with self._log_phase_statistics("shrink"):
             self.shrink_interesting_examples()
         self.exit_with(ExitReason.finished)
+
+    def new_conjecture_data_ir(self, ir_tree_prefix, *, observer=None):
+        provider = (
+            HypothesisProvider if self._switch_to_hypothesis_provider else self.provider
+        )
+        observer = observer or self.tree.new_observer()
+        if self.settings.backend != "hypothesis":
+            observer = DataObserver()
+
+        return ConjectureData.for_ir_tree(
+            ir_tree_prefix, observer=observer, provider=provider
+        )
 
     def new_conjecture_data(self, prefix, max_length=BUFFER_SIZE, observer=None):
         provider = (

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -381,9 +381,31 @@ class Shrinker:
         test function."""
         return self.engine.call_count
 
+    def check_calls(self):
+        if self.calls - self.calls_at_last_shrink >= self.max_stall:
+            raise StopShrinking
+
+    def cached_test_function_ir(self, tree):
+        result = self.engine.cached_test_function_ir(tree)
+        self.incorporate_test_data(result)
+        self.check_calls()
+        return result
+
     def consider_new_tree(self, tree):
-        data = self.engine.ir_tree_to_data(tree)
-        return self.consider_new_buffer(data.buffer)
+        tree = tree[: len(self.nodes)]
+
+        def startswith(t1, t2):
+            return t1[: len(t2)] == t2
+
+        if startswith(tree, self.nodes):
+            return True
+
+        if startswith(self.nodes, tree):
+            return False
+
+        previous = self.shrink_target
+        self.cached_test_function_ir(tree)
+        return previous is not self.shrink_target
 
     def consider_new_buffer(self, buffer):
         """Returns True if after running this buffer the result would be
@@ -430,12 +452,10 @@ class Shrinker:
         that the result is either an Overrun object (if the buffer is
         too short to be a valid test case) or a ConjectureData object
         with status >= INVALID that would result from running this buffer."""
-
         buffer = bytes(buffer)
         result = self.engine.cached_test_function(buffer, extend=self.__extend)
         self.incorporate_test_data(result)
-        if self.calls - self.calls_at_last_shrink >= self.max_stall:
-            raise StopShrinking
+        self.check_calls()
         return result
 
     def debug(self, msg):

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -300,8 +300,11 @@ def draw_value(ir_type, kwargs):
 
 
 @st.composite
-def ir_nodes(draw, *, was_forced=None):
-    (ir_type, kwargs) = draw(ir_types_and_kwargs())
+def ir_nodes(draw, *, was_forced=None, ir_type=None):
+    if ir_type is None:
+        (ir_type, kwargs) = draw(ir_types_and_kwargs())
+    else:
+        kwargs = draw(kwargs_strategy(ir_type))
     # ir nodes don't include forced in their kwargs. see was_forced attribute
     del kwargs["forced"]
     value = draw_value(ir_type, kwargs)

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -30,6 +30,7 @@ from hypothesis.internal.floats import SIGNALING_NAN
 from hypothesis.internal.intervalsets import IntervalSet
 
 from tests.common.debug import minimal
+from tests.conjecture.common import ir_nodes
 
 
 class PrngProvider(PrimitiveProvider):
@@ -243,6 +244,18 @@ def test_backend_can_shrink_floats():
         )
 
     assert f == 101.0
+
+
+# mostly a shoehorned coverage test until the shrinker is migrated to the ir
+# and calls cached_test_function_ir with backends consistently.
+@given(ir_nodes())
+def test_new_conjecture_data_ir_with_backend(node):
+    def test(data):
+        getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
+
+    with temp_register_backend("prng", PrngProvider):
+        runner = ConjectureRunner(test, settings=settings(backend="prng"))
+        runner.cached_test_function_ir([node])
 
 
 # trivial provider for tests which don't care about drawn distributions.

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -667,3 +667,18 @@ def test_misaligned_nodes_before_valid_draw(data):
     cd.freeze()
     assert cd.status is Status.VALID
     assert cd.examples.ir_tree_nodes == [node]
+
+
+@given(ir_nodes(was_forced=True, ir_type="float"))
+def test_simulate_forced_floats(node):
+    tree = DataTree()
+
+    cd = ConjectureData.for_ir_tree([node], observer=tree.new_observer())
+    cd.draw_float(**node.kwargs, forced=node.value)
+    with pytest.raises(StopTest):
+        cd.conclude_test(Status.VALID)
+
+    cd = ConjectureData.for_ir_tree([node], observer=tree.new_observer())
+    tree.simulate_test_function(cd)
+    cd.freeze()
+    assert cd.examples.ir_tree_nodes == [node]

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -28,7 +28,8 @@ from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck, Flaky
 from hypothesis.internal.compat import int_from_bytes
 from hypothesis.internal.conjecture import engine as engine_module
-from hypothesis.internal.conjecture.data import ConjectureData, Overrun, Status, IRNode
+from hypothesis.internal.conjecture.data import ConjectureData, IRNode, Overrun, Status
+from hypothesis.internal.conjecture.datatree import compute_max_children
 from hypothesis.internal.conjecture.engine import (
     MIN_TEST_CALLS,
     ConjectureRunner,
@@ -39,7 +40,6 @@ from hypothesis.internal.conjecture.engine import (
 from hypothesis.internal.conjecture.pareto import DominanceRelation, dominance
 from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
 from hypothesis.internal.entropy import deterministic_PRNG
-from hypothesis.internal.conjecture.datatree import compute_max_children
 
 from tests.common.debug import minimal
 from tests.common.strategies import SLOW, HardToShrink

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -15,12 +15,20 @@ from unittest.mock import Mock
 
 import pytest
 
-from hypothesis import HealthCheck, Phase, Verbosity, settings
+from hypothesis import (
+    HealthCheck,
+    Phase,
+    Verbosity,
+    assume,
+    given,
+    settings,
+    strategies as st,
+)
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck, Flaky
 from hypothesis.internal.compat import int_from_bytes
 from hypothesis.internal.conjecture import engine as engine_module
-from hypothesis.internal.conjecture.data import ConjectureData, Overrun, Status
+from hypothesis.internal.conjecture.data import ConjectureData, Overrun, Status, IRNode
 from hypothesis.internal.conjecture.engine import (
     MIN_TEST_CALLS,
     ConjectureRunner,
@@ -31,6 +39,7 @@ from hypothesis.internal.conjecture.engine import (
 from hypothesis.internal.conjecture.pareto import DominanceRelation, dominance
 from hypothesis.internal.conjecture.shrinker import Shrinker, block_program
 from hypothesis.internal.entropy import deterministic_PRNG
+from hypothesis.internal.conjecture.datatree import compute_max_children
 
 from tests.common.debug import minimal
 from tests.common.strategies import SLOW, HardToShrink
@@ -39,6 +48,7 @@ from tests.conjecture.common import (
     SOME_LABEL,
     TEST_SETTINGS,
     buffer_size_limit,
+    ir_nodes,
     run_to_buffer,
     shrinking_from,
 )
@@ -1523,3 +1533,96 @@ def test_too_slow_report():
     got = state.timing_report()
     print(got)
     assert expected == got
+
+
+def _draw(cd, node):
+    return getattr(cd, f"draw_{node.ir_type}")(**node.kwargs)
+
+
+@given(st.data())
+# drawing a second node with a different ir_type is hard to satisfy, as hypothesis
+# biases towards the first defined ir_type early on.
+@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
+def test_extensions_of_misaligned_trees_are_cached(data):
+    # ConjectureData treats all ir node prefixes as if they were not forced,
+    # so was_forced doesn't make a difference when drawing. In fact, was_forced
+    # will always be False after running a tree through ConjectureData, so comparing
+    # for equality before and after is easiest if was_forced is always False.
+    node = data.draw(ir_nodes(was_forced=False))
+    misaligned_node = data.draw(ir_nodes(was_forced=False))
+    assume(node.ir_type != misaligned_node.ir_type)
+    # avoid trivial nodes resulting in exhausting the tree extremely early
+    assume(compute_max_children(node.ir_type, node.kwargs) > 100)
+
+    def test(cd):
+        _draw(cd, node)
+        _draw(cd, node)
+
+    runner = ConjectureRunner(test)
+
+    def _assert_cached(cd):
+        assert runner.call_count == 1
+        assert cd.status is Status.INVALID
+        assert cd.examples.ir_tree_nodes == [node]
+
+    assert runner.call_count == 0
+
+    cd = runner.cached_test_function_ir([node, misaligned_node])
+    _assert_cached(cd)
+
+    cd = runner.cached_test_function_ir([node, misaligned_node])
+    _assert_cached(cd)
+
+    extension = data.draw(st.lists(ir_nodes(was_forced=False)))
+    cd = runner.cached_test_function_ir([node, misaligned_node] + extension)
+    _assert_cached(cd)
+
+
+@given(ir_nodes(was_forced=False), ir_nodes(was_forced=False))
+@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
+def test_misaligned_tree_does_not_clobber_cache(node, misaligned_node):
+    assume(node.ir_type != misaligned_node.ir_type)
+    assume(compute_max_children(node.ir_type, node.kwargs) > 100)
+
+    def test(cd):
+        _draw(cd, node)
+
+    runner = ConjectureRunner(test)
+    assert runner.call_count == 0
+
+    data_buffer = runner.cached_test_function(b"")
+    assert runner.call_count == 1
+    assert data_buffer.status is Status.OVERRUN
+
+    data_ir = runner.cached_test_function_ir([misaligned_node])
+    assert data_ir.status is Status.INVALID
+    assert data_ir.buffer == b""
+    assert runner.call_count == 2
+
+    result = runner.cached_test_function(b"")
+    assert runner.call_count == 2
+    assert result == data_buffer
+
+
+@pytest.mark.parametrize("forced_first", [True, False])
+@given(node=ir_nodes(was_forced=False))
+def test_cache_ignores_was_forced(forced_first, node):
+    assume(compute_max_children(node.ir_type, node.kwargs) > 100)
+    forced_node = IRNode(
+        ir_type=node.ir_type,
+        value=node.value,
+        kwargs=node.kwargs,
+        was_forced=True,
+    )
+
+    def test(cd):
+        _draw(cd, node)
+
+    runner = ConjectureRunner(test)
+    assert runner.call_count == 0
+
+    runner.cached_test_function_ir([forced_node] if forced_first else [node])
+    assert runner.call_count == 1
+
+    runner.cached_test_function_ir([node] if forced_first else [forced_node])
+    assert runner.call_count == 1

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1574,7 +1574,7 @@ def test_extensions_of_misaligned_trees_are_cached(data):
     _assert_cached(cd)
 
     extension = data.draw(st.lists(ir_nodes(was_forced=False)))
-    cd = runner.cached_test_function_ir([node, misaligned_node] + extension)
+    cd = runner.cached_test_function_ir([node, misaligned_node, *extension])
     _assert_cached(cd)
 
 

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -32,7 +32,12 @@ from hypothesis.internal.floats import SMALLEST_SUBNORMAL, next_down, next_up
 from hypothesis.internal.intervalsets import IntervalSet
 
 from tests.common.debug import minimal
-from tests.conjecture.common import fresh_data, ir_types_and_kwargs, kwargs_strategy
+from tests.conjecture.common import (
+    fresh_data,
+    ir_nodes,
+    ir_types_and_kwargs,
+    kwargs_strategy,
+)
 
 
 def draw_value(ir_type, kwargs):
@@ -329,15 +334,6 @@ def test_ir_nodes(random):
         ),
     ]
     assert data.examples.ir_tree_nodes == expected_tree_nodes
-
-
-@st.composite
-def ir_nodes(draw, *, was_forced=None):
-    (ir_type, kwargs) = draw(ir_types_and_kwargs())
-    value = draw_value(ir_type, kwargs)
-    was_forced = draw(st.booleans()) if was_forced is None else was_forced
-
-    return IRNode(ir_type=ir_type, value=value, kwargs=kwargs, was_forced=was_forced)
 
 
 @given(ir_nodes())

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -928,3 +928,8 @@ def test_conservative_nontrivial_nodes(node):
         return getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
 
     assert ir_value_equal(node.ir_type, minimal(values()), node.value)
+
+
+@given(ir_nodes())
+def test_ir_node_is_hashable(ir_node):
+    hash(ir_node)


### PR DESCRIPTION
I was not expecting to go this deep into the caching logic, but it became more and more clear to me while working on #3962 that our internal `mark_invalid` for misaligned datas actually requires some more thought, and we were only getting away with it before by luck.

The issue goes something like this. Say a test function draws an integer then a boolean. That means a data with an ir prefix of `[0, True]` is valid and a data of `[0, 2]` is misaligned. The latter hits an internal `mark_invalid` and has `Status.INVALID`. Now, how should `[0, 2]` be cached? Its resulting ir tree is  just `[0]`, since it was invalid "between" 0 and 2 and we don't know what value the test function would have drawn in this scenario. But mapping `[0]: invalid` in our cache would be incorrect! In this case `[0]` is actually an overrun because we draw twice. Moreoever, some extensions of `[0]` like `[0, True]` are valid while others are not.

A separate problem is how do we get nice caching behavior out of `DataTree.simulate_test_function`? We would like extensions of `[0, 2]` to be simulated to `[0, 2]` as invalid. But `DataTree` has a fundamental invariant that splitting at differing kwargs/ir types is flaky, and you can only split at differing values. So we cannot store `[0, 2]` in the standard way, as it would be immediately rejected as flaky alongside `[0, True]`. 

This pull special-cases the "invalid because misaligned" caching logic to include the node in the prefix we were invalid at, such that we cache `[0, 2]: invalid`. It also adds similar special logic for DataTree such that `simulate_test_function` will `conclude_test(Status.INVALID)` in all the right places. This already happened in practice for misaligned datas when drawing, except in the case of a null transition, where we need to probe one draw further to see if we would have been invalid.

This pull does *not* take the extra step of also caching/simulating `[0, 1]` to invalid, given `[0, 2]` is invalid. In practice this is possible: if `[0, 2]` is invalid because 2 has the wrong ir type, then any value at `i=1` which differs in ir type can also be simulated to invalid without calling through to the test function. I think we could revisit this later if need be.

I'm not enormously happy with this solution, fwiw. Would love to go with a more principled solution if one exists.