### PR TITLE
Migrate some tests to the typed choice sequence

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Internal cleanup.
+his patch refactors some internals to prepare for future work using our IR (:issue:`3921`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal cleanup.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1182,6 +1182,10 @@ class ConjectureResult:
     def as_result(self) -> "ConjectureResult":
         return self
 
+    @property
+    def choices(self) -> tuple[IRType, ...]:
+        return tuple(node.value for node in self.ir_nodes)
+
 
 # Masks for masking off the first byte of an n-bit buffer.
 # The appropriate mask is stored at position n % 8.
@@ -2106,6 +2110,10 @@ class ConjectureData:
             len(self.buffer),
             ", frozen" if self.frozen else "",
         )
+
+    @property
+    def choices(self) -> tuple[IRType, ...]:
+        return tuple(node.value for node in self.ir_nodes)
 
     # A bit of explanation of the `observe` and `fake_forced` arguments in our
     # draw_* functions.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -779,9 +779,9 @@ class ConjectureRunner:
         if data.status == Status.INTERESTING:
             status = f"{status} ({data.interesting_origin!r})"
 
-        nodes = data.ir_nodes
         self.debug(
-            f"{len(nodes)} nodes {[n.value for n in nodes]} -> {status}, {data.output}"
+            f"{len(data.choices)} choices {data.choices} -> {status}"
+            f"{', ' + data.output if data.output else ''}"
         )
 
     def run(self) -> None:
@@ -1369,7 +1369,7 @@ class ConjectureRunner:
                 ),
                 key=lambda kv: (sort_key(kv[1].buffer), sort_key(repr(kv[0]))),
             )
-            self.debug(f"Shrinking {target!r}: {[n.value for n in example.ir_nodes]}")
+            self.debug(f"Shrinking {target!r}: {data.choices}")
 
             if not self.settings.report_multiple_bugs:
                 # If multi-bug reporting is disabled, we shrink our currently-minimal

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -413,7 +413,7 @@ class Shrinker:
         buffer = bytes(buffer)
         return buffer.startswith(self.buffer) or self.incorporate_new_buffer(buffer)
 
-    def incorporate_new_buffer(self, buffer):
+    def incorporate_new_buffer(self, buffer):  # pragma: no cover
         """Either runs the test function on this buffer and returns True if
         that changed the shrink_target, or determines that doing so would
         be useless and returns False without running it."""

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -813,6 +813,10 @@ class Shrinker:
         return self.shrink_target.ir_nodes
 
     @property
+    def choices(self):
+        return self.shrink_target.choices
+
+    @property
     def examples(self):
         return self.shrink_target.examples
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -413,7 +413,9 @@ class Shrinker:
         buffer = bytes(buffer)
         return buffer.startswith(self.buffer) or self.incorporate_new_buffer(buffer)
 
-    def incorporate_new_buffer(self, buffer):  # pragma: no cover
+    def incorporate_new_buffer(
+        self, buffer
+    ):  # pragma: no cover # removing function soon
         """Either runs the test function on this buffer and returns True if
         that changed the shrink_target, or determines that doing so would
         be useless and returns False without running it."""

--- a/hypothesis-python/tests/common/debug.py
+++ b/hypothesis-python/tests/common/debug.py
@@ -18,7 +18,7 @@ from hypothesis.internal.reflection import get_pretty_function_description
 
 from tests.common.utils import no_shrink
 
-TIME_INCREMENT = 0.0001
+TIME_INCREMENT = 0.00001
 
 
 class Timeout(BaseException):

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -49,10 +49,6 @@ def run_to_data(f):
         return last_data
 
 
-def run_to_buffer(f):
-    return bytes(run_to_data(f).buffer)
-
-
 def run_to_nodes(f):
     return run_to_data(f).ir_nodes
 
@@ -81,7 +77,7 @@ def shrinking_from(start):
                     phases=set(settings.default.phases) - {Phase.explain},
                 ),
             )
