### PR TITLE
Fix `compute_max_children` for integer weights

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes an error when using :func:`~hypothesis.strategies.integers` with certain values for ``min_value`` and ``max_value``.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch fixes an error when using :func:`~hypothesis.strategies.integers` with certain values for ``min_value`` and ``max_value``.
+This patch fixes a regression from :ref:`version 6.115.2 <v6.115.2>` where generating values from :func:`~hypothesis.strategies.integers` with certain values for ``min_value`` and ``max_value`` would error.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -174,18 +174,13 @@ def compute_max_children(ir_type, kwargs):
     if ir_type == "integer":
         min_value = kwargs["min_value"]
         max_value = kwargs["max_value"]
-        weights = kwargs["weights"]
 
         if min_value is None and max_value is None:
             # full 128 bit range.
             return 2**128 - 1
         if min_value is not None and max_value is not None:
             # count between min/max value.
-            n = max_value - min_value + 1
-            # remove any values with a zero probability of being drawn (weight=0).
-            if weights is not None:
-                n -= sum(weight == 0 for weight in weights)
-            return n
+            return max_value - min_value + 1
 
         # hard case: only one bound was specified. Here we probe either upwards
         # or downwards with our full 128 bit generation, but only half of these
@@ -274,14 +269,7 @@ def all_children(ir_type, kwargs):
             yield from range(-(2**127) + 1, 2**127 - 1)
 
         elif min_value is not None and max_value is not None:
-            if weights is None:
-                yield from range(min_value, max_value + 1)
-            else:
-                # skip any values with a corresponding weight of 0 (can never be drawn).
-                for weight, n in zip(weights, range(min_value, max_value + 1)):
-                    if weight == 0:
-                        continue
-                    yield n
+            yield from range(min_value, max_value + 1)
         else:
             assert (min_value is None) ^ (max_value is None)
             # hard case: only one bound was specified. Here we probe in 128 bits

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -262,7 +262,6 @@ def all_children(ir_type, kwargs):
     if ir_type == "integer":
         min_value = kwargs["min_value"]
         max_value = kwargs["max_value"]
-        weights = kwargs["weights"]
 
         if min_value is None and max_value is None:
             # full 128 bit range.

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -163,13 +163,18 @@ def integer_kwargs(
 
         # Sampler doesn't play well with super small floats, so exclude them
         weights = draw(
-            st.dictionaries(st.integers(), st.floats(0.001, 1), max_size=255)
+            st.dictionaries(
+                st.integers(min_value=min_value, max_value=max_value),
+                st.floats(0.001, 1),
+                max_size=255,
+            )
         )
         # invalid to have a weighting that disallows all possibilities
         assume(sum(weights.values()) != 0)
+        # re-normalize probabilities to sum to some arbitrary target < 1
         target = draw(st.floats(0.001, 0.999))
-        # re-normalize probabilities to sum to some arbitrary value < 1
-        weights = {k: v / target for k, v in weights.items()}
+        factor = target / sum(weights.values())
+        weights = {k: v * factor for k, v in weights.items()}
         # float rounding error can cause this to fail.
         assume(sum(weights.values()) == target)
     else:

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -57,8 +57,7 @@ def test_compute_max_children_is_positive(ir_type_and_kwargs):
 @pytest.mark.parametrize(
     "ir_type, kwargs, count_children",
     [
-        ("integer", {"min_value": 1, "max_value": 2, "weights": [0, 1]}, 1),
-        ("integer", {"min_value": 1, "max_value": 4, "weights": [0, 0.5, 0, 0.5]}, 2),
+        ("integer", {"min_value": 1, "max_value": 2, "weights": {1: 0.1, 2: 0.1}}, 2),
         # only possibility is the empty string
         (
             "string",
@@ -275,7 +274,7 @@ def test_draw_string_single_interval_with_equal_bounds(s, n):
         {
             "min_value": 1,
             "max_value": 2,
-            "weights": [0, 1],
+            "weights": {1: 0.2, 2: 0.4},
             "shrink_towards": 0,
         },
     )


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4140.

I forgot to update `compute_max_children` for the weights change. In particular, this block was at fault:

```python
for weight, n in zip(weights, range(min_value, max_value + 1)):
    if weight == 0:
        continue
    yield n
```

where the zip truncates when `weights` is smaller than the range (I am eagerly awaiting `strict=True` in 3.10).

This wasn't caught in testing because all of the `weights` examples in `integer_kwargs` got filtered out due to an incorrect computation of the target sum, which unconditionally failed an `assume`. I should have checked this more carefully, especially when it touches `st.integers`, which is empirically the most used strategy in all of hypothesis (and it's not even close). 