### PR TITLE
Stack depth of return-type warning in @composite strategy

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This fixes a previously un-adjusted stack depth for a return-type annotation warning for :func:`hypothesis.composite` on Python 3.10/3.11.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This fixes a previously un-adjusted stack depth for a return-type annotation warning for :func:`hypothesis.composite` on Python 3.10/3.11.
+This fixes a previously un-adjusted stack depth for a return-type annotation warning for :func:`@composite <hypothesis.strategies.composite>` on Python 3.10/3.11.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1837,7 +1837,7 @@ def _composite(f):
             f"Return-type annotation is `{ret_repr}`, but the decorated "
             "function should return a value (not a strategy)"
         )
-        if is_hypothesis_file(filename) and IN_COVERAGE_TESTS:
+        if is_hypothesis_file(filename) and IN_COVERAGE_TESTS:  # pragma: no cover
             message += f"\nMessage is from {filename}, line {lineno}"
 
         warnings.warn(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1823,7 +1823,10 @@ def _composite(f):
     if get_origin(sig.return_annotation) is SearchStrategy:
         ret_repr = repr(sig.return_annotation).replace("hypothesis.strategies.", "st.")
 
-        stacklevel = 3 if sys.version_info[:2] >= (3, 12) else 1
+        if sys.version_info[:2] >= (3, 12) or sys.platform == "win32":
+            stacklevel = 3
+        else:
+            stacklevel = 5
 
         stack = traceback.extract_stack()
         frame = stack[-(stacklevel + 1)]

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -83,8 +83,8 @@ from hypothesis.internal.compat import (
     get_type_hints,
     is_typed_named_tuple,
 )
-from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.conjecture.utils import calc_label_from_cls, check_sample
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.escalation import is_hypothesis_file
 from hypothesis.internal.floats import float_of

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1823,7 +1823,7 @@ def _composite(f):
     if get_origin(sig.return_annotation) is SearchStrategy:
         ret_repr = repr(sig.return_annotation).replace("hypothesis.strategies.", "st.")
 
-        stacklevel = 3 if sys.version_info[:2] >= (3, 12) else 5
+        stacklevel = 3 if sys.version_info[:2] >= (3, 12) else 1
 
         stack = traceback.extract_stack()
         frame = stack[-(stacklevel + 1)]

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -197,16 +197,16 @@ def test_drawfn_cannot_be_instantiated():
 
 @pytest.mark.skipif(sys.version_info[:2] == (3, 9), reason="stack depth varies???")
 def test_warns_on_strategy_annotation():
-    with pytest.warns(HypothesisWarning, match="Return-type annotation") as w:
+    # with pytest.warns(HypothesisWarning, match="Return-type annotation") as w:
 
-        @st.composite
-        def my_integers(draw: st.DrawFn) -> st.SearchStrategy[int]:
-            return draw(st.integers())
+    @st.composite
+    def my_integers(draw: st.DrawFn) -> st.SearchStrategy[int]:
+        return draw(st.integers())
 
-    if sys.version_info[:2] > (3, 9):
+    # if sys.version_info[:2] > (3, 9):
 
-        assert len(w.list) == 1
-        assert w.list[0].filename == __file__  # check stacklevel points to user code
+    #     assert len(w.list) == 1
+    #     assert w.list[0].filename == __file__  # check stacklevel points to user code
 
 
 def test_composite_allows_overload_without_draw():

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -197,19 +197,13 @@ def test_drawfn_cannot_be_instantiated():
 
 @pytest.mark.skipif(sys.version_info[:2] == (3, 9), reason="stack depth varies???")
 def test_warns_on_strategy_annotation():
-    # TODO: print the stack on Python 3.10 and 3.11 to determine the appropriate
-    #       stack depth to use.  Consider adding a debug-print if IN_COVERAGE_TESTS
-    #       and the relevant depth is_hypothesis_file(), for easier future fixing.
-    #
-    # Meanwhile, the test is not skipped on 3.10/3.11 as it is still required for
-    # coverage of the warning-generating branch.
     with pytest.warns(HypothesisWarning, match="Return-type annotation") as w:
-
         @st.composite
         def my_integers(draw: st.DrawFn) -> st.SearchStrategy[int]:
             return draw(st.integers())
 
-    if sys.version_info[:2] > (3, 11):  # TEMP: see PR #3961
+    if sys.version_info[:2] > (3, 9):
+        
         assert len(w.list) == 1
         assert w.list[0].filename == __file__  # check stacklevel points to user code
 

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -197,16 +197,16 @@ def test_drawfn_cannot_be_instantiated():
 
 @pytest.mark.skipif(sys.version_info[:2] == (3, 9), reason="stack depth varies???")
 def test_warns_on_strategy_annotation():
-    # with pytest.warns(HypothesisWarning, match="Return-type annotation") as w:
+    with pytest.warns(HypothesisWarning, match="Return-type annotation") as w:
 
-    @st.composite
-    def my_integers(draw: st.DrawFn) -> st.SearchStrategy[int]:
-        return draw(st.integers())
+        @st.composite
+        def my_integers(draw: st.DrawFn) -> st.SearchStrategy[int]:
+            return draw(st.integers())
 
-    # if sys.version_info[:2] > (3, 9):
+    if sys.version_info[:2] > (3, 9):
 
-    #     assert len(w.list) == 1
-    #     assert w.list[0].filename == __file__  # check stacklevel points to user code
+        assert len(w.list) == 1
+        assert w.list[0].filename == __file__  # check stacklevel points to user code
 
 
 def test_composite_allows_overload_without_draw():

--- a/hypothesis-python/tests/cover/test_composite.py
+++ b/hypothesis-python/tests/cover/test_composite.py
@@ -198,12 +198,13 @@ def test_drawfn_cannot_be_instantiated():
 @pytest.mark.skipif(sys.version_info[:2] == (3, 9), reason="stack depth varies???")
 def test_warns_on_strategy_annotation():
     with pytest.warns(HypothesisWarning, match="Return-type annotation") as w:
+
         @st.composite
         def my_integers(draw: st.DrawFn) -> st.SearchStrategy[int]:
             return draw(st.integers())
 
     if sys.version_info[:2] > (3, 9):
-        
+
         assert len(w.list) == 1
         assert w.list[0].filename == __file__  # check stacklevel points to user code
 


### PR DESCRIPTION
Fixes issue #3985

I checked where the frames pointed to and it seemed that pointing back to the user code seemed most reasonable. If we were to point to internal hypothesis code, the best for `py3.10/3.11`: `stackdepth=3` at `core.py, line 1893` for `def composite(f: Callable[..., Ex]) -> Callable[..., SearchStrategy[Ex]]:`. The best for `py3.12`: `stackdepth=1` at `core.py, line 1888` for `return _composite(f)`.