### PR TITLE
Benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: Restore cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: |
           ~/.cache
@@ -298,12 +298,32 @@ jobs:
           ~/.local
           vendor/bundle
           .tox/
-        key: deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}-${{ matrix.task }}
+        key: deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
-          deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}
-          deps-${{ runner.os }}
+          bench-${{ runner.os }}
     - name: Run tests
-      run: ./build.sh benchmark
+      run: ./build.sh benchmark -- --hypothesis-bench-repeats=10 --hypothesis-bench-json=${{ github.workspace }}/bench.json
+    - name: Restore benchmark history
+      uses: actions/cache@v3
+      with:
+        path: ./bench-data.json
+        key: bench-${{ runner.os }}
+    - name: Process benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'customSmallerIsBetter'
+        output-file-path: ./bench.json
+        external-data-json-path: ./bench-data.json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        summary-always: true
+        #alert-threshold: "100%"
+        # comment-on-alert fails with permission error, see:
+        # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+        comment-on-alert: false
+        fail-on-alert: false
+        #save-data-file: {{ branch == master }}  # so that PR is always compared to master
+    - name: Show json
+      run: cat ./bench-data.json
 
   deploy:
     if: "github.event_name == 'push' && github.repository == 'HypothesisWorks/hypothesis'"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,7 +301,9 @@ jobs:
         key: deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}
         restore-keys: deps-${{ runner.os }}
     - name: Run tests
-      run: ./build.sh benchmark -- --hypothesis-bench-repeats=10 --hypothesis-bench-json=${{ github.workspace }}/bench.json
+      run: |
+        ./build.sh benchmark -- \
+          --hypothesis-bench-repeats=1 --count=20 --repeat-scope=session --hypothesis-bench-json=${{ github.workspace }}/bench.json
     - name: Restore benchmark history
       uses: actions/cache@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,6 +279,32 @@ jobs:
           parallel --max-procs 100% --max-args 20 --keep-order --line-buffer \
             python -m pytest -p no:cacheprovider <<< $TEST_FILES
 
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Restore cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache
+          ~/wheelhouse
+          ~/.local
+          vendor/bundle
+          .tox/
+        key: deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}-${{ matrix.task }}
+        restore-keys: |
+          deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}
+          deps-${{ runner.os }}
+    - name: Run tests
+      run: ./build.sh benchmark
+
   deploy:
     if: "github.event_name == 'push' && github.repository == 'HypothesisWorks/hypothesis'"
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -316,12 +316,12 @@ jobs:
         external-data-json-path: ./bench-data.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
         summary-always: true
-        #alert-threshold: "100%"
+        alert-threshold: "100%"
+        fail-on-alert: true
+        #save-data-file: {{ branch == master }}  # so that PR is always compared to master
         # comment-on-alert fails with permission error, see:
         # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
         comment-on-alert: false
-        fail-on-alert: false
-        #save-data-file: {{ branch == master }}  # so that PR is always compared to master
     - name: Show json
       run: cat ./bench-data.json
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,8 +324,8 @@ jobs:
         # comment-on-alert fails with permission error, see:
         # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
         comment-on-alert: false
-    - name: Show json
-      run: cat ./bench-data.json
+      #- name: Show json
+      #run: cat ./bench-data.json
 
   deploy:
     if: "github.event_name == 'push' && github.repository == 'HypothesisWorks/hypothesis'"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -299,15 +299,16 @@ jobs:
           vendor/bundle
           .tox/
         key: deps-${{ runner.os }}-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: |
-          bench-${{ runner.os }}
+        restore-keys: deps-${{ runner.os }}
     - name: Run tests
       run: ./build.sh benchmark -- --hypothesis-bench-repeats=10 --hypothesis-bench-json=${{ github.workspace }}/bench.json
     - name: Restore benchmark history
       uses: actions/cache@v3
       with:
         path: ./bench-data.json
-        key: bench-${{ runner.os }}
+        # ensure there is never an exact key match, so that the latest restore-key is used
+        key: bench-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: bench-${{ runner.os }}
     - name: Process benchmark result
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -317,8 +318,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         summary-always: true
         alert-threshold: "100%"
