### PR TITLE
Automatically reload settings profile if it's redefined

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This changes the behaviour of settings profiles so that if you reregister the currently loaded profile it will automatically reload it. Previously you would have had to load it again.
+
+In particular this means that if you register a "ci" profile, it will automatically be used when Hypothesis detects you are running on CI.

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -258,6 +258,21 @@ Hypothesis will automatically detect certain common CI environments and use the 
 when running in them.
 In particular, if you wish to use the ``ci`` profile, setting the ``CI`` environment variable will do this.
 
+If you want to customise your CI behaviour, registering a new version of the ``ci`` profile will automatically be picked up in CI. For example, if you wanted to run more examples in CI, you might configure it as follows:
+
+
+.. code-block:: python
+
+    settings.register_profile(
+        "ci",
+        settings(
+            settings.get_profile("ci"),
+            max_examples=1000,
+        ),
+    )
+
+This will configure your CI to run 1000 examples per test rather than the default of 100, and this change will automatically be picked up when running on a CI server.
+
 .. _healthchecks:
 
 -------------

--- a/hypothesis-python/docs/settings.rst
+++ b/hypothesis-python/docs/settings.rst
@@ -251,15 +251,14 @@ by your conftest you can load one with the command line option ``--hypothesis-pr
 
 
 Hypothesis comes with two built-in profiles, ``ci`` and ``default``.
-``ci`` is set up to have good defaults for running in a CI environment, so emphasizes determinism, while the 
+``ci`` is set up to have good defaults for running in a CI environment, so emphasizes determinism, while the
 ``default`` settings are picked to be more likely to find bugs and to have a good workflow when used for local development.
 
-Hypothesis will automatically detect certain common CI environments and use the CI profile automatically
+Hypothesis will automatically detect certain common CI environments and use the ci profile automatically
 when running in them.
 In particular, if you wish to use the ``ci`` profile, setting the ``CI`` environment variable will do this.
 
-If you want to customise your CI behaviour, registering a new version of the ``ci`` profile will automatically be picked up in CI. For example, if you wanted to run more examples in CI, you might configure it as follows:
-
+This will still be the case if you register your own ci profile. For example, if you wanted to run more examples in CI, you might configure it as follows:
 
 .. code-block:: python
 

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -774,8 +774,7 @@ CI = settings(
 settings.register_profile("ci", CI)
 
 
-# This is tested in a subprocess so the branch doesn't show up in coverage.
-if is_in_ci():  # pragma: no
+if is_in_ci():
     settings.load_profile("ci")
 
 assert settings.default is not None

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -317,6 +317,10 @@ class settings(metaclass=settingsMeta):
         :class:`~hypothesis.settings`: optional ``parent`` settings, and
         keyword arguments for each setting that will be set differently to
         parent (or settings.default, if parent is None).
+
+        If you register a profile that has already been defined and that profile
+        is the currently loaded profile, the new changes will take effect immediately,
+        and do not require reloading the profile.
         """
         check_type(str, name, "name")
         settings._profiles[name] = settings(parent=parent, **kwargs)

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -97,7 +97,7 @@ class settingsMeta(type):
         v = default_variable.value
         if v is not None:
             return v
-        if hasattr(settings, "_current_profile"):
+        if getattr(settings, "_current_profile", None) is not None:
             settings.load_profile(settings._current_profile)
             assert default_variable.value is not None
         return default_variable.value
@@ -132,6 +132,7 @@ class settings(metaclass=settingsMeta):
     __definitions_are_locked = False
     _profiles: ClassVar[dict[str, "settings"]] = {}
     __module__ = "hypothesis"
+    _current_profile = None
 
     def __getattr__(self, name):
         if name in all_settings:
@@ -319,6 +320,8 @@ class settings(metaclass=settingsMeta):
         """
         check_type(str, name, "name")
         settings._profiles[name] = settings(parent=parent, **kwargs)
+        if settings._current_profile == name:
+            settings.load_profile(name)
 
     @staticmethod
     def get_profile(name: str) -> "settings":
@@ -768,7 +771,7 @@ settings.register_profile("ci", CI)
 
 
 # This is tested in a subprocess so the branch doesn't show up in coverage.
-if is_in_ci():  # pragma: no cover
+if is_in_ci():  # pragma: no
     settings.load_profile("ci")
 
 assert settings.default is not None


### PR DESCRIPTION
This is me following up on my [note for later](https://github.com/HypothesisWorks/hypothesis/pull/4152#issuecomment-2450522626).

Previously if you reregistered a profile you'd need to then load it again before it came into use. This changes the logic so that's not the case.

The main motivation for this is is that if a user registers a CI profile this now ensure it will automatically be used on CI.