-            runner.cached_test_function(start)
+            runner.cached_test_function_ir(start)
             assert runner.interesting_examples
             (last_data,) = runner.interesting_examples.values()
             return runner.new_shrinker(

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -537,7 +537,7 @@ def test_debug_data(capsys):
     runner.run()
 
     out, _ = capsys.readouterr()
-    assert re.match("\\d+ choices \\[.*\\] -> ", out)
+    assert re.match(r"\d+ choices \(.*\) -> ", out)
     assert "INTERESTING" in out
 
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -59,44 +59,30 @@ from tests.conjecture.common import (
     buffer_size_limit,
     ir,
     ir_nodes,
-    run_to_buffer,
+    run_to_nodes,
     shrinking_from,
 )
 
 
-def test_can_index_results():
-    @run_to_buffer
-    def f(data):
-        data.draw_bytes(5, 5)
-        data.mark_interesting()
-
-    assert f.index(0) == 0
-    assert f.count(0) == 5
-
-
 def test_non_cloneable_intervals():
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         data.draw_bytes(10, 10)
         data.draw_bytes(9, 9)
         data.mark_interesting()
 
-    assert x == bytes(19)
+    assert tuple(n.value for n in nodes) == (bytes(10), bytes(9))
 
 
 def test_deletable_draws():
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         while True:
             x = data.draw_bytes(2, 2)
             if x[0] == 255:
                 data.mark_interesting()
 
-    assert x == bytes([255, 0])
-
-
-def zero_dist(random, n):
-    return bytes(n)
+    assert tuple(n.value for n in nodes) == (b"\xff\x00",)
 
 
 def test_can_load_data_from_a_corpus():
@@ -194,7 +180,7 @@ def test_variadic_draw():
         result = []
         while True:
             data.start_example(SOME_LABEL)
-            d = data.draw_bytes(1, 1)[0] & 7
+            d = data.draw_integer(0, 2**8 - 1) & 7
             if d:
                 result.append(data.draw_bytes(d, d))
             data.stop_example()
@@ -202,12 +188,12 @@ def test_variadic_draw():
                 break
         return result
 
-    @run_to_buffer
-    def b(data):
+    @run_to_nodes
+    def nodes(data):
         if any(all(d) for d in draw_list(data)):
             data.mark_interesting()
 
-    ls = draw_list(ConjectureData.for_buffer(b))
+    ls = draw_list(ConjectureData.for_ir_tree(nodes))
     assert len(ls) == 1
     assert len(ls[0]) == 1
 
@@ -220,14 +206,14 @@ def test_draw_to_overrun(monkeypatch):
     # If we do get unlucky in such a way then we need more than 500 shrinks to finish.
     monkeypatch.setattr(engine_module, "MAX_SHRINKS", 1000)
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         d = (data.draw_bytes(1, 1)[0] - 8) & 0xFF
         data.draw_bytes(128 * d, 128 * d)
         if d >= 2:
             data.mark_interesting()
 
-    assert x == bytes([10]) + bytes(128 * 2)
+    assert tuple(n.value for n in nodes) == (bytes([10]),) + (bytes(128 * 2),)
 
 
 def test_can_navigate_to_a_valid_example():
@@ -303,8 +289,8 @@ def test_stops_after_max_examples_when_generating_more_bugs(examples):
 def test_interleaving_engines():
     children = []
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         rnd = Random(data.draw_bytes(1, 1))
 
         def g(d2):
@@ -317,7 +303,7 @@ def test_interleaving_engines():
         if runner.interesting_examples:
             data.mark_interesting()
 
-    assert x == b"\0"
+    assert tuple(n.value for n in nodes) == (b"\0",)
     for c in children:
         assert not c.interesting_examples
 
@@ -360,8 +346,8 @@ def test_erratic_draws():
 
     with pytest.raises(FlakyStrategyDefinition):
 
-        @run_to_buffer
-        def x(data):
+        @run_to_nodes
+        def nodes(data):
             nonlocal n
             data.draw_bytes(n, n)
             data.draw_bytes(255 - n, 255 - n)
@@ -374,13 +360,13 @@ def test_erratic_draws():
 def test_no_read_no_shrink():
     count = 0
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         nonlocal count
         count += 1
         data.mark_interesting()
 
-    assert x == b""
+    assert nodes == ()
     assert count == 1
 
 
@@ -388,8 +374,8 @@ def test_one_dead_branch():
     with deterministic_PRNG():
         seen = set()
 
-        @run_to_buffer
-        def x(data):
+        @run_to_nodes
+        def nodes(data):
             i = data.draw_bytes(1, 1)[0]
             if i > 0:
                 data.mark_invalid()
@@ -415,15 +401,15 @@ def test_does_not_save_on_interrupt():
     assert not db.data
 
 
-def test_returns_written():
+def test_returns_forced():
     value = b"\0\1\2\3"
 
-    @run_to_buffer
-    def written(data):
+    @run_to_nodes
+    def nodes(data):
         data.draw_bytes(len(value), len(value), forced=value)
         data.mark_interesting()
 
-    assert value == written
+    assert tuple(n.value for n in nodes) == (value,)
 
 
 def fails_health_check(label, **kwargs):
@@ -551,7 +537,7 @@ def test_debug_data(capsys):
     runner.run()
 
     out, _ = capsys.readouterr()
-    assert re.match("\\d+ nodes \\[.*\\] -> ", out)
+    assert re.match("\\d+ choices \\[.*\\] -> ", out)
     assert "INTERESTING" in out
 
 
@@ -659,11 +645,11 @@ def test_discarding(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function(bytes([0, 1] * 10)),
+        lambda runner: runner.cached_test_function_ir(ir(False, True) * 10),
     )
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         count = 0
         while count < 10:
             data.start_example(SOME_LABEL)
@@ -673,11 +659,11 @@ def test_discarding(monkeypatch):
             data.stop_example(discard=not b)
         data.mark_interesting()
 
-    assert x == bytes(bytes([1]) * 10)
+    assert tuple(n.value for n in nodes) == (True,) * 10
 
 
 def test_can_remove_discarded_data():
-    @shrinking_from(bytes([0] * 10 + [11]))
+    @shrinking_from(ir(0) * 10 + ir(11))
     def shrinker(data: ConjectureData):
         while True:
             data.start_example(SOME_LABEL)
@@ -688,11 +674,11 @@ def test_can_remove_discarded_data():
         data.mark_interesting()
 
     shrinker.remove_discarded()
-    assert list(shrinker.buffer) == [11]
+    assert shrinker.choices == (11,)
 
 
 def test_discarding_iterates_to_fixed_point():
-    @shrinking_from(bytes(list(range(100, -1, -1))))
+    @shrinking_from(ir(*list(range(100, -1, -1))))
     def shrinker(data: ConjectureData):
         data.start_example(0)
         data.draw_integer(0, 2**8 - 1)
@@ -702,11 +688,11 @@ def test_discarding_iterates_to_fixed_point():
         data.mark_interesting()
 
     shrinker.remove_discarded()
-    assert list(shrinker.buffer) == [1, 0]
+    assert shrinker.choices == (1, 0)
 
 
 def test_discarding_is_not_fooled_by_empty_discards():
-    @shrinking_from(bytes([1, 1]))
+    @shrinking_from(ir(1, 1))
     def shrinker(data: ConjectureData):
         data.draw_integer(0, 2**1 - 1)
         data.start_example(0)
@@ -718,8 +704,8 @@ def test_discarding_is_not_fooled_by_empty_discards():
     assert shrinker.shrink_target.has_discards
 
 
-def test_discarding_can_fail(monkeypatch):
-    @shrinking_from(bytes([1]))
+def test_discarding_can_fail():
+    @shrinking_from(ir(1))
     def shrinker(data: ConjectureData):
         data.start_example(0)
         data.draw_boolean()
@@ -734,16 +720,16 @@ def test_shrinking_from_mostly_zero(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda self: self.cached_test_function(bytes(5) + bytes([2])),
+        lambda self: self.cached_test_function_ir(ir(0) * 5 + ir(2)),
     )
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         s = [data.draw_integer(0, 2**8 - 1) for _ in range(6)]
         if any(s):
             data.mark_interesting()
 
-    assert x == bytes(5) + bytes([1])
+    assert tuple(n.value for n in nodes) == (0,) * 5 + (1,)
 
 
 def test_handles_nesting_of_discard_correctly(monkeypatch):
@@ -751,11 +737,11 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function(bytes([0, 0, 1, 1])),
+        lambda runner: runner.cached_test_function_ir(ir(False, False, True, True)),
     )
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         while True:
             data.start_example(SOME_LABEL)
             succeeded = data.draw_boolean()
