### PR TITLE
Add and use `realize` and `avoid_realization` backend hooks

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch iterates on our experimental support for alternative backends (:ref:`alternative-backends`). See :pull:`4029` for details.

--- a/hypothesis-python/setup.py
+++ b/hypothesis-python/setup.py
@@ -60,7 +60,7 @@ extras = {
     "pytest": ["pytest>=4.6"],
     "dpcontracts": ["dpcontracts>=0.4"],
     "redis": ["redis>=3.0.0"],
-    "crosshair": ["hypothesis-crosshair>=0.0.4", "crosshair-tool>=0.0.55"],
+    "crosshair": ["hypothesis-crosshair>=0.0.7", "crosshair-tool>=0.0.59"],
     # zoneinfo is an odd one: every dependency is conditional, because they're
     # only necessary on old versions of Python or Windows systems or emscripten.
     "zoneinfo": [

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1113,6 +1113,10 @@ class StateForActualGivenExecution:
                     self.settings.backend != "hypothesis"
                     and not getattr(runner, "_switch_to_hypothesis_provider", False)
                 )
+                data._observability_args = data.provider.realize(
+                    data._observability_args
+                )
+                self._string_repr = data.provider.realize(self._string_repr)
                 tc = make_testcase(
                     start_timestamp=self._start_timestamp,
                     test_name_or_nodeid=self.test_identifier,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1225,7 +1225,16 @@ class PrimitiveProvider(abc.ABC):
     def per_test_case_context_manager(self):
         return contextlib.nullcontext()
 
-    def realize(self, value):
+    def realize(self, value: T) -> T:
+        """
+        Called whenever hypothesis requires a concrete (non-symbolic) value from
+        a potentially symbolic value. Hypothesis will not check that `value` is
+        symbolic before calling `realize`, so you should handle the case where
+        `value` is non-symbolic.
+
+        The returned value should be non-symbolic.
+        """
+
         return value
 
     @abc.abstractmethod
@@ -1895,6 +1904,14 @@ class HypothesisProvider(PrimitiveProvider):
 AVAILABLE_PROVIDERS = {
     "hypothesis": "hypothesis.internal.conjecture.data.HypothesisProvider",
 }
+
+
+# eventually we'll want to expose this publicly, but for now it lives as psuedo-internal.
+def realize(value: object) -> object:
+    from hypothesis.control import current_build_context
+
+    context = current_build_context()
+    return context.data.provider.realize(value)
 
 
 class ConjectureData:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -471,6 +471,9 @@ class ConjectureRunner:
                             )
 
                         node.value = value
+                        node.kwargs = {
+                            k: data.provider.realize(v) for k, v in node.kwargs.items()
+                        }
 
                 self._cache(data)
                 if data.invalid_at is not None:  # pragma: no branch # coverage bug?

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -455,7 +455,7 @@ class ConjectureRunner:
                 self.stats_per_test_case.append(call_stats)
                 if self.settings.backend != "hypothesis":
                     for node in data.examples.ir_tree_nodes:
-                        value = data.provider.post_test_case_hook(node.value)
+                        value = data.provider.realize(node.value)
                         expected_type = {
                             "string": str,
                             "float": float,
@@ -466,10 +466,14 @@ class ConjectureRunner:
                         if type(value) is not expected_type:
                             raise HypothesisException(
                                 f"expected {expected_type} from "
-                                f"{data.provider.post_test_case_hook.__qualname__}, "
-                                f"got {type(value)} ({value!r})"
+                                f"{data.provider.realize.__qualname__}, "
+                                f"got {type(value)}"
                             )
+
                         node.value = value
+                        node.kwargs = {
+                            k: data.provider.realize(v) for k, v in node.kwargs.items()
+                        }
 
                 self._cache(data)
                 if data.invalid_at is not None:  # pragma: no branch # coverage bug?

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -30,6 +30,7 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
     overload,
 )
 
@@ -56,6 +57,7 @@ from hypothesis.internal.conjecture.data import (
     Example,
     HypothesisProvider,
     InterestingOrigin,
+    IRKWargsType,
     IRNode,
     Overrun,
     PrimitiveProvider,
@@ -470,10 +472,15 @@ class ConjectureRunner:
                                 f"got {type(value)}"
                             )
 
+                        kwargs = cast(
+                            IRKWargsType,
+                            {
+                                k: data.provider.realize(v)
+                                for k, v in node.kwargs.items()
+                            },
+                        )
                         node.value = value
-                        node.kwargs = {
-                            k: data.provider.realize(v) for k, v in node.kwargs.items()
-                        }
+                        node.kwargs = kwargs
 
                 self._cache(data)
                 if data.invalid_at is not None:  # pragma: no branch # coverage bug?

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -471,9 +471,6 @@ class ConjectureRunner:
                             )
 
                         node.value = value
