### PR TITLE
Store reference to time.perf_counter for gc accounting

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch addresses the issue of hypothesis potentially accessing
+mocked ``time.perf_counter`` during test execution (:issue:`4051`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -421,6 +421,10 @@ _gc_initialized = False
 _gc_start = 0
 _gc_cumulative_time = 0
 
+# Since gc_callback potentially runs in test context, and perf_counter
+# might be monkeypatched, we store a reference to the real one.
+_perf_counter = time.perf_counter
+
 
 def gc_cumulative_time() -> float:
     global _gc_initialized
@@ -430,7 +434,7 @@ def gc_cumulative_time() -> float:
             def gc_callback(phase, info):
                 global _gc_start, _gc_cumulative_time
                 try:
-                    now = time.perf_counter()
+                    now = _perf_counter()
                     if phase == "start":
                         _gc_start = now
                     elif phase == "stop" and _gc_start > 0:

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -116,6 +116,8 @@ def _consistently_increment_time(monkeypatch):
     # non-determinism due to GC running at arbitrary times, we patch the GC observer
     # to NOT increment time.
 
+    monkeypatch.setattr(junkdrawer, "_perf_counter", time)
+
     if hasattr(gc, "callbacks"):
         # ensure timer callback is added, then bracket it by freeze/unfreeze below
         junkdrawer.gc_cumulative_time()


### PR DESCRIPTION
Closes #4051.
