### PR TITLE
Make cache.clear() thread-global

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Very minor internal change.

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -167,8 +167,7 @@ class GenericCache:
 
     def clear(self):
         """Remove all keys, regardless of their pinned status."""
-        del self.data[:]
-        self.keys_to_indices.clear()
+        self._threadlocal = threading.local()
 
     def __repr__(self):
         return "{" + ", ".join(f"{e.key!r}: {e.value!r}" for e in self.data) + "}"


### PR DESCRIPTION
In the threaded case, clearing the cache only for the current thread might lead to invalid cache entries staying alive on other threads.

This may never be a problem in practice, and threading is unsupported; but given the subtlety that any issue arising from this would have, it seems safer to just clear it for all threads.