-        fail-on-alert: true
-        #save-data-file: {{ branch == master }}  # so that PR is always compared to master
+        fail-on-alert: false
         # comment-on-alert fails with permission error, see:
         # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
         comment-on-alert: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,41 +24,41 @@ jobs:
     strategy:
       matrix:
         task:
-          - check-whole-repo-tests
+          #- check-whole-repo-tests
           - lint
           - check-format
-          - check-coverage
-          - check-conjecture-coverage
-          - check-py38-cover
-          - check-py38-nocover
-          - check-py38-niche
-          - check-pypy38-cover
-          - check-py39-cover
-          - check-pypy39-cover
-          - check-py310-cover
-          - check-py310-nocover
-          - check-py310-niche
-          - check-pypy310-cover
+          #- check-coverage
+          #- check-conjecture-coverage
+          #- check-py38-cover
+          #- check-py38-nocover
+          #- check-py38-niche
+          #- check-pypy38-cover
+          #- check-py39-cover
+          #- check-pypy39-cover
+          #- check-py310-cover
+          #- check-py310-nocover
+          #- check-py310-niche
+          #- check-pypy310-cover
           # - check-py310-pyjion  # see notes in tox.ini
-          - check-py311-cover
-          - check-py311-nocover
-          - check-py311-niche
-          - check-py312-cover
-          - check-py312-nocover
-          - check-py312-niche
-          - check-py313-cover
-          - check-py313-nocover
-          - check-py313-niche
+          #- check-py311-cover
+          #- check-py311-nocover
+          #- check-py311-niche
+          #- check-py312-cover
+          #- check-py312-nocover
+          #- check-py312-niche
+          #- check-py313-cover
+          #- check-py313-nocover
+          #- check-py313-niche
           # - check-py313t-cover
           # - check-py313t-nocover
           # - check-py313t-niche
-          - check-py314-cover
-          - check-py314-nocover
-          - check-py314-niche
+          #- check-py314-cover
+          #- check-py314-nocover
+          #- check-py314-niche
           # - check-py314t-cover
           # - check-py314t-nocover
           # - check-py314t-niche
-          - check-quality
+          #- check-quality
           ## Skip all the (inactive/old) Rust and Ruby tests pending fixes
           # - lint-ruby
           # - check-ruby-tests
@@ -69,20 +69,20 @@ jobs:
           # - check-rust-tests
           # - audit-conjecture-rust
           # - lint-conjecture-rust
-          - check-py39-nose
-          - check-py39-pytest46
-          - check-py39-pytest54
-          - check-pytest62
-          - check-django50
-          - check-django42
-          - check-pandas22
-          - check-pandas21
-          - check-pandas20
-          - check-pandas15
-          - check-pandas14
-          - check-pandas13
-          - check-py39-pandas12
-          - check-py39-pandas11
+          #- check-py39-nose
+          #- check-py39-pytest46
+          #- check-py39-pytest54
+          #- check-pytest62
+          #- check-django50
+          #- check-django42
+          #- check-pandas22
+          #- check-pandas21
+          #- check-pandas20
+          #- check-pandas15
+          #- check-pandas14
+          #- check-pandas13
+          #- check-py39-pandas12
+          #- check-py39-pandas11
           ## `-cover` is too slow under crosshair; use a custom split
           # - check-crosshair-custom-cover/test_[a-d]*
           # - check-crosshair-custom-cover/test_[e-i]*
@@ -91,8 +91,8 @@ jobs:
           # - check-crosshair-custom-pytest/test_*
           # - check-crosshair-nocover
           # - check-crosshair-niche
-          - check-py38-oldestnumpy
-          - check-numpy-nightly
+          #- check-py38-oldestnumpy
+          #- check-numpy-nightly
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -146,6 +146,7 @@ jobs:
           hypothesis-python/branch-check*
 
   test-win:
+    if: ${{ false }}
     runs-on: windows-latest
     strategy:
       matrix:
