### PR TITLE
Move `ir_nodes` from `Examples` to `ConjectureResult`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal renamings.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -2158,8 +2158,6 @@ class ConjectureData:
             self.index_ir += 1
             self.length_ir += size
 
-        if self.length_ir > self.max_length_ir:
-            self.mark_overrun()
         return value
 
     def draw_integer(

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -85,9 +85,7 @@ class Optimiser:
         # We allow transitions that leave the score unchanged as long as they
         # don't increase the number of nodes. This gives us a certain amount of
         # freedom for lateral moves that will take us out of local maxima.
-        if len(data.examples.ir_tree_nodes) <= len(
-            self.current_data.examples.ir_tree_nodes
-        ):
+        if len(data.ir_nodes) <= len(self.current_data.ir_nodes):
             self.current_data = data
             return True
         return False
@@ -101,10 +99,10 @@ class Optimiser:
         nodes_examined = set()
 
         prev = None
-        i = len(self.current_data.examples.ir_tree_nodes) - 1
+        i = len(self.current_data.ir_nodes) - 1
         while i >= 0 and self.improvements <= self.max_improvements:
             if prev is not self.current_data:
-                i = len(self.current_data.examples.ir_tree_nodes) - 1
+                i = len(self.current_data.ir_nodes) - 1
                 prev = self.current_data
 
             if i in nodes_examined:
@@ -112,7 +110,7 @@ class Optimiser:
                 continue
 
             nodes_examined.add(i)
-            node = self.current_data.examples.ir_tree_nodes[i]
+            node = self.current_data.ir_nodes[i]
             assert node.index is not None
             # we can only (sensibly & easily) define hill climbing for
             # numeric-style nodes. It's not clear hill-climbing a string is
@@ -134,7 +132,7 @@ class Optimiser:
                 if abs(k) > 2**20:
                     return False
 
-                node = self.current_data.examples.ir_tree_nodes[i]
+                node = self.current_data.ir_nodes[i]
                 assert node.index is not None
                 if node.was_forced:
                     return False  # pragma: no cover
@@ -170,7 +168,7 @@ class Optimiser:
                     return False
 
                 for _ in range(3):
-                    nodes = self.current_data.examples.ir_tree_nodes
+                    nodes = self.current_data.ir_nodes
                     attempt_nodes = (
                         nodes[: node.index]
                         + (node.copy(with_value=new_value),)
@@ -188,9 +186,7 @@ class Optimiser:
                         return False
 
                     assert isinstance(attempt, ConjectureResult)
-                    if len(attempt.examples.ir_tree_nodes) == len(
-                        self.current_data.examples.ir_tree_nodes
-                    ):
+                    if len(attempt.ir_nodes) == len(self.current_data.ir_nodes):
                         return False
 
                     for j, ex in enumerate(self.current_data.examples):
@@ -201,14 +197,14 @@ class Optimiser:
                         ex_attempt = attempt.examples[j]
                         if ex.ir_length == ex_attempt.ir_length:
                             continue  # pragma: no cover
-                        replacement = attempt.examples.ir_tree_nodes[
+                        replacement = attempt.ir_nodes[
                             ex_attempt.ir_start : ex_attempt.ir_end
                         ]
                         if self.consider_new_data(
                             self.engine.cached_test_function_ir(
                                 nodes[: node.index]
                                 + replacement
-                                + self.current_data.examples.ir_tree_nodes[ex.ir_end :]
+                                + self.current_data.ir_nodes[ex.ir_end :]
                             )
                         ):
                             return True

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -618,4 +618,4 @@ def test_simulate_forced_floats(node):
     data = ConjectureData.for_ir_tree([node], observer=tree.new_observer())
     tree.simulate_test_function(data)
     data.freeze()
-    assert data.examples.ir_tree_nodes == (node,)
+    assert data.ir_nodes == (node,)

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -380,7 +380,7 @@ def test_ir_nodes(random):
             was_forced=True,
         ),
     )
-    assert data.examples.ir_tree_nodes == expected_tree_nodes
+    assert data.ir_nodes == expected_tree_nodes
 
 
 @given(ir_nodes())


### PR DESCRIPTION
The motivation for this is that we sometimes want to access the ir nodes of a `ConjectureData` that hasn't been frozen/concluded yet, similar to how we sometimes do for the buffer.