@@ -766,7 +752,7 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
             if succeeded:
                 data.mark_interesting()
 
-    assert x == bytes([1, 1])
+    assert tuple(n.value for n in nodes) == (True, True)
 
 
 def test_database_clears_secondary_key():
@@ -879,7 +865,7 @@ def test_exit_because_shrink_phase_timeout(monkeypatch):
 
 
 def test_dependent_block_pairs_can_lower_to_zero():
-    @shrinking_from([1, 0, 1])
+    @shrinking_from(ir(True, 1))
     def shrinker(data: ConjectureData):
         if data.draw_boolean():
             n = data.draw_integer(0, 2**16 - 1)
@@ -890,11 +876,11 @@ def test_dependent_block_pairs_can_lower_to_zero():
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
-    assert list(shrinker.shrink_target.buffer) == [0, 1]
+    assert shrinker.choices == (False, 1)
 
 
 def test_handle_size_too_large_during_dependent_lowering():
-    @shrinking_from([1, 255, 0])
+    @shrinking_from(ir(True, 255, 0))
     def shrinker(data: ConjectureData):
         if data.draw_boolean():
             data.draw_integer(0, 2**16 - 1)
@@ -906,9 +892,7 @@ def test_handle_size_too_large_during_dependent_lowering():
 
 
 def test_block_may_grow_during_lexical_shrinking():
-    initial = bytes([2, 1, 1])
-
-    @shrinking_from(initial)
+    @shrinking_from(ir(2, 1, 1))
     def shrinker(data: ConjectureData):
         n = data.draw_integer(0, 2**8 - 1)
         if n == 2:
@@ -919,11 +903,11 @@ def test_block_may_grow_during_lexical_shrinking():
         data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
-    assert list(shrinker.shrink_target.buffer) == [0, 0, 0]
+    assert shrinker.choices == (0, 0)
 
 
 def test_lower_common_node_offset_does_nothing_when_changed_blocks_are_zero():
-    @shrinking_from([1, 0, 1, 0])
+    @shrinking_from(ir(True, False, True, False))
     def shrinker(data: ConjectureData):
         data.draw_boolean()
         data.draw_boolean()
@@ -934,11 +918,11 @@ def test_lower_common_node_offset_does_nothing_when_changed_blocks_are_zero():
     shrinker.mark_changed(1)
     shrinker.mark_changed(3)
     shrinker.lower_common_node_offset()
-    assert list(shrinker.shrink_target.buffer) == [1, 0, 1, 0]
+    assert shrinker.choices == (True, False, True, False)
 
 
 def test_lower_common_node_offset_ignores_zeros():
