### PR TITLE
Disable line coverage events where not used

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Hypothesis collects coverage information during the :ref:`shrinking hypothesis.Phase.shrink` and :ref:`explain hypothesis.Phase.explain` phases in order to show a more informative error message. On 3.12+, this uses :mod:`sys.monitoring`. This patch improves the performance of coverage collection on 3.12+ by disabling events we don't need.

--- a/hypothesis-python/src/hypothesis/internal/scrutineer.py
+++ b/hypothesis-python/src/hypothesis/internal/scrutineer.py
@@ -76,7 +76,6 @@ class Tracer:
             if event == "call":
                 return self.trace
             elif event == "line":
-                # manual inlining of self.trace_line for performance.
                 fname = frame.f_code.co_filename
                 if should_trace_file(fname):
                     current_location = (fname, frame.f_lineno)
@@ -87,10 +86,12 @@ class Tracer:
 
     def trace_line(self, code: types.CodeType, line_number: int) -> None:
         fname = code.co_filename
-        if should_trace_file(fname):
-            current_location = (fname, line_number)
-            self.branches.add((self._previous_location, current_location))
-            self._previous_location = current_location
+        if not should_trace_file(fname):
+            return sys.monitoring.DISABLE
+
+        current_location = (fname, line_number)
+        self.branches.add((self._previous_location, current_location))
+        self._previous_location = current_location
 
     def __enter__(self):
         if not self._should_trace:


### PR DESCRIPTION
[Disables events](https://docs.python.org/3/library/sys.monitoring.html#disabling-events) which are not used, for performance. Helps with (and probably closes) #4179.