### PR TITLE
Experimental changes for Crosshair support

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds ``.span_start()`` and ``.span_end()`` methods
+to our internal ``PrimitiveProvider`` interface, for use by
+:ref:`alternative-backends`.


### PR DESCRIPTION
cc @pschanely 

- following #4165, the Tracer no longer branches (in a way visible to Crosshair) on whether sys.settrace() is active
- `span_start()` and `span_end()` methods to make recognising recursive strategies easier.
  - not yet tested, but that's why the PR is marked experimental.
- experimental engine change which I think should let us raise `Unsatisfiable` after an alternative backend gives up.
  - I'm not sure of this though, and would appreciate a pointer to the affected tests so that we can get this behavior deliberately checked by our test suite.