### PR TITLE
Fold integer endpoint upweighting into `weights=`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release improves integer shrinking by folding the endpoint upweighting for :func:`~hypothesis.strategies.integers` into the ``weights`` parameter of our IR (:issue:`3921`).
+
+If you maintain an alternative backend as part of our (for now explicitly unstable) :ref:`alternative-backends`, this release changes the type of the ``weights`` parameter to ``draw_integer`` and may be a breaking change for you.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -2374,18 +2374,7 @@ class ConjectureData:
         if self.provider.avoid_realization:
             return kwargs
 
-        key = []
-        for k, v in kwargs.items():
-            if ir_type == "float" and k in ["min_value", "max_value"]:
-                # handle -0.0 vs 0.0, etc.
-                v = float_to_int(v)
-            elif ir_type == "integer" and k == "weights":
-                # make hashable
-                v = v if v is None else tuple(v)
-            key.append((k, v))
-
-        key = (ir_type, *sorted(key))
-
+        key = (ir_type, *ir_kwargs_key(ir_type, kwargs))
         try:
             return POOLED_KWARGS_CACHE[key]
         except KeyError:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1491,17 +1491,13 @@ class HypothesisProvider(PrimitiveProvider):
                 self._cd, forced=None if forced is None else 0, fake_forced=fake_forced
             )
 
