### PR TITLE
Allow alternative backends to provide observability metadata

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,7 @@
 RELEASE_TYPE: minor
 
-:ref:`alternative-backends` can now implement a ``.get_observability_data()``
-method, providing the ``x['metadata']['backend']`` dictionary in our
-:doc:`observability output <observability>` (:issue:`3845` and `hypothesis-crosshair#22
+:ref:`alternative-backends` can now implement ``.observe_test_case()``
+and ``observe_information_message()`` methods, to record backend-specific
+metadata and messages in our :doc:`observability output <observability>`
+(:issue:`3845` and `hypothesis-crosshair#22
 <https://github.com/pschanely/hypothesis-crosshair/issues/22>`__).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+:ref:`alternative-backends` can now implement a ``.get_observability_data()``
+method, providing the ``x['metadata']['backend']`` dictionary in our
+:doc:`observability output <observability>` (:issue:`3845` and `hypothesis-crosshair#22
+<https://github.com/pschanely/hypothesis-crosshair/issues/22>`__).

--- a/hypothesis-python/docs/schema_observations.json
+++ b/hypothesis-python/docs/schema_observations.json
@@ -74,7 +74,7 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "enum": [ "info", "alert", "error"],
+                    "enum": ["info", "alert", "error"],
                     "description": "A tag which labels this observation as general information to show the user.  Hypothesis uses info messages to report statistics; alert or error messages can be provided by plugins."
                 },
                 "title": {
@@ -82,8 +82,8 @@
                     "description": "The title of this message"
                 },
                 "content": {
-                    "type": "string",
-                    "description": "The body of the message.  May use markdown."
+                    "type": ["string", "object"],
+                    "description": "The body of the message.  Strings are presumed to be human-readable messages in markdown format; dictionaries may contain arbitrary information (as for test-case metadata)."
                 },
                 "property": {
                     "type": "string",
@@ -94,7 +94,7 @@
                     "description": "unix timestamp at which we started running this test function, so that later analysis can group test cases by run."
                 }
             },
-            "required": [ "type", "title", "content", "property", "run_start"],
+            "required": ["type", "title", "content", "property", "run_start"],
             "additionalProperties": false
         }
     ]

--- a/hypothesis-python/scripts/other-tests.sh
+++ b/hypothesis-python/scripts/other-tests.sh
@@ -67,7 +67,7 @@ if [ "$(python -c $'import platform, sys; print(sys.version_info.releaselevel ==
   $PYTEST tests/ghostwriter/
   pip uninstall -y black
 
-  if [ "$(python -c "import platform; print(platform.python_implementation() not in {'PyPy', 'GraalVM'})")" = "True" ] ; then
+  if [ "$HYPOTHESIS_PROFILE" != "crosshair" ] && [ "$(python -c "import platform; print(platform.python_implementation() not in {'PyPy', 'GraalVM'})")" = "True" ] ; then
     $PYTEST tests/array_api tests/numpy
   fi
 fi

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1122,6 +1122,7 @@ class StateForActualGivenExecution:
                     data._observability_args
                 )
                 self._string_repr = data.provider.realize(self._string_repr)
+                backend_metadata = data.provider.get_observability_data()
                 tc = make_testcase(
                     start_timestamp=self._start_timestamp,
                     test_name_or_nodeid=self.test_identifier,
@@ -1132,6 +1133,7 @@ class StateForActualGivenExecution:
                     timing=self._timing_features,
                     coverage=tractable_coverage_report(trace) or None,
                     phase=phase,
+                    backend_metadata=backend_metadata,
                 )
                 deliver_json_blob(tc)
             self._timing_features = {}

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1186,6 +1186,14 @@ class ConjectureResult:
 BYTE_MASKS = [(1 << n) - 1 for n in range(8)]
 BYTE_MASKS[0] = 255
 
+_Lifetime: TypeAlias = Literal["test_case", "test_function"]
+
+
+class _BackendInfoMsg(TypedDict):
+    type: str
+    title: str
+    content: Union[str, Dict[str, Any]]
+
 
 class PrimitiveProvider(abc.ABC):
     # This is the low-level interface which would also be implemented
@@ -1212,7 +1220,7 @@ class PrimitiveProvider(abc.ABC):
     # lifetime can access the passed ConjectureData object.
     #
     # Non-hypothesis providers probably want to set a lifetime of test_function.
-    lifetime = "test_function"
+    lifetime: _Lifetime = "test_function"
 
     # Solver-based backends such as hypothesis-crosshair use symbolic values
     # which record operations performed on them in order to discover new paths.
