### PR TITLE
Adjust `post_test_case_hook` scope

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes an issue when realizing symbolics with our experimental :obj:`~hypothesis.settings.backend` setting.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1211,7 +1211,7 @@ class PrimitiveProvider(abc.ABC):
     def __init__(self, conjecturedata: Optional["ConjectureData"], /) -> None:
         self._cd = conjecturedata
 
-    def post_test_case_hook(self, value):
+    def post_test_case_hook(self, value: IRType) -> IRType:
         # hook for providers to modify values returned by draw_* after a full
         # test case concludes. Originally exposed for crosshair to reify its
         # symbolic values into actual values.
@@ -1966,7 +1966,9 @@ class ConjectureData:
         self.max_depth = 0
         self.has_discards = False
 
-        self.provider = provider(self) if isinstance(provider, type) else provider
+        self.provider: PrimitiveProvider = (
+            provider(self) if isinstance(provider, type) else provider
+        )
         assert isinstance(self.provider, PrimitiveProvider)
 
         self.__result: "Optional[ConjectureResult]" = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -453,6 +453,14 @@ class ConjectureRunner:
                     ),
                 }
                 self.stats_per_test_case.append(call_stats)
+                if self.settings.backend != "hypothesis":
+                    for node in data.examples.ir_tree_nodes:
+                        value = data.provider.post_test_case_hook(node.value)
+                        assert (
+                            value is not None
+                        ), "providers must return a non-null value from post_test_case_hook"
+                        node.value = value
+
                 self._cache(data)
                 if data.invalid_at is not None:  # pragma: no branch # coverage bug?
                     self.misaligned_count += 1
@@ -496,14 +504,6 @@ class ConjectureRunner:
 
         if data.status == Status.INTERESTING:
             if self.settings.backend != "hypothesis":
-                for node in data.examples.ir_tree_nodes:
-                    value = data.provider.post_test_case_hook(node.value)
-                    # require providers to return something valid here.
-                    assert (
-                        value is not None
-                    ), "providers must return a non-null value from post_test_case_hook"
-                    node.value = value
-
                 # drive the ir tree through the test function to convert it
                 # to a buffer
                 data = ConjectureData.for_ir_tree(data.examples.ir_tree_nodes)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -508,6 +508,11 @@ class ConjectureRunner:
                 # to a buffer
                 data = ConjectureData.for_ir_tree(data.examples.ir_tree_nodes)
                 self.__stoppable_test_function(data)
+                data.freeze()
+                # should we raise Flaky here instead?
+                if data.status != Status.INTERESTING:
+                    self.exit_with(ExitReason.flaky)
+
                 self._cache(data)
 
             key = data.interesting_origin

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -467,7 +467,7 @@ class ConjectureRunner:
                             raise HypothesisException(
                                 f"expected {expected_type} from "
                                 f"{data.provider.post_test_case_hook.__qualname__}, "
-                                f"got {type(value)} ({value})"
+                                f"got {type(value)} ({value!r})"
                             )
                         node.value = value
 

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -18,7 +18,7 @@ import pytest
 
 from hypothesis import given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import Flaky, InvalidArgument
 from hypothesis.internal.compat import int_to_bytes
 from hypothesis.internal.conjecture.data import (
     AVAILABLE_PROVIDERS,
@@ -354,3 +354,19 @@ def test_case_lifetime():
             <= test_case_lifetime_init_count
             <= test_function_count + 10
         )
+
+
+def test_flaky_with_backend():
+    with temp_register_backend("trivial", TrivialProvider):
+
+        calls = 0
+
+        @given(st.integers())
+        @settings(backend="trivial", database=None)
+        def test_function(n):
+            nonlocal calls
+            calls += 1
+            assert n != calls % 2
+
+        with pytest.raises(Flaky):
+            test_function()


### PR DESCRIPTION
Move `post_test_case_hook` higher up so it correctly handles symbolic lifetimes. Reported in https://github.com/pschanely/CrossHair/issues/263, regressed in https://github.com/HypothesisWorks/hypothesis/pull/3977.

Also includes a bandaid for flakiness when replaying interesting non-hypothesis backend examples. I ran into this when we flakily raised `DeadlineExceeded` with the crosshair backend. I think probably we want to raise `Flaky` here instead of silently exiting though.