### PR TITLE
Fix overly strict type assertion

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes an overly strict internal type assertion.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1072,20 +1072,23 @@ class ConjectureRunner:
                     failed_mutations += 1
                     continue
 
-                assert isinstance(new_data, ConjectureResult)
-                if (
-                    new_data.status >= data.status
-                    and data.buffer != new_data.buffer
-                    and all(
-                        k in new_data.target_observations
-                        and new_data.target_observations[k] >= v
-                        for k, v in data.target_observations.items()
-                    )
-                ):
-                    data = new_data
-                    failed_mutations = 0
+                if new_data is Overrun:
+                    failed_mutations += 1  # pragma: no cover # annoying case
                 else:
-                    failed_mutations += 1
+                    assert isinstance(new_data, ConjectureResult)
+                    if (
+                        new_data.status >= data.status
+                        and data.buffer != new_data.buffer
+                        and all(
+                            k in new_data.target_observations
+                            and new_data.target_observations[k] >= v
+                            for k, v in data.target_observations.items()
+                        )
+                    ):
+                        data = new_data
+                        failed_mutations = 0
+                    else:
+                        failed_mutations += 1
 
     def optimise_targets(self) -> None:
         """If any target observations have been made, attempt to optimise them


### PR DESCRIPTION
Regressed in #3961. See recent failure https://github.com/HypothesisWorks/hypothesis/actions/runs/9066538054/job/24909659955 on https://github.com/HypothesisWorks/hypothesis/commit/5983af0b284b7c30cea15d68cba89972977ad402.

`new_data` can in fact be `Overrun`, though it is still safe to set `data = new_data` because `data` starts as `>= OVERRUN` and we maintain a `new_data.status >= data.status` invariant.

Some annoying duplicated code here for the `failed_mutations` case to make the type checker happy...cleanest way I could find to do it, but possibly a better way exists.