@@ -194,6 +195,7 @@ jobs:
       run: python -m pytest --numprocesses auto ${{ matrix.whichtests == 'nocover' && 'hypothesis-python/tests/nocover' || 'hypothesis-python/tests/ --ignore=hypothesis-python/tests/nocover/ --ignore=hypothesis-python/tests/quality/ --ignore=hypothesis-python/tests/ghostwriter/ --ignore=hypothesis-python/tests/patching/' }}
 
   test-osx:
+    if: ${{ false }}
     runs-on: macos-latest
     strategy:
       matrix:
@@ -226,6 +228,7 @@ jobs:
   # See https://pyodide.org/en/stable/development/building-and-testing-packages.html#testing-packages-against-pyodide
   # and https://github.com/numpy/numpy/blob/9a650391651c8486d8cb8b27b0e75aed5d36033e/.github/workflows/emscripten.yml
   test-pyodide:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 18

--- a/hypothesis-python/tests/benchmark/conftest.py
+++ b/hypothesis-python/tests/benchmark/conftest.py
@@ -1,0 +1,109 @@
+import contextlib
+import json
+import statistics
+import subprocess
+import time
+
+import numpy as np
+import pytest
+
+# Performance measurements on shared CI workers is notoriously unreliable. Here,
+# some tricks are used to work around it:
+#
+# - Use the time.process_time (CPU time) timer, in an attempt to exclude the effect
+#   of uncontrolled concurrent processes on the server.
+# - Report the ratio between a fixed amount of synthetic work and @given, instead
+#   of absolute times.
+# - Run the test parts (synthetic/@given) interleaved many times, so that temporal
+#   load fluctuations impact both parts more equally.
+
+
+timer = time.process_time  # store a reference in case the time module is monkeypatched
+
+
+def stats(d):
+    # stable funny-statistics:
+    # throw away extreme quintiles, return the middle three as min/expected/max
+    return np.array(statistics.quantiles(d, n=6)[1:-1])
+
+
+@pytest.fixture
+def bench(request):
+
+    def benchmarker(test, exc=None):
+        repeat = max(5, request.config.option.hypothesis_bench_repeats)
+
+        def timed(f, number):
+            before = timer()
+            for _ in range(number):
+                with contextlib.suppress(exc) if exc else contextlib.nullcontext():
+                    f()
+            return timer() - before
+
+        def single_synthetic_example():
+            # add some exemplary synthetic baseline work (build a dict from a
+            # lambda fn with some getattrs mixed in, raise and catch an exception,
+            # plus the context manager inside timed)
+            try:
+                f = lambda i: i * i
+                f.a = {}
+                for i in range(500):
+                    f.a[i] = f(i)
+                assert not f.a
+            except AssertionError:
+                pass
+
+        time_inner = []
+        time_given = []
+        max_examples = test._hypothesis_internal_use_settings.max_examples
+
+        for _ in range(repeat):
+            # interleave measurements to smoothen effect of varying load
+            time_inner.append(timed(single_synthetic_example, number=max_examples))
+            time_given.append(timed(test, number=1))
+        ratio = stats(np.array(time_given) / np.array(time_inner))
+
+        request.config._bench_ratios[request.node.nodeid] = ratio
+
+        # Verify that we got our exception
+        if exc is not None:
+            try:
+                test()
+            except exc:
+                pass
+            else:
+                raise AssertionError(f"Did not see expected {exc}")
+
+    return benchmarker
+
+
+def pytest_addoption(parser):
+    parser.addoption("--hypothesis-bench-repeats", type=int, action="store", default=5)
+
+
+def pytest_configure(config):
+    config._bench_ratios = {}
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    terminalreporter.ensure_newline()
+    terminalreporter.section(
+        "relative overhead (per example) - lower is better"
+    )
+    for testid, (dmin, davg, dmax) in config._bench_ratios.items():
+        msg = f"{davg:5.1f}   ({dmin:5.1f} --{dmax:5.1f} )   {testid}"
+        terminalreporter.write_line(msg, yellow=True, bold=True)
+
+    proc = subprocess.run(["git", "show", "--summary", "HEAD^"], capture_output=True, encoding="utf8")
+    with open("bench.json", "w") as f:
+        # github-actions-benchmark `customSmallerIsBetter`
+        json.dump([
+            {
+                "name": testid,
+                "unit": "ratio",
+                "value": davg,
+                "range": [dmin, dmax],
+                "extra": proc.stdout,
+            }
+            for testid, (dmin, davg, dmax) in config._bench_ratios.items()
+        ], f)

