### PR TITLE
Sample RELEASE.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,8 @@ Just tell me how to make a pull request
 
 1. Make your change and ensure it has adequate tests
 2. Create ``hypothesis-python/RELEASE.rst`` with ``RELEASE_TYPE: patch``
-   for small bugfixes, or ``minor`` for new features.  See recent PRs for examples.
+   for small bugfixes, or ``minor`` for new features.  See ``RELEASE-sample.rst``
+   as an example.
 3. Add yourself to the list in ``AUTHORS.rst`` and open a PR!
 
 For more detail, read on; for even more, continue to the ``guides/`` directory!

--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -1,0 +1,22 @@
+RELEASE_TYPE: patch
+
+"patch" should be replaced by "minor" if changes are visible in the
+public API, or "major" if there are breaking changes.
+
+The remaining lines are the actual changelog text for this release,
+which should:
+
+- concisely describe what changed and why
+- use ``double backticks`` for verbatim code
+- use Sphinx cross-references to any functions or classes mentioned
+  :pypi:`<package>` for package links
+  :func:`<function>` for link to functions
+  :func:`~<package.function>` for abbreviated link to functions
+  :issue:`<issue number>` for issues
+  A sample documentation link is below.
+- finish with a note of thanks from the maintainers:
+  "Thanks to <your name> for this bug fix / feature / contribution"
+  (depending on which it is).  If this is your first contribution,
+  don't forget to add yourself to AUTHORS.rst!
+
+See also `the documentation <guides/documentation.rst#changelog-entries>`_

--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -1,7 +1,14 @@
 RELEASE_TYPE: patch
 
-"patch" should be replaced by "minor" if changes are visible in the
-public API, or "major" if there are breaking changes.
+This patch improves import-detection in :doc:`the Ghostwriter <ghostwriter>`
+(:issue:`3884`), particularly for :func:`~hypothesis.strategies.from_type`
+and strategies from ``hypothesis.extra.*``.
+
+---
+
+In the example above, "patch" on the first line should be replaced by
+"minor" if changes are visible in the public API, or "major" if there
+are breaking changes.
 
 The remaining lines are the actual changelog text for this release,
 which should:
@@ -19,8 +26,3 @@ which should:
   (depending on which it is).  If this is your first contribution,
   don't forget to add yourself to AUTHORS.rst!
 
-Here's a concrete example:
-
-This patch improves import-detection in :doc:`the Ghostwriter <ghostwriter>`
-(:issue:`3884`), particularly for :func:`~hypothesis.strategies.from_type`
-and strategies from ``hypothesis.extra.*``.

--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -4,7 +4,7 @@ This patch improves import-detection in :doc:`the Ghostwriter <ghostwriter>`
 (:issue:`3884`), particularly for :func:`~hypothesis.strategies.from_type`
 and strategies from ``hypothesis.extra.*``.
 
-Thanks to <contribtor's name or handle> for this <contribution/fix/feature>!
+Thanks to <contributor's name or handle> for this <contribution/fix/feature>!
 
 ---
 
