### PR TITLE
Default to CI-appropriate settings when running on CI

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Hypothesis now detects if it is running on a CI server and provides better default settings for running on CI in this case.

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -250,6 +250,14 @@ by your conftest you can load one with the command line option ``--hypothesis-pr
     $ pytest tests --hypothesis-profile <profile-name>
 
 
+Hypothesis comes with two built-in profiles, ``ci`` and ``default``.
+``ci`` is set up to have good defaults for running in a CI environment, so emphasizes determinism, while the 
+``default`` settings are picked to be more likely to find bugs and to have a good workflow when used for local development.
+
+Hypothesis will automatically detect certain common CI environments and use the CI profile automatically
+when running in them.
+In particular, if you wish to use the ``ci`` profile, setting the ``CI`` environment variable will do this.
+
 .. _healthchecks:
 
 -------------

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1564,23 +1564,23 @@ def given(
                     "to ensure that each example is run in a separate "
                     "database transaction."
                 )
-            if settings.database is not None:
-                nonlocal prev_self
-                # Check selfy really is self (not e.g. a mock) before we health-check
-                cur_self = (
-                    stuff.selfy
-                    if getattr(type(stuff.selfy), test.__name__, None) is wrapped_test
-                    else None
+
+            nonlocal prev_self
+            # Check selfy really is self (not e.g. a mock) before we health-check
+            cur_self = (
+                stuff.selfy
+                if getattr(type(stuff.selfy), test.__name__, None) is wrapped_test
+                else None
+            )
+            if prev_self is Unset:
+                prev_self = cur_self
+            elif cur_self is not prev_self:
+                msg = (
+                    f"The method {test.__qualname__} was called from multiple "
+                    "different executors. This may lead to flaky tests and "
+                    "nonreproducible errors when replaying from database."
                 )
-                if prev_self is Unset:
-                    prev_self = cur_self
-                elif cur_self is not prev_self:
-                    msg = (
-                        f"The method {test.__qualname__} was called from multiple "
-                        "different executors. This may lead to flaky tests and "
-                        "nonreproducible errors when replaying from database."
-                    )
-                    fail_health_check(settings, msg, HealthCheck.differing_executors)
+                fail_health_check(settings, msg, HealthCheck.differing_executors)
 
             state = StateForActualGivenExecution(
                 stuff, test, settings, random, wrapped_test
@@ -1675,7 +1675,6 @@ def given(
                 # The exception caught here should either be an actual test
                 # failure (or BaseExceptionGroup), or some kind of fatal error
                 # that caused the engine to stop.
-
                 generated_seed = wrapped_test._hypothesis_internal_use_generated_seed
                 with local_settings(settings):
                     if not (state.failed_normally or generated_seed is None):

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -12,7 +12,7 @@ import os
 from warnings import filterwarnings
 
 from hypothesis import HealthCheck, Phase, Verbosity, settings
-from hypothesis._settings import not_set
+from hypothesis._settings import CI, is_in_ci, not_set
 from hypothesis.internal.conjecture.data import AVAILABLE_PROVIDERS
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
@@ -45,13 +45,14 @@ def run():
         v = getattr(x, s.name)
         # Check if it has a dynamically defined default and if so skip comparison.
         if getattr(settings, s.name).show_default:
-            assert (
-                v == s.default
+            assert v == s.default or (
+                is_in_ci() and v == getattr(CI, s.name)
             ), f"({v!r} == x.{s.name}) != (s.{s.name} == {s.default!r})"
 
     settings.register_profile(
         "default",
         settings(
+            settings.get_profile("default"),
             max_examples=20 if IN_COVERAGE_TESTS else not_set,
             phases=list(Phase),  # Dogfooding the explain phase
         ),

--- a/hypothesis-python/tests/pytest/test_capture.py
+++ b/hypothesis-python/tests/pytest/test_capture.py
@@ -93,7 +93,8 @@ def test_healthcheck_traceback_is_hidden(x):
 """
 
 
-def test_healthcheck_traceback_is_hidden(testdir):
+def test_healthcheck_traceback_is_hidden(testdir, monkeypatch):
+    monkeypatch.delenv("CI", raising=False)
     script = testdir.makepyfile(TRACEBACKHIDE_HEALTHCHECK)
     result = testdir.runpytest(script, "--verbose")
     def_token = "__ test_healthcheck_traceback_is_hidden __"

--- a/hypothesis-python/tests/pytest/test_seeding.py
+++ b/hypothesis-python/tests/pytest/test_seeding.py
@@ -82,7 +82,10 @@ def test_failure(i):
 """
 
 
-def test_repeats_healthcheck_when_following_seed_instruction(testdir, tmp_path):
+def test_repeats_healthcheck_when_following_seed_instruction(
+    testdir, tmp_path, monkeypatch
+):
+    monkeypatch.delenv("CI", raising=False)
     health_check_test = HEALTH_CHECK_FAILURE.replace(
         "<file>", repr(str(tmp_path / "seen"))
     )


### PR DESCRIPTION
After one too many complaints about Hypothesis being unsuitable for CI usage, I finally got around to making it so that the trivial configuration for making it deterministic on CI happens out of the box for you. Now if you set the `CI` environment variable it will run deterministically (as long as your test code is deterministic).