### PR TITLE
Various small fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
           - check-py39-pytest46
           - check-py39-pytest54
           - check-pytest62
+          - check-django51
           - check-django50
           - check-django42
           - check-pandas22

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch avoids computing some string representations we won't need,
+giving a small speedup (part of :issue:`4139`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -864,15 +864,6 @@ class StateForActualGivenExecution:
             if expected_failure is not None:
                 nonlocal text_repr
                 text_repr = repr_call(test, args, kwargs)
-                if text_repr in self.xfail_example_reprs:
-                    warnings.warn(
-                        f"We generated {text_repr}, which seems identical "
-                        "to one of your `@example(...).xfail()` cases.  "
-                        "Revise the strategy to avoid this overlap?",
-                        HypothesisWarning,
-                        # Checked in test_generating_xfailed_examples_warns!
-                        stacklevel=6,
-                    )
 
             if print_example or current_verbosity() >= Verbosity.verbose:
                 printer = RepresentationPrinter(context=context)

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -477,9 +477,6 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs, original_s
             fragments_reported = []
             empty_data = ConjectureData.for_buffer(b"")
             try:
-                bits = ", ".join(nicerepr(x) for x in arguments) + ", ".join(
-                    f"{k}={nicerepr(v)}" for k, v in example_kwargs.items()
-                )
                 execute_example = partial(
                     state.execute_once,
                     empty_data,
@@ -492,7 +489,9 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs, original_s
                         execute_example()
                     else:
                         # @example(...).xfail(...)
-
+                        bits = ", ".join(nicerepr(x) for x in arguments) + ", ".join(
+                            f"{k}={nicerepr(v)}" for k, v in example_kwargs.items()
+                        )
                         try:
                             execute_example()
                         except failure_exceptions_to_catch() as err:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -121,20 +121,21 @@ def recursive_property(name, default):
 
         mapping = {}
         sentinel = object()
-        hit_recursion = [False]
+        hit_recursion = False
 
         # For a first pass we do a direct recursive calculation of the
         # property, but we block recursively visiting a value in the
         # computation of its property: When that happens, we simply
         # note that it happened and return the default value.
         def recur(strat):
+            nonlocal hit_recursion
             try:
                 return forced_value(strat)
             except AttributeError:
                 pass
             result = mapping.get(strat, sentinel)
             if result is calculating:
-                hit_recursion[0] = True
+                hit_recursion = True
                 return default
             elif result is sentinel:
                 mapping[strat] = calculating
@@ -150,7 +151,7 @@ def recursive_property(name, default):
         # a more careful fixed point calculation to get the exact
         # values. Hopefully our mapping is still pretty good and it
         # won't take a large number of updates to reach a fixed point.
-        if hit_recursion[0]:
+        if hit_recursion:
             needs_update = set(mapping)
 
             # We track which strategies use which in the course of

--- a/hypothesis-python/tests/cover/test_example.py
+++ b/hypothesis-python/tests/cover/test_example.py
@@ -11,7 +11,7 @@
 import pytest
 
 from hypothesis import example, given, strategies as st
-from hypothesis.errors import HypothesisWarning, InvalidArgument
+from hypothesis.errors import InvalidArgument
 
 from tests.common.utils import fails_with
 
@@ -117,22 +117,3 @@ def test_error_on_unexpected_pass_single_elem_tuple(x):
 @given(st.none())
 def test_error_on_unexpected_pass_multi(x):
     pass
-
-
-def test_generating_xfailed_examples_warns():
-    @given(st.integers())
-    @example(1)
-    @example(0).xfail(raises=ZeroDivisionError)
-    def foo(x):
-        assert 1 / x
-
-    with pytest.warns(
-        HypothesisWarning,
-        match=r"Revise the strategy to avoid this overlap",
-    ) as wrec:
-        with pytest.raises(ZeroDivisionError):
-            foo()
-
-        warning_locations = sorted(w.filename for w in wrec.list)
-        # See the reference in core.py to this test
-        assert __file__ in warning_locations, "probable stacklevel bug"

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -61,7 +61,7 @@ def test_gives_flaky_error_if_assumption_is_flaky():
 
 def test_flaky_with_context_when_fails_only_under_tracing(monkeypatch):
     # make anything fail under tracing
-    monkeypatch.setattr(Tracer, "can_trace", lambda: True)
+    monkeypatch.setattr(Tracer, "can_trace", staticmethod(lambda: True))
     monkeypatch.setattr(Tracer, "__enter__", lambda *_: 1 / 0)
     # ensure tracing is always entered inside _execute_once_for_engine
     monkeypatch.setattr(StateForActualGivenExecution, "_should_trace", lambda _: True)

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -161,14 +161,21 @@ commands =
 setenv=
     PYTHONWARNDEFAULTENCODING=1
 commands =
-    pip install django~=4.2.0
+    pip install django==4.2.16
     python -bb -X dev -m tests.django.manage test tests.django {posargs}
 
 [testenv:django50]
 setenv=
     PYTHONWARNDEFAULTENCODING=1
 commands =
-    pip install django~=5.0.0
+    pip install django==5.0.9
+    python -bb -X dev -m tests.django.manage test tests.django {posargs}
+
+[testenv:django51]
+setenv=
+    PYTHONWARNDEFAULTENCODING=1
+commands =
+    pip install django==5.1.3
     python -bb -X dev -m tests.django.manage test tests.django {posargs}
 
 [testenv:py{39}-nose]


### PR DESCRIPTION
- refactoring the tracer, *ala* #4164, since that doesn't really have a downside
- avoiding pprint logic to support `@example(...).xfail()` when there are no xfail examples, closing #4139 by expanding on #4063
- some Django-update logic which closes #4031 - it's not fully automated but we won't miss an update
- one more use of `nonlocal`, following #4156