--- a/hypothesis-python/tests/benchmark/conftest.py
+++ b/hypothesis-python/tests/benchmark/conftest.py
@@ -1,3 +1,13 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
 import contextlib
 import json
 import statistics
@@ -87,23 +97,26 @@ def pytest_configure(config):
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     terminalreporter.ensure_newline()
-    terminalreporter.section(
-        "relative overhead (per example) - lower is better"
-    )
+    terminalreporter.section("relative overhead (per example) - lower is better")
     for testid, (dmin, davg, dmax) in config._bench_ratios.items():
         msg = f"{davg:5.1f}   ({dmin:5.1f} --{dmax:5.1f} )   {testid}"
         terminalreporter.write_line(msg, yellow=True, bold=True)
 
-    proc = subprocess.run(["git", "show", "--summary", "HEAD^"], capture_output=True, encoding="utf8")
+    proc = subprocess.run(
+        ["git", "show", "--summary", "HEAD^"], capture_output=True, encoding="utf8"
+    )
     with open("bench.json", "w") as f:
         # github-actions-benchmark `customSmallerIsBetter`
-        json.dump([
-            {
-                "name": testid,
-                "unit": "ratio",
-                "value": davg,
-                "range": [dmin, dmax],
-                "extra": proc.stdout,
-            }
-            for testid, (dmin, davg, dmax) in config._bench_ratios.items()
-        ], f)
+        json.dump(
+            [
+                {
+                    "name": testid,
+                    "unit": "ratio",
+                    "value": davg,
+                    "range": [dmin, dmax],
+                    "extra": proc.stdout,
+                }
+                for testid, (dmin, davg, dmax) in config._bench_ratios.items()
+            ],
+            f,
+        )

--- a/hypothesis-python/tests/benchmark/test_strategies.py
+++ b/hypothesis-python/tests/benchmark/test_strategies.py
@@ -36,11 +36,11 @@ def test_integers_generation(bench, _vary_max_examples):
 def test_integers_shrink(bench):
 
     @given(st.integers(min_value=0))
-    @settings(database=None, phases=[Phase.generate, Phase.shrink], max_examples=50)
+    @settings(database=None, phases=[Phase.generate, Phase.shrink])
     def test(x):
         assert x < 10
 
-    bench(test, exc=AssertionError)
+    bench(test, expected_exc=AssertionError)
 
 
 def test_unique_lists_sampled_from(bench, _vary_max_examples):

--- a/hypothesis-python/tests/benchmark/test_strategies.py
+++ b/hypothesis-python/tests/benchmark/test_strategies.py
@@ -1,3 +1,13 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
 import pytest
 
 from hypothesis import Phase, given, settings, strategies as st
@@ -5,7 +15,9 @@ from hypothesis import Phase, given, settings, strategies as st
 
 @pytest.fixture(params=[10, 100])
 def _vary_max_examples(request):
-    settings.register_profile("_max_examples_fixture", settings(max_examples=request.param))
+    settings.register_profile(
+        "_max_examples_fixture", settings(max_examples=request.param)
+    )
     settings.load_profile("_max_examples_fixture")
     yield
     settings.load_profile("default")
@@ -43,17 +55,21 @@ def test_unique_lists_sampled_from(bench, _vary_max_examples):
 
 def test_fixed_dictionaries_generate(bench, _vary_max_examples):  # adapted from #4014
 
