### PR TITLE
Filter-rewriting for more efficient `from_type(pydantic.types.condate)`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of :func:`~hypothesis.strategies.from_type` with
+`pydantic.types.condate <https://docs.pydantic.dev/latest/api/types/#pydantic.types.condate>`__
+(:issue:`4000`).

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -236,9 +236,9 @@ def get_numeric_predicate_bounds(predicate: Predicate) -> ConstructivePredicate:
         options = {
             # We're talking about op(arg, x) - the reverse of our usual intuition!
             operator.lt: {"min_value": arg, "exclude_min": True},  # lambda x: arg < x
-            operator.le: {"min_value": arg},  # lambda x: arg <= x
-            operator.eq: {"min_value": arg, "max_value": arg},  # lambda x: arg == x
-            operator.ge: {"max_value": arg},  # lambda x: arg >= x
+            operator.le: {"min_value": arg},  #                      lambda x: arg <= x
+            operator.eq: {"min_value": arg, "max_value": arg},  #    lambda x: arg == x
+            operator.ge: {"max_value": arg},  #                      lambda x: arg >= x
             operator.gt: {"max_value": arg, "exclude_max": True},  # lambda x: arg > x
             # Special-case our default predicates for length bounds
             min_len: {"min_value": arg, "len": True},

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import datetime as dt
 import decimal
 import math
 import operator
@@ -624,3 +625,20 @@ def test_regex_filter_rewriting(data, strategy, pattern, method):
 @given(st.text().filter(re.compile("abc").sub))
 def test_error_on_method_which_requires_multiple_args(_):
     pass
+
+
+def test_dates_filter_rewriting():
+    today = dt.date.today()
+
+    assert st.dates().filter(partial(operator.lt, dt.date.max)).is_empty
+    assert st.dates().filter(partial(operator.gt, dt.date.min)).is_empty
+    assert st.dates(min_value=today).filter(partial(operator.gt, today)).is_empty
+    assert st.dates(max_value=today).filter(partial(operator.lt, today)).is_empty
+
+    bare = unwrap_strategies(st.dates())
+    assert bare.filter(partial(operator.ge, dt.date.max)) is bare
+    assert bare.filter(partial(operator.le, dt.date.min)) is bare
+
+    new = bare.filter(partial(operator.le, today))
+    assert not new.is_empty
+    assert new is not bare


### PR DESCRIPTION
Closes #4000; dealing with timezones makes datetimes and times not worth the trouble.