-                        node.kwargs = {
-                            k: data.provider.realize(v) for k, v in node.kwargs.items()
-                        }
 
                 self._cache(data)
                 if data.invalid_at is not None:  # pragma: no branch # coverage bug?

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -22,7 +22,6 @@ import string
 from importlib import resources
 
 from hypothesis import strategies as st
-from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.strategies._internal.utils import defines_strategy
@@ -181,8 +180,3 @@ def urls() -> st.SearchStrategy[str]:
         paths,
         st.just("") | _url_fragments_strategy,
     )
-
-
-def realize(value):
-    context = current_build_context()
-    return context.data.provider.realize(value)

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -22,6 +22,7 @@ import string
 from importlib import resources
 
 from hypothesis import strategies as st
+from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.strategies._internal.utils import defines_strategy
@@ -180,3 +181,8 @@ def urls() -> st.SearchStrategy[str]:
         paths,
         st.just("") | _url_fragments_strategy,
     )
+
+
+def realize(value):
+    context = current_build_context()
+    return context.data.provider.realize(value)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -71,10 +71,9 @@ def cacheable(fn: "T") -> "T":
     @proxies(fn)
     def cached_strategy(*args, **kwargs):
         context = _current_build_context.value
-        if context is not None:
-            realize = context.data.provider.realize
-            args = (realize(v) for v in args)
-            kwargs = {k: realize(v) for k, v in kwargs.items()}
+        if context is not None and context.data.provider.avoid_realization:
+            return fn(*args, **kwargs)
+
         try:
             kwargs_cache_key = {(k, convert_value(v)) for k, v in kwargs.items()}
         except TypeError:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -65,10 +65,16 @@ def clear_cache() -> None:
 
 
 def cacheable(fn: "T") -> "T":
+    from hypothesis.control import _current_build_context
     from hypothesis.strategies._internal.strategies import SearchStrategy
 
     @proxies(fn)
     def cached_strategy(*args, **kwargs):
+        context = _current_build_context.value
+        if context is not None:
+            realize = context.data.provider.realize
+            args = (realize(v) for v in args)
+            kwargs = {k: realize(v) for k, v in kwargs.items()}
         try:
             kwargs_cache_key = {(k, convert_value(v)) for k, v in kwargs.items()}
         except TypeError:

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -24,6 +24,7 @@ from hypothesis.internal.conjecture.data import (
     AVAILABLE_PROVIDERS,
     ConjectureData,
     PrimitiveProvider,
+    realize,
 )
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import SIGNALING_NAN
@@ -390,3 +391,27 @@ def test_bad_realize():
             match="expected .* from BadRealizeProvider.realize",
         ):
             test_function()
+
+
+class RealizeProvider(TrivialProvider):
+    avoid_realization = True
+
+    def realize(self, value):
+        if isinstance(value, int):
+            return 42
+        return value
+
+
+def test_realize():
+    with temp_register_backend("realize", RealizeProvider):
+
+        values = []
+
+        @given(st.integers())
+        @settings(backend="realize")
+        def test_function(n):
+            values.append(realize(n))
+
+        test_function()
+
+        assert all(n == 42 for n in values)

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -415,3 +415,16 @@ def test_realize():
         test_function()
 
         assert all(n == 42 for n in values)
+
+
+def test_realize_dependent_draw():
+    with temp_register_backend("realize", RealizeProvider):
+
+        @given(st.data())
+        @settings(backend="realize")
+        def test_function(data):
+            n1 = data.draw(st.integers())
+            n2 = data.draw(st.integers(n1, n1 + 10))
+            assert n1 <= n2
+
+        test_function()

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -372,21 +372,21 @@ def test_flaky_with_backend():
             test_function()
 
 
-class BadPostTestCaseHookProvider(TrivialProvider):
-    def post_test_case_hook(self, value):
+class BadRealizeProvider(TrivialProvider):
+    def realize(self, value):
         return None
 
 
-def test_bad_post_test_case_hook():
-    with temp_register_backend("bad_hook", BadPostTestCaseHookProvider):
+def test_bad_realize():
+    with temp_register_backend("bad_realize", BadRealizeProvider):
 
         @given(st.integers())
-        @settings(backend="bad_hook")
+        @settings(backend="bad_realize")
         def test_function(n):
             pass
 
         with pytest.raises(
             HypothesisException,
-            match="expected .* from BadPostTestCaseHookProvider.post_test_case_hook",
+            match="expected .* from BadRealizeProvider.realize",
         ):
             test_function()