@@ -23,8 +23,9 @@ which should:
   :class:`package.class` for link to classes (abbreviated: as above)
   :issue:`issue-number` for issues
   :doc:`link text <chapter#anchor>` for documentation references (``https://hypothesis.readthedocs.io/en/latest/<chapter>.html#<anchor>``)
-- finish with a note of thanks from the maintainers:
-  "Thanks to <your name> for this bug fix / feature / contribution"
-  (depending on which it is).  If this is your first contribution,
-  don't forget to add yourself to AUTHORS.rst!
+- finish with a note of thanks from the maintainers. If this is your first
+  contribution, don't forget to add yourself to AUTHORS.rst!
 
+After the PR is merged, the contents of this file (except the first line)
+are automatically added to ``docs/changes.rst``. More examples are found
+in that file.

--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -9,14 +9,18 @@ which should:
 - concisely describe what changed and why
 - use ``double backticks`` for verbatim code
 - use Sphinx cross-references to any functions or classes mentioned
-  :pypi:`<package>` for package links
-  :func:`<function>` for link to functions
-  :func:`~<package.function>` for abbreviated link to functions
-  :issue:`<issue number>` for issues
-  A sample documentation link is below.
+  :pypi:`package` for links to external packages
+  :func:`package.function` for link to functions, or :func:`~package.function` for abbreviated link
+  :class:`package.class` for link to classes (abbreviated: as above)
+  :issue:`issue-number` for issues
+  :doc:`link text <chapter#anchor>` for documentation references (``https://hypothesis.readthedocs.io/en/latest/<chapter>.html#<anchor>``)
 - finish with a note of thanks from the maintainers:
   "Thanks to <your name> for this bug fix / feature / contribution"
   (depending on which it is).  If this is your first contribution,
   don't forget to add yourself to AUTHORS.rst!
 
-See also `the documentation <guides/documentation.rst#changelog-entries>`_
+Here's a concrete example:
+
+This patch improves import-detection in :doc:`the Ghostwriter <ghostwriter>`
+(:issue:`3884`), particularly for :func:`~hypothesis.strategies.from_type`
+and strategies from ``hypothesis.extra.*``.

--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -4,20 +4,22 @@ This patch improves import-detection in :doc:`the Ghostwriter <ghostwriter>`
 (:issue:`3884`), particularly for :func:`~hypothesis.strategies.from_type`
 and strategies from ``hypothesis.extra.*``.
 
+Thanks to <contribtor's name or handle> for this <contribution/fix/feature>!
+
 ---
 
 In the example above, "patch" on the first line should be replaced by
 "minor" if changes are visible in the public API, or "major" if there
-are breaking changes.
+are breaking changes.  Note that only maintainers should ever make a major release.
 
 The remaining lines are the actual changelog text for this release,
 which should:
 
-- concisely describe what changed and why
+- concisely describe what changed _in the public API_, and why.  Internal-only changes can be documented as e.g. "This release improves an internal invariant." (the complete changelog for version 6.99.11)
 - use ``double backticks`` for verbatim code
 - use Sphinx cross-references to any functions or classes mentioned
   :pypi:`package` for links to external packages
-  :func:`package.function` for link to functions, or :func:`~package.function` for abbreviated link
+  :func:`package.function` for link to functions, where the link text will be ``package.function``, or :func:`~package.function` to show ``function``.
   :class:`package.class` for link to classes (abbreviated: as above)
   :issue:`issue-number` for issues
   :doc:`link text <chapter#anchor>` for documentation references (``https://hypothesis.readthedocs.io/en/latest/<chapter>.html#<anchor>``)

--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -9,23 +9,28 @@ Thanks to <contributor's name or handle> for this <contribution/fix/feature>!
 ---
 
 In the example above, "patch" on the first line should be replaced by
-"minor" if changes are visible in the public API, or "major" if there
-are breaking changes.  Note that only maintainers should ever make a major release.
+"minor" if changes are visible in the public API, or "major" if there are
+breaking changes.  Note that only maintainers should ever make a major
+release.
 
 The remaining lines are the actual changelog text for this release,
 which should:
 
-- concisely describe what changed _in the public API_, and why.  Internal-only changes can be documented as e.g. "This release improves an internal invariant." (the complete changelog for version 6.99.11)
-- use ``double backticks`` for verbatim code
-- use Sphinx cross-references to any functions or classes mentioned
-  :pypi:`package` for links to external packages
-  :func:`package.function` for link to functions, where the link text will be ``package.function``, or :func:`~package.function` to show ``function``.
-  :class:`package.class` for link to classes (abbreviated: as above)
-  :issue:`issue-number` for issues
-  :doc:`link text <chapter#anchor>` for documentation references (``https://hypothesis.readthedocs.io/en/latest/<chapter>.html#<anchor>``)
+- concisely describe what changed _in the public API_, and why.
+  Internal-only changes can be documented as e.g. "This release improves
+  an internal invariant." (the complete changelog for version 6.99.11)
+- use ``double backticks`` for verbatim code,
+- use Sphinx cross-references to any functions or classes mentioned:
+  - :pypi:`package` for links to external packages,
+  - :func:`package.function` for link to functions, where the link text will
+    be ``package.function``, or :func:`~package.function` to show ``function``,
+  - :class:`package.class` for link to classes (abbreviated as above),
+  - :issue:`issue-number` for referencing issues,
+  - :doc:`link text <chapter#anchor>` for documentation references
+    (``https://hypothesis.readthedocs.io/en/latest/<chapter>.html#<anchor>``)
 - finish with a note of thanks from the maintainers. If this is your first
   contribution, don't forget to add yourself to AUTHORS.rst!
 
 After the PR is merged, the contents of this file (except the first line)
-are automatically added to ``docs/changes.rst``. More examples are found
+are automatically added to ``docs/changes.rst``. More examples can be found
 in that file.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal developer documentation, no user-visible changes.

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -32,6 +32,7 @@ PYTHON_TESTS = HYPOTHESIS_PYTHON / "tests"
 DOMAINS_LIST = PYTHON_SRC / "hypothesis" / "vendor" / "tlds-alpha-by-domain.txt"
 
 RELEASE_FILE = HYPOTHESIS_PYTHON / "RELEASE.rst"
+RELEASE_SAMPLE_FILE = HYPOTHESIS_PYTHON / "RELEASE-sample.rst"
 
 assert PYTHON_SRC.exists()
 
@@ -50,6 +51,10 @@ assert __version_info__ is not None
 
 def has_release():
     return RELEASE_FILE.exists()
+
+
+def has_release_sample():
+    return RELEASE_SAMPLE_FILE.exists()
 
 
 def parse_release_file():

--- a/whole_repo_tests/test_release_files.py
+++ b/whole_repo_tests/test_release_files.py
@@ -20,7 +20,8 @@ def test_release_file_exists_and_is_valid(project):
     if project.has_source_changes():
         assert project.has_release(), (
             "There are source changes but no RELEASE.rst. Please create "
-            "one to describe your changes."
+            "one to describe your changes. An example can be found in "
+            "RELEASE-sample.rst."
         )
         rm.parse_release_file(project.RELEASE_FILE)
 

--- a/whole_repo_tests/test_release_files.py
+++ b/whole_repo_tests/test_release_files.py
@@ -23,7 +23,7 @@ def test_release_file_exists_and_is_valid(project):
             "one to describe your changes. An example can be found in "
             "RELEASE-sample.rst."
         )
-        assert project.has_release_example(), (
+        assert project.has_release_sample(), (
             "The RELEASE-sample.rst file is missing. Please copy it "
             "to RELEASE.rst, rather than moving it."
         )

--- a/whole_repo_tests/test_release_files.py
+++ b/whole_repo_tests/test_release_files.py
@@ -23,6 +23,10 @@ def test_release_file_exists_and_is_valid(project):
             "one to describe your changes. An example can be found in "
             "RELEASE-sample.rst."
         )
+        assert project.has_release_example(), (
+            "The RELEASE-sample.rst file is missing. Please copy it "
+            "to RELEASE.rst, rather than moving it."
+        )
         rm.parse_release_file(project.RELEASE_FILE)
 
 

--- a/whole_repo_tests/test_rst_is_valid.py
+++ b/whole_repo_tests/test_rst_is_valid.py
@@ -23,7 +23,8 @@ def is_sphinx(f):
 ALL_RST = [
     f
     for f in tools.all_files()
-    if os.path.basename(f) != "RELEASE.rst" and f.endswith(".rst")
+    if os.path.basename(f) not in ["RELEASE.rst", "RELEASE-sample.rst"]
+    and f.endswith(".rst")
 ]
 
 


### PR DESCRIPTION
I've always missed a sample `RELEASE.rst` to start with, so I wouldn't have to search for examples in recent "good" PRs.

I think something like this would be useful! Ideally with examples of all relevant (for us) Sphinx roles, which I was hoping you could help with :tulip: 