### PR TITLE
Always use a repr_pretty if provided

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch changes the priority order of pretty printing logic so that a user
+provided pretty printing method will always be used in preference to e.g.
+printing it like a dataclass.


### PR DESCRIPTION
Continuing my small tweaks to pretty printing logic...

This changes the priority order for our pretty printing logic to always prefer a user provided `_repr_pretty_` to any of our more general heuristics, on the grounds that if the user provided one they probably meant it to be used.

This is particularly relevant in scenarios where the `_repr_pretty_` is inherited from some base class defining it. I ran into this in a scenario where we had a base type that wanted to define a universal pretty printing method, but because its subtypes were dataclasses they weren't inheriting the defined method. This seems obviously wrong.

The priority order is now:

1. Singleton printers.
2. Any defined pretty printing method.
3. Everything else.