### PR TITLE
WIP: Add async testing within stateful rules

### DIFF
--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -829,6 +829,9 @@ class StateForActualGivenExecution:
                         math.fsum(data._stateful_run_times.values()) - arg_stateful
                     )
                     in_gctime = gc_cumulative_time() - arg_gctime
+                    print(
+                        f"runtime: {finish=}, {start=}, {in_drawtime=}, {in_stateful=}, {in_gctime=}"
+                    )
                     runtime = finish - start - in_drawtime - in_stateful - in_gctime
                     self._timing_features = {
                         "execute:test": runtime,
@@ -841,9 +844,14 @@ class StateForActualGivenExecution:
                     if not is_final:
                         current_deadline = (current_deadline // 4) * 5
                     if runtime >= current_deadline.total_seconds():
-                        raise DeadlineExceeded(
-                            datetime.timedelta(seconds=runtime), self.settings.deadline
-                        )
+                        pass
+                        # raise DeadlineExceeded(
+                        #     datetime.timedelta(seconds=runtime), self.settings.deadline
+                        # )
+                print(f"{runtime=}, {current_deadline.total_seconds()=}")
+                print(
+                    f"{current_deadline=}, {current_deadline is not None=}, {runtime >= current_deadline.total_seconds()=}"
+                )
                 return result
 
         def run(data):
@@ -1530,21 +1538,21 @@ def given(
                 wrapped_test, arguments, kwargs, given_kwargs, new_signature.parameters
             )
 
-            if (
-                inspect.iscoroutinefunction(test)
-                and get_executor(stuff.selfy) is default_executor
-            ):
-                # See https://github.com/HypothesisWorks/hypothesis/issues/3054
-                # If our custom executor doesn't handle coroutines, or we return an
-                # awaitable from a non-async-def function, we just rely on the
-                # return_value health check.  This catches most user errors though.
-                raise InvalidArgument(
-                    "Hypothesis doesn't know how to run async test functions like "
-                    f"{test.__name__}.  You'll need to write a custom executor, "
-                    "or use a library like pytest-asyncio or pytest-trio which can "
-                    "handle the translation for you.\n    See https://hypothesis."
-                    "readthedocs.io/en/latest/details.html#custom-function-execution"
-                )
+            # if (
+            #     inspect.iscoroutinefunction(test)
+            #     and get_executor(stuff.selfy) is default_executor
+            # ):
+            #     # See https://github.com/HypothesisWorks/hypothesis/issues/3054
+            #     # If our custom executor doesn't handle coroutines, or we return an
+            #     # awaitable from a non-async-def function, we just rely on the
+            #     # return_value health check.  This catches most user errors though.
+            #     raise InvalidArgument(
+            #         "Hypothesis doesn't know how to run async test functions like "
+            #         f"{test.__name__}.  You'll need to write a custom executor, "
+            #         "or use a library like pytest-asyncio or pytest-trio which can "
+            #         "handle the translation for you.\n    See https://hypothesis."
+            #         "readthedocs.io/en/latest/details.html#custom-function-execution"
+            #     )
 
             runner = stuff.selfy
             if isinstance(stuff.selfy, TestCase) and test.__name__ in dir(TestCase):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -840,10 +840,10 @@ class StateForActualGivenExecution:
                 if (current_deadline := self.settings.deadline) is not None:
                     if not is_final:
                         current_deadline = (current_deadline // 4) * 5
-                    # if runtime >= current_deadline.total_seconds():
-                    #     raise DeadlineExceeded(
-                    #         datetime.timedelta(seconds=runtime), self.settings.deadline
-                    #     )
+                    if runtime >= current_deadline.total_seconds():
+                        raise DeadlineExceeded(
+                            datetime.timedelta(seconds=runtime), self.settings.deadline
+                        )
                 return result
 
         def run(data):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -829,9 +829,6 @@ class StateForActualGivenExecution:
                         math.fsum(data._stateful_run_times.values()) - arg_stateful
                     )
                     in_gctime = gc_cumulative_time() - arg_gctime
-                    print(
-                        f"runtime: {finish=}, {start=}, {in_drawtime=}, {in_stateful=}, {in_gctime=}"
-                    )
                     runtime = finish - start - in_drawtime - in_stateful - in_gctime
                     self._timing_features = {
                         "execute:test": runtime,
@@ -844,13 +841,9 @@ class StateForActualGivenExecution:
                     if not is_final:
                         current_deadline = (current_deadline // 4) * 5
                     # if runtime >= current_deadline.total_seconds():
-                    # raise DeadlineExceeded(
-                    #     datetime.timedelta(seconds=runtime), self.settings.deadline
-                    # )
-                print(f"{runtime=}, {current_deadline.total_seconds()=}")
-                print(
-                    f"{current_deadline=}, {current_deadline is not None=}, {runtime >= current_deadline.total_seconds()=}"
-                )
+                    #     raise DeadlineExceeded(
+                    #         datetime.timedelta(seconds=runtime), self.settings.deadline
+                    #     )
                 return result
 
         def run(data):

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -843,11 +843,10 @@ class StateForActualGivenExecution:
                 if (current_deadline := self.settings.deadline) is not None:
                     if not is_final:
                         current_deadline = (current_deadline // 4) * 5
-                    if runtime >= current_deadline.total_seconds():
-                        pass
-                        # raise DeadlineExceeded(
-                        #     datetime.timedelta(seconds=runtime), self.settings.deadline
-                        # )
+                    # if runtime >= current_deadline.total_seconds():
+                    # raise DeadlineExceeded(
+                    #     datetime.timedelta(seconds=runtime), self.settings.deadline
+                    # )
                 print(f"{runtime=}, {current_deadline.total_seconds()=}")
                 print(
                     f"{current_deadline=}, {current_deadline is not None=}, {runtime >= current_deadline.total_seconds()=}"
@@ -1538,21 +1537,21 @@ def given(
                 wrapped_test, arguments, kwargs, given_kwargs, new_signature.parameters
             )
 
-            # if (
-            #     inspect.iscoroutinefunction(test)
-            #     and get_executor(stuff.selfy) is default_executor
-            # ):
-            #     # See https://github.com/HypothesisWorks/hypothesis/issues/3054
-            #     # If our custom executor doesn't handle coroutines, or we return an
-            #     # awaitable from a non-async-def function, we just rely on the
-            #     # return_value health check.  This catches most user errors though.
-            #     raise InvalidArgument(
-            #         "Hypothesis doesn't know how to run async test functions like "
-            #         f"{test.__name__}.  You'll need to write a custom executor, "
-            #         "or use a library like pytest-asyncio or pytest-trio which can "
-            #         "handle the translation for you.\n    See https://hypothesis."
-            #         "readthedocs.io/en/latest/details.html#custom-function-execution"
-            #     )
+            if (
+                inspect.iscoroutinefunction(test)
+                and get_executor(stuff.selfy) is default_executor
+            ):
+                # See https://github.com/HypothesisWorks/hypothesis/issues/3054
+                # If our custom executor doesn't handle coroutines, or we return an
+                # awaitable from a non-async-def function, we just rely on the
+                # return_value health check.  This catches most user errors though.
+                raise InvalidArgument(
+                    "Hypothesis doesn't know how to run async test functions like "
+                    f"{test.__name__}.  You'll need to write a custom executor, "
+                    "or use a library like pytest-asyncio or pytest-trio which can "
+                    "handle the translation for you.\n    See https://hypothesis."
+                    "readthedocs.io/en/latest/details.html#custom-function-execution"
+                )
 
             runner = stuff.selfy
             if isinstance(stuff.selfy, TestCase) and test.__name__ in dir(TestCase):

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -465,6 +465,7 @@ class AsyncIORuleBasedStateMachine(RuleBasedStateMachine):
 
     def _execute_fn(self, rule, stateful_run_times, **data):
         if inspect.iscoroutinefunction(rule.function):
+            # Make sure to wrap it in get_async_result_with_time once debugged
             self.tg.create_task(rule.function(self, **data))
             return
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -18,7 +18,6 @@ execution to date.
 import collections
 import inspect
 import trio
-# import asyncio
 from collections.abc import Iterable, Sequence
 from copy import copy
 from functools import lru_cache, wraps
@@ -491,42 +490,6 @@ class TrioRuleBasedStateMachine(RuleBasedStateMachine):
             return trio.run(run_with_nursery, *args, **kwargs)
 
         return wrapper
-
-
-# class AsyncIORuleBasedStateMachine(RuleBasedStateMachine):
-#     def __init__(self):
-#         super().__init__()
-
-#     def _execute_fn(self, rule, stateful_run_times, **data):
-#         if inspect.iscoroutinefunction(rule.function):
-#             # Async case: Run with async_time_tracker and schedule with asyncio
-#             formatted_task = partial(
-#                 get_async_result_with_time,
-#                 rule.function,
-#                 stateful_run_times,
-#                 self,
-#                 **data,
-#             )
-#             asyncio.create_task(formatted_task())
-#             return  # Async functions don’t return values immediately
-#         return super()._execute_fn(rule, stateful_run_times, **data)
-
-#     def loop_setup(self, fn):
-#         @wraps(fn)
-#         def wrapper(*args, **kwargs):
-#             async def run_in_event_loop(*args, **kwargs):
-#                 self.tasks = []
-#                 result = fn(*args, **kwargs)
-
-#                 if self.tasks:
-#                     await asyncio.gather(*self.tasks)
-
-#                 return result
-
-#             return asyncio.run(run_in_event_loop(*args, **kwargs))
-
-#         return wrapper
-
 
 def async_manager_decorator(fn):
     @wraps(fn)

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -473,8 +473,9 @@ class TrioRuleBasedStateMachine(RuleBasedStateMachine):
             )
             self.nursery.start_soon(formatted_task)
 
-            # TODO: Maybe include a warning for async functions
-            # that include a return statement that users cannot return values?
+            # TODO: At the moment, we can't return any values for async functions. Should this remain the case?
+            # Trio doesn't seem to (https://stackoverflow.com/questions/51567451/capture-the-return-value-from-nursery-objects).
+            # Maybe include an error for `return` keywords in async @rules
             return
 
         return super()._execute_fn(rule, stateful_run_times, **data)
@@ -495,9 +496,6 @@ def async_manager_decorator(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         machine = args[0]
-        # print(
-        #     f"{machine=}, {type(machine)=}, {isinstance(machine, RuleBasedStateMachine)=}"
-        # )
         if hasattr(machine, "loop_setup") and callable(machine.loop_setup):
             return machine.loop_setup(fn)(*args, **kwargs)
         return fn(*args, **kwargs)
@@ -523,7 +521,7 @@ def get_sync_result_with_time(func, stateful_run_times, *args, **kwargs):
 
 
 async def get_async_result_with_time(func, stateful_run_times, *args, **kwargs):
-    # This is just to play nicely with python syntax
+    """This is mainly a copy of the sync version of the method, but plays nicely with python async/await"""
     label = f"execute:rule:{func.__name__}"
     start = perf_counter()
     start_gc = gc_cumulative_time()

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -350,12 +350,6 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
         for _, v in inspect.getmembers(cls):
             r = getattr(v, RULE_MARKER, None)
             if r is not None:
-                # if type(cls) in _ASYNC_STATE_MACHINES:
-                #     if inspect.iscoroutinefunction(r):
-                #         r.context_manager =
-                #         cls._rules_per_class[cls].append((r, "async"))
-                #     else:
-                #         cls._rules_per_class[cls].append((r, "sync"))
                 cls._rules_per_class[cls].append(r)
         return cls._rules_per_class[cls]
 
@@ -453,9 +447,6 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
 class TrioRuleBasedStateMachine(RuleBasedStateMachine):
     def __init__(self):
         super().__init__()
-
-
-# _ASYNC_STATE_MACHINES = [TrioRuleBasedStateMachine]
 
 
 def async_manager_decorator(fn):

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1399,8 +1399,8 @@ def test_async():
             print("func3 end.")
 
     out = []
-    # mach_lst = [Async, Sync]
-    mach_lst = [Async]
+    mach_lst = [Async, Sync]
+    # mach_lst = [Async]
     # mach_lst = [Sync]
     for machine in mach_lst:
         start = time.time()

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1348,63 +1348,37 @@ import time
 
 
 def test_async():
+    function_sleep_duration = 1.5
+
     class Async(TrioRuleBasedStateMachine):
-        buns = Bundle("buns")
 
-        @initialize(target=buns)
-        def create_bun(self):
-            return 0
-
-        @rule(bun=buns)
-        async def func1(self, bun):
+        @rule()
+        async def func1(self):
             print("func1 start.")
-            await trio.sleep(1.5)
+            await trio.sleep(function_sleep_duration)
             print("func1 end.")
-
-        @rule(bun=buns)
-        def func2(self, bun):
-            print("func2 start.")
-            time.sleep(0.3)
-            print("func2 end.")
-
-        @rule(bun=buns)
-        async def func3(self, bun):
-            print("func3 start.")
-            await trio.sleep(1.5)
-            print("func3 end.")
 
     class Sync(RuleBasedStateMachine):
-        buns = Bundle("buns")
 
-        @initialize(target=buns)
-        def create_bun(self):
-            return 0
-
-        @rule(bun=buns)
-        def func1(self, bun):
+        @rule()
+        def func1(self):
             print("func1 start.")
-            time.sleep(1.5)
+            time.sleep(function_sleep_duration)
             print("func1 end.")
 
-        @rule(bun=buns)
-        def func2(self, bun):
+        @rule()
+        def func2(self):
             print("func2 start.")
-            time.sleep(1.5)
+            time.sleep(function_sleep_duration)
             print("func2 end.")
-
-        @rule(bun=buns)
-        def func3(self, bun):
-            print("func3 start.")
-            time.sleep(1.5)
-            print("func3 end.")
 
     out = []
     mach_lst = [Async, Sync]
-    # mach_lst = [Async]
-    # mach_lst = [Sync]
     for machine in mach_lst:
         start = time.time()
-        machine.TestCase.settings = Settings(stateful_step_count=10, max_examples=1)
+        machine.TestCase.settings = Settings(
+            stateful_step_count=10, max_examples=1, deadline=None
+        )
         run_state_machine_as_test(machine)
         print(f"This should print after the rest of the stuff")
         end = time.time()
@@ -1412,6 +1386,5 @@ def test_async():
         print(f"Finished: {end=} {start=} {duration=} ")
         out.append(duration)
 
-    print(f"TODO: This works as a standalone script, but async on pytest is weird.")
     for duration, machine in zip(out, mach_lst):
         print(f"Test for machine {machine} took {duration}")

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1336,12 +1336,6 @@ def test_async():
             await trio.sleep(1.5)
             print("func3 end.")
 
-    Async.TestCase.settings = Settings(stateful_step_count=10, max_examples=1)
-    # trio.run(run_state_machine_as_test, Machine)
-    run_state_machine_as_test(Async)
-
-
-def test_sync():
     class Sync(RuleBasedStateMachine):
         buns = Bundle("buns")
 
@@ -1367,5 +1361,20 @@ def test_sync():
             time.sleep(1.5)
             print("func3 end.")
 
-    Sync.TestCase.settings = Settings(stateful_step_count=10, max_examples=1)
-    run_state_machine_as_test(Sync)
+    out = []
+    # mach_lst = [Async, Sync]
+    mach_lst = [Async]
+    # mach_lst = [Sync]
+    for machine in mach_lst:
+        start = time.time()
+        machine.TestCase.settings = Settings(stateful_step_count=10, max_examples=1)
+        run_state_machine_as_test(machine)
+        print(f"This should print after the rest of the stuff")
+        end = time.time()
+        duration = end - start
+        print(f"Finished: {end=} {start=} {duration=} ")
+        out.append(duration)
+
+    print(f"TODO: This works as a standalone script, but async on pytest is weird.")
+    for duration, machine in zip(out, mach_lst):
+        print(f"Test for machine {machine} took {duration}")


### PR DESCRIPTION
Gives a start to having concurrency *within* each rule outlined in #4107.

Eventually it seems like a good idea to have a single nursery for the entire run, but this will give a good start. It's gonna need a bit more plumbing, but putting it out there in case if there's any comments in the PR direction!