### PR TITLE
Remove now-incorrect numpy assertion

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch removes a now-incorrect internal assertion about numpy's typing after recent numpy changes (currently only in numpy's nightly release).

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -1305,7 +1305,6 @@ def _dtype_from_args(args):
     else:
         # Two args: ndarray[shape, type], NDArray[*]
         assert len(args) == 2
-        assert args[0] is Any
         dtype = _unpack_dtype(args[1])
 
     if dtype is Any:


### PR DESCRIPTION
Failed on numpy nightlies: closes https://github.com/HypothesisWorks/hypothesis/issues/4102. 

This is in `src/`, so actual users will start hitting this once the numpy nightly becomes not nightly.

(possibly this was the root cause of the other #4102 errors, we'll see what ci says.)