### PR TITLE
extra/django: fix from_model for non-auto-created AutoFields

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+The :func:`~hypothesis.extra.django.from_model` function currently
+tries to create a strategy for :obj:`~django:django.db.models.AutoField`
+fields if they don't have :attr:`~django:django.db.models.Field.auto_created`
+set to `True`.  The docs say it's supposed to skip all
+:obj:`~django:django.db.models.AutoField` fields, so this patch updates
+the code to do what the docs say (:issue:`3978`).

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -104,6 +104,7 @@ def from_model(
         if (
             name not in field_strategies
             and not field.auto_created
+            and not isinstance(field, dm.AutoField)
             and field.default is dm.fields.NOT_PROVIDED
         ):
             field_strategies[name] = from_field(field)

--- a/hypothesis-python/tests/django/toystore/models.py
+++ b/hypothesis-python/tests/django/toystore/models.py
@@ -145,3 +145,7 @@ class CompanyExtension(models.Model):
     company = models.OneToOneField(Company, primary_key=True, on_delete=models.CASCADE)
 
     self_modifying = SelfModifyingField()
+
+
+class UserSpecifiedAutoId(models.Model):
+    my_id = models.AutoField(primary_key=True)

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -43,6 +43,7 @@ from tests.django.toystore.models import (
     RestrictedFields,
     SelfLoop,
     Store,
+    UserSpecifiedAutoId,
 )
 
 register_field_strategy(CustomishField, just("a"))
@@ -202,3 +203,10 @@ class TestPosOnlyArg(TestCase):
         self.assertRaises(TypeError, from_model)
         self.assertRaises(TypeError, from_model, Car, None)
         self.assertRaises(TypeError, from_model, model=Customer)
+
+
+class TestUserSpecifiedAutoId(TestCase):
+    @given(from_model(UserSpecifiedAutoId))
+    def test_user_specified_auto_id(self, user_specified_auto_id):
+        self.assertIsInstance(user_specified_auto_id, UserSpecifiedAutoId)
+        self.assertIsNotNone(user_specified_auto_id.pk)


### PR DESCRIPTION
the docs say `from_model()` won't try to create a strategy for any `AutoField`s, but the code only does that for `AutoField`s that have `auto_created` set to `True.  this updates the code to match the docs.

this resolves issue #3978.