### PR TITLE
Use a more performant `LRUCache` for ir kwargs caches

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves our example generation performance by adjusting our internal cache implementation.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -41,7 +41,7 @@ from typing import (
 import attr
 
 from hypothesis.errors import Frozen, InvalidArgument, StopTest
-from hypothesis.internal.cache import LRUReusedCache
+from hypothesis.internal.cache import LRUCache
 from hypothesis.internal.compat import add_note, floor, int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
 from hypothesis.internal.conjecture.junkdrawer import (
@@ -200,9 +200,11 @@ NASTY_FLOATS = sorted(
 NASTY_FLOATS = list(map(float, NASTY_FLOATS))
 NASTY_FLOATS.extend([-x for x in NASTY_FLOATS])
 
-FLOAT_INIT_LOGIC_CACHE = LRUReusedCache(4096)
-
-POOLED_KWARGS_CACHE = LRUReusedCache(4096)
+# These caches, especially the kwargs cache, can be quite hot and so we prefer
+# LRUCache over LRUReusedCache for performance. We lose scan resistance, but
+# that's probably fine here.
+FLOAT_INIT_LOGIC_CACHE = LRUCache(4096)
+POOLED_KWARGS_CACHE = LRUCache(4096)
 
 DRAW_STRING_DEFAULT_MAX_SIZE = 10**10  # "arbitrarily large"
 

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -24,12 +24,12 @@ from hypothesis import (
     strategies as st,
 )
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.cache import GenericCache, LRUReusedCache
+from hypothesis.internal.cache import GenericCache, LRUCache, LRUReusedCache
 
 from tests.common.utils import skipif_emscripten
 
 
-class LRUCache(GenericCache):
+class LRUCacheAlternative(GenericCache):
     __slots__ = ("__tick",)
 
     def __init__(self, max_size):
@@ -84,7 +84,8 @@ class RandomCache(GenericCache):
 
 
 @pytest.mark.parametrize(
-    "implementation", [LRUCache, LFUCache, LRUReusedCache, ValueScored, RandomCache]
+    "implementation",
+    [LRUCache, LFUCache, LRUReusedCache, ValueScored, RandomCache, LRUCacheAlternative],
 )
 @example(writes=[(0, 0), (3, 0), (1, 0), (2, 0), (2, 0), (1, 0)], size=4)
 @example(writes=[(0, 0)], size=1)
@@ -298,6 +299,15 @@ def test_iterates_over_remaining_keys():
     for i in range(3):
         cache[i] = "hi"
     assert sorted(cache) == [1, 2]
+
+
+def test_lru_cache_is_actually_lru():
+    cache = LRUCache(2)
+    cache[1] = 1  # [1]
+    cache[2] = 2  # [1, 2]
+    cache[1]  # [2, 1]
+    cache[3] = 2  # [2, 1, 3] -> drop least recently used -> [1, 3]
+    assert list(cache) == [1, 3]
 
 
 @skipif_emscripten


### PR DESCRIPTION
Introduces a new, more performant, "pure LRU" cache in place of our scan resistant one. 

I'm unsure how desirable scan resistance here is. I imagine it was introduced back when this cache was being used purely for `ConjectureData` caches. We pay a pretty hefty price for it in the heap rebalancing, though, so I think the tradeoff here is worthwhile.

Should mostly address #4014. This takes https://github.com/HypothesisWorks/hypothesis/issues/4014#issuecomment-2257127814 from 5s -> 3.9s (#4063 not included)