### PR TITLE
Small test cleanups

### DIFF
--- a/hypothesis-python/tests/common/costbounds.py
+++ b/hypothesis-python/tests/common/costbounds.py
@@ -19,12 +19,13 @@ def find_integer_cost(n):
     except KeyError:
         pass
 
-    cost = [0]
+    cost = 0
 
     def test(i):
-        cost[0] += 1
+        nonlocal cost
+        cost += 1
         return i <= n
 
     find_integer(test)
 
-    return FIND_INTEGER_COSTS.setdefault(n, cost[0])
+    return FIND_INTEGER_COSTS.setdefault(n, cost)

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -85,20 +85,23 @@ def _consistently_increment_time(monkeypatch):
 
     Replacing time with a fake version under our control avoids this problem.
     """
-    frozen = [False]
+    frozen = False
 
-    current_time = [time_module.time()]
+    current_time = time_module.time()
 
     def time():
-        if not frozen[0]:
-            current_time[0] += TIME_INCREMENT
-        return current_time[0]
+        nonlocal current_time
+        if not frozen:
+            current_time += TIME_INCREMENT
+        return current_time
 
     def sleep(naptime):
-        current_time[0] += naptime
+        nonlocal current_time
+        current_time += naptime
 
     def freeze():
-        frozen[0] = True
+        nonlocal frozen
+        frozen = True
 
     def _patch(name, fn):
         monkeypatch.setattr(time_module, name, wraps(getattr(time_module, name))(fn))
@@ -119,14 +122,16 @@ def _consistently_increment_time(monkeypatch):
         # ensure timer callback is added, then bracket it by freeze/unfreeze below
         junkdrawer.gc_cumulative_time()
 
-        _was_frozen = [False]
+        _was_frozen = False
 
         def _freezer(*_):
-            _was_frozen[0] = frozen[0]
-            frozen[0] = True
+            nonlocal _was_frozen, frozen
+            _was_frozen = frozen
+            frozen = True
 
         def _unfreezer(*_):
-            frozen[0] = _was_frozen[0]
+            nonlocal _was_frozen, frozen
+            frozen = _was_frozen
 
         gc.callbacks.insert(0, _freezer)  # freeze before gc callback
         gc.callbacks.append(_unfreezer)  # unfreeze after

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -157,7 +157,7 @@ def test_detects_flakiness():
     runner = ConjectureRunner(tf)
     runner.run()
     assert runner.exit_reason == ExitReason.flaky
-    assert count == [MIN_TEST_CALLS + 1]
+    assert count == MIN_TEST_CALLS + 1
 
 
 def recur(i, data):
@@ -656,7 +656,7 @@ def test_discarding(monkeypatch):
 
 def test_can_remove_discarded_data():
     @shrinking_from(bytes([0] * 10 + [11]))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         while True:
             data.start_example(SOME_LABEL)
             b = data.draw_integer(0, 2**8 - 1)
@@ -671,7 +671,7 @@ def test_can_remove_discarded_data():
 
 def test_discarding_iterates_to_fixed_point():
     @shrinking_from(bytes(list(range(100, -1, -1))))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         data.start_example(0)
         data.draw_integer(0, 2**8 - 1)
         data.stop_example(discard=True)
@@ -685,7 +685,7 @@ def test_discarding_iterates_to_fixed_point():
 
 def test_discarding_is_not_fooled_by_empty_discards():
     @shrinking_from(bytes([1, 1]))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         data.draw_integer(0, 2**1 - 1)
         data.start_example(0)
         data.stop_example(discard=True)
@@ -698,7 +698,7 @@ def test_discarding_is_not_fooled_by_empty_discards():
 
 def test_discarding_can_fail(monkeypatch):
     @shrinking_from(bytes([1]))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         data.start_example(0)
         data.draw_boolean()
         data.stop_example(discard=True)
@@ -857,7 +857,7 @@ def test_exit_because_shrink_phase_timeout(monkeypatch):
 
 def test_dependent_block_pairs_can_lower_to_zero():
     @shrinking_from([1, 0, 1])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         if data.draw_boolean():
             n = data.draw_integer(0, 2**16 - 1)
         else:
@@ -872,7 +872,7 @@ def test_dependent_block_pairs_can_lower_to_zero():
 
 def test_handle_size_too_large_during_dependent_lowering():
     @shrinking_from([1, 255, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         if data.draw_boolean():
             data.draw_integer(0, 2**16 - 1)
             data.mark_interesting()
@@ -886,7 +886,7 @@ def test_block_may_grow_during_lexical_shrinking():
     initial = bytes([2, 1, 1])
 
     @shrinking_from(initial)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         n = data.draw_integer(0, 2**8 - 1)
         if n == 2:
             data.draw_integer(0, 2**8 - 1)
@@ -901,7 +901,7 @@ def test_block_may_grow_during_lexical_shrinking():
 
 def test_lower_common_node_offset_does_nothing_when_changed_blocks_are_zero():
     @shrinking_from([1, 0, 1, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         data.draw_boolean()
         data.draw_boolean()
         data.draw_boolean()
@@ -916,7 +916,7 @@ def test_lower_common_node_offset_does_nothing_when_changed_blocks_are_zero():
 
 def test_lower_common_node_offset_ignores_zeros():
     @shrinking_from([2, 2, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         n = data.draw_integer(0, 2**8 - 1)
         data.draw_integer(0, 2**8 - 1)
         data.draw_integer(0, 2**8 - 1)
@@ -1448,7 +1448,7 @@ def test_does_cache_if_extend_is_not_used():
         d2 = runner.cached_test_function(b"\0", extend=8)
         assert d1.status == d2.status == Status.VALID
         assert d1.buffer == d2.buffer
-        assert calls[0] == 1
+        assert calls == 1
 
 
 def test_does_result_for_reuse():
@@ -1465,7 +1465,7 @@ def test_does_result_for_reuse():
         d2 = runner.cached_test_function(d1.buffer)
         assert d1.status == d2.status == Status.VALID
         assert d1.buffer == d2.buffer
-        assert calls[0] == 1
+        assert calls == 1
 
 
 def test_does_not_cache_overrun_if_extending():

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -189,10 +189,11 @@ def test_self_organising_list_raises_not_found_when_none_satisfy():
 
 
 def test_self_organising_list_moves_to_front():
-    count = [0]
+    count = 0
 
     def zero(n):
-        count[0] += 1
+        nonlocal count
+        count += 1
         return n == 0
 
     x = SelfOrganisingList(range(20))

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -198,7 +198,7 @@ def test_self_organising_list_moves_to_front():
     x = SelfOrganisingList(range(20))
 
     assert x.find(zero) == 0
-    assert count[0] == 20
+    assert count == 20
 
     assert x.find(zero) == 0
-    assert count[0] == 21
+    assert count == 21

--- a/hypothesis-python/tests/conjecture/test_lstar.py
+++ b/hypothesis-python/tests/conjecture/test_lstar.py
@@ -124,10 +124,11 @@ def test_iteration_with_dead_nodes():
 
 
 def test_learning_is_just_checking_when_fully_explored():
-    count = [0]
+    count = 0
 
     def accept(s):
-        count[0] += 1
+        nonlocal count
+        count += 1
         return len(s) <= 5 and all(c == 0 for c in s)
 
     learner = LStar(accept)
@@ -138,20 +139,21 @@ def test_learning_is_just_checking_when_fully_explored():
 
     assert list(learner.dfa.all_matching_strings()) == [bytes(n) for n in range(6)]
 
-    (prev,) = count
+    prev = count
 
     learner.learn([2] * 11)
 
-    calls = count[0] - prev
+    calls = count - prev
 
     assert calls == 1
 
 
 def test_canonicalises_values_to_zero_where_appropriate():
-    calls = [0]
+    calls = 0
 
     def member(s):
-        calls[0] += 1
+        nonlocal calls
+        calls += 1
         return len(s) == 10
 
     learner = LStar(member)
@@ -159,11 +161,11 @@ def test_canonicalises_values_to_zero_where_appropriate():
     learner.learn(bytes(10))
     learner.learn(bytes(11))
 
-    (prev,) = calls
+    prev = calls
 
     assert learner.dfa.matches(bytes([1] * 10))
 
-    assert calls[0] == prev
+    assert calls == prev
 
 
 def test_normalizing_defaults_to_zero():

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -12,6 +12,7 @@ import time
 
 import pytest
 
+from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import (
     Shrinker,
@@ -27,7 +28,7 @@ from tests.conjecture.common import SOME_LABEL, run_to_buffer, shrinking_from
 @pytest.mark.parametrize("n", [1, 5, 8, 15])
 def test_can_shrink_variable_draws_with_just_deletion(n):
     @shrinking_from([n] + [0] * (n - 1) + [1])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         n = data.draw_integer(0, 2**4 - 1)
         b = [data.draw_integer(0, 2**8 - 1) for _ in range(n)]
         if any(b):
@@ -71,7 +72,7 @@ def test_duplicate_blocks_that_go_away():
         data.mark_interesting()
 
     @shrinking_from(base_buf)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         x = data.draw_integer(0, 2**24 - 1)
         y = data.draw_integer(0, 2**24 - 1)
         if x != y:
@@ -88,7 +89,7 @@ def test_duplicate_blocks_that_go_away():
 
 def test_accidental_duplication():
     @shrinking_from([18] * 20)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         x = data.draw_integer(0, 2**8 - 1)
         y = data.draw_integer(0, 2**8 - 1)
         if x != y:
@@ -106,7 +107,7 @@ def test_accidental_duplication():
 
 def test_can_zero_subintervals():
     @shrinking_from(bytes([3, 0, 0, 0, 1]) * 10)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         for _ in range(10):
             data.start_example(SOME_LABEL)
             n = data.draw_integer(0, 2**8 - 1)
@@ -137,7 +138,7 @@ def test_can_pass_to_an_indirect_descendant():
     good = {initial, target}
 
     @shrinking_from(initial)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         tree(data)
         if bytes(data.buffer) in good:
             data.mark_interesting()
@@ -160,7 +161,7 @@ def shrink(buffer, *passes):
 
 def test_shrinking_blocks_from_common_offset():
     @shrinking_from([11, 10])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         m = data.draw_integer(0, 2**8 - 1)
         n = data.draw_integer(0, 2**8 - 1)
         if abs(m - n) <= 1 and max(m, n) > 0:
@@ -194,7 +195,7 @@ def test_handle_empty_draws():
 def test_can_reorder_examples():
     # grouped by iteration: (1, 0, 1) (1, 0, 1) (0) (0) (0)
     @shrinking_from([1, 0, 1, 1, 0, 1, 0, 0, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         total = 0
         for _ in range(5):
             data.start_example(label=0)
@@ -230,7 +231,7 @@ def test_permits_but_ignores_raising_order(monkeypatch):
 
 def test_block_deletion_can_delete_short_ranges():
     @shrinking_from([v for i in range(5) for _ in range(i + 1) for v in [0, i]])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         while True:
             n = data.draw_integer(0, 2**16 - 1)
             for _ in range(n):
@@ -261,7 +262,7 @@ def test_dependent_block_pairs_is_up_to_shrinking_integers():
             data.mark_interesting()
 
     @shrinking_from(buf)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         size = sizes[distribution.sample(data)]
         result = data.draw_integer(0, 2**size - 1)
         sign = (-1) ** (result & 1)
@@ -294,7 +295,7 @@ def test_finding_a_minimal_balanced_binary_tree():
 
     # Starting from an unbalanced tree of depth six
     @shrinking_from([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         _, b = tree(data)
         if not b:
             data.mark_interesting()
@@ -306,7 +307,7 @@ def test_finding_a_minimal_balanced_binary_tree():
 
 def test_node_programs_are_adaptive():
     @shrinking_from(bytes(1000) + bytes([1]))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         while not data.draw_boolean():
             pass
         data.mark_interesting()
@@ -320,7 +321,7 @@ def test_node_programs_are_adaptive():
 
 def test_zero_examples_with_variable_min_size():
     @shrinking_from(bytes([255]) * 100)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         any_nonzero = False
         for i in range(1, 10):
             any_nonzero |= data.draw_integer(0, 2**i - 1) > 0
@@ -334,7 +335,7 @@ def test_zero_examples_with_variable_min_size():
 
 def test_zero_contained_examples():
     @shrinking_from(bytes([1]) * 8)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         for _ in range(4):
             data.start_example(1)
             if data.draw_integer(0, 2**8 - 1) == 0:
@@ -351,7 +352,7 @@ def test_zero_contained_examples():
 
 def test_zig_zags_quickly():
     @shrinking_from(bytes([255]) * 4)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         m = data.draw_integer(0, 2**16 - 1)
         n = data.draw_integer(0, 2**16 - 1)
         if m == 0 or n == 0:
@@ -398,7 +399,7 @@ def test_zig_zags_quickly_with_shrink_towards(
             data.mark_interesting()
 
     @shrinking_from(buf)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         m = data.draw_integer(min_value, max_value, shrink_towards=shrink_towards)
         n = data.draw_integer(min_value, max_value, shrink_towards=shrink_towards)
         # avoid trivial counterexamples
@@ -414,7 +415,7 @@ def test_zig_zags_quickly_with_shrink_towards(
 
 def test_zero_irregular_examples():
     @shrinking_from([255] * 6)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         data.start_example(1)
         data.draw_integer(0, 2**8 - 1)
         data.draw_integer(0, 2**16 - 1)
@@ -433,7 +434,7 @@ def test_zero_irregular_examples():
 
 def test_retain_end_of_buffer():
     @shrinking_from([1, 2, 3, 4, 5, 6, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         interesting = False
         while True:
             n = data.draw_integer(0, 2**8 - 1)
@@ -450,7 +451,7 @@ def test_retain_end_of_buffer():
 
 def test_can_expand_zeroed_region():
     @shrinking_from([255] * 5)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         seen_non_zero = False
         for _ in range(5):
             if data.draw_integer(0, 2**8 - 1) == 0:
@@ -466,7 +467,7 @@ def test_can_expand_zeroed_region():
 
 def test_can_expand_deleted_region():
     @shrinking_from([1, 2, 3, 4, 0, 0])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         def t():
             data.start_example(1)
 
@@ -494,7 +495,7 @@ def test_can_expand_deleted_region():
 
 def test_shrink_pass_method_is_idempotent():
     @shrinking_from([255])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         data.draw_integer(0, 2**8 - 1)
         data.mark_interesting()
 
@@ -510,7 +511,7 @@ def test_will_terminate_stalled_shrinks():
     time.freeze()
 
     @shrinking_from([255] * 100)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         count = 0
 
         for _ in range(100):
@@ -526,7 +527,7 @@ def test_will_terminate_stalled_shrinks():
 
 def test_will_let_fixate_shrink_passes_do_a_full_run_through():
     @shrinking_from(range(50))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         for i in range(50):
             if data.draw_integer(0, 2**8 - 1) != i:
                 data.mark_invalid()
@@ -545,7 +546,7 @@ def test_will_let_fixate_shrink_passes_do_a_full_run_through():
 @pytest.mark.parametrize("n_gap", [0, 1, 2, 3])
 def test_can_simultaneously_lower_non_duplicated_nearby_blocks(n_gap):
     @shrinking_from([1, 1] + [0] * n_gap + [0, 2])
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         # Block off lowering the whole buffer
         if data.draw_integer(0, 2**1 - 1) == 0:
             data.mark_invalid()
@@ -570,7 +571,7 @@ def test_redistribute_integer_pairs_with_forced_node():
         data.mark_interesting()
 
     @shrinking_from(buf)
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         n1 = data.draw_integer(0, 100)
         n2 = data.draw_integer(0, 100, forced=10)
         if n1 + n2 > 20:

--- a/hypothesis-python/tests/cover/test_cache_implementation.py
+++ b/hypothesis-python/tests/cover/test_cache_implementation.py
@@ -137,11 +137,12 @@ def test_always_evicts_the_lowest_scoring_value(writes, data):
         scores[key] = data.draw(st.integers(0, 1000), label=f"scores[{key!r}]")
         return scores[key]
 
-    last_entry = [None]
+    last_entry = None
 
     class Cache(GenericCache):
         def new_entry(self, key, value):
-            last_entry[0] = key
+            nonlocal last_entry
+            last_entry = key
             evicted.discard(key)
             assert key not in scores
             return new_score(key)
@@ -155,7 +156,7 @@ def test_always_evicts_the_lowest_scoring_value(writes, data):
             assert score == scores[key]
             del scores[key]
             if len(scores) > 1:
-                assert score <= min(v for k, v in scores.items() if k != last_entry[0])
+                assert score <= min(v for k, v in scores.items() if k != last_entry)
             evicted.add(key)
 
     target = Cache(max_size=size)

--- a/hypothesis-python/tests/cover/test_core.py
+++ b/hypothesis-python/tests/cover/test_core.py
@@ -34,10 +34,11 @@ def test_stops_after_max_examples_if_satisfying():
 
 
 def test_stops_after_ten_times_max_examples_if_not_satisfying():
-    count = [0]
+    count = 0
 
     def track(x):
-        count[0] += 1
+        nonlocal count
+        count += 1
         reject()
 
     max_examples = 100
@@ -48,7 +49,7 @@ def test_stops_after_ten_times_max_examples_if_not_satisfying():
     # Very occasionally we can generate overflows in generation, which also
     # count towards our example budget, which means that we don't hit the
     # maximum.
-    assert count[0] <= 10 * max_examples
+    assert count <= 10 * max_examples
 
 
 some_normal_settings = settings()
@@ -65,18 +66,19 @@ def test_settings_are_default_in_given(x):
 
 
 def test_given_shrinks_pytest_helper_errors():
-    final_value = [None]
+    final_value = None
 
     @settings(derandomize=True, max_examples=100)
     @given(s.integers())
     def inner(x):
-        final_value[0] = x
+        nonlocal final_value
+        final_value = x
         if x > 100:
             pytest.fail(f"{x=} is too big!")
 
     with pytest.raises(Failed):
         inner()
-    assert final_value[0] == 101
+    assert final_value == 101
 
 
 def test_pytest_skip_skips_shrinking():

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -51,13 +51,14 @@ def test_slow_with_none_deadline(i):
 
 
 def test_raises_flaky_if_a_test_becomes_fast_on_rerun():
-    once = [True]
+    once = True
 
     @settings(deadline=500, backend="hypothesis")
     @given(st.integers())
     def test_flaky_slow(i):
-        if once[0]:
-            once[0] = False
+        nonlocal once
+        if once:
+            once = False
             time.sleep(1)
 
     with pytest.raises(FlakyFailure):
@@ -80,17 +81,18 @@ def test_deadlines_participate_in_shrinking():
 
 def test_keeps_you_well_above_the_deadline():
     seen = set()
-    failed_once = [False]
+    failed_once = False
 
     @settings(deadline=100, backend="hypothesis")
     @given(st.integers(0, 2000))
     def slow(i):
+        nonlocal failed_once
         # Make sure our initial failure isn't something that immediately goes flaky.
-        if not failed_once[0]:
+        if not failed_once:
             if i * 0.9 <= 100:
                 return
             else:
-                failed_once[0] = True
+                failed_once = True
 
         t = i / 1000
         if i in seen:
@@ -104,13 +106,14 @@ def test_keeps_you_well_above_the_deadline():
 
 
 def test_gives_a_deadline_specific_flaky_error_message():
-    once = [True]
+    once = True
 
     @settings(deadline=100, backend="hypothesis")
     @given(st.integers())
     def slow_once(i):
-        if once[0]:
-            once[0] = False
+        nonlocal once
+        if once:
+            once = False
             time.sleep(0.2)
 
     with pytest.raises(FlakyFailure) as err:

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -25,12 +25,13 @@ class Nope(Exception):
 
 
 def test_fails_only_once_is_flaky():
-    first_call = [True]
+    first_call = True
 
     @given(integers())
     def rude(x):
-        if first_call[0]:
-            first_call[0] = False
+        nonlocal first_call
+        if first_call:
+            first_call = False
             raise Nope
 
     with pytest.raises(FlakyFailure, match="Falsified on the first call but") as e:

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -98,16 +98,17 @@ def test_functions_strategy_return_type_inference(f):
 
 
 def test_functions_valid_within_given_invalid_outside():
-    cache = [None]
+    cache = None
 
     @given(functions())
     def t(f):
+        nonlocal cache
+        cache = f
         assert f() is None
-        cache[0] = f
 
     t()
     with pytest.raises(InvalidState):
-        cache[0]()
+        cache()
 
 
 def test_can_call_default_like_arg():

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -102,15 +102,16 @@ def test_registered_Random_is_seeded_by_random_module_strategy():
     register_random(r)
     state = r.getstate()
     results = set()
-    count = [0]
+    count = 0
 
     @given(st.integers())
     def inner(x):
+        nonlocal count
         results.add(r.random())
-        count[0] += 1
+        count += 1
 
     inner()
-    assert count[0] > len(results) * 0.9, "too few unique random numbers"
+    assert count > len(results) * 0.9, "too few unique random numbers"
     assert state == r.getstate()
 
 

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -119,14 +119,15 @@ def test_errors_with_did_not_reproduce_if_rejected():
 
 
 def test_prints_reproduction_if_requested():
-    failing_example = [None]
+    failing_example = None
 
     @settings(print_blob=True, database=None, max_examples=100)
     @given(st.integers())
     def test(i):
-        if failing_example[0] is None and i != 0:
-            failing_example[0] = i
-        assert i not in failing_example
+        nonlocal failing_example
+        if failing_example is None and i != 0:
+            failing_example = i
+        assert i != failing_example
 
     with pytest.raises(AssertionError) as err:
         test()

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -334,23 +334,26 @@ def test_machine_with_no_terminals_is_invalid():
 
 
 def test_minimizes_errors_in_teardown():
-    counter = [0]
+    counter = 0
 
     class Foo(RuleBasedStateMachine):
         @initialize()
         def init(self):
-            counter[0] = 0
+            nonlocal counter
+            counter = 0
 
         @rule()
         def increment(self):
-            counter[0] += 1
+            nonlocal counter
+            counter += 1
 
         def teardown(self):
-            assert not counter[0]
+            nonlocal counter
+            assert not counter
 
     with raises(AssertionError):
         run_state_machine_as_test(Foo)
-    assert counter[0] == 1
+    assert counter == 1
 
 
 class RequiresInit(RuleBasedStateMachine):

--- a/hypothesis-python/tests/cover/test_statistical_events.py
+++ b/hypothesis-python/tests/cover/test_statistical_events.py
@@ -130,14 +130,15 @@ def test_apparently_instantaneous_tests():
 
 
 def test_flaky_exit():
-    first = [True]
+    first = True
 
     @settings(derandomize=True)
     @given(st.integers())
     def test(i):
+        nonlocal first
         if i > 1001:
-            if first[0]:
-                first[0] = False
+            if first:
+                first = False
                 print("Hi")
                 raise AssertionError
 

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -159,12 +159,13 @@ def test_integers_from_are_from(x):
 
 
 def test_does_not_catch_interrupt_during_falsify():
-    calls = [0]
+    called = False
 
     @given(integers())
     def flaky_base_exception(x):
-        if not calls[0]:
-            calls[0] = 1
+        nonlocal called
+        if not called:
+            called = True
             raise KeyboardInterrupt
 
     with raises(KeyboardInterrupt):

--- a/hypothesis-python/tests/nocover/test_baseexception.py
+++ b/hypothesis-python/tests/nocover/test_baseexception.py
@@ -48,13 +48,14 @@ def test_exception_propagates_fine_from_strategy(e):
 
 @pytest.mark.parametrize("e", [KeyboardInterrupt, ValueError])
 def test_baseexception_no_rerun_no_flaky(e):
-    runs = [0]
+    runs = 0
     interrupt = 3
 
     @given(integers())
     def test_raise_baseexception(x):
-        runs[0] += 1
-        if runs[0] == interrupt:
+        nonlocal runs
+        runs += 1
+        if runs == interrupt:
             raise e
 
     if issubclass(e, (KeyboardInterrupt, SystemExit, GeneratorExit)):
@@ -62,7 +63,7 @@ def test_baseexception_no_rerun_no_flaky(e):
         with pytest.raises(e):
             test_raise_baseexception()
 
-        assert runs[0] == interrupt
+        assert runs == interrupt
     else:
         with pytest.raises(FlakyFailure):
             test_raise_baseexception()

--- a/hypothesis-python/tests/nocover/test_cacheable.py
+++ b/hypothesis-python/tests/nocover/test_cacheable.py
@@ -52,7 +52,7 @@ def test_cacheable_things_are_cached():
 
 
 def test_local_types_are_garbage_collected_issue_493():
-    store = [None]
+    store = None
 
     def run_locally():
         class Test:
@@ -61,11 +61,12 @@ def test_local_types_are_garbage_collected_issue_493():
             def test(self, i):
                 pass
 
-        store[0] = weakref.ref(Test)
+        nonlocal store
+        store = weakref.ref(Test)
         Test().test()
 
     run_locally()
     del run_locally
-    assert store[0]() is not None
+    assert store() is not None
     gc.collect()
-    assert store[0]() is None
+    assert store() is None

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -103,7 +103,7 @@ def test_node_programs_fail_efficiently(monkeypatch):
     # Create 256 byte-sized blocks. None of the blocks can be deleted, and
     # every deletion attempt produces a different buffer.
     @shrinking_from(bytes(range(256)))
-    def shrinker(data):
+    def shrinker(data: ConjectureData):
         values = set()
         for _ in range(256):
             v = data.draw_integer(0, 2**8 - 1)

--- a/hypothesis-python/tests/nocover/test_deferred_errors.py
+++ b/hypothesis-python/tests/nocover/test_deferred_errors.py
@@ -54,16 +54,17 @@ def test_errors_on_example():
 
 
 def test_does_not_recalculate_the_strategy():
-    calls = [0]
+    calls = 0
 
     @defines_strategy()
     def foo():
-        calls[0] += 1
+        nonlocal calls
+        calls += 1
         return st.just(1)
 
     f = foo()
-    assert calls == [0]
+    assert calls == 0
     check_can_generate_examples(f)
-    assert calls == [1]
+    assert calls == 1
     check_can_generate_examples(f)
-    assert calls == [1]
+    assert calls == 1

--- a/hypothesis-python/tests/nocover/test_limits.py
+++ b/hypothesis-python/tests/nocover/test_limits.py
@@ -12,12 +12,13 @@ from hypothesis import given, settings, strategies as st
 
 
 def test_max_examples_are_respected():
-    counter = [0]
+    counter = 0
 
     @given(st.random_module(), st.integers())
     @settings(max_examples=100)
     def test(rnd, i):
-        counter[0] += 1
+        nonlocal counter
+        counter += 1
 
     test()
-    assert counter == [100]
+    assert counter == 100

--- a/hypothesis-python/tests/nocover/test_targeting.py
+++ b/hypothesis-python/tests/nocover/test_targeting.py
@@ -61,7 +61,7 @@ def test_targeting_can_be_disabled():
     strat = st.lists(st.integers(0, 255))
 
     def score(enabled):
-        result = [0]
+        result = 0
         phases = [Phase.generate]
         if enabled:
             phases.append(Phase.target)
@@ -70,12 +70,13 @@ def test_targeting_can_be_disabled():
         @settings(database=None, max_examples=200, phases=phases)
         @given(strat)
         def test(ls):
+            nonlocal result
             score = float(sum(ls))
-            result[0] = max(result[0], score)
+            result = max(result, score)
             target(score)
 
         test()
-        return result[0]
+        return result
 
     assert score(enabled=True) > score(enabled=False)
 

--- a/hypothesis-python/tests/nocover/test_threading.py
+++ b/hypothesis-python/tests/nocover/test_threading.py
@@ -14,13 +14,14 @@ from hypothesis import given, strategies as st
 
 
 def test_can_run_given_in_thread():
-    has_run_successfully = [False]
+    has_run_successfully = False
 
     @given(st.integers())
     def test(n):
-        has_run_successfully[0] = True
+        nonlocal has_run_successfully
+        has_run_successfully = True
 
     t = threading.Thread(target=test)
     t.start()
     t.join()
-    assert has_run_successfully[0]
+    assert has_run_successfully


### PR DESCRIPTION
- use `nonlocal` rather than updating list elements, a much-delayed cleanup from the Python 2 days
- add `: ConjectureData` to get better editor support in some common cases