-            return (
-                self._draw_bounded_integer(
-                    min_value,
-                    max_value,
-                    forced=forced,
-                    center=shrink_towards,
-                    fake_forced=fake_forced,
-                )
-                if idx == 0
+            return self._draw_bounded_integer(
+                min_value,
+                max_value,
                 # implicit reliance on dicts being sorted for determinism
-                else list(weights)[idx - 1]
+                forced=forced if idx == 0 else list(weights)[idx - 1],
+                center=shrink_towards,
+                fake_forced=fake_forced,
             )
 
         if min_value is None and max_value is None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -2139,6 +2139,9 @@ class ConjectureData:
             # complicates shrinking as we can no longer assume we can force
             # a value to the unmapped probability mass if that mass might be 0.
             assert sum(weights.values()) < 1
+            # similarly, things get simpler if we assume every value is possible.
+            # we'll want to drop this restriction eventually.
+            assert all(w != 0 for w in weights.values())
 
         if forced is not None and (min_value is None or max_value is None):
             # We draw `forced=forced - shrink_towards` here internally, after clamping.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -88,7 +88,7 @@ T = TypeVar("T")
 class IntegerKWargs(TypedDict):
     min_value: Optional[int]
     max_value: Optional[int]
-    weights: Optional[Sequence[float]]
+    weights: Optional[dict[int, float]]
     shrink_towards: int
 
 
@@ -1287,7 +1287,7 @@ class PrimitiveProvider(abc.ABC):
         max_value: Optional[int] = None,
         *,
         # weights are for choosing an element index from a bounded range
-        weights: Optional[Sequence[float]] = None,
+        weights: Optional[dict[int, float]] = None,
         shrink_towards: int = 0,
         forced: Optional[int] = None,
         fake_forced: bool = False,
@@ -1456,8 +1456,7 @@ class HypothesisProvider(PrimitiveProvider):
         min_value: Optional[int] = None,
         max_value: Optional[int] = None,
         *,
-        # weights are for choosing an element index from a bounded range
-        weights: Optional[Sequence[float]] = None,
+        weights: Optional[dict[int, float]] = None,
         shrink_towards: int = 0,
         forced: Optional[int] = None,
         fake_forced: bool = False,
@@ -1475,22 +1474,35 @@ class HypothesisProvider(PrimitiveProvider):
             assert min_value is not None
             assert max_value is not None
 
-            sampler = Sampler(weights, observe=False)
-            gap = max_value - shrink_towards
+            # format of weights is a mapping of ints to p, where sum(p) < 1.
+            # The remaining probability mass is uniformly distributed over
+            # *all* ints (not just the unmapped ones; this is somewhat undesirable,
+            # but simplifies things).
+            #
+            # We assert that sum(p) is strictly less than 1 because it simplifies
+            # handling forced values when we can force into the unmapped probability
+            # mass. We should eventually remove this restriction.
+            sampler = Sampler(
+                [1 - sum(weights.values()), *weights.values()], observe=False
+            )
+            # if we're forcing, it's easiest to force into the unmapped probability
+            # mass and then force the drawn value after.
+            idx = sampler.sample(
+                self._cd, forced=None if forced is None else 0, fake_forced=fake_forced
+            )
 
-            forced_idx = None
-            if forced is not None:
-                if forced >= shrink_towards:
-                    forced_idx = forced - shrink_towards
-                else:
-                    forced_idx = shrink_towards + gap - forced
-            idx = sampler.sample(self._cd, forced=forced_idx, fake_forced=fake_forced)
-
-            # For range -2..2, interpret idx = 0..4 as [0, 1, 2, -1, -2]
-            if idx <= gap:
-                return shrink_towards + idx
-            else:
-                return shrink_towards - (idx - gap)
+            return (
+                self._draw_bounded_integer(
+                    min_value,
+                    max_value,
+                    forced=forced,
+                    center=shrink_towards,
+                    fake_forced=fake_forced,
+                )
+                if idx == 0
+                # implicit reliance on dicts being sorted for determinism
+                else list(weights)[idx - 1]
+            )
 
         if min_value is None and max_value is None:
             return self._draw_unbounded_integer(forced=forced, fake_forced=fake_forced)
@@ -2116,8 +2128,7 @@ class ConjectureData:
         min_value: Optional[int] = None,
         max_value: Optional[int] = None,
         *,
-        # weights are for choosing an element index from a bounded range
-        weights: Optional[Sequence[float]] = None,
+        weights: Optional[dict[int, float]] = None,
         shrink_towards: int = 0,
         forced: Optional[int] = None,
         fake_forced: bool = False,
@@ -2127,9 +2138,11 @@ class ConjectureData:
         if weights is not None:
             assert min_value is not None
             assert max_value is not None
-            width = max_value - min_value + 1
-            assert width <= 255  # arbitrary practical limit
-            assert len(weights) == width
+            assert len(weights) <= 255  # arbitrary practical limit
+            # We can and should eventually support total weights. But this
+            # complicates shrinking as we can no longer assume we can force
+            # a value to the unmapped probability mass if that mass might be 0.
+            assert sum(weights.values()) < 1
 
         if forced is not None and (min_value is None or max_value is None):
             # We draw `forced=forced - shrink_towards` here internally, after clamping.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -66,24 +66,21 @@ class IntegersStrategy(SearchStrategy):
 
     def do_draw(self, data):
         # For bounded integers, make the bounds and near-bounds more likely.
-        forced = None
+        weights = None
         if (
             self.end is not None
             and self.start is not None
             and self.end - self.start > 127
         ):
-            bits = data.draw_integer(0, 127)
-            forced = {
-                122: self.start,
-                123: self.start,
-                124: self.end,
-                125: self.end,
-                126: self.start + 1,
-                127: self.end - 1,
-            }.get(bits)
+            weights = {
+                self.start: (2 / 128),
+                self.start + 1: (1 / 128),
+                self.end - 1: (1 / 128),
+                self.end: (2 / 128),
+            }
 
         return data.draw_integer(
-            min_value=self.start, max_value=self.end, forced=forced
+            min_value=self.start, max_value=self.end, weights=weights
         )
 
     def filter(self, condition):

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -10,7 +10,6 @@
 
 import math
 import sys
-from collections.abc import Sequence
 from contextlib import contextmanager
 from random import Random
 from typing import Optional
@@ -67,8 +66,7 @@ class PrngProvider(PrimitiveProvider):
         min_value: Optional[int] = None,
         max_value: Optional[int] = None,
         *,
-        # weights are for choosing an element index from a bounded range
-        weights: Optional[Sequence[float]] = None,
+        weights: Optional[dict[int, float]] = None,
         shrink_towards: int = 0,
         forced: Optional[int] = None,
         fake_forced: bool = False,

--- a/hypothesis-python/tests/conjecture/test_forced.py
+++ b/hypothesis-python/tests/conjecture/test_forced.py
@@ -68,7 +68,7 @@ def test_forced_many(data):
             "min_value": -1,
             "max_value": 1,
             "shrink_towards": 1,
-            "weights": [0.1] * 3,
+            "weights": {-1: 0.2, 0: 0.2, 1: 0.2},
             "forced": 0,
         },
     )
@@ -80,8 +80,32 @@ def test_forced_many(data):
             "min_value": -1,
             "max_value": 1,
             "shrink_towards": -1,
-            "weights": [0.1] * 3,
+            "weights": {-1: 0.2, 0: 0.2, 1: 0.2},
             "forced": 0,
+        },
+    )
+)
+@example(
+    (
+        "integer",
+        {
+            "min_value": 10,
+            "max_value": 1_000,
+            "shrink_towards": 17,
+            "weights": {20: 0.1},
+            "forced": 15,
+        },
+    )
+)
+@example(
+    (
+        "integer",
+        {
+            "min_value": -1_000,
+            "max_value": -10,
+            "shrink_towards": -17,
+            "weights": {-20: 0.1},
+            "forced": -15,
         },
     )
 )

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -562,7 +562,7 @@ def test_can_simultaneously_lower_non_duplicated_nearby_blocks(n_gap):
     assert list(shrinker.buffer) == [1, 0] + [0] * n_gap + [0, 1]
 
 
