### PR TITLE
Improve internal warning tests

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch treats ``HypothesisWarning`` exceptions as fatal
+failures during test execution, thus not reporting warnings
+as inconsistent (flaky) when run with ``-Werror``.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch treats ``HypothesisWarning`` exceptions as fatal
-failures during test execution, thus not reporting warnings
-as inconsistent (flaky) when run with ``-Werror``.
+This patch improves the reporting of certain flaky errors.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -798,6 +798,15 @@ class StateForActualGivenExecution:
             current_pytest_item.value, "nodeid", None
         ) or get_pretty_function_description(self.wrapped_test)
 
+    def _should_trace(self):
+        _trace_obs = TESTCASE_CALLBACKS and OBSERVABILITY_COLLECT_COVERAGE
+        _trace_failure = (
+            self.failed_normally
+            and not self.failed_due_to_deadline
+            and {Phase.shrink, Phase.explain}.issubset(self.settings.phases)
+        )
+        return _trace_obs or _trace_failure
+
     def execute_once(
         self,
         data,
@@ -1006,21 +1015,6 @@ class StateForActualGivenExecution:
         """
         trace: Trace = set()
         try:
-            # this is actually covered by our tests, but only on >= 3.12.
-            if (
-                sys.version_info[:2] >= (3, 12)
-                and sys.monitoring.get_tool(MONITORING_TOOL_ID) is not None
-            ):  # pragma: no cover
-                warnings.warn(
-                    "avoiding tracing test function because tool id "
-                    f"{MONITORING_TOOL_ID} is already taken by tool "
-                    f"{sys.monitoring.get_tool(MONITORING_TOOL_ID)}.",
-                    HypothesisWarning,
-                    # I'm not sure computing a correct stacklevel is reasonable
-                    # given the number of entry points here.
-                    stacklevel=1,
-                )
-
             _can_trace = (
                 (sys.version_info[:2] < (3, 12) and sys.gettrace() is None)
                 or (
@@ -1028,13 +1022,7 @@ class StateForActualGivenExecution:
                     and sys.monitoring.get_tool(MONITORING_TOOL_ID) is None
                 )
             ) and not PYPY
-            _trace_obs = TESTCASE_CALLBACKS and OBSERVABILITY_COLLECT_COVERAGE
-            _trace_failure = (
-                self.failed_normally
-                and not self.failed_due_to_deadline
-                and {Phase.shrink, Phase.explain}.issubset(self.settings.phases)
-            )
-            if _can_trace and (_trace_obs or _trace_failure):  # pragma: no cover
+            if _can_trace and self._should_trace():  # pragma: no cover
                 # This is in fact covered by our *non-coverage* tests, but due to the
                 # settrace() contention *not* by our coverage tests.  Ah well.
                 with Tracer() as tracer:
@@ -1062,7 +1050,6 @@ class StateForActualGivenExecution:
             # OK to re-raise it.
             raise
         except (
-            HypothesisWarning,
             FailedHealthCheck,
             *skip_exceptions_to_reraise(),
         ):
@@ -1070,12 +1057,11 @@ class StateForActualGivenExecution:
             # engine, so we re-raise them.
             raise
         except failure_exceptions_to_catch() as e:
-            # If the error was raised by Hypothesis-internal code, re-raise it
-            # as a fatal error instead of treating it as a test failure.
+            # If an unhandled (i.e., non-Hypothesis) error was raised by
+            # Hypothesis-internal code, re-raise it as a fatal error instead
+            # of treating it as a test failure.
             filepath = traceback.extract_tb(e.__traceback__)[-1][0]
-            if is_hypothesis_file(filepath) and not isinstance(
-                e, (HypothesisException, StopTest, UnsatisfiedAssumption)
-            ):
+            if is_hypothesis_file(filepath) and not isinstance(e, HypothesisException):
                 raise
 
             if data.frozen:
@@ -1183,6 +1169,22 @@ class StateForActualGivenExecution:
                 rep = get_pretty_function_description(self.test)
                 raise Unsatisfiable(f"Unable to satisfy assumptions of {rep}")
 
+        # If we have not traced executions, warn about that now (but only
+        # on >=3.12, since otherwise we'd always warn when running coverage)
+        if (
+            self._should_trace()
+            and sys.version_info[:2] >= (3, 12)
+            and sys.monitoring.get_tool(MONITORING_TOOL_ID) is not None
+        ):  # pragma: no cover
+            # actually covered by our tests, but only on >= 3.12
+            warnings.warn(
+                "avoiding tracing test function because tool id "
+                f"{MONITORING_TOOL_ID} is already taken by tool "
+                f"{sys.monitoring.get_tool(MONITORING_TOOL_ID)}.",
+                HypothesisWarning,
+                stacklevel=3,
+            )
+
         if not self.falsifying_examples:
             return
         elif not (self.settings.report_multiple_bugs and pytest_shows_exceptiongroups):
@@ -1221,10 +1223,20 @@ class StateForActualGivenExecution:
                             info._expected_traceback,
                         ),
                     )
-            except (UnsatisfiedAssumption, StopTest) as e:
+            except StopTest:
+                err = Flaky(
+                    "Inconsistent results: An example which failed on the "
+                    "first run now succeeds (or fails with another error)."
+                )
+                # Link the expected exception from the first run. Not sure
+                # how to access the current exception, if it failed
+                # differently on this run.
+                err.__cause__ = err.__context__ = info._expected_exception
+                errors_to_report.append((fragments, err))
+            except UnsatisfiedAssumption as e:
                 err = Flaky(
                     "Unreliable assumption: An example which satisfied "
-                    "assumptions on the first run now fails it.",
+                    "assumptions on the first run now fails it."
                 )
                 err.__cause__ = err.__context__ = e
                 errors_to_report.append((fragments, err))

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -60,7 +60,6 @@ from hypothesis.errors import (
     FailedHealthCheck,
     Flaky,
     Found,
-    HypothesisDeprecationWarning,
     HypothesisException,
     HypothesisWarning,
     InvalidArgument,
@@ -1063,7 +1062,7 @@ class StateForActualGivenExecution:
             # OK to re-raise it.
             raise
         except (
-            HypothesisDeprecationWarning,
+            HypothesisWarning,
             FailedHealthCheck,
             *skip_exceptions_to_reraise(),
         ):

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -10,6 +10,7 @@
 
 import contextlib
 import sys
+import warnings
 from io import StringIO
 from types import SimpleNamespace
 
@@ -220,6 +221,15 @@ def temp_registered(type_, strat_or_factory):
         from_type.__clear_cache()
         if prev is not None:
             register_type_strategy(type_, prev)
+
+
+@contextlib.contextmanager
+def raises_warning(expected_warning, match=None):
+    """Use instead of pytest.warns to check that the raised warning is handled properly"""
+    with raises(expected_warning, match=match) as r:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=expected_warning)
+            yield r
 
 
 # Specifies whether we can represent subnormal floating point numbers.

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -12,8 +12,6 @@ import gc
 import random
 import sys
 import time as time_module
-import warnings
-from contextlib import contextmanager
 from functools import wraps
 
 import pytest
@@ -26,6 +24,7 @@ from hypothesis.internal.detection import is_hypothesis_test
 
 from tests.common import TIME_INCREMENT
 from tests.common.setup import run
+from tests.common.utils import raises_warning
 
 run()
 
@@ -60,22 +59,14 @@ def pytest_addoption(parser):
         parser.addoption(arg, action="store", default=1.0)
 
 
-@pytest.fixture(params=["warns", "raises"])
+@pytest.fixture(scope="function", params=["warns", "raises"])
 def warns_or_raises(request):
     """This runs the test twice: first to check that a warning is emitted
     and execution continues successfully despite the warning; then to check
     that the raised warning is handled properly.
     """
     if request.param == "raises":
-
-        @contextmanager
-        def raises(expected_warning, *args, **kwargs):
-            with pytest.raises(expected_warning, *args, **kwargs) as r:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("error", category=expected_warning)
-                    yield r
-
-        return raises
+        return raises_warning
     else:
         return pytest.warns
 

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -69,10 +69,11 @@ def warns_or_raises(request):
     if request.param == "raises":
 
         @contextmanager
-        def raises(*args, **kwargs):
-            with warnings.catch_warnings(), pytest.raises(*args, **kwargs) as r:
-                warnings.simplefilter("error")
-                yield r
+        def raises(expected_warning, *args, **kwargs):
+            with pytest.raises(expected_warning, *args, **kwargs) as r:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", category=expected_warning)
+                    yield r
 
         return raises
     else:

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -8,9 +8,10 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
 import sys
 import warnings
+
+import pytest
 
 from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
 from hypothesis.core import StateForActualGivenExecution
@@ -53,10 +54,9 @@ def test_gives_flaky_error_if_assumption_is_flaky():
         oops()
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 12), reason="no warning before 3.12")
 def test_flaky_with_context_when_fails_only_under_tracing(monkeypatch):
     # make anything fail under tracing
-    monkeypatch.setattr(Tracer, "__enter__", lambda *_: 1/0)
+    monkeypatch.setattr(Tracer, "__enter__", lambda *_: 1 / 0)
     # ensure tracing is always entered inside _execute_once_for_engine
     monkeypatch.setattr(StateForActualGivenExecution, "_should_trace", lambda _: True)
 

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -8,8 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import warnings
-
 import pytest
 
 from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
@@ -65,9 +63,7 @@ def test_flaky_with_context_when_fails_only_under_tracing(monkeypatch):
         pass
 
     with pytest.raises(Flaky, match="failed on the first run now succeeds") as e:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            test()
+        test()
     assert isinstance(e.value.__context__, ZeroDivisionError)
 
 

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import sys
 import warnings
 
 import pytest
@@ -56,6 +55,7 @@ def test_gives_flaky_error_if_assumption_is_flaky():
 
 def test_flaky_with_context_when_fails_only_under_tracing(monkeypatch):
     # make anything fail under tracing
+    monkeypatch.setattr(Tracer, "can_trace", lambda: True)
     monkeypatch.setattr(Tracer, "__enter__", lambda *_: 1 / 0)
     # ensure tracing is always entered inside _execute_once_for_engine
     monkeypatch.setattr(StateForActualGivenExecution, "_should_trace", lambda _: True)

--- a/hypothesis-python/tests/cover/test_monitoring.py
+++ b/hypothesis-python/tests/cover/test_monitoring.py
@@ -36,6 +36,7 @@ def test_monitoring_warns_on_registered_tool_id(warns_or_raises):
 
             @given(st.integers())
             def f(n):
-                assert True
+                raise AssertionError()
 
-            f()
+            with pytest.raises(AssertionError):
+                f()

--- a/hypothesis-python/tests/cover/test_monitoring.py
+++ b/hypothesis-python/tests/cover/test_monitoring.py
@@ -28,11 +28,11 @@ def using_tool_id(tool_id, tool_name):
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 12), reason="new namespace")
-def test_monitoring_warns_on_registered_tool_id():
+def test_monitoring_warns_on_registered_tool_id(warns_or_raises):
 
     # scrutineer can't run if something has already registered its tool id.
     with using_tool_id(MONITORING_TOOL_ID, "rogue"):
-        with pytest.warns(HypothesisWarning, match=r"is already taken by tool rogue"):
+        with warns_or_raises(HypothesisWarning, match=r"already taken by tool rogue"):
 
             @given(st.integers())
             def f(n):

--- a/hypothesis-python/tests/cover/test_monitoring.py
+++ b/hypothesis-python/tests/cover/test_monitoring.py
@@ -36,7 +36,7 @@ def test_monitoring_warns_on_registered_tool_id(warns_or_raises):
 
             @given(st.integers())
             def f(n):
-                raise AssertionError()
+                raise AssertionError
 
             with pytest.raises(AssertionError):
                 f()


### PR DESCRIPTION
Fixes #4021 

When a warning is raised (due to `-Werror`) during test execution, it may cause the test to raise `Flaky` from `StopTest`. This makes the error message less informative.

~~This PR makes `HypothesisWarning` fatal, not only `HypothesisDeprecationWarning`. Because the warnings are meant to be seen.~~