-    @shrinking_from([2, 2, 0])
+    @shrinking_from(ir(2, 2, 0))
     def shrinker(data: ConjectureData):
         n = data.draw_integer(0, 2**8 - 1)
         data.draw_integer(0, 2**8 - 1)
@@ -949,7 +933,7 @@ def test_lower_common_node_offset_ignores_zeros():
     for i in range(3):
         shrinker.mark_changed(i)
     shrinker.lower_common_node_offset()
-    assert list(shrinker.shrink_target.buffer) == [1, 1, 0]
+    assert shrinker.choices == (1, 1, 0)
 
 
 def test_cached_test_function_returns_right_value():
@@ -1035,9 +1019,7 @@ def test_branch_ending_in_write():
             attempt = prefix + ir(False, False)
             data = runner.cached_test_function_ir(attempt)
             assert data.status is Status.VALID
-            assert startswith(
-                [n.value for n in attempt], [n.value for n in data.ir_nodes]
-            )
+            assert startswith(tuple(n.value for n in attempt), data.choices)
 
 
 def test_exhaust_space():

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -19,7 +19,7 @@ from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import float_to_int
 
-from tests.conjecture.common import run_to_buffer
+from tests.conjecture.common import ir
 
 EXPONENTS = list(range(flt.MAX_EXPONENT + 1))
 assert len(EXPONENTS) == 2**11
@@ -126,18 +126,13 @@ def test_reverse_bits_table_has_right_elements():
 def float_runner(start, condition, *, kwargs=None):
     kwargs = {} if kwargs is None else kwargs
 
-    @run_to_buffer
-    def buf(data):
-        data.draw_float(forced=start, **kwargs)
-        data.mark_interesting()
-
     def test_function(data):
         f = data.draw_float(**kwargs)
         if condition(f):
             data.mark_interesting()
 
     runner = ConjectureRunner(test_function)
-    runner.cached_test_function(buf)
+    runner.cached_test_function_ir(ir((float(start), kwargs)))
     assert runner.interesting_examples
     return runner
 
@@ -148,7 +143,7 @@ def minimal_from(start, condition, *, kwargs=None):
     runner = float_runner(start, condition, kwargs=kwargs)
     runner.shrink_interesting_examples()
     (v,) = runner.interesting_examples.values()
-    data = ConjectureData.for_buffer(v.buffer)
+    data = ConjectureData.for_ir_tree(v.ir_nodes)
     result = data.draw_float(**kwargs)
     assert condition(result)
     return result

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -22,12 +22,12 @@ from hypothesis.internal.conjecture.shrinker import (
 )
 from hypothesis.internal.conjecture.utils import Sampler
 
-from tests.conjecture.common import SOME_LABEL, run_to_buffer, shrinking_from
+from tests.conjecture.common import SOME_LABEL, ir, run_to_nodes, shrinking_from
 
 
 @pytest.mark.parametrize("n", [1, 5, 8, 15])
 def test_can_shrink_variable_draws_with_just_deletion(n):
-    @shrinking_from([n] + [0] * (n - 1) + [1])
+    @shrinking_from(ir(n) + ir(0) * (n - 1) + ir(1))
     def shrinker(data: ConjectureData):
         n = data.draw_integer(0, 2**4 - 1)
         b = [data.draw_integer(0, 2**8 - 1) for _ in range(n)]
@@ -45,36 +45,26 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
         "shrink",
         lambda self: self.fixate_shrink_passes(["minimize_individual_nodes"]),
     )
+    monkeypatch.setattr(
+        ConjectureRunner,
+        "generate_new_examples",
+        lambda runner: runner.cached_test_function_ir(ir(b"\0") * 10),
+    )
 
-    def gen(self):
-        self.cached_test_function(10)
-
-    monkeypatch.setattr(ConjectureRunner, "generate_new_examples", gen)
-
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         for _ in range(10):
             data.draw_bytes(1, 1)
         data.mark_interesting()
 
-    assert x == bytes(10)
+    assert tuple(n.value for n in nodes) == (b"\0",) * 10
 
 
-def test_duplicate_blocks_that_go_away():
-    # careful not to go over 24 bits (> 2**24), which triggers a more complicated
-    # interpretation of the buffer in draw_integer due to size sampling.
-    @run_to_buffer
-    def base_buf(data):
-        x = data.draw_integer(0, 2**24 - 1, forced=1234567)
-        _y = data.draw_integer(0, 2**24 - 1, forced=1234567)
-        for _ in range(x & 255):
-            data.draw_bytes(1, 1)
-        data.mark_interesting()
-
-    @shrinking_from(base_buf)
+def test_duplicate_nodes_that_go_away():
+    @shrinking_from(ir(1234567, 1234567) + ir(b"\1") * (1234567 & 255))
     def shrinker(data: ConjectureData):
-        x = data.draw_integer(0, 2**24 - 1)
-        y = data.draw_integer(0, 2**24 - 1)
+        x = data.draw_integer(min_value=0)
+        y = data.draw_integer(min_value=0)
         if x != y:
             data.mark_invalid()
         b = [data.draw_bytes(1, 1) for _ in range(x & 255)]
