### PR TITLE
Serialize global random generator initialization when invoking hypothesis under concurrent loads 

### DIFF
--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -26,6 +26,7 @@ import zlib
 from collections import defaultdict
 from functools import partial
 from random import Random
+import threading
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -155,7 +156,7 @@ TestFunc = TypeVar("TestFunc", bound=Callable)
 running_under_pytest = False
 pytest_shows_exceptiongroups = True
 global_force_seed = None
-_hypothesis_global_random = None
+_hypothesis_global_random = threading.local()
 
 
 @attr.s()
@@ -639,9 +640,9 @@ def get_random_for_wrapped_test(test, wrapped_test):
         return Random(global_force_seed)
     else:
         global _hypothesis_global_random
-        if _hypothesis_global_random is None:  # pragma: no cover
-            _hypothesis_global_random = Random()
-        seed = _hypothesis_global_random.getrandbits(128)
+        if _hypothesis_global_random.r is None:  # pragma: no cover
+            _hypothesis_global_random.r = Random()
+        seed = _hypothesis_global_random.r.getrandbits(128)
         wrapped_test._hypothesis_internal_use_generated_seed = seed
         return Random(seed)
 

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -640,7 +640,7 @@ def get_random_for_wrapped_test(test, wrapped_test):
         return Random(global_force_seed)
     else:
         global _hypothesis_global_random
-        if _hypothesis_global_random.r is None:  # pragma: no cover
+        if not hasattr(_hypothesis_global_random.r) is None:  # pragma: no cover
             _hypothesis_global_random.r = Random()
         seed = _hypothesis_global_random.r.getrandbits(128)
         wrapped_test._hypothesis_internal_use_generated_seed = seed

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -14,6 +14,7 @@ import random
 import sys
 import warnings
 from itertools import count
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, Hashable, Tuple
 from weakref import WeakValueDictionary
 
@@ -54,6 +55,7 @@ class NumpyRandomWrapper:
 
 
 NP_RANDOM = None
+RANDOM_LOCK = Lock()
 
 
 if not (PYPY or GRAALPY):
@@ -192,9 +194,10 @@ def deterministic_PRNG(seed=0):
     bad idea in principle, and breaks all kinds of independence assumptions
     in practice.
     """
-    if hypothesis.core._hypothesis_global_random is None:  # pragma: no cover
-        hypothesis.core._hypothesis_global_random = random.Random()
-        register_random(hypothesis.core._hypothesis_global_random)
+    with RANDOM_LOCK:
+        if hypothesis.core._hypothesis_global_random is None:  # pragma: no cover
+            hypothesis.core._hypothesis_global_random = random.Random()
+            register_random(hypothesis.core._hypothesis_global_random)
 
     seed_all, restore_all = get_seeder_and_restorer(seed)
     seed_all()

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -132,11 +132,11 @@ def test_given_does_not_pollute_state():
 
         test()
         state_a = random.getstate()
-        state_a2 = core._hypothesis_global_random.getstate()
+        state_a2 = core._hypothesis_global_random.r.getstate()
 
         test()
         state_b = random.getstate()
-        state_b2 = core._hypothesis_global_random.getstate()
+        state_b2 = core._hypothesis_global_random.r.getstate()
 
         assert state_a == state_b
         assert state_a2 != state_b2
@@ -146,11 +146,11 @@ def test_find_does_not_pollute_state():
     with deterministic_PRNG():
         find(st.random_module(), lambda r: True)
         state_a = random.getstate()
-        state_a2 = core._hypothesis_global_random.getstate()
+        state_a2 = core._hypothesis_global_random.r.getstate()
 
         find(st.random_module(), lambda r: True)
         state_b = random.getstate()
-        state_b2 = core._hypothesis_global_random.getstate()
+        state_b2 = core._hypothesis_global_random.r.getstate()
 
         assert state_a == state_b
         assert state_a2 != state_b2

--- a/hypothesis-python/tests/nocover/test_randomization.py
+++ b/hypothesis-python/tests/nocover/test_randomization.py
@@ -17,9 +17,9 @@ from tests.common.utils import no_shrink
 
 def test_seeds_off_internal_random():
     s = settings(phases=no_shrink, database=None)
-    r = core._hypothesis_global_random.getstate()
+    r = core._hypothesis_global_random.r.getstate()
     x = find(st.integers(), lambda x: True, settings=s)
-    core._hypothesis_global_random.setstate(r)
+    core._hypothesis_global_random.r.setstate(r)
     y = find(st.integers(), lambda x: True, settings=s)
     assert x == y
 


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/4028#issuecomment-2311829962

This PR adds a lock around the initialization of the Hypothesis global random generator, this prevents issues such as https://github.com/HypothesisWorks/hypothesis/issues/4028#issuecomment-2311127923 from occurring under free-threaded Python.