### PR TITLE
Implement `all_children` for unbounded integers

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare internal error when using :func:`~hypothesis.strategies.integers` with a high ``max_examples`` setting (:issue:`3974`).

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -272,6 +272,19 @@ def test_compute_max_children_and_all_children_agree(ir_type_and_kwargs):
     assert len(list(all_children(ir_type, kwargs))) == max_children
 
 
+# it's very hard to test that unbounded integer ranges agree with
+# compute_max_children, because they by necessity require iterating over 2**127
+# or more elements. We do the not great approximation of checking just the first
+# element is what we expect.
+@pytest.mark.parametrize(
+    "min_value, max_value, first",
+    [(None, None, -(2**127) + 1), (None, 42, (-(2**127) + 1) + 42), (42, None, 42)],
+)
+def test_compute_max_children_unbounded_integer_ranges(min_value, max_value, first):
+    kwargs = {"min_value": min_value, "max_value": max_value, "weights": None}
+    assert first == next(all_children("integer", kwargs))
+
+
 @given(st.randoms())
 def test_ir_nodes(random):
     data = fresh_data(random=random)

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -255,7 +255,6 @@ def test_draw_string_single_interval_with_equal_bounds(s, n):
             "min_value": 1,
             "max_value": 2,
             "weights": [0, 1],
-            "smallest_nonzero_magnitude": SMALLEST_SUBNORMAL,
         },
     )
 )


### PR DESCRIPTION
closes #3974. Turns out this definitely can happen in practice! 

The reproducer in the issue is actually the worst case for this bug. Conditions for triggering are a strategy with a single unbounded `st.integers` strategy as the heaviest (or only) branching point in its choice tree. I'm guessing we're saturating the 8 and/or 16 bit integer buckets and then getting unlucky by trying to draw from said buckets 10 times in a row, triggering our deduplication fallback to exhaustive enumeration.