### PR TITLE
[experimental] Run crosshair in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,12 +83,15 @@ jobs:
           # - check-py39-pandas12
           # - check-py39-pandas11
           ## `-cover` is too slow under crosshair; use a custom split
-          # - check-crosshair-custom-cover/test_[a-d]*
-          # - check-crosshair-custom-cover/test_[e-i]*
-          # - check-crosshair-custom-cover/test_[j-r]*
-          # - check-crosshair-custom-cover/test_[s-z]*
-          # - check-crosshair-custom-pytest/test_*
-          # - check-crosshair-nocover
+          - check-crosshair-custom-cover/test_[a-d]*
+          - check-crosshair-custom-cover/test_[e-i]*
+          - check-crosshair-custom-cover/test_[j-r]*
+          - check-crosshair-custom-cover/test_[s-z]*
+          - check-crosshair-custom-pytest/test_*
+          - check-crosshair-custom-nocover/test_[a-d]*
+          - check-crosshair-custom-nocover/test_[e-i]*
+          - check-crosshair-custom-nocover/test_[j-r]*
+          - check-crosshair-custom-nocover/test_[s-z]*
           # - check-crosshair-niche
           - check-py39-oldestnumpy
           - check-numpy-nightly
@@ -129,7 +132,7 @@ jobs:
         export TASK=${{ matrix.task }}
         if [[ $TASK == check-crosshair-custom-* ]]; then
           GROUP="${TASK#check-crosshair-custom-}"
