### PR TITLE
Migrate `explain` phase to the typed choice sequence

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch migrates the :obj:`~hypothesis.Phase.explain` :ref:`phase <phases>` to our IR layer (:issue:`3921`). This should improve both its speed and precision.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -149,10 +149,10 @@ class BuildContext:
         arg_labels = {}
         kwargs = {}
         for k, s in kwarg_strategies.items():
-            start_idx = self.data.index
+            start_idx = self.data.index_ir
             with deprecate_random_in_strategy("from {}={!r}", k, s) as check:
                 obj = check(self.data.draw(s, observe_as=f"generate:{k}"))
-            end_idx = self.data.index
+            end_idx = self.data.index_ir
             kwargs[k] = obj
 
             # This high up the stack, we can't see or really do much with the conjecture

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -627,7 +627,7 @@ class Examples:
         def finish(self):
             return tuple(self.result)
 
-    ir_tree_nodes: "tuple[IRNode]" = calculated_example_property(_ir_tree_nodes)
+    ir_tree_nodes: "tuple[IRNode, ...]" = calculated_example_property(_ir_tree_nodes)
 
     class _label_indices(ExampleProperty):
         def start_example(self, i: int, label_index: int) -> None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -974,7 +974,8 @@ class IRNode:
     ) -> "IRNode":
         # we may want to allow this combination in the future, but for now it's
         # a footgun.
-        assert not self.was_forced, "modifying a forced node doesn't make sense"
+        if self.was_forced:
+            assert with_value is None, "modifying a forced node doesn't make sense"
         # explicitly not copying index. node indices are only assigned via
         # ExampleRecord. This prevents footguns with relying on stale indices
         # after copying.
@@ -1109,6 +1110,12 @@ def ir_value_permitted(value, ir_type, kwargs):
         return True
 
     raise NotImplementedError(f"unhandled type {type(value)} of ir value {value}")
+
+
+def ir_size(nodes: Sequence[IRNode]) -> int:
+    # TODO some node-specific notion of size: strings = # of elements,
+    # ints = some function of the number of bits, etc
+    return len(nodes)
 
 
 def ir_value_key(ir_type, v):
@@ -1988,18 +1995,20 @@ class ConjectureData:
     @classmethod
     def for_ir_tree(
         cls,
-        ir_tree_prefix: list[IRNode],
+        ir_tree_prefix: Sequence[IRNode],
         *,
         observer: Optional[DataObserver] = None,
         provider: Union[type, PrimitiveProvider] = HypothesisProvider,
         max_length: Optional[int] = None,
+        random: Optional[Random] = None,
     ) -> "ConjectureData":
         from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 
         return cls(
-            max_length=BUFFER_SIZE if max_length is None else max_length,
+            max_length=BUFFER_SIZE,
+            max_length_ir=ir_size(ir_tree_prefix) if max_length is None else max_length,
             prefix=b"",
-            random=None,
+            random=random,
             ir_tree_prefix=ir_tree_prefix,
             observer=observer,
             provider=provider,
@@ -2013,14 +2022,18 @@ class ConjectureData:
         random: Optional[Random],
         observer: Optional[DataObserver] = None,
         provider: Union[type, PrimitiveProvider] = HypothesisProvider,
-        ir_tree_prefix: Optional[list[IRNode]] = None,
+        ir_tree_prefix: Optional[Sequence[IRNode]] = None,
+        max_length_ir: Optional[int] = None,
     ) -> None:
+        from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR
+
         if observer is None:
             observer = DataObserver()
         assert isinstance(observer, DataObserver)
         self._bytes_drawn = 0
         self.observer = observer
         self.max_length = max_length
+        self.max_length_ir = BUFFER_SIZE_IR if max_length_ir is None else max_length_ir
         self.is_find = False
         self.overdraw = 0
         self.__prefix = bytes(prefix)
@@ -2032,6 +2045,7 @@ class ConjectureData:
         self.blocks = Blocks(self)
         self.buffer: "Union[bytes, bytearray]" = bytearray()
         self.index = 0
+        self.index_ir = 0
         self.output = ""
         self.status = Status.VALID
         self.frozen = False
