### PR TITLE
Fix deploy docs

### DIFF
--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -65,19 +65,21 @@ def has_source_changes():
     return tools.has_changes([PYTHON_SRC])
 
 
-def build_docs(builder="html"):
+def build_docs(*, builder="html", only=[]):
     # See https://www.sphinx-doc.org/en/stable/man/sphinx-build.html
     # (unfortunately most options only have the short flag version)
     tools.scripts.pip_tool(
-        "sphinx-build",
-        "-W",
-        "--keep-going",
-        "-T",
-        "-E",
-        "-b",
-        builder,
-        "docs",
-        "docs/_build/" + builder,
+        *[
+            "sphinx-build",
+            "-W",
+            "-T",
+            "-E",
+            "-b",
+            builder,
+            "docs",
+            "docs/_build/" + builder,
+            *only,
+        ],
         cwd=HYPOTHESIS_PYTHON,
     )
 
@@ -189,7 +191,7 @@ def upload_distribution():
 
     # Construct plain-text + markdown version of this changelog entry,
     # with link to canonical source.
-    build_docs(builder="text")
+    build_docs(builder="text", only=["docs/changes.rst"])
     textfile = os.path.join(HYPOTHESIS_PYTHON, "docs", "_build", "text", "changes.txt")
     with open(textfile, encoding="utf-8") as f:
         lines = f.readlines()

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -65,21 +65,19 @@ def has_source_changes():
     return tools.has_changes([PYTHON_SRC])
 
 
-def build_docs(*, builder="html", only=[]):
+def build_docs(*, builder="html", only=()):
     # See https://www.sphinx-doc.org/en/stable/man/sphinx-build.html
     # (unfortunately most options only have the short flag version)
     tools.scripts.pip_tool(
-        *[
-            "sphinx-build",
-            "-W",
-            "-T",
-            "-E",
-            "-b",
-            builder,
-            "docs",
-            "docs/_build/" + builder,
-            *only,
-        ],
+        "sphinx-build",
+        "-W",
+        "-T",
+        "-E",
+        "-b",
+        builder,
+        "docs",
+        "docs/_build/" + builder,
+        *only,
         cwd=HYPOTHESIS_PYTHON,
     )
 

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -209,7 +209,7 @@ def upload_distribution():
         "https://api.github.com/repos/HypothesisWorks/hypothesis/releases",
         headers={
             "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer: {os.environ['GH_TOKEN']}",
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
             "X-GitHub-Api-Version": "2022-11-28",
         },
         json={


### PR DESCRIPTION
This pull fixes timeouts on our [`deploy`](https://github.com/HypothesisWorks/hypothesis/blob/21502bafae188563133a7fd4cbc0e512e53810a2/.github/workflows/main.yml#L273) CI job, on as seen as far back as dec 2023 ([CI job](https://github.com/HypothesisWorks/hypothesis/actions/runs/7333908116/job/19970286343)) - or [more recently, with logs](https://github.com/HypothesisWorks/hypothesis/actions/runs/11374162227/job/31643181680#step:5:667). I tracked this down to a hang on building `.. jsonschema::` in `observability.rst`, only when using text mode (as our deploy script does). We don't need to build the whole docs there, so I didn't dig further and sidestepped the issue by only building the necessary changes.

In passing, I've also removed `--keep-going`, which seems redundant as of sphinx 8.1 (we are on 8.1.3):

> Changed in version 8.1: sphinx-build no longer exits on the first warning, meaning that in effect --fail-on-warning is always enabled. The option is retained for compatibility, but may be removed at some later date.
> https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going

And I have attempted a speculative and untested fix for #3756 by fixing the Bearer format, which does not have a colon according to [github's docs](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28). Possibly github parses it fine anyway, but it can't possibly be worse than the status quo of "releases dont work".