### PR TITLE
Improve handling of GroupedMetadata

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+This release improves our support for the :pypi:`annotated-types` iterable
+``GroupedMetadata`` protocol.  In order to treat the elements "as if they
+had been unpacked", if one such element is a :class:`~hypothesis.strategies.SearchStrategy`
+we now resolve to that strategy.  Previously, we treated this as an unknown
+filter predicate.
+
+We expect this to be useful for libraries implementing custom metadata -
+instead of requiring downstream integration, they can implement the protocol
+and yield a lazily-created strategy.  Doing so only if Hypothesis is in
+:obj:`sys.modules` gives powerful integration with no runtime overhead
+or extra dependencies.

--- a/hypothesis-python/tests/cover/test_lookup_py39.py
+++ b/hypothesis-python/tests/cover/test_lookup_py39.py
@@ -45,7 +45,7 @@ def test_typing_Annotated(annotated_type, expected_strategy_repr):
 
 
 PositiveInt = typing.Annotated[int, st.integers(min_value=1)]
-MoreThenTenInt = typing.Annotated[PositiveInt, st.integers(min_value=10 + 1)]
+MoreThanTenInt = typing.Annotated[PositiveInt, st.integers(min_value=10 + 1)]
 WithTwoStrategies = typing.Annotated[int, st.integers(), st.none()]
 ExtraAnnotationNoStrategy = typing.Annotated[PositiveInt, "metadata"]
 
@@ -54,7 +54,7 @@ def arg_positive(x: PositiveInt):
     assert x > 0
 
 
-def arg_more_than_ten(x: MoreThenTenInt):
+def arg_more_than_ten(x: MoreThanTenInt):
     assert x > 10
 
 
@@ -161,3 +161,18 @@ def test_lookup_registered_tuple():
     with temp_registered(tuple, st.just(sentinel)):
         assert_simple_property(st.from_type(typ), lambda v: v is sentinel)
     assert_simple_property(st.from_type(typ), lambda v: v is not sentinel)
+
+
+sentinel = object()
+
+
+class LazyStrategyAnnotation:
+    __is_annotated_types_grouped_metadata__ = True
+
+    def __iter__(self):
+        return iter([st.just(sentinel)])
+
+
+@given(...)
+def test_grouped_protocol_strategy(x: typing.Annotated[int, LazyStrategyAnnotation()]):
+    assert x is sentinel

--- a/hypothesis-python/tests/test_annotated_types.py
+++ b/hypothesis-python/tests/test_annotated_types.py
@@ -18,6 +18,7 @@ from hypothesis import given, strategies as st
 from hypothesis.errors import HypothesisWarning, ResolutionFailed
 from hypothesis.strategies._internal.lazy import unwrap_strategies
 from hypothesis.strategies._internal.strategies import FilteredStrategy
+from hypothesis.strategies._internal.types import _get_constraints
 
 from tests.common.debug import check_can_generate_examples
 
@@ -117,3 +118,22 @@ def test_collection_size_from_slice(data):
     t = Annotated[MyCollection, "we just ignore this", slice(1, 10)]
     value = data.draw(st.from_type(t))
     assert 1 <= len(value) <= 10
+
+
+class GroupedStuff:
+    __is_annotated_types_grouped_metadata__ = True
+
+    def __init__(self, *args) -> None:
+        self._args = args
+
+    def __iter__(self):
+        return iter(self._args)
+
+    def __repr__(self) -> str:
+        return f"GroupedStuff({', '.join(map(repr, self._args))})"
+
+
+def test_flattens_grouped_metadata():
+    grp = GroupedStuff(GroupedStuff(GroupedStuff(at.Len(min_length=1, max_length=5))))
+    constraints = list(_get_constraints(grp))
+    assert constraints == [at.MinLen(1), at.MaxLen(5)]


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/3980, closes https://github.com/HypothesisWorks/hypothesis/pull/3981.  

Motivated by https://github.com/pydantic/pydantic/issues/4682#issuecomment-2105327657; supporting nested-`GroupedMetadata` and short-circuiting if such an item contains an `st.SearchStrategy` will allow for extensive control purely from downstream code.