### PR TITLE
Cache fixes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Clean up internal cache implementation.

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -60,7 +60,7 @@ class GenericCache:
 
     def __init__(self, max_size):
         if max_size <= 0:
-            raise InvalidArgument("Cache size must be nonzero.")
+            raise InvalidArgument("Cache size must be at least one.")
 
         self.max_size = max_size
 

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -149,8 +149,8 @@ class GenericCache:
             self.__balance(i)
 
     def unpin(self, key):
-        """Undo one previous call to ``pin(key)``. Once all calls are
-        undone this key may be evicted as normal."""
+        """Undo one previous call to ``pin(key)``. The value stays the same.
+        Once all calls are undone this key may be evicted as normal."""
         i = self.keys_to_indices[key]
         entry = self.data[i]
         if entry.pins == 0:

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -128,7 +128,7 @@ class GenericCache:
 
         if evicted is not None:
             if self.data[0] is not entry:
-                assert evicted.score <= self.data[0].score
+                assert evicted.sort_key <= self.data[0].sort_key
             self.on_evict(evicted.key, evicted.value, evicted.score)
 
     def __iter__(self):
@@ -202,7 +202,7 @@ class GenericCache:
             assert self.keys_to_indices[e.key] == i
             for j in [i * 2 + 1, i * 2 + 2]:
                 if j < len(self.data):
-                    assert e.score <= self.data[j].score, self.data
+                    assert e.sort_key <= self.data[j].sort_key, self.data
 
     def __entry_was_accessed(self, i):
         entry = self.data[i]
@@ -238,7 +238,8 @@ class GenericCache:
         while True:
             children = [j for j in (2 * i + 1, 2 * i + 2) if j < len(self.data)]
             if len(children) == 2:
-                children.sort(key=lambda j: self.data[j].score)
+                # try smallest child first
+                children.sort(key=lambda j: self.data[j].sort_key)
             for j in children:
                 if self.__out_of_order(i, j):
                     self.__swap(i, j)

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -232,9 +232,7 @@ class GenericCache:
                 self.__swap(parent, i)
                 i = parent
             else:
-                # This branch is never taken on versions of Python where dicts
-                # preserve their insertion order (pypy or cpython >= 3.7)
-                break  # pragma: no cover
+                break
         while True:
             children = [j for j in (2 * i + 1, 2 * i + 2) if j < len(self.data)]
             if len(children) == 2:

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -30,6 +30,7 @@ class Entry:
             # worry about their relative order.
             return (1,)
 
+
 Unset = object()
 
 

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -58,6 +58,9 @@ class GenericCache:
     __slots__ = ("max_size", "_threadlocal")
 
     def __init__(self, max_size):
+        if max_size <= 0:
+            raise ValueError("Cache size must be nonzero.")
+
         self.max_size = max_size
 
         # Implementation: We store a binary heap of Entry objects in self.data,
@@ -104,8 +107,6 @@ class GenericCache:
         return result.value
 
     def __setitem__(self, key, value):
-        if self.max_size == 0:
-            return
         evicted = None
         try:
             i = self.keys_to_indices[key]

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -13,7 +13,6 @@ import threading
 import attr
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.utils.conventions import not_set
 
 
 @attr.s(slots=True)
@@ -135,18 +134,13 @@ class GenericCache:
     def __iter__(self):
         return iter(self.keys_to_indices)
 