-def test_redistribute_block_pairs_with_forced_node():
+def test_redistribute_integer_pairs_with_forced_node():
     @run_to_buffer
     def buf(data):
         data.draw_integer(0, 100, forced=15)
@@ -576,8 +576,8 @@ def test_redistribute_block_pairs_with_forced_node():
         if n1 + n2 > 20:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["redistribute_block_pairs"])
-    # redistribute_block_pairs shouldn't try modifying forced nodes while
+    shrinker.fixate_shrink_passes(["redistribute_integer_pairs"])
+    # redistribute_integer_pairs shouldn't try modifying forced nodes while
     # shrinking. Since the second draw is forced, this isn't possible to shrink
     # with just this pass.
     assert shrinker.buffer == buf

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -90,21 +90,6 @@ def test_can_mark_invalid():
     assert x.status == Status.INVALID
 
 
-@given(st.data(), st.integers(1, 100))
-def test_can_draw_weighted_integer_range(data, n):
-    weights = [1] * n + [0] * n
-    for _ in range(10):
-        # If the weights are working, then we'll never draw a value with weight=0
-        x = data.conjecture_data.draw_integer(1, 2 * n, weights=weights)
-        assert x <= n
-
-
-@given(st.binary(min_size=10))
-def test_can_draw_weighted_integer_range_2(buffer):
-    data = ConjectureData.for_buffer(buffer)
-    data.draw_integer(0, 7, weights=[1] * 8, shrink_towards=6)
-
-
 def test_can_mark_invalid_with_why():
     x = ConjectureData.for_buffer(b"")
     with pytest.raises(StopTest):

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -191,7 +191,9 @@ def test_single_bounds(lo, hi, to):
 def test_bounds_and_weights():
     for to in (0, 1, 2):
         data = ConjectureData.for_buffer([0] * 100 + [2] * 100)
-        val = data.draw_integer(0, 2, shrink_towards=to, weights=[1, 1, 1])
+        val = data.draw_integer(
+            0, 2, shrink_towards=to, weights={0: 0.2, 1: 0.2, 2: 0.2}
+        )
         assert val == to, to
 
 

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -349,6 +349,19 @@ def test_sum_of_pair():
     ) == (1, 1000)
 
 
+def test_sum_of_pair_separated():
+    @st.composite
+    def separated_sum(draw):
+        n1 = draw(st.integers(0, 1000))
+        draw(st.text())
+        draw(st.booleans())
+        draw(st.integers())
+        n2 = draw(st.integers(0, 1000))
+        return (n1, n2)
+
+    assert minimal(separated_sum(), lambda x: sum(x) > 1000) == (1, 1000)
+
+
 def test_calculator_benchmark():
     """This test comes from
     https://github.com/jlink/shrinking-challenge/blob/main/challenges/calculator.md,


### PR DESCRIPTION
This makes `st.integers` map to a single `draw_integer` call in our IR, improving efficiency for shrinking, and possibly generation due to e.g. example copying (`generate_mutations_from`). Previously discussed at https://github.com/HypothesisWorks/hypothesis/pull/4101#discussion_r1753038201 and other intermittent places. 

The new interface is:

```python
    @abc.abstractmethod
    def draw_integer(
        self,
        min_value: Optional[int] = None,
        max_value: Optional[int] = None,
        *,
        # previously:
        # weights: Optional[Sequence[float]] = None,
        weights: Optional[dict[int, float]] = None,
        shrink_towards: int = 0,
        forced: Optional[int] = None,
    ) -> int:
```

I've made several practical compromises here to ease implementation:
- `sum(p)` must be strictly less than 1. In other words, weights cannot be a total interval. This allows the forcing implementation to force into the remaining probability mass, which is not possible if it is 0.
- The remaining probability mass - `1 - sum(p)` - gets distributed over *all* values, not just the unmapped ones. I think this is fine for current usages, but something to improve in the future.

This approach is actually not my preferred api interface. I would like to have `weights: dict[IntervalSet, float]` which maps *intervals* to p. This would make it possible to express things like "downweight everything below zero". Unfortunately, I had difficulty getting this approach to work with shrinking. My WIP branch is at https://github.com/HypothesisWorks/hypothesis/compare/master...tybug:hypothesis:integer-weights?expand=1, but I don't expect to come back to it in the near future.

--- 

@pschanely I think you ignore `weights` in hypothesis-crosshair, so I don't expect this to change anything for you, but I thought you'd appreciate a heads up for interface changes regardless 🙂 