@@ -2087,7 +2101,6 @@ class ConjectureData:
 
         self.ir_tree_nodes = ir_tree_prefix
         self.misaligned_at: Optional[MisalignedAt] = None
-        self._node_index = 0
         self.start_example(TOP_LABEL)
 
     def __repr__(self) -> str:
@@ -2121,6 +2134,39 @@ class ConjectureData:
     # Setting `fake_forced` to true says that yes, we want to force a particular
     # value to be returned, but we don't want to treat that block as fixed for
     # e.g. the shrinker.
+
+    def _draw(self, ir_type, kwargs, *, observe, forced, fake_forced):
+        if self.index_ir >= self.max_length_ir:
+            self.mark_overrun()
+
+        if self.ir_tree_nodes is not None and observe:
+            if self.index_ir < len(self.ir_tree_nodes):
+                node_value = self._pop_ir_tree_node(ir_type, kwargs, forced=forced)
+            else:
+                (node_value, _buf) = ir_to_buffer(
+                    ir_type, kwargs, forced=forced, random=self.__random
+                )
+
+            if forced is None:
+                forced = node_value
+                fake_forced = True
+
+        value = getattr(self.provider, f"draw_{ir_type}")(
+            **kwargs, forced=forced, fake_forced=fake_forced
+        )
+
+        if observe:
+            getattr(self.observer, f"draw_{ir_type}")(
+                value, kwargs=kwargs, was_forced=forced is not None and not fake_forced
+            )
+            self.__example_record.record_ir_draw(
+                ir_type,
+                value,
+                kwargs=kwargs,
+                was_forced=forced is not None and not fake_forced,
+            )
+            self.index_ir += 1
+        return value
 
     def draw_integer(
         self,
@@ -2172,28 +2218,9 @@ class ConjectureData:
                 "shrink_towards": shrink_towards,
             },
         )
-
-        if self.ir_tree_nodes is not None and observe:
-            node_value = self._pop_ir_tree_node("integer", kwargs, forced=forced)
-            if forced is None:
-                assert isinstance(node_value, int)
-                forced = node_value
-                fake_forced = True
-
-        value = self.provider.draw_integer(
-            **kwargs, forced=forced, fake_forced=fake_forced
+        return self._draw(
+            "integer", kwargs, observe=observe, forced=forced, fake_forced=fake_forced
         )
-        if observe:
-            self.observer.draw_integer(
-                value, kwargs=kwargs, was_forced=forced is not None and not fake_forced
-            )
-            self.__example_record.record_ir_draw(
-                "integer",
-                value,
-                kwargs=kwargs,
-                was_forced=forced is not None and not fake_forced,
-            )
-        return value
 
     def draw_float(
         self,
@@ -2229,28 +2256,9 @@ class ConjectureData:
                 "smallest_nonzero_magnitude": smallest_nonzero_magnitude,
             },
         )
-
-        if self.ir_tree_nodes is not None and observe:
-            node_value = self._pop_ir_tree_node("float", kwargs, forced=forced)
-            if forced is None:
-                assert isinstance(node_value, float)
-                forced = node_value
-                fake_forced = True
-
-        value = self.provider.draw_float(
-            **kwargs, forced=forced, fake_forced=fake_forced
+        return self._draw(
+            "float", kwargs, observe=observe, forced=forced, fake_forced=fake_forced
         )
-        if observe:
-            self.observer.draw_float(
-                value, kwargs=kwargs, was_forced=forced is not None and not fake_forced
-            )
-            self.__example_record.record_ir_draw(
-                "float",
-                value,
-                kwargs=kwargs,
-                was_forced=forced is not None and not fake_forced,
-            )
-        return value
 
     def draw_string(
         self,
@@ -2273,27 +2281,9 @@ class ConjectureData:
                 "max_size": max_size,
             },
         )
