### PR TITLE
Avoid pretty printing overhead in most cases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves generation speed in some cases by avoiding pretty-printing overhead for non-failing examples.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -139,10 +139,9 @@ class BuildContext:
         self.known_object_printers = defaultdict(list)
 
     def record_call(self, obj, func, args, kwargs):
-        name = get_pretty_function_description(func)
         self.known_object_printers[IDKey(obj)].append(
-            lambda obj, p, cycle: p.maybe_repr_known_object_as_call(
-                obj, cycle, name, args, kwargs
+            lambda obj, p, cycle, *, _func=func: p.maybe_repr_known_object_as_call(
+                obj, cycle, get_pretty_function_description(_func), args, kwargs
             )
         )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -59,6 +59,7 @@ from hypothesis.control import (
     current_build_context,
     deprecate_random_in_strategy,
     note,
+    should_note,
 )
 from hypothesis.errors import (
     HypothesisSideeffectWarning,
@@ -2115,9 +2116,11 @@ class DataObject:
         if TESTCASE_CALLBACKS:
             self.conjecture_data._observability_args[desc] = to_jsonable(result)
 
-        printer.text(desc)
-        printer.pretty(result)
-        note(printer.getvalue())
+        # optimization to avoid needless printer.pretty
+        if should_note():
+            printer.text(desc)
+            printer.pretty(result)
+            note(printer.getvalue())
         return result
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/functions.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/functions.py
@@ -10,7 +10,7 @@
 
 from weakref import WeakKeyDictionary
 
-from hypothesis.control import note
+from hypothesis.control import note, should_note
 from hypothesis.errors import InvalidState
 from hypothesis.internal.reflection import (
     convert_positional_arguments,
@@ -50,13 +50,15 @@ class FunctionStrategy(SearchStrategy):
                 cache = self._cache.setdefault(inner, {})
                 if key not in cache:
                     cache[key] = data.draw(self.returns)
-                    rep = repr_call(self.like, args, kwargs, reorder=False)
-                    note(f"Called function: {rep} -> {cache[key]!r}")
+                    if should_note():  # optimization to avoid needless repr_call
+                        rep = repr_call(self.like, args, kwargs, reorder=False)
+                        note(f"Called function: {rep} -> {cache[key]!r}")
                 return cache[key]
             else:
                 val = data.draw(self.returns)
-                rep = repr_call(self.like, args, kwargs, reorder=False)
-                note(f"Called function: {rep} -> {val!r}")
+                if should_note():
+                    rep = repr_call(self.like, args, kwargs, reorder=False)
+                    note(f"Called function: {rep} -> {val!r}")
                 return val
 
         return inner

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -712,8 +712,13 @@ class ValidSyntaxRepr:
         return "ValidSyntaxRepr(...)"
 
 
-@given(st.none().map(InvalidSyntaxRepr))
-def test_pprint_with_call_or_repr_as_call(x):
+@given(st.data())
+def test_pprint_with_call_or_repr_as_call(data):
+    # mapped pprint repr only triggers for failing examples - which makes an
+    # end to end test given hypothesis difficult. fake our way around it.
+    current_build_context().is_final = True
+
+    x = data.draw(st.none().map(InvalidSyntaxRepr))
     p = pretty.RepresentationPrinter(context=current_build_context())
     p.pretty(x)
     assert p.getvalue() == "InvalidSyntaxRepr(None)"
@@ -721,6 +726,16 @@ def test_pprint_with_call_or_repr_as_call(x):
 
 @given(st.just(InvalidSyntaxRepr()).map(ValidSyntaxRepr))
 def test_pprint_with_call_or_repr_as_repr(x):
+    p = pretty.RepresentationPrinter(context=current_build_context())
+    p.pretty(x)
+    assert p.getvalue() == "ValidSyntaxRepr(...)"
+
+
+@given(st.data())
+def test_pprint_map_with_cycle(data):
+    current_build_context().is_final = True
+    x = data.draw(st.just(ValidSyntaxRepr()).map(lambda x: x))
+
     p = pretty.RepresentationPrinter(context=current_build_context())
     p.pretty(x)
     assert p.getvalue() == "ValidSyntaxRepr(...)"


### PR DESCRIPTION
Found while investigating #4014. This manually hoists the `should_note` call up a level to avoid computation when not necessary. 

This is particularly bad for `@given(st.data())`, which reprs each draw, and also `fixed_dictionaries`, which incurred lambda source extractions in `record_call` via `MappedStrategy.map`.

This takes https://github.com/HypothesisWorks/hypothesis/issues/4014#issuecomment-2257127814 from 5s -> 4.5s.