-          ./build.sh check-crosshair-custom -- -n auto $(cd hypothesis-python ; echo tests/$GROUP)
+          ./build.sh check-crosshair-custom -- -n auto $(cd hypothesis-python && echo tests/$GROUP | xargs -n1 echo | grep -v "_py312" | xargs)
         else
           ./build.sh
         fi

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ To install Hypothesis:
 pip install hypothesis
 ```
 
-There are also [optional extras available](https://hypothesis.readthedocs.io/en/latest/packaging.html#other-python-libraries).
+There are also [optional extras available](https://hypothesis.readthedocs.io/en/latest/extras.html).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch improves the interaction between the :pypi:`hypothesis-crosshair`
+:ref:`backend <alternative-backends>` and :ref:`our observability tools <observability>`.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -955,27 +955,20 @@ class StateForActualGivenExecution:
                     printer.text("Trying example:")
 
                 if self.print_given_args:
-                    if data.provider.avoid_realization and not print_example:
-                        # we can do better here by adding
-                        # avoid_realization: bool = False to repr_call, which
-                        # maintains args/kwargs structure (and comments) but shows
-                        # <symbolic> in place of values. For now, this at least
-                        # avoids realization with verbosity <= verbose.
-                        printer.text(" <symbolics>")
-                    else:
-                        printer.text(" ")
-                        printer.repr_call(
-                            test.__name__,
-                            args,
-                            kwargs,
-                            force_split=True,
-                            arg_slices=argslices,
-                            leading_comment=(
-                                "# " + context.data.slice_comments[(0, 0)]
-                                if (0, 0) in context.data.slice_comments
-                                else None
-                            ),
-                        )
+                    printer.text(" ")
+                    printer.repr_call(
+                        test.__name__,
+                        args,
+                        kwargs,
+                        force_split=True,
+                        arg_slices=argslices,
+                        leading_comment=(
+                            "# " + context.data.slice_comments[(0, 0)]
+                            if (0, 0) in context.data.slice_comments
+                            else None
+                        ),
+                        avoid_realization=data.provider.avoid_realization,
+                    )
                 report(printer.getvalue())
 
             if TESTCASE_CALLBACKS:
@@ -991,11 +984,12 @@ class StateForActualGivenExecution:
                         if (0, 0) in context.data.slice_comments
                         else None
                     ),
+                    avoid_realization=data.provider.avoid_realization,
                 )
                 self._string_repr = printer.getvalue()
                 data._observability_arguments = {
-                    **dict(enumerate(map(to_jsonable, args))),
-                    **{k: to_jsonable(v) for k, v in kwargs.items()},
+                    k: to_jsonable(v, avoid_realization=data.provider.avoid_realization)
+                    for k, v in [*enumerate(args), *kwargs.items()]
                 }
 
             try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1136,7 +1136,8 @@ class ConjectureData:
                 )
                 raise
             if TESTCASE_CALLBACKS:
-                self._observability_args[key] = to_jsonable(v)
+                avoid = self.provider.avoid_realization
+                self._observability_args[key] = to_jsonable(v, avoid_realization=avoid)
             return v
         finally:
             self.stop_span()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -10,6 +10,7 @@
 
 import sys
 import threading
+from functools import partial
 from inspect import signature
 from typing import TYPE_CHECKING, Callable
 
@@ -156,7 +157,7 @@ def defines_strategy(
     return decorator
 
 
-def to_jsonable(obj: object) -> object:
+def to_jsonable(obj: object, *, avoid_realization: bool) -> object:
     """Recursively convert an object to json-encodable form.
 
     This is not intended to round-trip, but rather provide an analysis-ready
@@ -165,26 +166,30 @@ def to_jsonable(obj: object) -> object:
     """
     if isinstance(obj, (str, int, float, bool, type(None))):
         if isinstance(obj, int) and abs(obj) >= 2**63:
-            # Silently clamp very large ints to max_float, to avoid
-            # OverflowError when casting to float.
+            # Silently clamp very large ints to max_float, to avoid OverflowError when
+            # casting to float.  (but avoid adding more constraints to symbolic values)
+            if avoid_realization:
+                return "<symbolic>"
             obj = clamp(-sys.float_info.max, obj, sys.float_info.max)
             return float(obj)
         return obj
+    if avoid_realization:
+        return "<symbolic>"
+    recur = partial(to_jsonable, avoid_realization=avoid_realization)
     if isinstance(obj, (list, tuple, set, frozenset)):
         if isinstance(obj, tuple) and hasattr(obj, "_asdict"):
-            return to_jsonable(obj._asdict())  # treat namedtuples as dicts
-        return [to_jsonable(x) for x in obj]
+            return recur(obj._asdict())  # treat namedtuples as dicts
+        return [recur(x) for x in obj]
     if isinstance(obj, dict):
         return {
-            k if isinstance(k, str) else pretty(k): to_jsonable(v)
-            for k, v in obj.items()
+            k if isinstance(k, str) else pretty(k): recur(v) for k, v in obj.items()
         }
 
     # Hey, might as well try calling a .to_json() method - it works for Pandas!
     # We try this before the below general-purpose handlers to give folks a
     # chance to control this behavior on their custom classes.
     try:
-        return to_jsonable(obj.to_json())  # type: ignore
+        return recur(obj.to_json())  # type: ignore
     except Exception:
         pass
 
@@ -194,11 +199,11 @@ def to_jsonable(obj: object) -> object:
         and dcs.is_dataclass(obj)
         and not isinstance(obj, type)
     ):
-        return to_jsonable(dataclass_asdict(obj))
+        return recur(dataclass_asdict(obj))
     if attr.has(type(obj)):
-        return to_jsonable(attr.asdict(obj, recurse=False))  # type: ignore
+        return recur(attr.asdict(obj, recurse=False))  # type: ignore
     if (pyd := sys.modules.get("pydantic")) and isinstance(obj, pyd.BaseModel):
-        return to_jsonable(obj.model_dump())
+        return recur(obj.model_dump())
 
     # If all else fails, we'll just pretty-print as a string.
     return pretty(obj)

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -447,6 +447,7 @@ class RepresentationPrinter:
         force_split: Optional[bool] = None,
         arg_slices: Optional[dict[str, tuple[int, int]]] = None,
         leading_comment: Optional[str] = None,
+        avoid_realization: bool = False,
     ) -> None:
         """Helper function to represent a function call.
 
@@ -494,7 +495,10 @@ class RepresentationPrinter:
                     self.breakable(" " if i else "")
                 if k:
                     self.text(f"{k}=")
-                self.pretty(v)
+                if avoid_realization:
+                    self.text("<symbolic>")
+                else:
+                    self.pretty(v)
                 if force_split or i + 1 < len(all_args):
                     self.text(",")
                 comment = None

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -257,6 +257,7 @@ class Why(enum.Enum):
     # Some are crosshair issues, some hypothesis issues, others truly ok-to-xfail tests.
     symbolic_outside_context = "CrosshairInternal error (using value outside context)"
     nested_given = "nested @given decorators don't work with crosshair"
+    undiscovered = "crosshair may not find the failing input"
     other = "reasons not elsewhere categorized"
 
 
@@ -269,7 +270,7 @@ def xfail_on_crosshair(why: Why, /, *, strict=True, as_marks=False):
 
     current_backend = settings.get_profile(settings._current_profile).backend
     kw = {
-        "strict": strict,
+        "strict": strict and why != Why.undiscovered,
         "reason": f"Expected failure due to: {why.value}",
         "condition": current_backend == "crosshair",
     }

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import contextlib
+import enum
 import sys
 import warnings
 from io import StringIO
@@ -249,3 +250,29 @@ def capture_observations():
 # config option, so *linking against* something built this way can break us.
 # Everything is terrible
 PYTHON_FTZ = next_down(sys.float_info.min) == 0.0
+
+
+class Why(enum.Enum):
+    # Categorizing known failures, to ease later follow-up investigation.
+    # Some are crosshair issues, some hypothesis issues, others truly ok-to-xfail tests.
+    symbolic_outside_context = "CrosshairInternal error (using value outside context)"
+    nested_given = "nested @given decorators don't work with crosshair"
+    other = "reasons not elsewhere categorized"
+
+
+def xfail_on_crosshair(why: Why, /, *, strict=True, as_marks=False):
+    # run `pytest -m xf_crosshair` to select these tests!
+    try:
+        import pytest
+    except ImportError:
+        return lambda fn: fn
+
+    current_backend = settings.get_profile(settings._current_profile).backend
+    kw = {
+        "strict": strict,
+        "reason": f"Expected failure due to: {why.value}",
+        "condition": current_backend == "crosshair",
+    }
+    if as_marks:  # for use with pytest.param(..., marks=xfail_on_crosshair())
+        return (pytest.mark.xf_crosshair, pytest.mark.xfail(**kw))
+    return lambda fn: pytest.mark.xf_crosshair(pytest.mark.xfail(**kw)(fn))

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -94,6 +94,13 @@ def warns_or_raises(request):
         return pytest.warns
 
 
+# crosshair needs actual time for its path timeouts; load it before patching
+try:
+    import hypothesis_crosshair_provider.crosshair_provider  # noqa: F401
+except ImportError:
+    pass
+
+
 @pytest.fixture(scope="function", autouse=True)
 def _consistently_increment_time(monkeypatch):
     """Rather than rely on real system time we monkey patch time.time so that

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -75,7 +75,6 @@ def pytest_addoption(parser):
     parser.addoption("--hypothesis-update-outputs", action="store_true")
     parser.addoption("--hypothesis-benchmark-shrinks", type=str, choices=["new", "old"])
     parser.addoption("--hypothesis-benchmark-output", type=str)
-    parser.addoption("--hypothesis-learn-to-normalize", action="store_true")
 
     # New in pytest 6, so we add a shim on old versions to avoid missing-arg errors
     arg = "--durations-min"

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -54,6 +54,7 @@ def pytest_configure(config):
         "markers",
         "xp_min_version(api_version): run when greater or equal to api_version",
     )
+    config.addinivalue_line("markers", "xf_crosshair: selection for xfailing symbolics")
 
     if config.getoption("--hypothesis-benchmark-shrinks"):
         # we'd like to support xdist here, but a session-scope fixture won't

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -14,9 +14,10 @@ from contextlib import contextmanager
 from random import Random
 from typing import Optional
 
+import pytest
+
 from hypothesis import HealthCheck, Phase, assume, settings, strategies as st
-from hypothesis.control import current_build_context
-from hypothesis.errors import InvalidArgument
+from hypothesis.control import current_build_context, currently_in_test_context
 from hypothesis.internal.conjecture import engine as engine_module
 from hypothesis.internal.conjecture.choice import ChoiceNode, ChoiceT
 from hypothesis.internal.conjecture.data import ConjectureData, Status
@@ -103,10 +104,21 @@ def shrinking_from(start):
 
 
 def fresh_data(*, random=None, observer=None) -> ConjectureData:
+    context = current_build_context() if currently_in_test_context() else None
+    if context is not None and settings().backend == "crosshair":
+        # we should reeaxmine fresh_data sometime and see if we can replace it
+        # with nicer and higher level hypothesis idioms.
+        #
+        # For now it doesn't work well with crosshair tests. This is no big
+        # loss, because these tests often rely on hypothesis-provider-specific
+        # things.
+        pytest.skip(
+            "Fresh data is too low level (and too much of a hack) to be "
+            "worth supporting when testing with crosshair"
+        )
+
     if random is None:
-        try:
-            context = current_build_context()
-        except InvalidArgument:
+        if context is None:
             # ensure usage of fresh_data() is not flaky outside of property tests.
             raise ValueError(
                 "must pass a seeded Random instance to fresh_data() when "

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -444,7 +444,7 @@ def test_realization_with_verbosity(verbosity):
 
         with capture_out() as out:
             test_function()
-        assert "Trying example: <symbolics>" in out.getvalue()
+        assert "Trying example: test_function(\n    f=<symbolic>,\n)" in out.getvalue()
 
 
 @pytest.mark.parametrize("verbosity", [Verbosity.verbose, Verbosity.debug])

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -26,7 +26,7 @@ from hypothesis import (
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.cache import GenericCache, LRUCache, LRUReusedCache
 
-from tests.common.utils import skipif_emscripten
+from tests.common.utils import Why, skipif_emscripten, xfail_on_crosshair
 
 
 class LRUCacheAlternative(GenericCache):
@@ -116,6 +116,7 @@ def test_behaves_like_a_dict_with_losses(implementation, writes, size):
         assert len(target) <= min(len(model), size)
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 @settings(
     suppress_health_check={HealthCheck.too_slow}
     | set(settings.get_profile(settings._current_profile).suppress_health_check),

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -19,10 +19,11 @@ from hypothesis.errors import InvalidArgument, NoSuchExample, Unsatisfiable
 
 
 def test_stops_after_max_examples_if_satisfying():
-    tracker = []
+    count = 0
 
     def track(x):
-        tracker.append(x)
+        nonlocal count
+        count += 1
         return False
 
     max_examples = 100
@@ -30,7 +31,7 @@ def test_stops_after_max_examples_if_satisfying():
     with pytest.raises(NoSuchExample):
         find(s.integers(0, 10000), track, settings=settings(max_examples=max_examples))
 
-    assert len(tracker) == max_examples
+    assert count == max_examples
 
 
 def test_stops_after_ten_times_max_examples_if_not_satisfying():

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -659,6 +659,7 @@ def test_database_listener_memory():
 
 
 @skipif_emscripten
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ages")
 def test_database_listener_background_write():
     _database_conforms_to_listener_api(
         lambda path: BackgroundWriteDatabase(InMemoryExampleDatabase()),

--- a/hypothesis-python/tests/cover/test_datetimes.py
+++ b/hypothesis-python/tests/cover/test_datetimes.py
@@ -16,6 +16,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import dates, datetimes, timedeltas, times
 
 from tests.common.debug import assert_simple_property, find_any, minimal
+from tests.common.utils import Why, xfail_on_crosshair
 
 
 def test_can_find_positive_delta():
@@ -104,6 +105,7 @@ def test_single_date(val):
     assert find_any(dates(val, val)) is val
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_can_find_midnight():
     find_any(times(), lambda x: x.hour == x.minute == x.second == 0)
 

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -23,6 +23,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.vendor.pretty import pretty
 
 from tests.common.debug import check_can_generate_examples, minimal
+from tests.common.utils import Why, xfail_on_crosshair
 
 # Use `pretty` instead of `repr` for building test names, so that set and dict
 # parameters print consistently across multiple worker processes with different
@@ -437,6 +438,7 @@ def test_decimals():
     assert minimal(st.decimals(), lambda f: f.is_finite() and f >= 1) == 1
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_non_float_decimal():
     minimal(st.decimals(), lambda d: d.is_finite() and decimal.Decimal(float(d)) != d)
 

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -32,7 +32,7 @@ from hypothesis.strategies._internal.strategies import FilteredStrategy, MappedS
 from hypothesis.strategies._internal.strings import BytesStrategy, TextStrategy
 
 from tests.common.debug import check_can_generate_examples
-from tests.common.utils import fails_with
+from tests.common.utils import Why, fails_with, xfail_on_crosshair
 
 A_FEW = 15  # speed up massively-parametrized tests
 
@@ -375,9 +375,10 @@ def test_isidentifier_filter_properly_rewritten(al, data):
     assert example.isidentifier()
 
 
-@pytest.mark.parametrize("al", ["¥¦§©"])
-def test_isidentifer_filter_unsatisfiable(al):
-    fs = st.text(alphabet=al).filter(str.isidentifier)
+def test_isidentifer_filter_unsatisfiable():
+    alphabet = "¥¦§©"
+    assert not any(f"_{c}".isidentifier() for c in alphabet)
+    fs = st.text(alphabet=alphabet).filter(str.isidentifier)
     with pytest.raises(Unsatisfiable):
         check_can_generate_examples(fs)
 

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -182,6 +182,7 @@ def test_rewrite_unsatisfiable_filter(s, pred):
     assert s.filter(pred).is_empty
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @pytest.mark.parametrize(
     "pred",
     [

--- a/hypothesis-python/tests/cover/test_find.py
+++ b/hypothesis-python/tests/cover/test_find.py
@@ -12,7 +12,10 @@ from random import Random
 
 from hypothesis import Phase, find, settings, strategies as st
 
+from tests.common.utils import Why, xfail_on_crosshair
 
+
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_find_uses_provided_random():
     prev = None
 

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -20,13 +20,14 @@ from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.internal.scrutineer import Tracer
 from hypothesis.strategies import booleans, composite, integers, lists, random_module
 
-from tests.common.utils import no_shrink
+from tests.common.utils import Why, no_shrink, xfail_on_crosshair
 
 
 class Nope(Exception):
     pass
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_fails_only_once_is_flaky():
     first_call = True
 
@@ -44,6 +45,7 @@ def test_fails_only_once_is_flaky():
     assert isinstance(exceptions[0], Nope)
 
 
+@xfail_on_crosshair(Why.other)
 def test_fails_differently_is_flaky():
     call_count = 0
 
@@ -93,6 +95,7 @@ def rude_fn(x):
     assert list(map(type, exceptions[0].exceptions)) == [Nope]
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_gives_flaky_error_if_assumption_is_flaky():
     seen = set()
 
@@ -131,6 +134,7 @@ def test_flaky_with_context_when_fails_only_under_tracing(monkeypatch):
     assert isinstance(exceptions[0], ZeroDivisionError)
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_does_not_attempt_to_shrink_flaky_errors():
     values = []
 
@@ -162,6 +166,7 @@ def single_bool_lists(draw):
     return result
 
 
+@xfail_on_crosshair(Why.nested_given)
 @example([True, False, False, False], [3], None)
 @example([False, True, False, False], [3], None)
 @example([False, False, True, False], [3], None)

--- a/hypothesis-python/tests/cover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/cover/test_given_error_conditions.py
@@ -18,13 +18,10 @@ from hypothesis.strategies import booleans, integers, nothing
 from tests.common.utils import fails_with
 
 
-def test_raises_unsatisfiable_if_all_false_in_finite_set():
-    @given(booleans())
-    def test_assume_false(x):
-        reject()
-
-    with pytest.raises(Unsatisfiable):
-        test_assume_false()
+@fails_with(Unsatisfiable)
+@given(booleans())
+def test_raises_unsatisfiable_if_all_false_in_finite_set(x):
+    reject()
 
 
 def test_does_not_raise_unsatisfiable_if_some_false_in_finite_set():

--- a/hypothesis-python/tests/cover/test_health_checks.py
+++ b/hypothesis-python/tests/cover/test_health_checks.py
@@ -26,7 +26,7 @@ from hypothesis.stateful import (
 )
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
-from tests.common.utils import no_shrink
+from tests.common.utils import Why, no_shrink, xfail_on_crosshair
 
 HEALTH_CHECK_SETTINGS = settings(
     max_examples=11, database=None, suppress_health_check=()
@@ -235,6 +235,7 @@ def test_triply_nested_given_raises_healthcheck():
         f()
 
 
+@xfail_on_crosshair(Why.nested_given)
 def test_can_suppress_nested_given():
     @given(st.integers())
     @settings(suppress_health_check=[HealthCheck.nested_given], max_examples=5)
@@ -269,6 +270,7 @@ def test_cant_suppress_nested_given_on_inner():
         f()
 
 
+@xfail_on_crosshair(Why.nested_given)
 def test_suppress_triply_nested_given():
     # both suppressions are necessary here
     @given(st.integers())

--- a/hypothesis-python/tests/cover/test_interactive_example.py
+++ b/hypothesis-python/tests/cover/test_interactive_example.py
@@ -24,7 +24,7 @@ from hypothesis.errors import (
 from hypothesis.internal.compat import WINDOWS
 
 from tests.common.debug import find_any
-from tests.common.utils import fails_with, skipif_emscripten
+from tests.common.utils import Why, fails_with, skipif_emscripten, xfail_on_crosshair
 
 pytest_plugins = "pytester"
 
@@ -45,6 +45,7 @@ def test_exception_in_compare_can_still_have_example():
     st.one_of(st.none().map(lambda n: Decimal("snan")), st.just(Decimal(0))).example()
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_does_not_always_give_the_same_example():
     s = st.integers()
     assert len({s.example() for _ in range(100)}) >= 10

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -52,7 +52,7 @@ from tests.common.debug import (
     find_any,
     minimal,
 )
-from tests.common.utils import fails_with, temp_registered
+from tests.common.utils import Why, fails_with, temp_registered, xfail_on_crosshair
 
 sentinel = object()
 BUILTIN_TYPES = tuple(

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -876,6 +876,7 @@ def test_supportsop_types_support_protocol(protocol, data):
     assert issubclass(type(value), protocol)
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @pytest.mark.parametrize("restrict_custom_strategy", [True, False])
 def test_generic_aliases_can_be_conditionally_resolved_by_registered_function(
     restrict_custom_strategy,

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -619,6 +619,7 @@ class Tree:
         return f"Tree({self.left}, {self.right})"
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~19 mins")
 @given(tree=st.builds(Tree))
 def test_resolving_recursive_type(tree):
     assert isinstance(tree, Tree)
@@ -979,6 +980,10 @@ def test_no_byteswarning(_):
     pass
 
 
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="Crosshair doesn't generate the Decimal('snan'), so this runs for hours",
+)
 def test_hashable_type_unhashable_value():
     # Decimal("snan") is not hashable; we should be able to generate it.
     # See https://github.com/HypothesisWorks/hypothesis/issues/2320

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from hypothesis import example, given, strategies as st
+from hypothesis import example, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.reflection import (
     convert_positional_arguments,
@@ -126,6 +126,7 @@ class Node:
     right: typing.Union["Node", int]
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~11 mins")
 @given(st.builds(Node))
 def test_can_resolve_recursive_dataclass(val):
     assert isinstance(val, Node)

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -28,7 +28,7 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
 )
 
-from tests.common.utils import capture_observations
+from tests.common.utils import Why, capture_observations, xfail_on_crosshair
 
 
 @seed("deterministic so we don't miss some combination of features")
@@ -46,6 +46,7 @@ def do_it_all(l, a, x, data):
     1 / ((x or 1) % 7)
 
 
+@xfail_on_crosshair(Why.other, strict=False)  # flakey BackendCannotProceed ??
 def test_observability():
     with capture_observations() as ls:
         with pytest.raises(ZeroDivisionError):
@@ -70,6 +71,7 @@ def test_observability():
             )
 
 
+@xfail_on_crosshair(Why.other)
 def test_capture_unnamed_arguments():
     @given(st.integers(), st.floats(), st.data())
     def f(v1, v2, data):
@@ -88,6 +90,7 @@ def test_capture_unnamed_arguments():
         ], test_case
 
 
+@xfail_on_crosshair(Why.other)
 def test_capture_named_arguments():
     @given(named1=st.integers(), named2=st.floats(), data=st.data())
     def f(named1, named2, data):
@@ -136,6 +139,7 @@ class UltraSimpleMachine(RuleBasedStateMachine):
         assert abs(self.value) <= 100
 
 
+@xfail_on_crosshair(Why.other, strict=False)
 def test_observability_captures_stateful_reprs():
     with capture_observations() as ls:
         run_state_machine_as_test(UltraSimpleMachine)

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -56,6 +56,7 @@ def test_invalid_domain_arguments(max_length, max_element_length):
         )
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~300s each")
 @pytest.mark.parametrize("max_length", [None, 4, 8, 255])
 @pytest.mark.parametrize("max_element_length", [None, 1, 2, 4, 8, 63])
 def test_valid_domains_arguments(max_length, max_element_length):

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -325,6 +325,7 @@ def test_randbytes_have_right_length(rnd, n):
     assert len(rnd.randbytes(n)) == n
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes hours")
 @given(any_random)
 def test_can_manage_very_long_ranges_with_step(rnd):
     i = rnd.randrange(0, 2**256, 3)

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -26,6 +26,7 @@ from hypothesis.strategies._internal.random import (
 )
 
 from tests.common.debug import assert_all_examples, find_any
+from tests.common.utils import Why, xfail_on_crosshair
 
 
 def test_implements_all_random_methods():
@@ -180,6 +181,7 @@ def test_copying_synchronizes(r1, method_call):
     assert getattr(r1, method)(*args, **kwargs) == getattr(r2, method)(*args, **kwargs)
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)
 @pytest.mark.parametrize("use_true_random", [True, False])
 def test_seeding_to_different_values_does_not_synchronize(use_true_random):
     @given(
@@ -195,6 +197,7 @@ def test_seeding_to_different_values_does_not_synchronize(use_true_random):
         test()
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)
 @pytest.mark.parametrize("use_true_random", [True, False])
 def test_unrelated_calls_desynchronizes(use_true_random):
     @given(

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -104,6 +104,7 @@ def test_matching(category, predicate, invert, is_unicode):
     _test_matching_pattern(category, isvalidchar=pred, is_unicode=is_unicode)
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~30s each")
 @pytest.mark.parametrize(
     "pattern",
     [
@@ -190,6 +191,7 @@ def test_any_with_dotall_generate_newline_binary(pattern):
     find_any(st.from_regex(pattern), lambda s: s == b"\n", settings(max_examples=10**6))
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~30s each")
 @pytest.mark.parametrize(
     "pattern",
     ["\\d", "[\\d]", "[^\\D]", "\\w", "[\\w]", "[^\\W]", "\\s", "[\\s]", "[^\\S]"],

--- a/hypothesis-python/tests/cover/test_replay_logic.py
+++ b/hypothesis-python/tests/cover/test_replay_logic.py
@@ -14,6 +14,8 @@ from hypothesis import given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import ExceptionGroup
 
+from tests.common.utils import Why, xfail_on_crosshair
+
 
 def test_does_not_shrink_on_replay():
     database = InMemoryExampleDatabase()
@@ -86,6 +88,7 @@ def test_does_not_shrink_on_replay_with_multiple_bugs():
     assert call_count == 4
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_will_always_shrink_if_previous_example_does_not_replay():
     database = InMemoryExampleDatabase()
 

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -28,7 +28,7 @@ from hypothesis.core import decode_failure, encode_failure
 from hypothesis.errors import DidNotReproduce, InvalidArgument, UnsatisfiedAssumption
 from hypothesis.internal.conjecture.choice import choice_equal
 
-from tests.common.utils import capture_out, no_shrink
+from tests.common.utils import Why, capture_out, no_shrink, xfail_on_crosshair
 from tests.conjecture.common import ir, nodes
 
 
@@ -124,6 +124,7 @@ def test_errors_with_did_not_reproduce_if_rejected():
         test()
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_prints_reproduction_if_requested():
     failing_example = None
 

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -175,6 +175,7 @@ def test_does_not_print_reproduction_for_simple_data_examples_by_default():
     assert "@reproduce_failure" not in o.getvalue()
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_does_not_print_reproduction_for_large_data_examples_by_default():
     @settings(phases=no_shrink, print_blob=False)
     @given(st.data())

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -34,7 +34,7 @@ from tests.common.debug import (
     assert_simple_property,
     check_can_generate_examples,
 )
-from tests.common.utils import fails_with
+from tests.common.utils import Why, fails_with, xfail_on_crosshair
 
 an_enum = enum.Enum("A", "a b c")
 a_flag = enum.Flag("A", "a b c")

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -141,6 +141,7 @@ def stupid_sampled_sets(draw):
     return result
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @given(stupid_sampled_sets())
 def test_efficient_sets_of_samples_with_chained_transformations_slow_path(x):
     # This deliberately exercises the standard filtering logic without going

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -99,6 +99,10 @@ def test_efficient_dicts_with_sampled_keys(x):
     assert set(x) == set(range(50))
 
 
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~10 mins and raises Unsatisfiable",
+)
 @given(
     st.lists(
         st.tuples(st.sampled_from(range(20)), st.builds(list)),

--- a/hypothesis-python/tests/cover/test_seed_printing.py
+++ b/hypothesis-python/tests/cover/test_seed_printing.py
@@ -16,7 +16,7 @@ from hypothesis import Verbosity, assume, core, given, settings, strategies as s
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck
 
-from tests.common.utils import all_values, capture_out
+from tests.common.utils import Why, all_values, capture_out, xfail_on_crosshair
 
 
 @pytest.mark.parametrize("in_pytest", [False, True])
@@ -80,6 +80,7 @@ def test_uses_global_force(monkeypatch):
     assert "@seed" not in output[0]
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_does_print_on_reuse_from_database():
     passes_healthcheck = False
 

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -43,7 +43,12 @@ from hypothesis.stateful import (
 )
 from hypothesis.strategies import binary, data, integers, just, lists
 
-from tests.common.utils import capture_out, validate_deprecation
+from tests.common.utils import (
+    Why,
+    capture_out,
+    validate_deprecation,
+    xfail_on_crosshair,
+)
 from tests.nocover.test_stateful import DepthMachine
 
 NO_BLOB_SETTINGS = Settings(print_blob=False, phases=tuple(Phase)[:-1])
@@ -1183,6 +1188,8 @@ class MinStepsMachine(RuleBasedStateMachine):
         assert self.a >= 2
 
 
+# Replay overruns after we trigger a crosshair.util.IgnoreAttempt exception for n=3
+@xfail_on_crosshair(Why.other)
 def test_min_steps_argument():
     # You must pass a non-negative integer...
     for n_steps in (-1, "nan", 5.0):

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1325,7 +1325,9 @@ class LotsOfEntropyPerStepMachine(RuleBasedStateMachine):
         assert data
 
 
-TestLotsOfEntropyPerStepMachine = LotsOfEntropyPerStepMachine.TestCase
+@pytest.mark.skipif(Settings._current_profile == "crosshair", reason="takes hours")
+def test_lots_of_entropy():
+    run_state_machine_as_test(LotsOfEntropyPerStepMachine)
 
 
 def test_flatmap():

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1285,6 +1285,7 @@ state.teardown()
     )
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_multiple_common_targets():
     class Machine(RuleBasedStateMachine):
         a = Bundle("a")

--- a/hypothesis-python/tests/cover/test_targeting.py
+++ b/hypothesis-python/tests/cover/test_targeting.py
@@ -16,6 +16,8 @@ from hypothesis import example, given, strategies as st, target
 from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 
+from tests.common.utils import Why, xfail_on_crosshair
+
 
 @example(0.0, "this covers the branch where context.data is None")
 @given(
@@ -100,6 +102,7 @@ def test_cannot_target_same_label_twice(_):
         target(1.0, label="label")
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @given(st.none())
 def test_cannot_target_default_label_twice(_):
     target(0.0)

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -149,6 +149,7 @@ def test_can_be_given_keyword_args(x, name):
     assert len(name) < x
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @fails
 @given(one_of(floats(), booleans()), one_of(floats(), booleans()))
 def test_one_of_produces_different_values(x, y):
@@ -196,6 +197,7 @@ def test_removing_an_element_from_a_unique_list(xs, y):
     assert y not in xs
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @fails
 @given(lists(integers(), min_size=2), data())
 def test_removing_an_element_from_a_non_unique_list(xs, data):
@@ -219,6 +221,7 @@ def test_can_mix_sampling_with_generating(x, y):
     assert type(x) == type(y)
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @fails
 @given(frozensets(integers()))
 def test_can_find_large_sum_frozenset(xs):

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -40,6 +40,7 @@ from hypothesis.strategies import (
 )
 
 from tests.common.utils import (
+    Why,
     assert_falsifying_output,
     capture_out,
     fails,
@@ -47,6 +48,7 @@ from tests.common.utils import (
     no_shrink,
     raises,
     skipif_emscripten,
+    xfail_on_crosshair,
 )
 
 # This particular test file is run under both pytest and nose, so it can't
@@ -315,6 +317,7 @@ def test_has_ascii(x):
     assert any(c in ascii_characters for c in x)
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)
 def test_can_derandomize():
     values = []
 
@@ -404,6 +407,7 @@ def test_mixed_text(x):
     assert set(x).issubset(set("abcdefg"))
 
 
+@xfail_on_crosshair(Why.other, strict=False)  # runs ~five failing examples
 def test_when_set_to_no_simplifies_runs_failing_example_twice():
     failing = []
 
@@ -489,6 +493,7 @@ def test_empty_lists(xs):
     assert xs == []
 
 
+@xfail_on_crosshair(Why.other, strict=False)
 def test_given_usable_inline_on_lambdas():
     xs = []
     given(booleans())(lambda x: xs.append(x))()

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -33,7 +33,7 @@ from tests.common.debug import (
     check_can_generate_examples,
     find_any,
 )
-from tests.common.utils import fails_with, temp_registered
+from tests.common.utils import Why, fails_with, temp_registered, xfail_on_crosshair
 
 types_with_core_strat = {
     type_
@@ -256,8 +256,19 @@ def _check_instances(t):
     )
 
 
+def maybe_mark(x):
+    if x.__name__ in "Match Decimal IPv4Address":
+        marks = xfail_on_crosshair(Why.other, as_marks=True, strict=False)
+        return pytest.param(x, marks=marks)
+    return x
+
+
 @pytest.mark.parametrize(
-    "typ", sorted((x for x in _global_type_lookup if _check_instances(x)), key=str)
+    "typ",
+    sorted(
+        (maybe_mark(x) for x in _global_type_lookup if _check_instances(x)),
+        key=str,
+    ),
 )
 @given(data=st.data())
 def test_can_generate_from_all_registered_types(data, typ):

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -16,7 +16,7 @@ from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.strategies import booleans, integers, lists
 
 from tests.common.debug import minimal
-from tests.common.utils import capture_out, fails
+from tests.common.utils import Why, capture_out, fails, xfail_on_crosshair
 
 
 @contextmanager
@@ -63,6 +63,7 @@ def test_includes_progress_in_verbose_mode():
     assert "Trying example: " in out
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)
 def test_prints_initial_attempts_on_find():
     with capture_verbosity() as o:
 

--- a/hypothesis-python/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis-python/tests/datetime/test_dateutil_timezones.py
@@ -109,6 +109,7 @@ def test_dateutil_exists_our_not_exists_are_inverse(value):
     assert datetime_does_not_exist(value) == (not tz.datetime_exists(value))
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_datetimes_can_exclude_imaginary():
     find_any(
         datetimes(**DAY_WITH_IMAGINARY_HOUR_KWARGS, allow_imaginary=True),
@@ -120,6 +121,7 @@ def test_datetimes_can_exclude_imaginary():
     )
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @fails_with(FailedHealthCheck)
 @given(
     datetimes(

--- a/hypothesis-python/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis-python/tests/datetime/test_dateutil_timezones.py
@@ -20,7 +20,7 @@ from hypothesis.strategies import data, datetimes, just, sampled_from, times
 from hypothesis.strategies._internal.datetime import datetime_does_not_exist
 
 from tests.common.debug import assert_all_examples, find_any, minimal
-from tests.common.utils import fails_with
+from tests.common.utils import Why, fails_with, xfail_on_crosshair
 
 with warnings.catch_warnings():
     if sys.version_info[:2] >= (3, 12):
@@ -103,6 +103,7 @@ DAY_WITH_IMAGINARY_HOUR_KWARGS = {
 }
 
 
+@xfail_on_crosshair(Why.other, strict=False)  # fromutc argument must be a datetime
 @given(datetimes(timezones=timezones()) | datetimes(**DAY_WITH_IMAGINARY_HOUR_KWARGS))
 def test_dateutil_exists_our_not_exists_are_inverse(value):
     assert datetime_does_not_exist(value) == (not tz.datetime_exists(value))

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -20,6 +20,7 @@ from hypothesis.strategies import data, datetimes, just, sampled_from, times
 from hypothesis.strategies._internal.datetime import datetime_does_not_exist
 
 from tests.common.debug import assert_all_examples, find_any, minimal
+from tests.common.utils import Why, xfail_on_crosshair
 
 with warnings.catch_warnings():
     if sys.version_info[:2] >= (3, 12):
@@ -161,6 +162,7 @@ def test_datetimes_stay_within_naive_bounds(data, lo, hi):
         },
     ],
 )
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)
 def test_datetimes_can_exclude_imaginary(kw):
     # Sanity check: fail unless those days contain an imaginary hour to filter out
     find_any(datetimes(**kw, allow_imaginary=True), lambda x: not datetime_exists(x))

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -104,6 +104,7 @@ def test_time_bounds_must_be_naive(name, val):
         times(**{name: val}).validate()
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @pytest.mark.parametrize(
     "bound",
     [

--- a/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis-python/tests/datetime/test_zoneinfo_timezones.py
@@ -17,12 +17,14 @@ from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
 
 from tests.common.debug import assert_no_examples, find_any, minimal
+from tests.common.utils import Why, xfail_on_crosshair
 
 
 def test_utc_is_minimal():
     assert minimal(st.timezones()) is zoneinfo.ZoneInfo("UTC")
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_can_generate_non_utc():
     find_any(
         st.datetimes(timezones=st.timezones()).filter(lambda d: d.tzinfo.key != "UTC")

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -14,6 +14,8 @@ from hypothesis import given
 from hypothesis.errors import Flaky, FlakyFailure
 from hypothesis.strategies import composite, integers, none
 
+from tests.common.utils import Why, xfail_on_crosshair
+
 
 @pytest.mark.parametrize(
     "e", [KeyboardInterrupt, SystemExit, GeneratorExit, ValueError]
@@ -46,6 +48,7 @@ def test_exception_propagates_fine_from_strategy(e):
         test_do_nothing()
 
 
+@xfail_on_crosshair(Why.other, strict=False)  # extra replay from backend switch
 @pytest.mark.parametrize("e", [KeyboardInterrupt, ValueError])
 def test_baseexception_no_rerun_no_flaky(e):
     runs = 0
@@ -69,6 +72,7 @@ def test_baseexception_no_rerun_no_flaky(e):
             test_raise_baseexception()
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)  # KI and GE only
 @pytest.mark.parametrize(
     "e", [KeyboardInterrupt, SystemExit, GeneratorExit, ValueError]
 )

--- a/hypothesis-python/tests/nocover/test_characters.py
+++ b/hypothesis-python/tests/nocover/test_characters.py
@@ -11,7 +11,9 @@
 import string
 from encodings.aliases import aliases
 
-from hypothesis import given, strategies as st
+import pytest
+
+from hypothesis import given, settings, strategies as st
 
 IDENTIFIER_CHARS = string.ascii_letters + string.digits + "_"
 
@@ -47,6 +49,7 @@ lots_of_encodings = sorted(x for x in set(aliases).union(aliases.values()) if _e
 assert len(lots_of_encodings) > 100  # sanity-check
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes 2000s")
 @given(data=st.data(), codec=st.sampled_from(lots_of_encodings))
 def test_can_constrain_characters_to_codec(data, codec):
     s = data.draw(st.text(st.characters(codec=codec), min_size=100))

--- a/hypothesis-python/tests/nocover/test_characters.py
+++ b/hypothesis-python/tests/nocover/test_characters.py
@@ -15,6 +15,8 @@ import pytest
 
 from hypothesis import given, settings, strategies as st
 
+from tests.common.utils import Why, xfail_on_crosshair
+
 IDENTIFIER_CHARS = string.ascii_letters + string.digits + "_"
 
 
@@ -23,6 +25,7 @@ def test_large_blacklist(c):
     assert c not in IDENTIFIER_CHARS
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)  # seems like a crosshair bug here
 @given(st.data())
 def test_arbitrary_blacklist(data):
     blacklist = data.draw(st.text(st.characters(max_codepoint=1000), min_size=1))

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -14,10 +14,16 @@ from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import Shrinker, node_program
 
-from tests.common.utils import counts_calls, non_covering_examples
+from tests.common.utils import (
+    Why,
+    counts_calls,
+    non_covering_examples,
+    xfail_on_crosshair,
+)
 from tests.conjecture.common import run_to_nodes, shrinking_from
 
 
+@xfail_on_crosshair(Why.nested_given)
 def test_lot_of_dead_nodes():
     @run_to_nodes
     def nodes(data):
@@ -80,6 +86,7 @@ def test_can_discard(monkeypatch):
     assert len(nodes) == n
 
 
+@xfail_on_crosshair(Why.nested_given)
 @given(st.integers(0, 255), st.integers(0, 255))
 def test_cached_with_masked_byte_agrees_with_results(a, b):
     def f(data):

--- a/hypothesis-python/tests/nocover/test_database_agreement.py
+++ b/hypothesis-python/tests/nocover/test_database_agreement.py
@@ -12,7 +12,9 @@ import os
 import shutil
 import tempfile
 
-from hypothesis import strategies as st
+import pytest
+
+from hypothesis import settings, strategies as st
 from hypothesis.database import (
     BackgroundWriteDatabase,
     DirectoryBasedExampleDatabase,
@@ -28,7 +30,6 @@ class DatabaseComparison(RuleBasedStateMachine):
         exampledir = os.path.join(self.tempd, "examples")
 
         self.dbs = [
-            DirectoryBasedExampleDatabase(exampledir),
             InMemoryExampleDatabase(),
             DirectoryBasedExampleDatabase(exampledir),
             BackgroundWriteDatabase(InMemoryExampleDatabase()),
@@ -75,4 +76,6 @@ class DatabaseComparison(RuleBasedStateMachine):
         shutil.rmtree(self.tempd)
 
 
-TestDBs = DatabaseComparison.TestCase
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="isn't threadsafe")
+def test_database_equivalence():
+    DatabaseComparison.TestCase().runTest()

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -20,7 +20,12 @@ from hypothesis.database import (
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from hypothesis.internal.entropy import deterministic_PRNG
 
-from tests.common.utils import all_values, non_covering_examples
+from tests.common.utils import (
+    Why,
+    all_values,
+    non_covering_examples,
+    xfail_on_crosshair,
+)
 
 
 def has_a_non_zero_byte(x):
@@ -39,6 +44,7 @@ def test_saves_incremental_steps_in_database():
     assert len(all_values(database)) > 1
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context, strict=False)
 def test_clears_out_database_as_things_get_boring():
     key = b"a database key"
     database = InMemoryExampleDatabase()
@@ -71,6 +77,7 @@ def test_clears_out_database_as_things_get_boring():
         raise AssertionError
 
 
+@xfail_on_crosshair(Why.other, strict=False)
 def test_trashes_invalid_examples():
     key = b"a database key"
     database = InMemoryExampleDatabase()

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -32,6 +32,7 @@ def has_a_non_zero_byte(x):
     return any(bytes(x))
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_saves_incremental_steps_in_database():
     key = b"a database key"
     database = InMemoryExampleDatabase()

--- a/hypothesis-python/tests/nocover/test_duplication.py
+++ b/hypothesis-python/tests/nocover/test_duplication.py
@@ -15,6 +15,8 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.strategies._internal import SearchStrategy
 
+from tests.common.utils import Why, xfail_on_crosshair
+
 
 class Blocks(SearchStrategy):
     def __init__(self, n):
@@ -37,6 +39,7 @@ def test_does_not_duplicate_blocks(n):
     assert set(counts.values()) == {1}
 
 
+@xfail_on_crosshair(Why.other, strict=False)  # CrosshairInternal for n>0
 @pytest.mark.parametrize("n", range(1, 5))
 def test_mostly_does_not_duplicate_blocks_even_when_failing(n):
     counts = Counter()

--- a/hypothesis-python/tests/nocover/test_emails.py
+++ b/hypothesis-python/tests/nocover/test_emails.py
@@ -8,10 +8,13 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from hypothesis import given
+import pytest
+
+from hypothesis import given, settings
 from hypothesis.strategies import emails, just
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~7 mins")
 @given(emails())
 def test_is_valid_email(address: str):
     local, at_, domain = address.rpartition("@")

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -26,6 +26,7 @@ from hypothesis import (
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
+from tests.common.utils import Why, xfail_on_crosshair
 from tests.conjecture.common import interesting_origin
 
 
@@ -115,6 +116,7 @@ def run_language_test_for(root, data, seed):
     assume(runner.interesting_examples)
 
 
+@xfail_on_crosshair(Why.nested_given)  # technically nested-engine, but same problem
 @settings(
     suppress_health_check=list(HealthCheck),
     deadline=None,

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -26,6 +26,7 @@ from hypothesis.strategies import (
 )
 
 from tests.common.debug import find_any, minimal
+from tests.common.utils import Why, xfail_on_crosshair
 
 ConstantLists = integers().flatmap(lambda i: lists(just(i)))
 
@@ -47,15 +48,13 @@ def test_in_order(x):
     assert x[0] < x[1]
 
 
+# crosshair just generates increasingly-long lists of [0.0]
+@xfail_on_crosshair(Why.undiscovered)
 def test_flatmap_retrieve_from_db():
-    constant_float_lists = floats(0, 1).flatmap(lambda x: lists(just(x)))
-
     track = []
 
-    db = ExampleDatabase()
-
-    @given(constant_float_lists)
-    @settings(database=db)
+    @given(floats(0, 1).flatmap(lambda x: lists(just(x))))
+    @settings(database=ExampleDatabase())
     def record_and_test_size(xs):
         if sum(xs) >= 1:
             track.append(xs)
@@ -98,6 +97,7 @@ def test_mixed_list_flatmap():
     assert set(result) == {False, ""}
 
 
+@xfail_on_crosshair(Why.undiscovered)  # for n >= 8 at least
 @pytest.mark.parametrize("n", range(1, 10))
 def test_can_shrink_through_a_binding(n):
     bool_lists = integers(0, 100).flatmap(
@@ -106,6 +106,7 @@ def test_can_shrink_through_a_binding(n):
     assert minimal(bool_lists, lambda x: x.count(True) >= n) == [True] * n
 
 
+@xfail_on_crosshair(Why.undiscovered)  # for n >= 8 at least
 @pytest.mark.parametrize("n", range(1, 10))
 def test_can_delete_in_middle_of_a_binding(n):
     bool_lists = integers(1, 100).flatmap(

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -85,6 +85,7 @@ def test_flatmap_has_original_strategy_repr():
     assert repr(ints) in repr(ints_up)
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~6 mins")
 def test_mixed_list_flatmap():
     s = lists(booleans().flatmap(lambda b: booleans() if b else text()))
 

--- a/hypothesis-python/tests/nocover/test_floating.py
+++ b/hypothesis-python/tests/nocover/test_floating.py
@@ -20,7 +20,7 @@ from hypothesis.internal.floats import float_to_int
 from hypothesis.strategies import data, floats, lists
 
 from tests.common.debug import find_any
-from tests.common.utils import fails
+from tests.common.utils import Why, fails, xfail_on_crosshair
 
 TRY_HARDER = settings(
     max_examples=1000, suppress_health_check=[HealthCheck.filter_too_much]
@@ -93,6 +93,7 @@ def test_is_not_int(x):
     assert x != int(x)
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @fails
 @given(floats())
 @TRY_HARDER
@@ -128,6 +129,7 @@ def test_floats_are_in_range(x, y, data):
     assert x <= t <= y
 
 
+@xfail_on_crosshair(Why.undiscovered)
 @pytest.mark.parametrize("neg", [False, True])
 @pytest.mark.parametrize("snan", [False, True])
 def test_can_find_negative_and_signaling_nans(neg, snan):

--- a/hypothesis-python/tests/nocover/test_from_type_recipe.py
+++ b/hypothesis-python/tests/nocover/test_from_type_recipe.py
@@ -8,7 +8,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from hypothesis import given, strategies as st
+import pytest
+
+from hypothesis import given, settings, strategies as st
 from hypothesis.strategies._internal.types import _global_type_lookup
 
 from tests.common.debug import find_any
@@ -32,6 +34,7 @@ def everything_except(excluded_types):
     )
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~250s")
 @given(
     excluded_types=st.lists(
         st.sampled_from(TYPES), min_size=1, max_size=3, unique=True

--- a/hypothesis-python/tests/nocover/test_given_error_conditions.py
+++ b/hypothesis-python/tests/nocover/test_given_error_conditions.py
@@ -8,18 +8,15 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
-
 from hypothesis import HealthCheck, given, reject, settings
 from hypothesis.errors import Unsatisfiable
 from hypothesis.strategies import integers
 
+from tests.common.utils import fails_with
 
-def test_raises_unsatisfiable_if_all_false():
-    @given(integers())
-    @settings(max_examples=50, suppress_health_check=list(HealthCheck))
-    def test_assume_false(x):
-        reject()
 
-    with pytest.raises(Unsatisfiable):
-        test_assume_false()
+@fails_with(Unsatisfiable)
+@given(integers())
+@settings(max_examples=50, suppress_health_check=list(HealthCheck))
+def test_raises_unsatisfiable_if_all_false(x):
+    reject()

--- a/hypothesis-python/tests/nocover/test_health_checks.py
+++ b/hypothesis-python/tests/nocover/test_health_checks.py
@@ -20,6 +20,8 @@ from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.strategies._internal.lazy import LazyStrategy
 
+pytestmark = pytest.mark.skipif(settings._current_profile == "crosshair", reason="slow")
+
 large_strategy = st.binary(min_size=7000, max_size=7000)
 too_large_strategy = st.tuples(large_strategy, large_strategy)
 

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -11,7 +11,10 @@
 from hypothesis import given, settings
 from hypothesis.strategies import integers
 
+from tests.common.utils import Why, xfail_on_crosshair
 
+
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():
     values = []
 

--- a/hypothesis-python/tests/nocover/test_limits.py
+++ b/hypothesis-python/tests/nocover/test_limits.py
@@ -10,7 +10,10 @@
 
 from hypothesis import given, settings, strategies as st
 
+from tests.common.utils import Why, xfail_on_crosshair
 
+
+@xfail_on_crosshair(Why.other, strict=False)  # might run fewer
 def test_max_examples_are_respected():
     counter = 0
 

--- a/hypothesis-python/tests/nocover/test_lstar.py
+++ b/hypothesis-python/tests/nocover/test_lstar.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import pytest
+
 import hypothesis.strategies as st
 from hypothesis import Phase, example, given, settings
 from hypothesis.internal.conjecture.dfa.lstar import LStar
@@ -20,6 +22,7 @@ def byte_order(draw):
     return ls[:n]
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes 300s")
 @example({0}, [1])
 @given(st.sets(st.integers(0, 255)), byte_order())
 # This test doesn't even use targeting at all, but for some reason the

--- a/hypothesis-python/tests/nocover/test_nesting.py
+++ b/hypothesis-python/tests/nocover/test_nesting.py
@@ -12,9 +12,10 @@ from pytest import raises
 
 from hypothesis import HealthCheck, Verbosity, given, settings, strategies as st
 
-from tests.common.utils import no_shrink
+from tests.common.utils import Why, no_shrink, xfail_on_crosshair
 
 
+@xfail_on_crosshair(Why.nested_given)
 def test_nesting_1():
     @given(st.integers(0, 100))
     @settings(

--- a/hypothesis-python/tests/nocover/test_precise_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_precise_shrinking.py
@@ -59,6 +59,11 @@ from hypothesis.internal.conjecture.shrinker import sort_key
 
 T = TypeVar("T")
 
+pytestmark = pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="using internals for testing in a way crosshair doesn't support",
+)
+
 
 def safe_draw(data, strategy):
     """Set up just enough of the Hypothesis machinery to use draw on

--- a/hypothesis-python/tests/nocover/test_precise_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_precise_shrinking.py
@@ -11,7 +11,7 @@
 """
 This file tests for our ability to make precise shrinks.
 
-Terminology: A shrink is *precise* if there is a single example (draw call) that
+Terminology: A shrink is *precise* if there is a single span (draw call) that
 it replaces, without leaving any of the data before or after that draw call changed.
 Otherwise, it is sloppy.
 

--- a/hypothesis-python/tests/nocover/test_randomization.py
+++ b/hypothesis-python/tests/nocover/test_randomization.py
@@ -20,7 +20,7 @@ from hypothesis import (
     strategies as st,
 )
 
-from tests.common.utils import no_shrink
+from tests.common.utils import Why, no_shrink, xfail_on_crosshair
 
 
 def test_seeds_off_internal_random():
@@ -32,6 +32,7 @@ def test_seeds_off_internal_random():
     assert x == y
 
 
+@xfail_on_crosshair(Why.nested_given)
 def test_nesting_with_control_passes_health_check():
     @given(st.integers(0, 100), st.random_module())
     @settings(

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -17,7 +17,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
 
 from tests.common.debug import find_any, minimal
-from tests.common.utils import flaky
+from tests.common.utils import Why, flaky, xfail_on_crosshair
 
 
 def test_can_generate_with_large_branching():
@@ -79,6 +79,7 @@ def test_drawing_many_near_boundary():
     assert len(ls) == size
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_can_use_recursive_data_in_sets():
     nested_sets = st.recursive(st.booleans(), st.frozensets, max_leaves=3)
     find_any(nested_sets, settings=settings(deadline=None))

--- a/hypothesis-python/tests/nocover/test_recursive.py
+++ b/hypothesis-python/tests/nocover/test_recursive.py
@@ -12,6 +12,8 @@ import sys
 import threading
 import warnings
 
+import pytest
+
 from hypothesis import HealthCheck, given, settings, strategies as st
 
 from tests.common.debug import find_any, minimal
@@ -115,6 +117,7 @@ def test_can_form_sets_of_recursive_data():
     assert len(xs) == size
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="not threadsafe")
 def test_drawing_from_recursive_strategy_is_thread_safe():
     shared_strategy = st.recursive(
         st.integers(), lambda s: st.lists(s, max_size=2), max_leaves=20

--- a/hypothesis-python/tests/nocover/test_regressions.py
+++ b/hypothesis-python/tests/nocover/test_regressions.py
@@ -14,7 +14,10 @@ from hypothesis import given, strategies as st
 from hypothesis._settings import note_deprecation
 from hypothesis.errors import HypothesisDeprecationWarning
 
+from tests.common.utils import Why, xfail_on_crosshair
 
+
+@xfail_on_crosshair(Why.other)
 def test_note_deprecation_blames_right_code_issue_652():
     msg = "this is an arbitrary deprecation warning message"
 
@@ -58,6 +61,8 @@ def test_unique_floats_with_nan_is_not_flaky_3926(ls):
 
 # this will take a while to find the regression, but will eventually trigger it.
 # min_value=0 is critical to trigger the probing behavior which exhausts our buffer.
+# https://github.com/pschanely/CrossHair/issues/285 for an upstream fix.
+@xfail_on_crosshair(Why.other, strict=False)
 @given(st.integers(min_value=0, max_value=1 << 25_000))
 def test_overrun_during_datatree_simulation_3874(n):
     pass

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -21,7 +21,7 @@ from hypothesis.internal.compat import bit_count
 from hypothesis.strategies._internal.strategies import SampledFromStrategy
 
 from tests.common.debug import find_any, minimal
-from tests.common.utils import fails_with
+from tests.common.utils import Why, fails_with, xfail_on_crosshair
 
 
 @pytest.mark.parametrize("size", [100, 10**5, 10**6, 2**25])
@@ -101,6 +101,7 @@ def test_flag_enum_repr_uses_class_not_a_list():
     assert lazy_repr == "sampled_from(tests.nocover.test_sampled_from.AFlag)"
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_exhaustive_flags():
     # Generate powerset of flag combinations. There are only 2^3 of them, so
     # we can reasonably expect that they are all are found.

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -15,7 +15,7 @@ import operator
 
 import pytest
 
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import bit_count
 from hypothesis.strategies._internal.strategies import SampledFromStrategy
@@ -130,6 +130,7 @@ def test_flags_minimizes_bit_count():
     )
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~10 mins")
 def test_flags_finds_all_bits_set():
     assert find_any(st.sampled_from(LargeFlag), lambda f: f == ~LargeFlag(0))
 

--- a/hypothesis-python/tests/nocover/test_simple_numbers.py
+++ b/hypothesis-python/tests/nocover/test_simple_numbers.py
@@ -17,6 +17,7 @@ from hypothesis import given
 from hypothesis.strategies import floats, integers, lists
 
 from tests.common.debug import minimal
+from tests.common.utils import Why, xfail_on_crosshair
 
 
 def test_minimize_negative_int():
@@ -116,6 +117,7 @@ def test_can_minimal_infinite_negative_float():
     assert minimal(floats(), lambda x: x < -sys.float_info.max)
 
 
+@xfail_on_crosshair(Why.undiscovered)  # sometimes
 def test_can_minimal_float_on_boundary_of_representable():
     minimal(floats(), lambda x: x + 1 == x and not math.isinf(x))
 
@@ -153,6 +155,7 @@ def test_minimal_fractional_float():
     assert minimal(floats(), lambda x: x >= 1.5) == 2
 
 
+@xfail_on_crosshair(Why.undiscovered)
 def test_minimizes_lists_of_negative_ints_up_to_boundary():
     result = minimal(
         lists(integers(), min_size=10),

--- a/hypothesis-python/tests/nocover/test_simple_strings.py
+++ b/hypothesis-python/tests/nocover/test_simple_strings.py
@@ -10,10 +10,15 @@
 
 import unicodedata
 
+import pytest
+
 from hypothesis import given, settings
 from hypothesis.strategies import text
 
 
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair", reason="takes ~10 minutes"
+)
 @given(text(min_size=1, max_size=1))
 @settings(max_examples=2000)
 def test_does_not_generate_surrogates(t):

--- a/hypothesis-python/tests/nocover/test_stateful.py
+++ b/hypothesis-python/tests/nocover/test_stateful.py
@@ -23,6 +23,8 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
 )
 
+from tests.common.utils import Why
+
 
 def run_to_notes(TestClass):
     TestCase = TestClass.TestCase
@@ -204,6 +206,10 @@ with_cheap_bad_machines = pytest.mark.parametrize(
     "machine", bad_machines, ids=[t.__name__ for t in bad_machines]
 )
 def test_bad_machines_fail(machine):
+    if machine is CanSwarm and Settings._current_profile == "crosshair":
+        # and also takes 10 minutes, on top of not finding the failure
+        pytest.xfail(reason=str(Why.undiscovered))
+
     test_class = machine.TestCase
     try:
         test_class().runTest()

--- a/hypothesis-python/tests/nocover/test_targeting.py
+++ b/hypothesis-python/tests/nocover/test_targeting.py
@@ -12,6 +12,8 @@ import pytest
 
 from hypothesis import Phase, given, seed, settings, strategies as st, target
 
+from tests.common.utils import Why, xfail_on_crosshair
+
 pytest_plugins = "pytester"
 
 TESTSUITE = """
@@ -57,6 +59,7 @@ def test_target_returns_value(a, b):
     assert isinstance(difference, int)
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_targeting_can_be_disabled():
     strat = st.lists(st.integers(0, 255))
 

--- a/hypothesis-python/tests/nocover/test_targeting.py
+++ b/hypothesis-python/tests/nocover/test_targeting.py
@@ -83,6 +83,9 @@ def test_targeting_can_be_disabled():
     assert score(enabled=True) > score(enabled=False)
 
 
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair", reason="takes ~15 minutes"
+)
 def test_issue_2395_regression():
     @given(d=st.floats().filter(lambda x: abs(x) < 1000))
     @settings(max_examples=1000, database=None)

--- a/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
@@ -12,13 +12,15 @@ from typing import Dict as _Dict, ForwardRef, Union
 
 import pytest
 
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.errors import ResolutionFailed
 
 from tests.common import utils
 
 # Mutually-recursive types
 # See https://github.com/HypothesisWorks/hypothesis/issues/2722
+
+pytestmark = pytest.mark.skipif(settings._current_profile == "crosshair", reason="slow")
 
 
 @given(st.data())

--- a/hypothesis-python/tests/nocover/test_unusual_settings_configs.py
+++ b/hypothesis-python/tests/nocover/test_unusual_settings_configs.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import pytest
+
 from hypothesis import HealthCheck, Verbosity, assume, given, settings, strategies as st
 
 
@@ -17,6 +19,7 @@ def test_single_example(n):
     pass
 
 
+@pytest.mark.skipif(settings._current_profile == "crosshair", reason="hangs/crashes")
 @settings(
     max_examples=1,
     database=None,


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/3914

To reproduce this locally, you can run `make check-crosshair-cover/nocover/niche` for the same command as in CI, but I'd recommend `pytest --hypothesis-profile=crosshair hypothesis-python/tests/{cover,nocover,datetime} -m xf_crosshair --runxfail` to select and run only the xfailed tests.

## Hypothesis' problems

- Vast majority of failures are `Flaky: Inconsistent results from replaying a failing test...` - mostly backend-specific failures; we've both
     - [x] improved reporting in this case to show the crosshair-specific traceback
     - [x] got most of the affected tests passing
- [x] Invalid internal boolean probability, e.g. `"hypothesis/internal/conjecture/data.py", line 2277, in draw_boolean` `assert p > 2 ** (-64)`, fixed in [`1f845e0` (#4049)](https://github.com/HypothesisWorks/hypothesis/pull/4049/commits/1f845e05a13d16e42bc3cc38bda0129b6d3c0e6e)
- [x] many of our test helpers involved nested use of `@given`, fixed in https://github.com/HypothesisWorks/hypothesis/commit/3315be63163218f5b4027128e80a2b856b512fcc
- symbolic outside context
  - [x] due to charmap, fixed in https://github.com/HypothesisWorks/hypothesis/commit/48e89a6a4f920be01c6163e986dd0051541a5ac4
  - [x] due to `target()`, fixed in [`85712ad` (#4049)](https://github.com/HypothesisWorks/hypothesis/pull/4049/commits/85712ad480b4274a9f2a6c84c3ec04c6eb8c0498)
- [x] avoid uninstalling `typing_extensions` when crosshair depends on it
- [x] tests which are not really expected to pass on other backends.  I'm slowly applying a backend-specific xfail decorator to them, `@xfail_on_crosshair(...)`.
   - [x] tests which expect to raise a healthcheck, and fail because our crosshair profile disables healthchecks.  Disable only `.too_slow` and `.filter_too_much`, and skip remaining affected tests under crosshair.
   - [x] undo some over-broad skips, e.g. various xfail decorators, pytestmarks, `-k 'not decimal'` once we're closer
- [x] provide a special exception type for when running the test or realizing values would hit a `PathTimeout`; see https://github.com/pschanely/hypothesis-crosshair/issues/21 and https://github.com/HypothesisWorks/hypothesis/issues/3914#issuecomment-2277023708
   - [x] and something to signal that we've exhausted Crosshair's ability to explore the test.  If this is sound, we've verified the function and can stop!  (and should record that in the stop_reason).  If unsound, we can continue testing with Hypothesis' default backend - so it's important to distinguish.
     https://github.com/HypothesisWorks/hypothesis/pull/4092


## Probably Crosshair's problems

- [x] Repeated-registration error, see https://github.com/pschanely/hypothesis-crosshair/issues/17
- [x] `RecursionError`, see https://github.com/pschanely/CrossHair/issues/294
- [x] `unsupported operand type(s) for -: 'float' and 'SymbolicFloat'` in `test_float_clamper`
- [x] `TypeError: descriptor 'keys' for 'dict' objects doesn't apply to a 'ShellMutableMap' object` (or `'values'` or `'items'`).  Fixed in https://github.com/pschanely/CrossHair/pull/269
- [x] `TypeError: _int() got an unexpected keyword argument 'base'`
- [x] Buffer not realized for hash function, fixed in https://github.com/pschanely/CrossHair/issues/272
- [x] Internal error for case-insensitive regex https://github.com/pschanely/CrossHair/issues/274
- [x] `typing.get_type_hints()` raises `ValueError`, see https://github.com/pschanely/CrossHair/issues/275
- [x] json round-trip error below
- [x] `TypeError` in bytes regex, see https://github.com/pschanely/CrossHair/issues/276
- [x] Invalid args to `provider.draw_boolean()` inside `FeatureStrategy`, see https://github.com/pschanely/hypothesis-crosshair/issues/18 
- [x] Support `dict(name=value)`, see https://github.com/pschanely/CrossHair/issues/279
- [x] Error in `PurePath` constructor, see https://github.com/pschanely/CrossHair/issues/280
- [x] `zlib.compress()` not symbolic, see https://github.com/pschanely/CrossHair/issues/286
- [x] `int.from_bytes(map(...), ...)`, see https://github.com/pschanely/CrossHair/issues/291
- [x] base64 support, see https://github.com/pschanely/CrossHair/issues/293
- [ ] `TypeError: conversion from SymbolicInt to Decimal is not supported`; see also snan below
- [x] `TypeVar` problem, see https://github.com/pschanely/CrossHair/issues/292
- [ ] Crash on way-too-large integer, see https://github.com/pschanely/CrossHair/issues/285
- [x] `RecursionError` inside Lark, see https://github.com/pschanely/CrossHair/issues/297
- [x] https://github.com/pschanely/CrossHair/issues/307

#### Error in `operator.eq(Decimal('sNaN'), an_int)`

```python-traceback
____ test_rewriting_does_not_compare_decimal_snan ____
  File "hypothesis/strategies/_internal/strategies.py", line 1017, in do_filtered_draw
    if self.condition(value):
TypeError: argument must be an integer
while generating 's' from integers(min_value=1, max_value=5).filter(functools.partial(eq, Decimal('sNaN')))
```

#### Cases where crosshair doesn't find a failing example but Hypothesis does

Seems fine, there are plenty of cases in the other direction.  Tracked with `@xfail_on_crosshair(Why.undiscovered)` in case we want to dig in later.

#### Nested use of the Hypothesis engine (e.g. given-inside-given)

This is just explicitly unsupported for now.  Hypothesis should probably offer some way for backends to declare that they don't support this, and then raise a helpful error message if you try anyway.