@@ -82,13 +72,11 @@ def test_duplicate_blocks_that_go_away():
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_duplicated_nodes"])
-    # 24 bits for each integer = (24 * 2) / 8 = 6 bytes, which should all get
-    # reduced to 0.
-    assert shrinker.shrink_target.buffer == bytes(6)
+    assert shrinker.shrink_target.choices == (0, 0)
 
 
 def test_accidental_duplication():
-    @shrinking_from([18] * 20)
+    @shrinking_from(ir(12, 12) + ir(b"\2") * 12)
     def shrinker(data: ConjectureData):
         x = data.draw_integer(0, 2**8 - 1)
         y = data.draw_integer(0, 2**8 - 1)
@@ -101,12 +89,12 @@ def test_accidental_duplication():
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_duplicated_nodes"])
-    # x=5 y=5 b=[b'\x00', b'\x00', b'\x00', b'\x00', b'\x00']
-    assert list(shrinker.buffer) == [5] * 2 + [0] * 5
+    print(shrinker.choices)
+    assert shrinker.choices == (5, 5, *([b"\x00"] * 5))
 
 
 def test_can_zero_subintervals():
-    @shrinking_from(bytes([3, 0, 0, 0, 1]) * 10)
+    @shrinking_from(ir(3, 0, 0, 0, 1) * 10)
     def shrinker(data: ConjectureData):
         for _ in range(10):
             data.start_example(SOME_LABEL)
@@ -119,7 +107,7 @@ def test_can_zero_subintervals():
         data.mark_interesting()
 
     shrinker.shrink()
-    assert list(shrinker.buffer) == [0, 1] * 10
+    assert shrinker.choices == (0, 1) * 10
 
 
 def test_can_pass_to_an_indirect_descendant():
@@ -132,35 +120,22 @@ def test_can_pass_to_an_indirect_descendant():
             tree(data)
         data.stop_example(discard=True)
 
-    initial = bytes([1, 10, 0, 0, 1, 0, 0, 10, 0, 0])
-    target = bytes([0, 10])
-
+    initial = (1, 10, 0, 0, 1, 0, 0, 10, 0, 0)
+    target = (0, 10)
     good = {initial, target}
 
-    @shrinking_from(initial)
+    @shrinking_from(ir(*initial))
     def shrinker(data: ConjectureData):
         tree(data)
-        if bytes(data.buffer) in good:
+        if data.choices in good:
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["pass_to_descendant"])
-
-    assert shrinker.shrink_target.buffer == target
-
-
-def shrink(buffer, *passes):
-    def accept(f):
-        shrinker = shrinking_from(buffer)(f)
-
-        shrinker.fixate_shrink_passes(passes)
-
-        return list(shrinker.buffer)
-
-    return accept
+    assert shrinker.choices == target
 
 
 def test_shrinking_blocks_from_common_offset():
-    @shrinking_from([11, 10])
+    @shrinking_from(ir(11, 10))
     def shrinker(data: ConjectureData):
         m = data.draw_integer(0, 2**8 - 1)
         n = data.draw_integer(0, 2**8 - 1)
@@ -170,15 +145,12 @@ def test_shrinking_blocks_from_common_offset():
     shrinker.mark_changed(0)
     shrinker.mark_changed(1)
     shrinker.lower_common_node_offset()
-
-    x = shrinker.shrink_target.buffer
-
-    assert sorted(x) == [0, 1]
+    assert shrinker.choices in {(0, 1), (1, 0)}
 
 
 def test_handle_empty_draws():
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         while True:
             data.start_example(SOME_LABEL)
             n = data.draw_integer(0, 1)
@@ -189,12 +161,12 @@ def test_handle_empty_draws():
                 break
         data.mark_interesting()
 
-    assert x == bytes([0])
+    assert tuple(n.value for n in nodes) == (0,)
 
 
 def test_can_reorder_examples():
-    # grouped by iteration: (1, 0, 1) (1, 0, 1) (0) (0) (0)
-    @shrinking_from([1, 0, 1, 1, 0, 1, 0, 0, 0])
+    # grouped by iteration: (1, 1) (1, 1) (0) (0) (0)
+    @shrinking_from(ir(1, 1, 1, 1, 0, 0, 0))
     def shrinker(data: ConjectureData):
         total = 0
         for _ in range(5):
@@ -206,31 +178,28 @@ def test_can_reorder_examples():
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["reorder_examples"])
-
-    assert list(shrinker.buffer) == [0, 0, 0, 1, 0, 1, 1, 0, 1]
+    assert shrinker.choices == (0, 0, 0, 1, 1, 1, 1)
 
 
 def test_permits_but_ignores_raising_order(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function([1]),
+        lambda runner: runner.cached_test_function_ir(ir(1)),
     )
 
-    monkeypatch.setattr(
-        Shrinker, "shrink", lambda self: self.incorporate_new_buffer(bytes([2]))
-    )
+    monkeypatch.setattr(Shrinker, "shrink", lambda self: self.consider_new_tree(ir(2)))
 