-    def pin(self, key, value=not_set):
-        """Mark ``key`` as pinned. That is, it may not be evicted until
-        ``unpin(key)`` has been called. The same key may be pinned multiple
-        times and will not be unpinned until the same number of calls to
-        unpin have been made.
-
-        If value is set, an atomic set-and-pin operation will be performed.
-        Otherwise, KeyError is raised if the key is not present (due to
-        early eviction for example).
+    def pin(self, key, value):
+        """Mark ``key`` as pinned (with the given value). That is, it may not
+        be evicted until ``unpin(key)`` has been called. The same key may be
+        pinned multiple times, possibly changing its value, and will not be
+        unpinned until the same number of calls to unpin have been made.
         """
-        if value is not not_set:
-            self[key] = value
+        self[key] = value
 
         i = self.keys_to_indices[key]
         entry = self.data[i]

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -12,6 +12,8 @@ import threading
 
 import attr
 
+from hypothesis.utils.conventions import not_set
+
 
 @attr.s(slots=True)
 class Entry:
@@ -29,9 +31,6 @@ class Entry:
             # Pinned entries sort after unpinned ones. Beyond that, we don't
             # worry about their relative order.
             return (1,)
-
-
-Unset = object()
 
 
 class GenericCache:
@@ -140,16 +139,17 @@ class GenericCache:
     def __iter__(self):
         return iter(self.keys_to_indices)
 
-    def pin(self, key, value=Unset):
+    def pin(self, key, value=not_set):
         """Mark ``key`` as pinned. That is, it may not be evicted until
         ``unpin(key)`` has been called. The same key may be pinned multiple
         times and will not be unpinned until the same number of calls to
         unpin have been made.
 
         If value is set, an atomic set-and-pin operation will be performed.
-        Otherwise, KeyError is raised if the key has already been evicted.
+        Otherwise, KeyError is raised if the key is not present (due to
+        early eviction for example).
         """
-        if value is not Unset:
+        if value is not not_set:
             self[key] = value
 
         i = self.keys_to_indices[key]

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -198,6 +198,7 @@ class GenericCache:
         Asserts that all of the cache's invariants hold. When everything
         is working correctly this should be an expensive no-op.
         """
+        assert len(self.keys_to_indices) == len(self.data)
         for i, e in enumerate(self.data):
             assert self.keys_to_indices[e.key] == i
             for j in [i * 2 + 1, i * 2 + 2]:
