### PR TITLE
Handle overruns in `generate_novel_prefix`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a rare internal error when generating very large elements from strategies (:issue:`3874`).

--- a/hypothesis-python/tests/nocover/test_regressions.py
+++ b/hypothesis-python/tests/nocover/test_regressions.py
@@ -46,7 +46,6 @@ def test_performance_issue_2027(x, y):
     pass
 
 
-# if this test ever fails with a flaky error, #3926 has regressed.
 @given(
     st.lists(
         st.floats(allow_infinity=False),
@@ -54,4 +53,11 @@ def test_performance_issue_2027(x, y):
     )
 )
 def test_unique_floats_with_nan_is_not_flaky_3926(ls):
+    pass
+
+
+# this will take a while to find the regression, but will eventually trigger it.
+# min_value=0 is critical to trigger the probing behavior which exhausts our buffer.
+@given(st.integers(min_value=0, max_value=1 << 25_000))
+def test_overrun_during_datatree_simulation_3874(n):
     pass


### PR DESCRIPTION
closes #3874. Also includes a test case for recent coverage flakes in eg #3987.