### PR TITLE
Truncate novel prefixes

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch removes an assertion which was in fact possible in rare circumstances involving a small number of very large draws.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -999,7 +999,10 @@ class ConjectureRunner:
 
             self._current_phase = "generate"
             prefix = self.generate_novel_prefix()
-            assert len(prefix) <= BUFFER_SIZE
+            # it is possible, if unlikely, to generate a > BUFFER_SIZE novel prefix,
+            # as nodes in the novel tree may be variable sized due to eg integer
+            # probe retries.
+            prefix = prefix[:BUFFER_SIZE]
             if (
                 self.valid_examples <= small_example_cap
                 and self.call_count <= 5 * small_example_cap


### PR DESCRIPTION
Fixes a pathological bug I stumbled across while playing around with #3999:

```python
from hypothesis import *
from hypothesis import strategies as st

@given(st.data())
@settings(suppress_health_check=HealthCheck.all())
def f(data):
    data.conjecture_data.draw_integer(0, 1 << 30_000)
    data.conjecture_data.draw_integer(0, 1 << 30_000)
    data.conjecture_data.draw_integer(0, 1 << 30_000)

f()
```

```python
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1241, in _run
    self.generate_new_examples()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1002, in generate_new_examples
    assert len(prefix) <= BUFFER_SIZE
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

I didn't add this as a regression test because this property ends up failing with unsatisfiable after the assertion. 