### PR TITLE
Upgrade pinned dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,7 +231,7 @@ jobs:
       NODE_VERSION: 18
       # Note that the versions below must be updated in sync; we've automated
       # that with `update_pyodide_versions()` in our weekly cronjob.
-      PYODIDE_VERSION: 0.26.1
+      PYODIDE_VERSION: 0.26.2
       PYTHON_VERSION: 3.12.1
       EMSCRIPTEN_VERSION: 3.1.58
     steps:

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes compatibility with :pypi:`attrs==24.1.0 <attrs>`
+on the nightly build of CPython, 3.14.0 pre-alpha (:issue:`4067`).

--- a/hypothesis-python/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis-python/src/hypothesis/extra/django/_impl.py
@@ -204,7 +204,7 @@ def from_form(
 
     return _forms_impl(
         st.builds(
-            partial(form, **form_kwargs),
+            partial(form, **form_kwargs),  # type: ignore
             data=st.fixed_dictionaries(field_strategies),  # type: ignore
         )
     )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -155,9 +155,9 @@ class Status(IntEnum):
 
 
 @dataclass_transform()
-@attr.s(frozen=True, slots=True, auto_attribs=True)
+@attr.s(slots=True, frozen=True)
 class StructuralCoverageTag:
-    label: int
+    label: int = attr.ib()
 
 
 STRUCTURAL_COVERAGE_CACHE: Dict[int, StructuralCoverageTag] = {}

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/collection.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/collection.py
@@ -10,10 +10,7 @@
 
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.ordering import Ordering
-
-
-def identity(v):
-    return v
+from hypothesis.internal.conjecture.utils import identity
 
 
 class Collection(Shrinker):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/ordering.py
@@ -10,10 +10,7 @@
 
 from hypothesis.internal.conjecture.junkdrawer import find_integer
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
-
-
-def identity(v):
-    return v
+from hypothesis.internal.conjecture.utils import identity
 
 
 class Ordering(Shrinker):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -51,6 +51,10 @@ ONE_FROM_MANY_LABEL = calc_label_from_name("one more from many()")
 T = TypeVar("T")
 
 
+def identity(v: T) -> T:
+    return v
+
+
 def check_sample(
     values: Union[Type[enum.Enum], Sequence[T]], strategy_name: str
 ) -> Sequence[T]:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -83,7 +83,11 @@ from hypothesis.internal.compat import (
     get_type_hints,
     is_typed_named_tuple,
 )
-from hypothesis.internal.conjecture.utils import calc_label_from_cls, check_sample
+from hypothesis.internal.conjecture.utils import (
+    calc_label_from_cls,
+    check_sample,
+    identity,
+)
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.floats import float_of
 from hypothesis.internal.observability import TESTCASE_CALLBACKS
@@ -269,10 +273,6 @@ def sampled_from(
     if len(values) == 1:
         return just(values[0])
     return SampledFromStrategy(values, repr_)
-
-
-def identity(x):
-    return x
 
 
 @cacheable

--- a/hypothesis-python/tests/cover/test_attrs_inference.py
+++ b/hypothesis-python/tests/cover/test_attrs_inference.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
 import typing
 
 import attr
@@ -100,16 +101,21 @@ class HasPrivateAttribute:
     _x: int = attr.ib()
 
 
-@pytest.mark.parametrize("s", [st.just(42), ...])
+skip_on_314 = pytest.mark.skipif(sys.version_info[:2] >= (3, 14), reason="FIXME-py314")
+
+
+@pytest.mark.parametrize("s", [st.just(42), pytest.param(..., marks=skip_on_314)])
 def test_private_attribute(s):
     check_can_generate_examples(st.builds(HasPrivateAttribute, x=s))
 
 
+@skip_on_314
 def test_private_attribute_underscore_fails():
     with pytest.raises(TypeError, match="unexpected keyword argument '_x'"):
         check_can_generate_examples(st.builds(HasPrivateAttribute, _x=st.just(42)))
 
 
+@skip_on_314
 def test_private_attribute_underscore_infer_fails():
     # this has a slightly different failure case, because it goes through
     # attrs-specific resolution logic.
@@ -124,6 +130,6 @@ class HasAliasedAttribute:
     x: int = attr.ib(alias="crazyname")
 
 
-@pytest.mark.parametrize("s", [st.just(42), ...])
+@pytest.mark.parametrize("s", [st.just(42), pytest.param(..., marks=skip_on_314)])
 def test_aliased_attribute(s):
     check_can_generate_examples(st.builds(HasAliasedAttribute, crazyname=s))

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -12,14 +12,9 @@ import pytest
 
 from hypothesis import example, given, strategies as st
 from hypothesis.errors import HypothesisWarning, InvalidArgument
+from hypothesis.internal.conjecture.utils import identity
 
 from tests.common.utils import fails_with
-
-
-def identity(decorator):
-    # The "identity function hack" from https://peps.python.org/pep-0614/
-    # Method-chaining decorators are otherwise a syntax error in Python <= 3.8
-    return decorator
 
 
 @identity(example(False).via("Manually specified"))

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+from hypothesis.internal.conjecture.utils import identity
 from hypothesis.internal.reflection import get_pretty_function_description
 
 
@@ -163,10 +164,6 @@ def to_brackets():
 
 def test_can_handle_brackets_in_decorator_argument():
     assert get_pretty_function_description(to_brackets[0]) == "lambda: ()"
-
-
-def identity(x):
-    return x
 
 
 @arg_decorator(identity(lambda x: x + 1))

--- a/hypothesis-python/tests/dpcontracts/test_contracts.py
+++ b/hypothesis-python/tests/dpcontracts/test_contracts.py
@@ -14,11 +14,8 @@ from dpcontracts import require
 from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra.dpcontracts import fulfill
+from hypothesis.internal.conjecture.utils import identity
 from hypothesis.strategies import builds, integers
-
-
-def identity(x):
-    return x
 
 
 @require("division is undefined for zero", lambda args: args.n != 0)

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -8,15 +8,15 @@ annotated-types==0.7.0
     # via -r requirements/coverage.in
 async-timeout==4.0.3
     # via redis
-attrs==23.2.0
+attrs==24.1.0
     # via hypothesis (hypothesis-python/setup.py)
-black==24.4.2
+black==24.8.0
     # via -r requirements/coverage.in
 click==8.1.7
     # via
     #   -r requirements/coverage.in
     #   black
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via pytest-cov
 dpcontracts==0.6.0
     # via -r requirements/coverage.in
@@ -26,7 +26,7 @@ exceptiongroup==1.2.2 ; python_version < "3.11"
     #   pytest
 execnet==2.1.1
     # via pytest-xdist
-fakeredis==2.23.3
+fakeredis==2.23.5
     # via -r requirements/coverage.in
 iniconfig==2.0.0
     # via pytest
@@ -36,7 +36,7 @@ libcst==1.4.0
     # via -r requirements/coverage.in
 mypy-extensions==1.0.0
     # via black
-numpy==2.0.0
+numpy==2.0.1
     # via
     #   -r requirements/coverage.in
     #   pandas
@@ -57,9 +57,9 @@ pluggy==1.5.0
     # via pytest
 ptyprocess==0.7.0
     # via pexpect
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via -r requirements/coverage.in
-pytest==8.2.2
+pytest==8.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -78,7 +78,7 @@ pytz==2024.1
     #   pandas
 pyyaml==6.0.1
     # via libcst
-redis==5.0.7
+redis==5.0.8
     # via fakeredis
 six==1.16.0
     # via python-dateutil

--- a/requirements/fuzzing.txt
+++ b/requirements/fuzzing.txt
@@ -8,11 +8,11 @@ annotated-types==0.7.0
     # via -r requirements/coverage.in
 async-timeout==4.0.3
     # via redis
-attrs==23.2.0
+attrs==24.1.0
     # via
     #   hypothesis
     #   hypothesis (hypothesis-python/setup.py)
-black==24.4.2
+black==24.8.0
     # via
     #   -r requirements/coverage.in
     #   hypofuzz
@@ -29,7 +29,7 @@ click==8.1.7
     #   black
     #   flask
     #   hypothesis
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via
     #   hypofuzz
     #   pytest-cov
@@ -50,17 +50,17 @@ exceptiongroup==1.2.2 ; python_version < "3.11"
     #   pytest
 execnet==2.1.1
     # via pytest-xdist
-fakeredis==2.23.3
+fakeredis==2.23.5
     # via -r requirements/coverage.in
 flask==3.0.3
     # via dash
 hypofuzz==24.2.3
     # via -r requirements/fuzzing.in
-hypothesis[cli]==6.108.0
+hypothesis[cli]==6.108.9
     # via hypofuzz
 idna==3.7
     # via requests
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via dash
 iniconfig==2.0.0
     # via pytest
@@ -86,7 +86,7 @@ mypy-extensions==1.0.0
     # via black
 nest-asyncio==1.6.0
     # via dash
-numpy==2.0.0
+numpy==2.0.1
     # via
     #   -r requirements/coverage.in
     #   pandas
@@ -106,7 +106,7 @@ pexpect==4.9.0
     # via -r requirements/test.in
 platformdirs==4.2.2
     # via black
-plotly==5.22.0
+plotly==5.23.0
     # via dash
 pluggy==1.5.0
     # via pytest
@@ -114,11 +114,11 @@ psutil==6.0.0
     # via hypofuzz
 ptyprocess==0.7.0
     # via pexpect
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via -r requirements/coverage.in
 pygments==2.18.0
     # via rich
-pytest==8.2.2
+pytest==8.3.2
     # via
     #   -r requirements/test.in
     #   hypofuzz
@@ -138,7 +138,7 @@ pytz==2024.1
     #   pandas
 pyyaml==6.0.1
     # via libcst
-redis==5.0.7
+redis==5.0.8
     # via fakeredis
 requests==2.32.3
     # via
@@ -157,7 +157,7 @@ sortedcontainers==2.4.0
     #   fakeredis
     #   hypothesis
     #   hypothesis (hypothesis-python/setup.py)
-tenacity==8.5.0
+tenacity==9.0.0
     # via plotly
 tomli==2.0.1
     # via
@@ -182,5 +182,5 @@ zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.3.0
+setuptools==72.1.0
     # via dash

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    ./build.sh upgrade-requirements
 #
-attrs==23.2.0
+attrs==24.1.0
     # via hypothesis (hypothesis-python/setup.py)
 exceptiongroup==1.2.2 ; python_version < "3.11"
     # via
@@ -22,7 +22,7 @@ pluggy==1.5.0
     # via pytest
 ptyprocess==0.7.0
     # via pexpect
-pytest==8.2.2
+pytest==8.3.2
     # via
     #   -r requirements/test.in
     #   pytest-xdist

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -25,7 +25,6 @@ sphinx-selective-exclude
 tox
 twine
 types-click
-types-pkg_resources
 types-pytz
 types-redis
 typing-extensions

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -12,7 +12,7 @@ asgiref==3.8.1
     # via django
 asttokens==2.4.1
     # via stack-data
-attrs==23.2.0
+attrs==24.1.0
     # via hypothesis (hypothesis-python/setup.py)
 autoflake==2.3.1
     # via shed
@@ -22,13 +22,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via sphinx-codeautolink
-black==24.4.2
+black==24.8.0
     # via shed
 blinker==1.8.2
     # via pelican
 build==1.2.1
     # via pip-tools
-cachetools==5.3.3
+cachetools==5.4.0
     # via tox
 certifi==2024.7.4
     # via requests
@@ -48,9 +48,9 @@ colorama==0.4.6
     # via tox
 com2ann==0.3.0
     # via shed
-coverage==7.6.0
+coverage==7.6.1
     # via -r requirements/tools.in
-cryptography==42.0.8
+cryptography==43.0.0
     # via
     #   secretstorage
     #   types-pyopenssl
@@ -91,7 +91,7 @@ idna==3.7
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
     #   keyring
     #   twine
@@ -105,7 +105,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
@@ -119,7 +119,7 @@ jinja2==3.1.4
     #   sphinx
 jsonpointer==3.0.0
     # via sphinx-jsonschema
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lark==1.1.9
     # via -r requirements/tools.in
@@ -141,7 +141,7 @@ more-itertools==10.3.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.10.1
+mypy==1.11.1
     # via -r requirements/tools.in
 mypy-extensions==1.0.0
     # via
@@ -151,7 +151,7 @@ nh3==0.2.18
     # via readme-renderer
 nodeenv==1.9.1
     # via pyright
-numpy==2.0.0
+numpy==2.0.1
     # via -r requirements/tools.in
 ordered-set==4.1.0
     # via pelican
@@ -188,7 +188,7 @@ prompt-toolkit==3.0.47
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
@@ -207,9 +207,9 @@ pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pyright==1.1.371
+pyright==1.1.374
     # via -r requirements/tools.in
-pytest==8.2.2
+pytest==8.3.2
     # via -r requirements/tools.in
 python-dateutil==2.9.0.post0
     # via
@@ -217,7 +217,7 @@ python-dateutil==2.9.0.post0
     #   pelican
 pytz==2024.1
     # via feedgenerator
-pyupgrade==3.16.0
+pyupgrade==3.17.0
     # via shed
 pyyaml==6.0.1
     # via
@@ -242,7 +242,7 @@ rich==13.7.1
     # via
     #   pelican
     #   twine
-ruff==0.5.1
+ruff==0.5.6
     # via -r requirements/tools.in
 secretstorage==3.3.3
     # via keyring
@@ -260,7 +260,7 @@ sortedcontainers==2.4.0
     # via hypothesis (hypothesis-python/setup.py)
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.3.7
+sphinx==7.4.7
     # via
     #   -r requirements/tools.in
     #   sphinx-codeautolink
@@ -277,11 +277,11 @@ sphinx-rtd-theme==2.0.0
     # via -r requirements/tools.in
 sphinx-selective-exclude==1.0.3
     # via -r requirements/tools.in
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jquery==4.1
     # via
@@ -289,15 +289,15 @@ sphinxcontrib-jquery==4.1
     #   sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via django
 stack-data==0.6.3
     # via ipython
-tokenize-rt==5.2.0
+tokenize-rt==6.0.0
     # via pyupgrade
 tomli==2.0.1
     # via
@@ -310,7 +310,7 @@ tomli==2.0.1
     #   pytest
     #   sphinx
     #   tox
-tox==4.16.0
+tox==4.17.0
     # via -r requirements/tools.in
 traitlets==5.14.3
     # via
@@ -322,15 +322,13 @@ types-cffi==1.16.0.20240331
     # via types-pyopenssl
 types-click==7.1.8
     # via -r requirements/tools.in
-types-pkg-resources==0.1.3
-    # via -r requirements/tools.in
-types-pyopenssl==24.1.0.20240425
+types-pyopenssl==24.1.0.20240722
     # via types-redis
 types-pytz==2024.1.0.20240417
     # via -r requirements/tools.in
-types-redis==4.6.0.20240425
+types-redis==4.6.0.20240806
     # via -r requirements/tools.in
-types-setuptools==70.3.0.20240710
+types-setuptools==71.1.0.20240806
     # via types-cffi
 typing-extensions==4.12.2
     # via
@@ -352,13 +350,13 @@ watchfiles==0.22.0
     # via pelican
 wcwidth==0.2.13
     # via prompt-toolkit
-wheel==0.43.0
+wheel==0.44.0
     # via pip-tools
 zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.1.2
+pip==24.2
     # via pip-tools
-setuptools==70.3.0
+setuptools==72.1.0
     # via pip-tools

--- a/tooling/scripts/ensure-python.sh
+++ b/tooling/scripts/ensure-python.sh
@@ -49,7 +49,7 @@ if [ ! -e "$TARGET/bin/python" ] ; then
 
     if [ ! -d "$PYENV/.git" ]; then
       rm -rf "$PYENV"
-      git clone https://github.com/yyuu/pyenv.git "$PYENV"
+      git clone https://github.com/pyenv/pyenv.git "$PYENV"
     else
       back=$PWD
       cd "$PYENV"

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -290,10 +290,12 @@ def update_python_versions():
     ).group(1)
     best = {}
     for line in map(str.strip, result.splitlines()):
-        if m := re.match(r"(?:pypy)?3\.(?:[789]|\d\dt?)", line):
+        if m := re.match(r"(?:pypy)?3\.(?:[89]|\d\dt?)", line):
             key = m.group()
+            curr = best.get(key, line)
             if (
-                (stable.match(line) or not stable.match(best.get(key, line)))
+                (stable.match(line) or not stable.match(curr))
+                and not (line.endswith("-dev") and not curr.endswith("-dev"))
                 and int(key.split(".")[-1].rstrip("t")) >= int(min_minor_version)
                 and key.endswith("t") == line.endswith(("t", "t-dev"))
             ):
@@ -449,7 +451,7 @@ PYTHONS = {
     "3.10": "3.10.14",
     "3.11": "3.11.9",
     "3.12": "3.12.4",
-    "3.13": "3.13.0b3",
+    "3.13": "3.13.0rc1",
     "3.13t": "3.13t-dev",
     "3.14": "3.14-dev",
     "3.14t": "3.14t-dev",


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/4067.

Manually ran this because [`types-pkg-resources` got yanked](https://pypi.org/project/types-pkg-resources/), and so [our cronjob failed](https://github.com/HypothesisWorks/hypothesis/actions/runs/10256597580/job/28376009901).  I also adjusted our python version upgrade logic to pick the `.0rc1` over `-dev`.