@@ -1242,13 +1250,25 @@ class PrimitiveProvider(abc.ABC):
         """
         return value
 
-    def get_observability_data(self) -> Dict[str, Any]:
+    def observe_test_case(self) -> Dict[str, Any]:
         """Called at the end of the test case when observability mode is active.
 
         The return value should be a non-symbolic json-encodable dictionary,
         and will be included as `observation["metadata"]["backend"]`.
         """
         return {}
+
+    def observe_information_messages(
+        self, *, lifetime: _Lifetime
+    ) -> Iterable[_BackendInfoMsg]:
+        """Called at the end of each test case and again at end of the test function.
+
+        Return an iterable of `{type: info/alert/error, title: str, content: str|dict}`
+        dictionaries to be delivered as individual information messages.
+        (Hypothesis adds the `run_start` timestamp and `property` name for you.)
+        """
+        assert lifetime in ("test_case", "test_function")
+        yield from []
 
     @abc.abstractmethod
     def draw_boolean(
@@ -1314,7 +1334,6 @@ class HypothesisProvider(PrimitiveProvider):
     lifetime = "test_case"
 
     def __init__(self, conjecturedata: Optional["ConjectureData"], /):
-        assert conjecturedata is not None
         super().__init__(conjecturedata)
 
     def draw_boolean(

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1240,8 +1240,15 @@ class PrimitiveProvider(abc.ABC):
 
         The returned value should be non-symbolic.
         """
-
         return value
+
+    def get_observability_data(self) -> Dict[str, Any]:
+        """Called at the end of the test case when observability mode is active.
+
+        The return value should be a non-symbolic json-encodable dictionary,
+        and will be included as `observation["metadata"]["backend"]`.
+        """
+        return {}
 
     @abc.abstractmethod
     def draw_boolean(

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -17,7 +17,7 @@ import time
 import warnings
 from datetime import date, timedelta
 from functools import lru_cache
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from hypothesis.configuration import storage_directory
 from hypothesis.errors import HypothesisWarning
@@ -42,6 +42,7 @@ def make_testcase(
     timing: Dict[str, float],
     coverage: Optional[Dict[str, List[int]]] = None,
     phase: Optional[str] = None,
+    backend_metadata: Optional[Dict[str, Any]] = None,
 ) -> dict:
     if data.interesting_origin:
         status_reason = str(data.interesting_origin)
@@ -74,6 +75,7 @@ def make_testcase(
         "metadata": {
             "traceback": getattr(data.extra_information, "_expected_traceback", None),
             "predicates": data._observability_predicates,
+            "backend": backend_metadata or {},
             **_system_metadata(),
         },
         "coverage": coverage,

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -18,6 +18,7 @@ from hypothesis import Phase, settings
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.floats import next_down
+from hypothesis.internal.observability import TESTCASE_CALLBACKS
 from hypothesis.internal.reflection import proxies
 from hypothesis.reporting import default, with_reporter
 from hypothesis.strategies._internal.core import from_type, register_type_strategy
@@ -230,6 +231,16 @@ def raises_warning(expected_warning, match=None):
         with warnings.catch_warnings():
             warnings.simplefilter("error", category=expected_warning)
             yield r
+
+
+@contextlib.contextmanager
+def capture_observations():
+    ls = []
+    TESTCASE_CALLBACKS.append(ls.append)
+    try:
+        yield ls
+    finally:
+        TESTCASE_CALLBACKS.remove(ls.append)
 
 
 # Specifies whether we can represent subnormal floating point numbers.

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -8,8 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import contextlib
-
 import pytest
 
 from hypothesis import (
@@ -23,7 +21,6 @@ from hypothesis import (
     target,
 )
 from hypothesis.database import InMemoryExampleDatabase
-from hypothesis.internal.observability import TESTCASE_CALLBACKS
 from hypothesis.stateful import (
     RuleBasedStateMachine,
     invariant,
@@ -31,15 +28,7 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
 )
 
-
-@contextlib.contextmanager
-def capture_observations():
-    ls = []
-    TESTCASE_CALLBACKS.append(ls.append)
-    try:
-        yield ls
-    finally:
-        TESTCASE_CALLBACKS.remove(ls.append)
+from tests.common.utils import capture_observations
 
 
 @seed("deterministic so we don't miss some combination of features")


### PR DESCRIPTION
@pschanely you can put whatever (json-encodable) stuff in here that you might want 😁 

@hgoldstein95 fyi, you might be interested in https://github.com/pschanely/hypothesis-crosshair/issues/22 too.