-        if self.ir_tree_nodes is not None and observe:
-            node_value = self._pop_ir_tree_node("string", kwargs, forced=forced)
-            if forced is None:
-                assert isinstance(node_value, str)
-                forced = node_value
-                fake_forced = True
-
-        value = self.provider.draw_string(
-            **kwargs, forced=forced, fake_forced=fake_forced
+        return self._draw(
+            "string", kwargs, observe=observe, forced=forced, fake_forced=fake_forced
         )
-        if observe:
-            self.observer.draw_string(
-                value, kwargs=kwargs, was_forced=forced is not None and not fake_forced
-            )
-            self.__example_record.record_ir_draw(
-                "string",
-                value,
-                kwargs=kwargs,
-                was_forced=forced is not None and not fake_forced,
-            )
-        return value
 
     def draw_bytes(
         self,
@@ -2310,28 +2300,9 @@ class ConjectureData:
         kwargs: BytesKWargs = self._pooled_kwargs(
             "bytes", {"min_size": min_size, "max_size": max_size}
         )
-
-        if self.ir_tree_nodes is not None and observe:
-            node_value = self._pop_ir_tree_node("bytes", kwargs, forced=forced)
-            if forced is None:
-                assert isinstance(node_value, bytes)
-                forced = node_value
-                fake_forced = True
-
-        value = self.provider.draw_bytes(
-            **kwargs, forced=forced, fake_forced=fake_forced
+        return self._draw(
+            "bytes", kwargs, observe=observe, forced=forced, fake_forced=fake_forced
         )
-        if observe:
-            self.observer.draw_bytes(
-                value, kwargs=kwargs, was_forced=forced is not None and not fake_forced
-            )
-            self.__example_record.record_ir_draw(
-                "bytes",
-                value,
-                kwargs=kwargs,
-                was_forced=forced is not None and not fake_forced,
-            )
-        return value
 
     def draw_boolean(
         self,
@@ -2351,28 +2322,9 @@ class ConjectureData:
         assert (forced is not False) or p < (1 - eps)
 
         kwargs: BooleanKWargs = self._pooled_kwargs("boolean", {"p": p})
-
-        if self.ir_tree_nodes is not None and observe:
-            node_value = self._pop_ir_tree_node("boolean", kwargs, forced=forced)
-            if forced is None:
-                assert isinstance(node_value, bool)
-                forced = node_value
-                fake_forced = True
-
-        value = self.provider.draw_boolean(
-            **kwargs, forced=forced, fake_forced=fake_forced
+        return self._draw(
+            "boolean", kwargs, observe=observe, forced=forced, fake_forced=fake_forced
         )
-        if observe:
-            self.observer.draw_boolean(
-                value, kwargs=kwargs, was_forced=forced is not None and not fake_forced
-            )
-            self.__example_record.record_ir_draw(
-                "boolean",
-                value,
-                kwargs=kwargs,
-                was_forced=forced is not None and not fake_forced,
-            )
-        return value
 
     def _pooled_kwargs(self, ir_type, kwargs):
         """Memoize common dictionary objects to reduce memory pressure."""
@@ -2393,11 +2345,10 @@ class ConjectureData:
         from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 
         assert self.ir_tree_nodes is not None
+        # checked in _draw
+        assert self.index_ir < len(self.ir_tree_nodes)
 
-        if self._node_index == len(self.ir_tree_nodes):
-            self.mark_overrun()
-
-        node = self.ir_tree_nodes[self._node_index]
+        node = self.ir_tree_nodes[self.index_ir]
         value = node.value
         # If we're trying to:
         # * draw a different ir type at the same location
@@ -2422,7 +2373,7 @@ class ConjectureData:
         ):
             # only track first misalignment for now.
             if self.misaligned_at is None:
-                self.misaligned_at = (self._node_index, ir_type, kwargs, forced)
+                self.misaligned_at = (self.index_ir, ir_type, kwargs, forced)
             (_value, buffer) = ir_to_buffer(
                 node.ir_type, node.kwargs, forced=node.value
             )
@@ -2438,7 +2389,6 @@ class ConjectureData:
                 #   buffer_to_ir(ir_type, kwargs, buffer=bytes(BUFFER_SIZE))
                 self.mark_overrun()
 
-        self._node_index += 1
         return value
 
     def as_result(self) -> Union[ConjectureResult, _Overrun]:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -624,7 +624,10 @@ class Examples:
         def ir_node(self, ir_node: "IRNode") -> None:
             self.result.append(ir_node)
 
-    ir_tree_nodes: "list[IRNode]" = calculated_example_property(_ir_tree_nodes)
+        def finish(self):
+            return tuple(self.result)
+
+    ir_tree_nodes: "tuple[IRNode]" = calculated_example_property(_ir_tree_nodes)
 
     class _label_indices(ExampleProperty):
         def start_example(self, i: int, label_index: int) -> None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -13,7 +13,7 @@ import math
 import textwrap
 import time
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager, suppress
 from datetime import timedelta
 from enum import Enum
@@ -330,7 +330,7 @@ class ConjectureRunner:
     def _cache_key_ir(
         self,
         *,
-        nodes: Optional[list[IRNode]] = None,
+        nodes: Optional[Sequence[IRNode]] = None,
         data: Union[ConjectureData, ConjectureResult, None] = None,
     ) -> tuple[tuple[Any, ...], ...]:
         assert (nodes is not None) ^ (data is not None)
@@ -1239,7 +1239,7 @@ class ConjectureRunner:
 
     def new_conjecture_data_ir(
         self,
-        ir_tree_prefix: list[IRNode],
+        ir_tree_prefix: Sequence[IRNode],
         *,
         observer: Optional[DataObserver] = None,
         max_length: Optional[int] = None,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -744,34 +744,14 @@ class ConjectureRunner:
         if not self.report_debug_info:
             return
 
-        stack: list[Ls] = [[]]
-
-        def go(ex: Example) -> None:
-            if ex.length == 0:
-                return
-            if len(ex.children) == 0:
-                stack[-1].append(int_from_bytes(data.buffer[ex.start : ex.end]))
-            else:
-                node: Ls = []
-                stack.append(node)
-
-                for v in ex.children:
-                    go(v)
-                stack.pop()
-                if len(node) == 1:
-                    stack[-1].extend(node)
-                else:
-                    stack[-1].append(node)
-
-        go(data.examples[0])
-        assert len(stack) == 1
-
         status = repr(data.status)
-
         if data.status == Status.INTERESTING:
             status = f"{status} ({data.interesting_origin!r})"
 
-        self.debug(f"{data.index} bytes {stack[0]!r} -> {status}, {data.output}")
+        nodes = data.examples.ir_tree_nodes
+        self.debug(
+            f"{len(nodes)} nodes {[n.value for n in nodes]} -> {status}, {data.output}"
+        )
 
     def run(self) -> None:
         with local_settings(self.settings):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -59,7 +59,7 @@ from hypothesis.internal.conjecture.data import (
     Status,
     _Overrun,
     ir_kwargs_key,
-    ir_size,
+    ir_size_nodes,
     ir_value_key,
 )
 from hypothesis.internal.conjecture.datatree import (
@@ -387,7 +387,7 @@ class ConjectureRunner:
         except KeyError:
             pass
 
-        max_length = min(BUFFER_SIZE_IR, ir_size(nodes) + extend)
+        max_length = min(BUFFER_SIZE_IR, ir_size_nodes(nodes) + extend)
 
         # explicitly use a no-op DataObserver here instead of a TreeRecordingObserver.
         # The reason is we don't expect simulate_test_function to explore new choices

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -44,13 +44,7 @@ from hypothesis.errors import (
     StopTest,
 )
 from hypothesis.internal.cache import LRUReusedCache
-from hypothesis.internal.compat import (
-    NotRequired,
-    TypeAlias,
-    TypedDict,
-    ceil,
-    override,
-)
+from hypothesis.internal.compat import NotRequired, TypeAlias, TypedDict, ceil, override
 from hypothesis.internal.conjecture.data import (
     AVAILABLE_PROVIDERS,
     ConjectureData,
@@ -1488,15 +1482,18 @@ class ConjectureRunner:
             self.__data_cache[buffer] = result
         return result
 
-    def passing_buffers(self, prefix: bytes = b"") -> frozenset[bytes]:
-        """Return a collection of bytestrings which cause the test to pass.
+    def passing_choice_sequences(
+        self, prefix: Sequence[IRNode] = ()
+    ) -> frozenset[bytes]:
+        """Return a collection of choice sequence nodes which cause the test to pass.
 
         Optionally restrict this by a certain prefix, which is useful for explain mode.
         """
         return frozenset(
-            buf
-            for buf in self.__data_cache
-            if buf.startswith(prefix) and self.__data_cache[buf].status == Status.VALID
+            result.examples.ir_tree_nodes
+            for key in self.__data_cache_ir
+            if (result := self.__data_cache_ir[key]).status is Status.VALID
+            and startswith(result.examples.ir_tree_nodes, prefix)
         )
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -468,3 +468,15 @@ def gc_cumulative_time() -> float:
         _gc_initialized = True
 
     return _gc_cumulative_time
+
+
+def startswith(l1: Sequence[T], l2: Sequence[T]) -> bool:
+    if len(l1) < len(l2):
+        return False
+    return all(v1 == v2 for v1, v2 in zip(l1[: len(l2)], l2))
+
+
+def endswith(l1: Sequence[T], l2: Sequence[T]) -> bool:
+    if len(l1) < len(l2):
+        return False
+    return all(v1 == v2 for v1, v2 in zip(l1[-len(l2) :], l2))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1262,9 +1262,9 @@ class Shrinker:
 
             return self.consider_new_tree(
                 self.nodes[: node1.index]
-                + [node1.copy(with_value=node_value)]
+                + (node1.copy(with_value=node_value),)
                 + self.nodes[node1.index + 1 : node2.index]
-                + [node2.copy(with_value=next_node_value)]
+                + (node2.copy(with_value=next_node_value),)
                 + self.nodes[node2.index + 1 :]
             )
 
@@ -1413,7 +1413,7 @@ class Shrinker:
 
         lowered = (
             self.nodes[: node.index]
-            + [node.copy(with_value=node.value - 1)]
+            + (node.copy(with_value=node.value - 1),)
             + self.nodes[node.index + 1 :]
         )
         attempt = self.cached_test_function_ir(lowered)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
 import attr
@@ -22,6 +23,7 @@ from hypothesis.internal.conjecture.choicetree import (
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,
+    IRNode,
     Status,
     ir_to_buffer,
     ir_value_equal,
@@ -391,7 +393,7 @@ class Shrinker:
         self.check_calls()
         return result
 
-    def consider_new_tree(self, tree):
+    def consider_new_tree(self, tree: Sequence[IRNode]) -> bool:
         tree = tree[: len(self.nodes)]
 
         if startswith(tree, self.nodes):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -25,6 +25,7 @@ from hypothesis.internal.conjecture.data import (
     ConjectureResult,
     IRNode,
     Status,
+    ir_size_nodes,
     ir_to_buffer,
     ir_value_equal,
     ir_value_key,
@@ -597,7 +598,7 @@ class Shrinker:
 
                 attempt = nodes[:start] + tuple(replacement) + nodes[end:]
                 result = self.engine.cached_test_function_ir(
-                    attempt, extend=BUFFER_SIZE_IR - len(attempt)
+                    attempt, extend=BUFFER_SIZE_IR - ir_size_nodes(attempt)
                 )
 
                 # Turns out this was a variable-length part, so grab the infix...

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -23,11 +23,17 @@ from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,
     Status,
+    ir_to_buffer,
     ir_value_equal,
     ir_value_key,
     ir_value_permitted,
 )
-from hypothesis.internal.conjecture.junkdrawer import find_integer, replace_all
+from hypothesis.internal.conjecture.junkdrawer import (
+    endswith,
+    find_integer,
+    replace_all,
+    startswith,
+)
 from hypothesis.internal.conjecture.shrinking import (
     Bytes,
     Float,
@@ -388,9 +394,6 @@ class Shrinker:
     def consider_new_tree(self, tree):
         tree = tree[: len(self.nodes)]
 
-        def startswith(t1, t2):
-            return t1[: len(t2)] == t2
-
         if startswith(tree, self.nodes):
             return True
 
@@ -537,20 +540,21 @@ class Shrinker:
         self.explain()
 
     def explain(self):
+        from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR
+
         if not self.should_explain or not self.shrink_target.arg_slices:
             return
-        from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 
         self.max_stall = 1e999
         shrink_target = self.shrink_target
-        buffer = shrink_target.buffer
+        nodes = self.nodes
         chunks = defaultdict(list)
 
         # Before we start running experiments, let's check for known inputs which would
         # make them redundant.  The shrinking process means that we've already tried many
         # variations on the minimal example, so this can save a lot of time.
-        seen_passing_buffers = self.engine.passing_buffers(
-            prefix=buffer[: min(self.shrink_target.arg_slices)[0]]
+        seen_passing_seq = self.engine.passing_choice_sequences(
+            prefix=self.nodes[: min(self.shrink_target.arg_slices)[0]]
         )
 
         # Now that we've shrunk to a minimal failing example, it's time to try
@@ -562,8 +566,8 @@ class Shrinker:
             # Check for any previous examples that match the prefix and suffix,
             # so we can skip if we found a passing example while shrinking.
             if any(
-                seen.startswith(buffer[:start]) and seen.endswith(buffer[end:])
-                for seen in seen_passing_buffers
+                startswith(seen, nodes[:start]) and endswith(seen, nodes[end:])
+                for seen in seen_passing_seq
             ):
                 continue
 
@@ -578,47 +582,61 @@ class Shrinker:
                     # stop early if we're seeing mostly invalid examples
                     break  # pragma: no cover
 
-                buf_attempt_fixed = bytearray(buffer)
-                buf_attempt_fixed[start:end] = [
-                    self.random.randint(0, 255) for _ in range(end - start)
-                ]
-                result = self.engine.cached_test_function(
-                    buf_attempt_fixed, extend=BUFFER_SIZE - len(buf_attempt_fixed)
+                # replace start:end with random values
+                replacement = []
+                for i in range(start, end):
+                    node = nodes[i]
+                    if not node.was_forced:
+                        (value, _buf) = ir_to_buffer(
+                            node.ir_type, node.kwargs, random=self.random
+                        )
+                        node = node.copy(with_value=value)
+                    replacement.append(node)
+
+                attempt = nodes[:start] + tuple(replacement) + nodes[end:]
+                result = self.engine.cached_test_function_ir(
+                    attempt, extend=BUFFER_SIZE_IR - len(attempt)
                 )
 
                 # Turns out this was a variable-length part, so grab the infix...
-                if result.status == Status.OVERRUN:
+                if result.status is Status.OVERRUN:
                     continue  # pragma: no cover  # flakily covered
                 if not (
-                    len(buf_attempt_fixed) == len(result.buffer)
-                    and result.buffer.endswith(buffer[end:])
+                    len(attempt) == len(result.examples.ir_tree_nodes)
+                    and endswith(result.examples.ir_tree_nodes, nodes[end:])
                 ):
                     for ex, res in zip(shrink_target.examples, result.examples):
-                        assert ex.start == res.start
-                        assert ex.start <= start
+                        assert ex.ir_start == res.ir_start
+                        assert ex.ir_start <= start
                         assert ex.label == res.label
-                        if start == ex.start and end == ex.end:
-                            res_end = res.end
+                        if start == ex.ir_start and end == ex.ir_end:
+                            res_end = res.ir_end
                             break
                     else:
                         raise NotImplementedError("Expected matching prefixes")
 
-                    buf_attempt_fixed = (
-                        buffer[:start] + result.buffer[start:res_end] + buffer[end:]
+                    attempt = (
+                        nodes[:start]
+                        + result.examples.ir_tree_nodes[start:res_end]
+                        + nodes[end:]
                     )
-                    chunks[(start, end)].append(result.buffer[start:res_end])
-                    result = self.engine.cached_test_function(buf_attempt_fixed)
+                    chunks[(start, end)].append(
+                        result.examples.ir_tree_nodes[start:res_end]
+                    )
+                    result = self.engine.cached_test_function_ir(attempt)
 
-                    if result.status == Status.OVERRUN:
+                    if result.status is Status.OVERRUN:
                         continue  # pragma: no cover  # flakily covered
                 else:
-                    chunks[(start, end)].append(result.buffer[start:end])
+                    chunks[(start, end)].append(
+                        result.examples.ir_tree_nodes[start:end]
+                    )
 
                 if shrink_target is not self.shrink_target:  # pragma: no cover
                     # If we've shrunk further without meaning to, bail out.
                     self.shrink_target.slice_comments.clear()
                     return
-                if result.status == Status.VALID:
+                if result.status is Status.VALID:
                     # The test passed, indicating that this param can't vary freely.
                     # However, it's really hard to write a simple and reliable covering
                     # test, because of our `seen_passing_buffers` check above.
@@ -637,15 +655,15 @@ class Shrinker:
         chunks_by_start_index = sorted(chunks.items())
         for _ in range(500):  # pragma: no branch
             # no-branch here because we don't coverage-test the abort-at-500 logic.
-            new_buf = bytearray()
+            new_nodes = []
             prev_end = 0
             for (start, end), ls in chunks_by_start_index:
                 assert prev_end <= start < end, "these chunks must be nonoverlapping"
-                new_buf.extend(buffer[prev_end:start])
-                new_buf.extend(self.random.choice(ls))
+                new_nodes.extend(nodes[prev_end:start])
+                new_nodes.extend(self.random.choice(ls))
                 prev_end = end
 
-            result = self.engine.cached_test_function(new_buf)
+            result = self.engine.cached_test_function_ir(new_nodes)
 
             # This *can't* be a shrink because none of the components were.
             assert shrink_target is self.shrink_target

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -618,4 +618,4 @@ def test_simulate_forced_floats(node):
     data = ConjectureData.for_ir_tree([node], observer=tree.new_observer())
     tree.simulate_test_function(data)
     data.freeze()
-    assert data.examples.ir_tree_nodes == [node]
+    assert data.examples.ir_tree_nodes == (node,)

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -29,9 +29,16 @@ from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import FailedHealthCheck, FlakyStrategyDefinition
 from hypothesis.internal.compat import PYPY, bit_count, int_from_bytes
 from hypothesis.internal.conjecture import engine as engine_module
-from hypothesis.internal.conjecture.data import ConjectureData, IRNode, Overrun, Status
+from hypothesis.internal.conjecture.data import (
+    ConjectureData,
+    IRNode,
+    Overrun,
+    Status,
+    ir_size_nodes,
+)
 from hypothesis.internal.conjecture.datatree import compute_max_children
 from hypothesis.internal.conjecture.engine import (
+    BUFFER_SIZE_IR,
     MIN_TEST_CALLS,
     ConjectureRunner,
     ExitReason,
@@ -1610,7 +1617,9 @@ def test_overruns_with_extend_are_not_cached(node):
     assert data.status is Status.OVERRUN
 
     # cache miss
-    data = runner.cached_test_function_ir([node], extend=1)
+    data = runner.cached_test_function_ir(
+        [node], extend=BUFFER_SIZE_IR - ir_size_nodes([node])
+    )
     assert runner.call_count == 2
     assert data.status is Status.VALID
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -529,7 +529,7 @@ def test_debug_data(capsys):
     runner.run()
 
     out, _ = capsys.readouterr()
-    assert re.match("\\d+ bytes \\[.*\\] -> ", out)
+    assert re.match("\\d+ nodes \\[.*\\] -> ", out)
     assert "INTERESTING" in out
 
 

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -30,22 +30,8 @@ def fails_with_output(expected, error=AssertionError, **kw):
     return _inner
 
 
-# this should have a marked as freely varying, but
-# false negatives in our inquisitor code skip over it sometimes, depending on the
-# seen_passed_buffers. yet another thing that should be improved by moving to the ir.
 @fails_with_output(
-    [
-        """
-Falsifying example: test_inquisitor_comments_basic_fail_if_either(
-    # The test always failed when commented parts were varied together.
-    a=False,
-    b=True,
-    c=[],  # or any other generated value
-    d=True,
-    e=False,  # or any other generated value
-)
-""",
-        """
+    """
 Falsifying example: test_inquisitor_comments_basic_fail_if_either(
     # The test always failed when commented parts were varied together.
     a=False,  # or any other generated value
@@ -54,8 +40,7 @@ Falsifying example: test_inquisitor_comments_basic_fail_if_either(
     d=True,
     e=False,  # or any other generated value
 )
-""",
-    ]
+"""
 )
 @given(st.booleans(), st.booleans(), st.lists(st.none()), st.booleans(), st.booleans())
 def test_inquisitor_comments_basic_fail_if_either(a, b, c, d, e):

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -333,7 +333,7 @@ def test_ir_nodes(random):
     data.draw_integer(0, 100, forced=50)
 
     data.freeze()
-    expected_tree_nodes = [
+    expected_tree_nodes = (
         IRNode(
             ir_type="float",
             value=5.0,
@@ -378,7 +378,7 @@ def test_ir_nodes(random):
             },
             was_forced=True,
         ),
-    ]
+    )
     assert data.examples.ir_tree_nodes == expected_tree_nodes
 
 

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -29,6 +29,7 @@ from hypothesis.internal.conjecture.datatree import (
     all_children,
     compute_max_children,
 )
+from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR
 from hypothesis.internal.floats import SMALLEST_SUBNORMAL, next_down, next_up
 from hypothesis.internal.intervalsets import IntervalSet
 
@@ -424,7 +425,7 @@ def test_data_with_changed_forced_value(node):
     # This is actually fine; we'll just ignore the forced node (v1) and return
     # what the draw expects (v2).
 
-    data = ConjectureData.for_ir_tree([node])
+    data = ConjectureData.for_ir_tree([node], max_length=BUFFER_SIZE_IR)
 
     draw_func = getattr(data, f"draw_{node.ir_type}")
     kwargs = deepcopy(node.kwargs)

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -401,6 +401,12 @@ def test_ir_node_equality(node):
     assert node != 42
 
 
+@given(ir_nodes(was_forced=True))
+def test_cannot_modify_forced_nodes(node):
+    with pytest.raises(AssertionError):
+        node.copy(with_value=42)
+
+
 def test_data_with_empty_ir_tree_is_overrun():
     data = ConjectureData.for_ir_tree([])
     with pytest.raises(StopTest):

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -23,6 +23,8 @@ from hypothesis.internal.conjecture.junkdrawer import (
     clamp,
     replace_all,
     stack_depth_of_caller,
+    startswith,
+    endswith,
 )
 
 
@@ -202,3 +204,13 @@ def test_self_organising_list_moves_to_front():
 
     assert x.find(zero) == 0
     assert count[0] == 21
+
+
+@given(st.binary(), st.binary())
+def test_startswith(b1, b2):
+    assert b1.startswith(b2) == startswith(b1, b2)
+
+
+@given(st.binary(), st.binary())
+def test_endswith(b1, b2):
+    assert b1.endswith(b2) == endswith(b1, b2)

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -21,10 +21,10 @@ from hypothesis.internal.conjecture.junkdrawer import (
     SelfOrganisingList,
     binary_search,
     clamp,
+    endswith,
     replace_all,
     stack_depth_of_caller,
     startswith,
-    endswith,
 )
 
 

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -29,12 +29,17 @@ from hypothesis.database import (
     InMemoryExampleDatabase,
     MultiplexedDatabase,
     ReadOnlyDatabase,
+    ir_from_bytes,
+    ir_to_bytes,
 )
 from hypothesis.errors import HypothesisWarning
 from hypothesis.internal.compat import WINDOWS
+from hypothesis.internal.conjecture.data import ir_value_equal
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
 from hypothesis.strategies import binary, lists, tuples
 from hypothesis.utils.conventions import not_set
+
+from tests.conjecture.common import ir_nodes
 
 small_settings = settings(max_examples=50)
 
@@ -444,3 +449,20 @@ def test_database_directory_inaccessible(dirs, tmp_path, monkeypatch):
     ):
         database = ExampleDatabase(not_set)
     database.save(b"fizz", b"buzz")
+
+
+@given(lists(ir_nodes()))
+def test_ir_nodes_rountrips(nodes1):
+    s1 = ir_to_bytes([n.value for n in nodes1])
+    assert isinstance(s1, bytes)
+    ir2 = ir_from_bytes(s1)
+    assert len(nodes1) == len(ir2)
+
+    for n1, v2 in zip(nodes1, ir2):
+        v1 = n1.value
+        ir_type = n1.ir_type
+        assert type(v1) is type(v2)
+        assert ir_value_equal(ir_type, v1, v2)
+
+    s2 = ir_to_bytes(ir2)
+    assert s1 == s2


### PR DESCRIPTION
Closes #3864. Depends on #4159.