-    @given(st.fixed_dictionaries(
-        {
-            "fingerprints": st.fixed_dictionaries(
-                {
-                    key: st.dictionaries(st.integers(min_value=0, max_value=0x800),
-                                         st.integers(min_value=0, max_value=64))
-                    for key in range(8)
-                }
-            ),
-        }
-    ))
+    @given(
+        st.fixed_dictionaries(
+            {
+                "fingerprints": st.fixed_dictionaries(
+                    {
+                        key: st.dictionaries(
+                            st.integers(min_value=0, max_value=0x800),
+                            st.integers(min_value=0, max_value=64),
+                        )
+                        for key in range(8)
+                    }
+                ),
+            }
+        )
+    )
     @settings(database=None, phases=[Phase.generate])
     def test(x):
         pass
@@ -63,8 +79,12 @@ def test_fixed_dictionaries_generate(bench, _vary_max_examples):  # adapted from
 
 def test_dictionaries_generate(bench, _vary_max_examples):
 
-    @given(st.dictionaries(st.integers(min_value=0, max_value=2048),
-                           st.integers(min_value=0, max_value=64)))
+    @given(
+        st.dictionaries(
+            st.integers(min_value=0, max_value=2048),
+            st.integers(min_value=0, max_value=64),
+        )
+    )
     @settings(database=None, phases=[Phase.generate])
     def test(x):
         pass

--- a/hypothesis-python/tests/benchmark/test_strategies.py
+++ b/hypothesis-python/tests/benchmark/test_strategies.py
@@ -1,0 +1,72 @@
+import pytest
+
+from hypothesis import Phase, given, settings, strategies as st
+
+
+@pytest.fixture(params=[10, 100])
+def _vary_max_examples(request):
+    settings.register_profile("_max_examples_fixture", settings(max_examples=request.param))
+    settings.load_profile("_max_examples_fixture")
+    yield
+    settings.load_profile("default")
+
+
+def test_integers_generation(bench, _vary_max_examples):
+
+    @given(st.integers())
+    @settings(database=None, phases=[Phase.generate])
+    def test(x):
+        pass
+
+    bench(test)
+
+
+def test_integers_shrink(bench):
+
+    @given(st.integers(min_value=0))
+    @settings(database=None, phases=[Phase.generate, Phase.shrink], max_examples=50)
+    def test(x):
+        assert x < 10
+
+    bench(test, exc=AssertionError)
+
+
+def test_unique_lists_sampled_from(bench, _vary_max_examples):
+
+    @given(st.lists(st.sampled_from(range(2048)), unique=True))
+    @settings(database=None, phases=[Phase.generate])
+    def test(x):
+        pass
+
+    bench(test)
+
+
+def test_fixed_dictionaries_generate(bench, _vary_max_examples):  # adapted from #4014
+
+    @given(st.fixed_dictionaries(
+        {
+            "fingerprints": st.fixed_dictionaries(
+                {
+                    key: st.dictionaries(st.integers(min_value=0, max_value=0x800),
+                                         st.integers(min_value=0, max_value=64))
+                    for key in range(8)
+                }
+            ),
+        }
+    ))
+    @settings(database=None, phases=[Phase.generate])
+    def test(x):
+        pass
+
+    bench(test)
+
+
+def test_dictionaries_generate(bench, _vary_max_examples):
+
+    @given(st.dictionaries(st.integers(min_value=0, max_value=2048),
+                           st.integers(min_value=0, max_value=64)))
+    @settings(database=None, phases=[Phase.generate])
+    def test(x):
+        pass
+
+    bench(test)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -260,4 +260,4 @@ deps=
     -r../requirements/test.txt
     numpy
 commands=
-    python -bb -X dev -m pytest --hypothesis-bench-repeats=10 tests/benchmark {posargs}
+    python -bb -X dev -m pytest tests/benchmark {posargs}

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -258,6 +258,6 @@ commands=
 [testenv:benchmark]
 deps=
     -r../requirements/test.txt
-    numpy
+    pytest-repeat
 commands=
     python -bb -X dev -m pytest tests/benchmark {posargs}

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -248,10 +248,16 @@ commands =
         -m pytest -n auto tests/conjecture/ \
         --cov=hypothesis.internal.conjecture --cov-config=.coveragerc
 
-
 [testenv:examples3]
 deps=
     -r../requirements/test.txt
 commands=
     python -m pip install --editable examples/example_hypothesis_entrypoint
     python -bb -X dev -m pytest examples
