### PR TITLE
Include namespace classes in pretty printing

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release improves pretty printing of nested classes to include the outer class name in their printed representation.

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -582,6 +582,10 @@ def _seq_pprinter_factory(start, end, basetype):
     return inner
 
 
+def get_class_name(cls):
+    return _safe_getattr(cls, "__qualname__", cls.__name__)
+
+
 def _set_pprinter_factory(start, end, basetype):
     """Factory that returns a pprint function useful for sets and
     frozensets."""
@@ -600,7 +604,7 @@ def _set_pprinter_factory(start, end, basetype):
             return p.text(start + "..." + end)
         if not obj:
             # Special case.
-            p.text(basetype.__name__ + "()")
+            p.text(get_class_name(basetype) + "()")
         else:
             step = len(start)
             with p.group(step, start, end):
@@ -733,7 +737,7 @@ def _repr_pprint(obj, p, cycle):
 
 
 def pprint_fields(obj, p, cycle, fields):
-    name = obj.__class__.__name__
+    name = get_class_name(obj.__class__)
     if cycle:
         return p.text(f"{name}(...)")
     with p.group(1, name + "(", ")"):
@@ -879,7 +883,7 @@ def _repr_dataframe(obj, p, cycle):  # pragma: no cover
 
 
 def _repr_enum(obj, p, cycle):
-    tname = type(obj).__name__
+    tname = get_class_name(type(obj))
     if isinstance(obj, Flag):
         p.text(
             " | ".join(f"{tname}.{x.name}" for x in type(obj) if x & obj == x)

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -876,3 +876,28 @@ def test_does_not_include_no_init_fields_in_attrs_printing():
     assert pretty.pretty(record) == "AttrsClassWithNoInitField(x=1)"
     record.y = 1
     assert pretty.pretty(record) == "AttrsClassWithNoInitField(x=1)"
+
+
+class Namespace:
+    @dataclass
+    class DC:
+        x: int
+
+    @attrs.define
+    class A:
+        x: int
+
+    class E(Enum):
+        A = 1
+
+
+NAMESPACED_VALUES = [
+    Namespace.DC(x=1),
+    Namespace.A(x=1),
+    Namespace.E.A,
+]
+
+
+@pytest.mark.parametrize("obj", NAMESPACED_VALUES, ids=map(repr, NAMESPACED_VALUES))
+def test_includes_namespace_classes_in_pretty(obj):
+    assert pretty.pretty(obj).startswith("Namespace.")


### PR DESCRIPTION
Someone pointed out to me that the changes from #4133 now meant some nested types they had were no longer pretty printing with their namespace (despite this being in their repr). This PR fixes that. I also noticed that we had the same problem with enum types declared nested, so I fixed that too.