### PR TITLE
fix: Race condition inside internal cache implementation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release prevents a race condition inside internal cache implementation.
+


### PR DESCRIPTION
The issue is when multiple tests share the same cache kwargs, it may lead to an error like the one reported in https://github.com/schemathesis/schemathesis/issues/2269

Hopefully, the performance impact is negligible. At the moment I can't come up with a reasonably small test to reproduce the issue.