-    @run_to_buffer
-    def x(data):
+    @run_to_nodes
+    def nodes(data):
         data.draw_integer(0, 3)
         data.mark_interesting()
 
-    assert list(x) == [1]
+    assert tuple(n.value for n in nodes) == (1,)
 
 
 def test_block_deletion_can_delete_short_ranges():
-    @shrinking_from([v for i in range(5) for _ in range(i + 1) for v in [0, i]])
+    @shrinking_from(ir(*[v for i in range(5) for _ in range(i + 1) for v in [i]]))
     def shrinker(data: ConjectureData):
         while True:
             n = data.draw_integer(0, 2**16 - 1)
@@ -241,27 +210,15 @@ def test_block_deletion_can_delete_short_ranges():
                 data.mark_interesting()
 
     shrinker.fixate_shrink_passes([node_program("X" * i) for i in range(1, 5)])
-    assert list(shrinker.shrink_target.buffer) == [0, 4] * 5
+    assert shrinker.choices == (4,) * 5
 
 
 def test_dependent_block_pairs_is_up_to_shrinking_integers():
     # Unit test extracted from a failure in tests/nocover/test_integers.py
     distribution = Sampler([4.0, 8.0, 1.0, 1.0, 0.5])
-
     sizes = [8, 16, 32, 64, 128]
 
-    @run_to_buffer
-    def buf(data):
-        size = sizes[distribution.sample(data, forced=3)]
-        result = data.draw_integer(0, 2**size - 1, forced=65538)
-        sign = (-1) ** (result & 1)
-        result = (result >> 1) * sign
-        cap = data.draw_integer(0, 2**8 - 1, forced=1)
-
-        if result >= 32768 and cap == 1:
-            data.mark_interesting()
-
-    @shrinking_from(buf)
+    @shrinking_from(ir(3, True, 65538, 1))
     def shrinker(data: ConjectureData):
         size = sizes[distribution.sample(data)]
         result = data.draw_integer(0, 2**size - 1)
@@ -273,7 +230,7 @@ def test_dependent_block_pairs_is_up_to_shrinking_integers():
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
-    assert list(shrinker.shrink_target.buffer) == [1, 1, 0, 0, 1, 0, 0, 1]
+    assert shrinker.choices == (1, True, 65536, 1)
 
 
 def test_finding_a_minimal_balanced_binary_tree():
@@ -294,19 +251,18 @@ def test_finding_a_minimal_balanced_binary_tree():
         return result
 
     # Starting from an unbalanced tree of depth six
