### PR TITLE
Add better support for pretty-printing record types

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This improves the formatting of dataclasses and attrs classes when printing
+falsifying examples.

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -214,6 +214,24 @@ class RepresentationPrinter:
                                 meth = cls._repr_pretty_
                                 if callable(meth):
                                     return meth(obj, self, cycle)
+                            if hasattr(cls, "__attrs_attrs__"):
+                                return pprint_fields(
+                                    obj,
+                                    self,
+                                    cycle,
+                                    [at.name for at in cls.__attrs_attrs__ if at.init],
+                                )
+                            if hasattr(cls, "__dataclass_fields__"):
+                                return pprint_fields(
+                                    obj,
+                                    self,
+                                    cycle,
+                                    [
+                                        k
+                                        for k, v in cls.__dataclass_fields__.items()
+                                        if v.init
+                                    ],
+                                )
                 # Now check for object-specific printers which show how this
                 # object was constructed (a Hypothesis special feature).
                 printers = self.known_object_printers[IDKey(obj)]
@@ -712,6 +730,20 @@ def _repr_pprint(obj, p, cycle):
         if idx:
             p.break_()
         p.text(output_line)
+
+
+def pprint_fields(obj, p, cycle, fields):
+    name = obj.__class__.__name__
+    if cycle:
+        return p.text(f"{name}(...)")
+    with p.group(1, name + "(", ")"):
+        for idx, field in enumerate(fields):
+            if idx:
+                p.text(",")
+                p.breakable()
+            p.text(field)
+            p.text("=")
+            p.pretty(getattr(obj, field))
 
 
 def _function_pprint(obj, p, cycle):


### PR DESCRIPTION
This PR adds logic so that attrs and dataclass defined classes get pretty printed directly via their repr.

Use case: They mostly pretty print fine with reprs, but I wanted to define custom pretty printing for a type that was contained in a dataclass, which doesn't work if you rely on repr printing.

I've made this a minor release because it changes user visible behaviour in a way that we have no compatibility requirements on but that is arguably undesirable in some cases. In particular if a type is defined this way but has a custom repr, we will now ignore that repr. There's plenty of precedent for us doing that, and the logic of when we should use the repr after all is quite fiddly, so I think this is OK.