### PR DESCRIPTION
* `post_test_case_hook` has been renamed to `realize` and is used in more places where we want to realize symbolic values
* `avoid_realization` backend class variable added, which backends can set to disable features that would cause premature realization
* I've tentatively exposed `hypothesis.provisional.realize` as part of our unstable-but-public api, to address https://github.com/pschanely/hypothesis-crosshair/issues/7 among others. If we want to make this less public, we can put it in `hypothesis.internal.conjecture.data` for now.

@pschanely here are the local modifications I made to hypothesis-crosshair:

```python
class CrossHairPrimitiveProvider(PrimitiveProvider):
    avoid_realization = True
    ...
    def realize(self, value):
        return self.export_value(value)
```

This includes a fix for observability crashes (https://github.com/HypothesisWorks/hypothesis/issues/3914#issuecomment-2045735039). However, I get the following z3 unknown sat error when running crosshair with observability - any ideas @pschanely?

<details>

```
@given(st.integers(), st.integers())
@settings(database=None, deadline=None, backend="crosshair")
def f(n1, n2):
    assert n1 != 123454 or n2 != 12983
f()
```

```
1835780.259|                    |solver_is_sat() Z3 unknown sat reason: canceled
1835780.266|                    |solver_is_sat() Unknown satisfiability. Solver state follows:
 (declare-fun int_01 () Int)
(declare-fun newline (Int) Bool)
(declare-fun int_02 () Int)
(assert (not (> 0 int_01)))
(assert (not (<= 10 int_01)))
(assert (forall ((c Int))
  (! (= (newline c)
        (or (= 10 c)
            (= 11 c)
            (= 12 c)
            (= 13 c)
            (= 28 c)
            (= 29 c)
            (= 30 c)
            (= 133 c)
            (= 8232 c)
            (= 8233 c)))
     :pattern ((newline c)))))
(assert (not (newline (+ 48 int_01))))
(assert (not (and (= 10 (+ 48 int_01)))))
(assert (not (> 0 int_02)))
(assert (<= 10 int_02))
(assert (not (= 10 0)))
(assert (>= 10 0))
(assert (>= int_02 0))
(assert (<= 10 (div int_02 10)))
(assert (>= (div int_02 10) 0))
(assert (<= 10 (div (div int_02 10) 10)))
(assert (>= (div (div int_02 10) 10) 0))
(assert (<= 10 (div (div (div int_02 10) 10) 10)))
(assert (>= (div (div (div int_02 10) 10) 10) 0))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (<= 10 a!1)))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (>= a!1 0)))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (<= 10 (div a!1 10))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (>= (div a!1 10) 0)))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (<= 10 (div (div a!1 10) 10))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (>= (div (div a!1 10) 10) 0)))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (<= 10 (div (div (div a!1 10) 10) 10))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (>= (div (div (div a!1 10) 10) 10) 0)))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (<= 10 a!2))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (>= a!2 0))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (<= 10 (div a!2 10)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (>= (div a!2 10) 0))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (<= 10 (div (div a!2 10) 10)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (>= (div (div a!2 10) 10) 0))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (<= 10 (div (div (div a!2 10) 10) 10)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (>= (div (div (div a!2 10) 10) 10) 0))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (div (div (div (div a!2 10) 10) 10) 10)))
  (not (<= 10 a!3))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (div (div (div (div a!2 10) 10) 10) 10)))
  (not (newline (+ 48 a!3)))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (mod (div (div (div a!2 10) 10) 10) 10)))
  (not (newline (+ 48 a!3)))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (+ 48 (mod (div (div a!2 10) 10) 10))))
  (not (newline a!3))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (newline (+ 48 (mod (div a!2 10) 10)))))
  (not a!3)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
  (not (newline (+ 48 (mod a!2 10)))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (mod (div (div (div a!1 10) 10) 10) 10)))
  (not (newline (+ 48 a!2))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (+ 48 (mod (div (div a!1 10) 10) 10))))
  (not (newline a!2)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (newline (+ 48 (mod (div a!1 10) 10)))))
  (not a!2))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
  (not (newline (+ 48 (mod a!1 10))))))
(assert (let ((a!1 (mod (div (div (div int_02 10) 10) 10) 10)))
  (not (newline (+ 48 a!1)))))
(assert (let ((a!1 (+ 48 (mod (div (div int_02 10) 10) 10))))
  (not (newline a!1))))
(assert (let ((a!1 (newline (+ 48 (mod (div int_02 10) 10)))))
  (not a!1)))
(assert (not (newline (+ 48 (mod int_02 10)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (div (div (div (div a!2 10) 10) 10) 10)))
  (not (and (= 10 (+ 48 a!3))))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (mod (div (div (div a!2 10) 10) 10) 10)))
  (not (and (= 10 (+ 48 a!3))))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (+ 48 (mod (div (div a!2 10) 10) 10))))
  (not (and (= 10 a!3)))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (= 10 (+ 48 (mod (div a!2 10) 10)))))
  (not (and a!3))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (div (div (div (div a!1 10) 10) 10) 10)))
(let ((a!3 (and (= 10 (+ 48 (mod a!2 10))))))
  (not a!3)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (mod (div (div (div a!1 10) 10) 10) 10)))
  (not (and (= 10 (+ 48 a!2)))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (+ 48 (mod (div (div a!1 10) 10) 10))))
  (not (and (= 10 a!2))))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (= 10 (+ 48 (mod (div a!1 10) 10)))))
  (not (and a!2)))))
(assert (let ((a!1 (div (div (div (div int_02 10) 10) 10) 10)))
(let ((a!2 (and (= 10 (+ 48 (mod a!1 10))))))
  (not a!2))))
(assert (let ((a!1 (mod (div (div (div int_02 10) 10) 10) 10)))
  (not (and (= 10 (+ 48 a!1))))))
(assert (let ((a!1 (+ 48 (mod (div (div int_02 10) 10) 10))))
  (not (and (= 10 a!1)))))
(assert (let ((a!1 (= 10 (+ 48 (mod (div int_02 10) 10)))))
  (not (and a!1))))
(assert (let ((a!1 (and (= 10 (+ 48 (mod int_02 10))))))
  (not a!1)))
(assert (not (<= 9223372036854775808 (ite (< int_01 0) (- int_01) int_01))))
(assert (not (<= 9223372036854775808 (ite (< int_02 0) (- int_02) int_02))))
(assert (distinct 123454 int_01))
(assert (= 0 int_01))
(assert (= 1009639649990 int_02))
(assert (= 48 (+ 48 int_01)))

1835780.266|                     |__init__() UnknownSatisfiability 
1835780.267|           |condition_parser() Using parsers:  []
1835780.269|           |condition_parser() Using parsers:  []
1835780.271|           |condition_parser() Using parsers:  []
1835780.273|           |condition_parser() Using parsers:  []
1835780.275|           |condition_parser() Using parsers:  []
1835780.277|           |condition_parser() Using parsers:  []
1835780.279|           |condition_parser() Using parsers:  []
1835780.281|           |condition_parser() Using parsers:  []
You can add @seed(190406573799112539951356386259003876502) to this test to reproduce this failure.
Traceback (most recent call last):
  File "/Users/tybug/Desktop/Liam/coding/sandbox/hypothesis_/sandbox4.py", line 117, in <module>
    f()
  File "/Users/tybug/Desktop/Liam/coding/sandbox/hypothesis_/sandbox4.py", line 115, in f
    def f(n1, n2):
                   
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/core.py", line 1661, in wrapped_test
    raise the_error_hypothesis_found
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/core.py", line 1628, in wrapped_test
    state.run_engine()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/core.py", line 1156, in run_engine
    runner.run()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 759, in run
    self._run()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1221, in _run
    self.generate_new_examples()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 977, in generate_new_examples
    self.test_function(data)
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 434, in test_function
    self.__stoppable_test_function(data)
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 307, in __stoppable_test_function
    self._test_function(data)
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/core.py", line 1119, in _execute_once_for_engine
    self._string_repr = data.provider.realize(self._string_repr)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/hypothesis_crosshair_provider/crosshair_provider.py", line 297, in realize
    return self.export_value(value)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/hypothesis_crosshair_provider/crosshair_provider.py", line 294, in export_value
    return deep_realize(value)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/core.py", line 251, in deep_realize
    return deepcopyext(value, CopyMode.REALIZE, {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/copyext.py", line 37, in deepcopyext
    obj = obj.__ch_realize__()  # type: ignore
          ^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/libimpl/builtinslib.py", line 3149, in __ch_realize__
    return "".join(chr(realize(x)) for x in codepoints)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/libimpl/builtinslib.py", line 3149, in <genexpr>
    return "".join(chr(realize(x)) for x in codepoints)
                       ^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/core.py", line 244, in realize
    return value.__ch_realize__()  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/libimpl/builtinslib.py", line 1112, in __ch_realize__
    return context_statespace().find_model_value(self.var)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/statespace.py", line 927, in find_model_value
    ModelValueNode(self._random, expr, self.solver)
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/statespace.py", line 667, in __init__
    WorstResultNode.__init__(self, rand, expr == self.condition_value, solver)
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/statespace.py", line 598, in __init__
    if _PERFORM_EXTRA_SAT_CHECKS and not solver_is_sat(solver, expr):
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/crosshair/statespace.py", line 355, in solver_is_sat
    raise UnknownSatisfiability
crosshair.util.UnknownSatisfiability
```