### PR TITLE
Support Django 5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,9 +67,8 @@ jobs:
           - check-py39-pytest46
           - check-py39-pytest54
           - check-pytest62
+          - check-django50
           - check-django42
-          - check-django41
-          - check-django32
           - check-pandas22
           - check-pandas21
           - check-pandas20

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
-This release adds support for Django 5.0, and drops support for Django < 4.2.
+This release improves support for Django 5.0, and drops support for end-of-life Django versions (< 4.2).
 
 Thanks to Joshua Munn for this contribution.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds support for Django 5.0, and drops support for Django < 4.2.
+
+Thanks to Joshua Munn for this contribution.

--- a/hypothesis-python/src/hypothesis/extra/django/_fields.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_fields.py
@@ -57,7 +57,9 @@ def integers_for_field(min_value, max_value):
 def timezones():
     # From Django 4.0, the default is to use zoneinfo instead of pytz.
     assert getattr(django.conf.settings, "USE_TZ", False)
-    if getattr(django.conf.settings, "USE_DEPRECATED_PYTZ", True):
+    if django.VERSION < (5, 0, 0) and getattr(
+        django.conf.settings, "USE_DEPRECATED_PYTZ", True
+    ):
         from hypothesis.extra.pytz import timezones
     else:
         from hypothesis.strategies import timezones

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -13,7 +13,6 @@ import unittest
 from functools import partial
 from typing import TYPE_CHECKING, Optional, Type, TypeVar, Union
 
-import django
 from django import forms as df, test as dt
 from django.contrib.staticfiles import testing as dst
 from django.core.exceptions import ValidationError

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -106,9 +106,7 @@ def from_model(
             name not in field_strategies
             and not field.auto_created
             and not isinstance(field, dm.AutoField)
-            and not (
-                django.VERSION >= (5, 0, 0) and isinstance(field, dm.GeneratedField)
-            )
+            and not isinstance(field, getattr(dm, "GeneratedField", ()))
             and field.default is dm.fields.NOT_PROVIDED
         ):
             field_strategies[name] = from_field(field)

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -13,6 +13,7 @@ import unittest
 from functools import partial
 from typing import TYPE_CHECKING, Optional, Type, TypeVar, Union
 
+import django
 from django import forms as df, test as dt
 from django.contrib.staticfiles import testing as dst
 from django.core.exceptions import ValidationError
@@ -105,6 +106,9 @@ def from_model(
             name not in field_strategies
             and not field.auto_created
             and not isinstance(field, dm.AutoField)
+            and not (
+                django.VERSION >= (5, 0, 0) and isinstance(field, dm.GeneratedField)
+            )
             and field.default is dm.fields.NOT_PROVIDED
         ):
             field_strategies[name] = from_field(field)

--- a/hypothesis-python/tests/django/manage.py
+++ b/hypothesis-python/tests/django/manage.py
@@ -38,6 +38,12 @@ if __name__ == "__main__":
     except ImportError:
         RemovedInDjango50Warning = ()
 
+    try:
+        from django.utils.deprecation import RemovedInDjango60Warning
+    except ImportError:
+        RemovedInDjango60Warning = ()
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RemovedInDjango50Warning)
+        warnings.simplefilter("ignore", category=RemovedInDjango60Warning)
         execute_from_command_line(sys.argv)

--- a/hypothesis-python/tests/django/toys/settings.py
+++ b/hypothesis-python/tests/django/toys/settings.py
@@ -19,6 +19,8 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 
 import os
 
+import django
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -85,7 +87,8 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
+if django.VERSION < (5, 0, 0):
+    USE_L10N = True
 
 USE_TZ = os.environ.get("HYPOTHESIS_DJANGO_USETZ", "TRUE") == "TRUE"
 
@@ -121,3 +124,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+# Transitional setting until 6.0. See
+# https://docs.djangoproject.com/en/5.0/ref/forms/fields/#django.forms.URLField.assume_scheme
+FORMS_URLFIELD_ASSUME_HTTPS = True

--- a/hypothesis-python/tests/django/toystore/models.py
+++ b/hypothesis-python/tests/django/toystore/models.py
@@ -8,7 +8,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import django
 from django.core.exceptions import ValidationError
+from django.core.validators import MinValueValidator
 from django.db import models
 
 
