### PR TITLE
WIP: Add copying where it might be necessary

### DIFF
--- a/hypothesis-python/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis-python/src/hypothesis/extra/ghostwriter.py
@@ -95,6 +95,7 @@ from typing import (
     ForwardRef,
     NamedTuple,
     Optional,
+    Set,
     TypeVar,
     Union,
     get_args,


### PR DESCRIPTION
**NOTE**: This is not ready for review, I have a significant amount of documentation to add, I need to update the test suite, and I missed several cases that I am writing out below. I am posting this early to receive feedback on the broad strokes of the approach, the implementation is (right now) entirely incorrect.

**NOTE**: a re-open of #4118, but with best practices observed!

## Description
A proposed fix for #4113 that identifies what parameters might be mutated within a function that [Ghostwriter](https://hypothesis.readthedocs.io/en/latest/ghostwriter.html) is called on. To prevent side effects (particularly in equivalence mode), adds a call to `copy.deepcopy` to the parameter in the test function.

Right now, I mark a variable as potentially modified if:
- there is an instance of is on the left hand side of an `ast.Assign` or `ast.AugAssign` that is not inside an `ast.Subscript` or `ast.Slice`. This includes when it is being indexed into or an attribute of it is being assigned
- It or any of its attributes are being `Call`ed.  Even if this isn't on the left-hand side of an assignment, it is safe to assume that any call may create side effects. 

## Todo 
- [ ] Ignore names used inside `value` of `ast.Subscript` or `slice` in `ast.Slice`
- [ ] Get unit test passage to parity with main branch
- [ ] Correct documentation for `potentially_modified_vars`
- [ ] Rename visitors to have more intention-revealing names

