### PR TITLE
Implement `LazySequenceCopy.pop(i)`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves our shrinking of :func:`~hypothesis.strategies.sets` and :func:`~hypothesis.strategies.lists` with ``unique=True`` (:pull:`3987`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,4 @@
 RELEASE_TYPE: patch
 
-This patch improves our shrinking of :func:`~hypothesis.strategies.sets` and :func:`~hypothesis.strategies.lists` with ``unique=True`` (:pull:`3987`).
+This patch improves our shrinking of unique collections, such as  :func:`~hypothesis.strategies.dictionaries`,
+:func:`~hypothesis.strategies.sets`, and :func:`~hypothesis.strategies.lists` with ``unique=True``.

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -12,7 +12,6 @@ import codecs
 import copy
 import dataclasses
 import inspect
-import itertools
 import platform
 import sys
 import sysconfig
@@ -251,20 +250,6 @@ def bad_django_TestCase(runner):
 
         return not isinstance(runner, HypothesisTestCase)
 
-
-if sys.version_info[:2] < (3, 10):
-
-    # copied straight from
-    # https://docs.python.org/3/library/itertools.html#itertools.pairwise
-    def pairwise(iterable):
-        iterator = iter(iterable)
-        a = next(iterator, None)
-        for b in iterator:
-            yield a, b
-            a = b
-
-else:
-    pairwise = itertools.pairwise
 
 # see issue #3812
 if sys.version_info[:2] < (3, 12):

--- a/hypothesis-python/src/hypothesis/internal/compat.py
+++ b/hypothesis-python/src/hypothesis/internal/compat.py
@@ -12,6 +12,7 @@ import codecs
 import copy
 import dataclasses
 import inspect
+import itertools
 import platform
 import sys
 import sysconfig
@@ -250,6 +251,20 @@ def bad_django_TestCase(runner):
 
         return not isinstance(runner, HypothesisTestCase)
 
+
+if sys.version_info[:2] < (3, 10):
+
+    # copied straight from
+    # https://docs.python.org/3/library/itertools.html#itertools.pairwise
+    def pairwise(iterable):
+        iterator = iter(iterable)
+        a = next(iterator, None)
+        for b in iterator:
+            yield a, b
+            a = b
+
+else:
+    pairwise = itertools.pairwise
 
 # see issue #3812
 if sys.version_info[:2] < (3, 12):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choicetree.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from random import Random
 from typing import Callable, Dict, Iterable, List, Optional, Sequence
 
-from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy, pop_random
+from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
 
 
 def prefix_selection_order(
@@ -41,7 +41,8 @@ def random_selection_order(random: Random) -> Callable[[int, int], Iterable[int]
     def selection_order(depth: int, n: int) -> Iterable[int]:
         pending = LazySequenceCopy(range(n))
         while pending:
-            yield pop_random(random, pending)
+            i = random.randrange(0, len(pending))
+            yield pending.pop(i)
 
     return selection_order
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -203,13 +203,11 @@ class LazySequenceCopy:
     in O(1) time. The full list API is not supported yet but there's no reason
     in principle it couldn't be."""
 
-    __mask: Optional[Dict[int, int]]
-
     def __init__(self, values: Sequence[int]):
         self.__values = values
         self.__len = len(values)
-        self.__mask = None
-        self.__popped_indices = None
+        self.__mask: Optional[Dict[int, int]] = None
+        self.__popped_indices: Optional[SortedList] = None
 
     def __len__(self) -> int:
         if self.__popped_indices is None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -391,14 +391,6 @@ def find_integer(f: Callable[[int], bool]) -> int:
     return lo
 
 
-def pop_random(random: Random, seq: LazySequenceCopy) -> int:
-    """Remove and return a random element of seq. This runs in O(1) but leaves
-    the sequence in an arbitrary order."""
-    i = random.randrange(0, len(seq))
-    swap(seq, i, len(seq) - 1)
-    return seq.pop()
-
-
 class NotFound(Exception):
     pass
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -15,7 +15,7 @@ anything that lives here, please move it."""
 import array
 import sys
 import warnings
-from itertools import chain, pairwise
+from itertools import chain
 from random import Random
 from typing import (
     Callable,
@@ -35,6 +35,7 @@ from typing import (
 from sortedcontainers import SortedList
 
 from hypothesis.errors import HypothesisWarning
+from hypothesis.internal.compat import pairwise
 
 ARRAY_CODES = ["B", "H", "I", "L", "Q", "O"]
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -179,8 +179,7 @@ class ParetoFront:
             failures = 0
             while i + 1 < len(front) and failures < 10:
                 j = self.__random.randrange(i + 1, len(front))
-                swap(front, j, len(front) - 1)
-                candidate = front.pop()
+                candidate = front.pop(j)
                 dom = dominance(data, candidate)
                 assert dom != DominanceRelation.RIGHT_DOMINATES
                 if dom == DominanceRelation.LEFT_DOMINATES:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -287,12 +287,8 @@ class UniqueSampledListStrategy(UniqueListStrategy):
         remaining = LazySequenceCopy(self.element_strategy.elements)
 
         while remaining and should_draw.more():
-            i = len(remaining) - 1
-            j = data.draw_integer(0, i)
-            if j != i:
-                remaining[i], remaining[j] = remaining[j], remaining[i]
-            value = self.element_strategy._transform(remaining.pop())
-
+            j = data.draw_integer(0, len(remaining) - 1)
+            value = self.element_strategy._transform(remaining.pop(j))
             if value is not filter_not_satisfied and all(
                 key(value) not in seen for key, seen in zip(self.keys, seen_sets)
             ):

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -124,10 +124,10 @@ def test_flags_minimize_to_first_named_flag():
 
 
 def test_flags_minimizes_bit_count():
-    shrunk = minimal(st.sampled_from(LargeFlag), lambda f: bit_count(f.value) > 1)
-    # Ideal would be (bit0 | bit1), but:
-    # minimal(st.sets(st.sampled_from(range(10)), min_size=3)) == {0, 8, 9}  # not {0, 1, 2}
-    assert shrunk == LargeFlag.bit0 | LargeFlag.bit63  # documents actual behaviour
+    assert (
+        minimal(st.sampled_from(LargeFlag), lambda f: bit_count(f.value) > 1)
+        == LargeFlag.bit0 | LargeFlag.bit1
+    )
 
 
 def test_flags_finds_all_bits_set():

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -107,6 +107,10 @@ def test_minimize_sets_of_sets():
             assert any(s != t and t.issubset(s) for t in set_of_sets)
 
 
+def test_minimize_sets_sampled_from():
+    assert minimal(st.sets(st.sampled_from(range(10)), min_size=3)) == {0, 1, 2}
+
+
 def test_can_simplify_flatmap_with_bounded_left_hand_size():
     assert (
         minimal(booleans().flatmap(lambda x: lists(just(x))), lambda x: len(x) >= 10)


### PR DESCRIPTION
`UniqueSampledListStrategy` uses `LazySequenceCopy` to pop elements from the list. Because `LazySequenceCopy` only implemented pop-from-end, we swapped the element we wanted to pop to the end before popping. But this leaves the list in a bad state for shrinking: if `i = 0`, we just swapped the last element, which is the most complicated in shrinking order, to the front of the list, leaving it there for future passes. This means an ir tree of `[0, 0, 0]` indicating the first three elements of the sequence corresponds to `{0, 8, 9}` for `sets(range(10))`.

The solution is properly implementing `.pop(i)`. I've applied this in other places we use the swap trick, though I'm less confident than `UniqueSampledListStrategy` that this is not a behavioral change.