@@ -149,3 +151,23 @@ class CompanyExtension(models.Model):
 
 class UserSpecifiedAutoId(models.Model):
     my_id = models.AutoField(primary_key=True)
+
+
+if django.VERSION >= (5, 0, 0):
+    import math
+
+    class Pizza(models.Model):
+        AREA = math.pi * models.F("radius") ** 2
+
+        radius = models.IntegerField(validators=[MinValueValidator(1)])
+        slices = models.PositiveIntegerField(validators=[MinValueValidator(2)])
+        total_area = models.GeneratedField(
+            expression=AREA,
+            output_field=models.FloatField(),
+            db_persist=True,
+        )
+        slice_area = models.GeneratedField(
+            expression=AREA / models.F("slices"),
+            output_field=models.FloatField(),
+            db_persist=False,
+        )

--- a/hypothesis-python/tests/django/toystore/test_given_models.py
+++ b/hypothesis-python/tests/django/toystore/test_given_models.py
@@ -11,6 +11,7 @@
 import datetime as dt
 from uuid import UUID
 
+import django
 from django.conf import settings as django_settings
 from django.contrib.auth.models import User
 
@@ -210,3 +211,19 @@ class TestUserSpecifiedAutoId(TestCase):
     def test_user_specified_auto_id(self, user_specified_auto_id):
         self.assertIsInstance(user_specified_auto_id, UserSpecifiedAutoId)
         self.assertIsNotNone(user_specified_auto_id.pk)
+
+
+if django.VERSION >= (5, 0, 0):
+    from tests.django.toystore.models import Pizza
+
+    class TestModelWithGeneratedField(TestCase):
+        @given(from_model(Pizza))
+        def test_create_pizza(self, pizza):
+            """
+            Strategies are not inferred for GeneratedField.
+            """
+
+            pizza.full_clean()
+            # Check the expected types of the generated fields.
+            self.assertIsInstance(pizza.slice_area, float)
+            self.assertIsInstance(pizza.total_area, float)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -156,22 +156,18 @@ commands =
     niche: bash scripts/other-tests.sh
     custom: python -bb -X dev -m pytest {posargs}
 
-[testenv:django32]
-commands =
-    pip install .[pytz]
-    pip install django~=3.2.15
-    python -bb -X dev -m tests.django.manage test tests.django {posargs}
-
-[testenv:django41]
-commands =
-    pip install django~=4.1.0
-    python -bb -X dev -m tests.django.manage test tests.django {posargs}
-
 [testenv:django42]
 setenv=
     PYTHONWARNDEFAULTENCODING=1
 commands =
     pip install django~=4.2.0
+    python -bb -X dev -m tests.django.manage test tests.django {posargs}
+
+[testenv:django50]
+setenv=
+    PYTHONWARNDEFAULTENCODING=1
+commands =
+    pip install django~=5.0.0
     python -bb -X dev -m tests.django.manage test tests.django {posargs}
 
 [testenv:py{37,38,39}-nose]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -497,7 +497,7 @@ standard_tox_task("py39-pytest46", py="3.9")
 standard_tox_task("py39-pytest54", py="3.9")
 standard_tox_task("pytest62")
 
-for n in [32, 41, 42]:
+for n in [42, 50]:
     standard_tox_task(f"django{n}")
 
 for n in [13, 14, 15, 20, 21, 22]:


### PR DESCRIPTION
This PR adds support for Django 5.0, and drops support for Django < 4.2 as 4.2 is the [oldest currently supported version](https://endoflife.date/django).

Upgrade considerations:
- from 5.0 support for pytz in Django is [dropped](https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0) — use of pytz was [deprecated in 4.0](https://docs.djangoproject.com/en/5.0/releases/4.0/#zoneinfo-default-timezone-implementation) in favour of Python's built-in `zoneinfo`; and
- a transitional setting, [FORMS_URLFIELD_ASSUME_HTTPS](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-FORMS_URLFIELD_ASSUME_HTTPS) is added until 6.0, when the default for [URLField.assume_scheme](https://docs.djangoproject.com/en/5.0/ref/forms/fields/#django.forms.URLField.assume_scheme) will become `"https"`.

Django 5.0 adds a new field, [GeneratedField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.GeneratedField). As values of this field are managed by the database back-end, I updated `from_model` to ignore instances of `GeneratedField`.

I labelled this as a `minor` release, as I don't know whether dropping support for older versions of a dependency is considered a breaking change to the public API of Hypothesis.