@@ -226,23 +227,19 @@ class GenericCache:
         the heap property has been violated locally around i but previously
         held for all other indexes (and no other values have been modified),
         this fixes the heap so that the heap property holds everywhere."""
-        while i > 0:
-            parent = (i - 1) // 2
+        # bubble up (if score is too low for current position)
+        while (parent := (i - 1) // 2) >= 0:
             if self.__out_of_order(parent, i):
                 self.__swap(parent, i)
                 i = parent
             else:
                 break
-        while True:
-            children = [j for j in (2 * i + 1, 2 * i + 2) if j < len(self.data)]
-            if len(children) == 2:
-                # try smallest child first
-                children.sort(key=lambda j: self.data[j].sort_key)
-            for j in children:
-                if self.__out_of_order(i, j):
-                    self.__swap(i, j)
-                    i = j
-                    break
+        # or bubble down (if score is too high for current position)
+        while children := [j for j in (2 * i + 1, 2 * i + 2) if j < len(self.data)]:
+            smallest_child = min(children, key=lambda j: self.data[j].sort_key)
+            if self.__out_of_order(i, smallest_child):
+                self.__swap(i, smallest_child)
+                i = smallest_child
             else:
                 break
 

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -215,6 +215,8 @@ class GenericCache:
         new_score = self.on_access(entry.key, entry.value, entry.score)
         if new_score != entry.score:
             entry.score = new_score
+            # changing the score of a pinned entry cannot unbalance the heap, as
+            # we place all pinned entries after unpinned ones, regardless of score.
             if entry.pins == 0:
                 self.__balance(i)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -529,7 +529,7 @@ class ConjectureRunner:
             if changed:
                 self.save_buffer(data.buffer)
                 self.interesting_examples[key] = data.as_result()  # type: ignore
-                self.__data_cache.pin(data.buffer)
+                self.__data_cache.pin(data.buffer, data.as_result())
                 self.shrunk_examples.discard(key)
 
             if self.shrinks >= MAX_SHRINKS:
@@ -876,7 +876,7 @@ class ConjectureRunner:
         zero_data = self.cached_test_function(bytes(BUFFER_SIZE))
         if zero_data.status > Status.OVERRUN:
             assert isinstance(zero_data, ConjectureResult)
-            self.__data_cache.pin(zero_data.buffer)
+            self.__data_cache.pin(zero_data.buffer, zero_data.as_result())  # Pin forever
 
         if zero_data.status == Status.OVERRUN or (
             zero_data.status == Status.VALID

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -876,7 +876,9 @@ class ConjectureRunner:
         zero_data = self.cached_test_function(bytes(BUFFER_SIZE))
         if zero_data.status > Status.OVERRUN:
             assert isinstance(zero_data, ConjectureResult)
-            self.__data_cache.pin(zero_data.buffer, zero_data.as_result())  # Pin forever
+            self.__data_cache.pin(
+                zero_data.buffer, zero_data.as_result()
+            )  # Pin forever
 
         if zero_data.status == Status.OVERRUN or (
             zero_data.status == Status.VALID

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -334,7 +334,9 @@ def test_pin_and_unpin_are_noops_if_dropped():
         cache[i] = False
 
     assert 30 not in cache
-    cache.pin(30)
-    assert 30 not in cache
-    cache.unpin(30)
-    assert 30 not in cache
+    with pytest.raises(KeyError):
+        cache.pin(30)
+
+    cache.pin(30, False)
+    assert 30 in cache
+    assert cache.is_pinned(30)

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -237,6 +237,9 @@ def test_will_error_instead_of_evicting_pin():
     with pytest.raises(ValueError):
         cache[2] = 2
 
+    assert 1 in cache
+    assert 2 not in cache
+
 
 def test_will_error_for_bad_unpin():
     cache = LRUReusedCache(max_size=1)

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -186,13 +186,6 @@ def test_can_clear_a_cache():
     assert len(x) == 0
 
 
-def test_max_size_cache_ignores():
-    x = ValueScored(0)
-    x[0] = 1
-    with pytest.raises(KeyError):
-        x[0]
-
-
 def test_pinning_prevents_eviction():
     cache = LRUReusedCache(max_size=10)
     cache[20] = 1

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -23,6 +23,7 @@ from hypothesis import (
     settings,
     strategies as st,
 )
+from hypothesis.errors import InvalidArgument
 from hypothesis.internal.cache import GenericCache, LRUReusedCache
 
 from tests.common.utils import skipif_emscripten
@@ -184,6 +185,11 @@ def test_can_clear_a_cache():
     assert len(x) == 1
     x.clear()
     assert len(x) == 0
+
+
+def test_max_size_must_be_positive():
+    with pytest.raises(InvalidArgument):
+        ValueScored(max_size=0)
 
 
 def test_pinning_prevents_eviction():

--- a/hypothesis-python/tests/nocover/test_cache_implementation.py
+++ b/hypothesis-python/tests/nocover/test_cache_implementation.py
@@ -73,8 +73,9 @@ class CacheRules(RuleBasedStateMachine):
 
     @invariant()
     def check_values(self):
-        for k in getattr(self, "cache", ()):
-            assert self.__values[k] == self.cache[k]
+        self.cache.check_valid()
+        for key in self.cache:
+            assert self.__values[key] == self.cache[key]
 
     @rule(key=keys)
     def pin_key(self, key):

--- a/hypothesis-python/tests/nocover/test_cache_implementation.py
+++ b/hypothesis-python/tests/nocover/test_cache_implementation.py
@@ -79,7 +79,7 @@ class CacheRules(RuleBasedStateMachine):
     @rule(key=keys)
     def pin_key(self, key):
         if key in self.cache:
-            self.cache.pin(key)
+            self.cache.pin(key, self.__values[key])
             if self.__pins[key] == 0:
                 self.__total_pins += 1
             self.__pins[key] += 1


### PR DESCRIPTION
Fix some issues with the cache implementation. ~~No actual bugs, only latent issues and cleanup.~~

- The cache docs were were not in sync with the code: it was documented that `on_access` should return the updated score, but the code expected the score to be modified in-place. Code changed to match docs.
- Simplify by removing the unnecessary count of pinned entries.
- "ignore `pin()` on expired keys" is unsafe: if we later insert the key, the pin-state of the key is unknown. This can be observed "in the wild" in our current usage — by adding artificial cache pressure before `pin()` we fail when calling `unpin()` on a not-pinned key.
- `max_size=0` (ignoring new entries) is no longer allowed, as that violates the handy (for atomicity) "last entry successfully set is present in cache" invariant.

[edit]
- fix heap-property violation around pinned entries, caused by swapping with the wrong child due to comparing `score` instead of `sort_key`