-    @shrinking_from([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
+    @shrinking_from(ir(True) * 5 + ir(False) * 6)
     def shrinker(data: ConjectureData):
         _, b = tree(data)
         if not b:
             data.mark_interesting()
 
     shrinker.shrink()
-
-    assert list(shrinker.shrink_target.buffer) == [1, 0, 1, 0, 1, 0, 0]
+    assert shrinker.choices == (True, False, True, False, True, False, False)
 
 
 def test_node_programs_are_adaptive():
-    @shrinking_from(bytes(1000) + bytes([1]))
+    @shrinking_from(ir(False) * 1000 + ir(True))
     def shrinker(data: ConjectureData):
         while not data.draw_boolean():
             pass
@@ -315,12 +271,12 @@ def test_node_programs_are_adaptive():
     p = shrinker.add_new_pass(node_program("X"))
     shrinker.fixate_shrink_passes([p.name])
 
-    assert len(shrinker.shrink_target.buffer) == 1
+    assert len(shrinker.choices) == 1
     assert shrinker.calls <= 60
 
 
 def test_zero_examples_with_variable_min_size():
-    @shrinking_from(bytes([255]) * 100)
+    @shrinking_from(ir(255) * 100)
     def shrinker(data: ConjectureData):
         any_nonzero = False
         for i in range(1, 10):
@@ -330,11 +286,11 @@ def test_zero_examples_with_variable_min_size():
         data.mark_interesting()
 
     shrinker.shrink()
-    assert len([d for d in shrinker.shrink_target.blocks if not d.all_zero]) == 1
+    assert shrinker.choices == (0,) * 8 + (1,)
 
 
 def test_zero_contained_examples():
-    @shrinking_from(bytes([1]) * 8)
+    @shrinking_from(ir(1) * 8)
     def shrinker(data: ConjectureData):
         for _ in range(4):
             data.start_example(1)
@@ -347,11 +303,11 @@ def test_zero_contained_examples():
         data.mark_interesting()
 
     shrinker.shrink()
-    assert list(shrinker.shrink_target.buffer) == [1, 0] * 4
+    assert shrinker.choices == (1, 0) * 4
 
 
 def test_zig_zags_quickly():
-    @shrinking_from(bytes([255]) * 4)
+    @shrinking_from(ir(255) * 4)
     def shrinker(data: ConjectureData):
         m = data.draw_integer(0, 2**16 - 1)
         n = data.draw_integer(0, 2**16 - 1)
@@ -366,39 +322,28 @@ def test_zig_zags_quickly():
 
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
     assert shrinker.engine.valid_examples <= 100
-    assert list(shrinker.shrink_target.buffer) == [0, 1, 0, 1]
+    assert shrinker.choices == (1, 1)
 
 
 @pytest.mark.parametrize(
-    "min_value, max_value, forced, shrink_towards, expected_values",
+    "min_value, max_value, forced, shrink_towards, expected",
     [
         # this test disallows interesting values in radius 10 interval around shrink_towards
         # to avoid trivial shrinks messing with things, which is why the expected
         # values are ±10 from shrink_towards.
-        (-100, 0, -100, 0, [-10, -10]),
-        (-100, 0, -100, -35, [-25, -25]),
-        (0, 100, 100, 0, [10, 10]),
-        (0, 100, 100, 65, [75, 75]),
+        (-100, 0, -100, 0, (-10, -10)),
+        (-100, 0, -100, -35, (-25, -25)),
+        (0, 100, 100, 0, (10, 10)),
+        (0, 100, 100, 65, (75, 75)),
     ],
 )
 def test_zig_zags_quickly_with_shrink_towards(
-    min_value, max_value, forced, shrink_towards, expected_values
+    min_value, max_value, forced, shrink_towards, expected
 ):
     # we should be able to efficiently incorporate shrink_towards when dealing
     # with zig zags.
 
-    @run_to_buffer
-    def buf(data):
-        m = data.draw_integer(
-            min_value, max_value, shrink_towards=shrink_towards, forced=forced
-        )
-        n = data.draw_integer(
-            min_value, max_value, shrink_towards=shrink_towards, forced=forced
-        )
-        if abs(m - n) <= 1:
-            data.mark_interesting()
-
-    @shrinking_from(buf)
+    @shrinking_from(ir(forced) * 2)
     def shrinker(data: ConjectureData):
         m = data.draw_integer(min_value, max_value, shrink_towards=shrink_towards)
         n = data.draw_integer(min_value, max_value, shrink_towards=shrink_towards)
@@ -410,11 +355,11 @@ def test_zig_zags_quickly_with_shrink_towards(
 
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
     assert shrinker.engine.valid_examples <= 40
-    assert [node.value for node in shrinker.nodes] == expected_values
+    assert shrinker.choices == expected
 
 
 def test_zero_irregular_examples():
-    @shrinking_from([255] * 6)
+    @shrinking_from(ir(255) * 6)
     def shrinker(data: ConjectureData):
         data.start_example(1)
         data.draw_integer(0, 2**8 - 1)
@@ -429,11 +374,11 @@ def test_zero_irregular_examples():
             data.mark_interesting()
 
     shrinker.shrink()
-    assert list(shrinker.shrink_target.buffer) == [0] * 3 + [1, 0, 1]
+    assert shrinker.choices == (0,) * 2 + (1, 1)
 
 
 def test_retain_end_of_buffer():
-    @shrinking_from([1, 2, 3, 4, 5, 6, 0])
+    @shrinking_from(ir(1, 2, 3, 4, 5, 6, 0))
     def shrinker(data: ConjectureData):
         interesting = False
         while True:
@@ -446,11 +391,11 @@ def test_retain_end_of_buffer():
             data.mark_interesting()
 
     shrinker.shrink()
-    assert list(shrinker.buffer) == [6, 0]
+    assert shrinker.choices == (6, 0)
 
 
 def test_can_expand_zeroed_region():
-    @shrinking_from([255] * 5)
+    @shrinking_from(ir(255) * 5)
     def shrinker(data: ConjectureData):
         seen_non_zero = False
         for _ in range(5):
@@ -462,11 +407,11 @@ def test_can_expand_zeroed_region():
         data.mark_interesting()
 
     shrinker.shrink()
-    assert list(shrinker.shrink_target.buffer) == [0] * 5
+    assert shrinker.choices == (0,) * 5
 
 
 def test_can_expand_deleted_region():
-    @shrinking_from([1, 2, 3, 4, 0, 0])
+    @shrinking_from(ir(1, 2, 3, 4, 0, 0))
     def shrinker(data: ConjectureData):
         def t():
             data.start_example(1)
@@ -490,11 +435,11 @@ def test_can_expand_deleted_region():
             data.mark_interesting()
 
     shrinker.shrink()
-    assert list(shrinker.buffer) == [0, 0]
+    assert shrinker.choices == (0, 0)
 
 
 def test_shrink_pass_method_is_idempotent():
-    @shrinking_from([255])
+    @shrinking_from(ir(255))
     def shrinker(data: ConjectureData):
         data.draw_integer(0, 2**8 - 1)
         data.mark_interesting()
@@ -510,7 +455,7 @@ def test_will_terminate_stalled_shrinks():
     # as far as we're going to get.
     time.freeze()
 
-    @shrinking_from([255] * 100)
+    @shrinking_from(ir(255) * 100)
     def shrinker(data: ConjectureData):
         count = 0
 
@@ -526,7 +471,7 @@ def test_will_terminate_stalled_shrinks():
 
 
 def test_will_let_fixate_shrink_passes_do_a_full_run_through():
-    @shrinking_from(range(50))
+    @shrinking_from(ir(*list(range(50))))
     def shrinker(data: ConjectureData):
         for i in range(50):
             if data.draw_integer(0, 2**8 - 1) != i:
@@ -534,9 +479,7 @@ def test_will_let_fixate_shrink_passes_do_a_full_run_through():
         data.mark_interesting()
 
     shrinker.max_stall = 5
-
     passes = [node_program("X" * i) for i in range(1, 11)]
-
     with pytest.raises(StopShrinking):
         shrinker.fixate_shrink_passes(passes)
 
@@ -545,7 +488,7 @@ def test_will_let_fixate_shrink_passes_do_a_full_run_through():
 
 @pytest.mark.parametrize("n_gap", [0, 1, 2, 3])
 def test_can_simultaneously_lower_non_duplicated_nearby_blocks(n_gap):
-    @shrinking_from([1, 1] + [0] * n_gap + [0, 2])
+    @shrinking_from(ir(1, 1) + ir(0) * n_gap + ir(2))
     def shrinker(data: ConjectureData):
         # Block off lowering the whole buffer
         if data.draw_integer(0, 2**1 - 1) == 0:
@@ -559,18 +502,11 @@ def test_can_simultaneously_lower_non_duplicated_nearby_blocks(n_gap):
             data.mark_interesting()
 
     shrinker.fixate_shrink_passes(["lower_blocks_together"])
-
-    assert list(shrinker.buffer) == [1, 0] + [0] * n_gap + [0, 1]
+    assert shrinker.choices == (1, 0) + (0,) * n_gap + (1,)
 
 
 def test_redistribute_integer_pairs_with_forced_node():
-    @run_to_buffer
-    def buf(data):
-        data.draw_integer(0, 100, forced=15)
-        data.draw_integer(0, 100, forced=10)
-        data.mark_interesting()
-
-    @shrinking_from(buf)
+    @shrinking_from(ir(15, 10))
     def shrinker(data: ConjectureData):
         n1 = data.draw_integer(0, 100)
         n2 = data.draw_integer(0, 100, forced=10)
@@ -581,4 +517,4 @@ def test_redistribute_integer_pairs_with_forced_node():
     # redistribute_integer_pairs shouldn't try modifying forced nodes while
     # shrinking. Since the second draw is forced, this isn't possible to shrink
     # with just this pass.
-    assert shrinker.buffer == buf
+    assert shrinker.choices == (15, 10)

--- a/hypothesis-python/tests/cover/test_filtered_strategy.py
+++ b/hypothesis-python/tests/cover/test_filtered_strategy.py
@@ -12,20 +12,14 @@ import hypothesis.strategies as st
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies._internal.strategies import FilteredStrategy
 
-from tests.conjecture.common import run_to_buffer
+from tests.conjecture.common import ir
 
 
 def test_filter_iterations_are_marked_as_discarded():
     variable_equal_to_zero = 0  # non-local references disables filter-rewriting
     x = st.integers().filter(lambda x: x == variable_equal_to_zero)
 
-    @run_to_buffer
-    def buf(data):
-        data.draw_integer(forced=1)
-        data.draw_integer(forced=0)
-        data.mark_interesting()
-
-    data = ConjectureData.for_buffer(buf)
+    data = ConjectureData.for_ir_tree(ir(1, 0))
     assert data.draw(x) == 0
     assert data.has_discards
 

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -25,7 +25,7 @@ from hypothesis.internal.compat import ceil
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
-from tests.conjecture.common import run_to_buffer
+from tests.conjecture.common import ir
 
 
 @st.composite
@@ -74,13 +74,6 @@ def test_avoids_zig_zag_trap(p):
     m, marker, lower_bound = p
     n_bits = m.bit_length() + 1
 
-    @run_to_buffer
-    def buf(data):
-        _m = data.draw_integer(0, 2**n_bits - 1, forced=m)
-        _n = data.draw_integer(0, 2**n_bits - 1, forced=m + 1)
-        _marker = data.draw_bytes(len(marker), len(marker), forced=marker)
-        data.mark_interesting()
-
     def test_function(data):
         m = data.draw_integer(0, 2**n_bits - 1)
         if m < lower_bound:
@@ -98,7 +91,7 @@ def test_avoids_zig_zag_trap(p):
         random=Random(0),
     )
 
-    runner.cached_test_function(buf)
+    runner.cached_test_function_ir(ir(m, m + 1, marker))
     assert runner.interesting_examples
     runner.run()
     (v,) = runner.interesting_examples.values()


### PR DESCRIPTION
This will probably be one of a few pulls in this vein, to keep the migration reasonable piecewise.

The new code piece here is `data.choices`. I'm quite happy to report that in working on the full typed choice sequence migration there seems to be a decent separation between when you need just `list[IRType]` (when constructing a ConjectureData) and when you need the full nodes (after running a ConjectureData; the shrinker, and the database because of `sort_key`). Therefore an attribute for accessing the former is convenient.

To preempt a review comment: "why have some buffers changed from (0, n) to (n)?" because the first 0 represents the bounded integer weighted endpoint choice for the buffer. Only occurs for bounded integers above `2**8 - 1`. 