+
+[testenv:benchmark]
+deps=
+    -r../requirements/test.txt
+    numpy
+commands=
+    python -bb -X dev -m pytest --hypothesis-bench-repeats=10 tests/benchmark {posargs}

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -495,6 +495,11 @@ def check_py310_pyjion(*args):
     run_tox("py310-pyjion", PYTHONS["3.10"], *args)
 
 
+@python_tests
+def benchmark(*args):
+    run_tox("benchmark", PYTHONS[ci_version], *args)
+
+
 @task()
 def tox(*args):
     if len(args) < 2:


### PR DESCRIPTION
Experimental PR for CI runs.

End goal is performance bench as part of CI.

---
Most numbers differ by only a few percent between CI and my local machine, despite runtime being almost 50% higher on CI.

There is one test that differs by >10%, the explanation is - in general terms, I haven't investigated - that the overhead is less similar to the synthetic "unit-of-work" workload than for the other tests.

Local:
```
================================================================ overhead relative to example cost - lower is better [5it] =================================================================
  6.7   (  6.6 --  6.7 )   hypothesis-python/tests/benchmark/test_strategies.py::test_integers_generation[10]
  5.6   (  5.6 --  5.7 )   hypothesis-python/tests/benchmark/test_strategies.py::test_integers_generation[100]
  7.6   (  7.4 --  7.7 )   hypothesis-python/tests/benchmark/test_strategies.py::test_integers_shrink
  8.0   (  7.9 --  8.3 )   hypothesis-python/tests/benchmark/test_strategies.py::test_unique_lists_sampled_from[10]
 11.5   ( 11.4 -- 12.4 )   hypothesis-python/tests/benchmark/test_strategies.py::test_unique_lists_sampled_from[100]
 27.7   ( 27.1 -- 27.8 )   hypothesis-python/tests/benchmark/test_strategies.py::test_fixed_dictionaries_generate[10]
 60.5   ( 58.9 -- 63.1 )   hypothesis-python/tests/benchmark/test_strategies.py::test_fixed_dictionaries_generate[100]
  9.8   (  8.8 -- 10.4 )   hypothesis-python/tests/benchmark/test_strategies.py::test_dictionaries_generate[10]
 28.0   ( 27.7 -- 31.3 )   hypothesis-python/tests/benchmark/test_strategies.py::test_dictionaries_generate[100]
==================================================================================== 9 passed in 6.73s =====================================================================================
```
CI:
```
========== overhead relative to example cost - lower is better [5it] ===========
  7.0   (  6.9 --  7.1 )   hypothesis-python/tests/benchmark/test_strategies.py::test_integers_generation[10]
  5.5   (  5.5 --  5.5 )   hypothesis-python/tests/benchmark/test_strategies.py::test_integers_generation[100]
  7.9   (  7.8 --  8.1 )   hypothesis-python/tests/benchmark/test_strategies.py::test_integers_shrink
  8.5   (  8.3 --  9.5 )   hypothesis-python/tests/benchmark/test_strategies.py::test_unique_lists_sampled_from[10]
 12.2   ( 11.9 -- 12.8 )   hypothesis-python/tests/benchmark/test_strategies.py::test_unique_lists_sampled_from[100]
 29.1   ( 28.9 -- 29.3 )   hypothesis-python/tests/benchmark/test_strategies.py::test_fixed_dictionaries_generate[10]
 68.0   ( 67.2 -- 75.6 )   hypothesis-python/tests/benchmark/test_strategies.py::test_fixed_dictionaries_generate[100]
  9.3   (  9.3 --  9.5 )   hypothesis-python/tests/benchmark/test_strategies.py::test_dictionaries_generate[10]
 28.7   ( 28.5 -- 28.8 )   hypothesis-python/tests/benchmark/test_strategies.py::test_dictionaries_generate[100]
============================== 9 passed in 9.98s ===============================
```

---

![Screenshot_20240819_092830](https://github.com/user-attachments/assets/e06654a3-d599-426c-bf8b-daac9668222c)

