### PR TITLE
Report all generated arguments in observability

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch fixes a bug where only interactively-generated values (via ``data.draw``) would be reported in the ``arguments`` field of our :doc:`observability output <observability>`. Now, all values are reported.
+This patch fixes a bug since :ref:`v6.99.13` where only interactively-generated values (via ``data.draw``) would be reported in the ``arguments`` field of our :doc:`observability output <observability>`. Now, all values are reported.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where only interactively-generated values (via ``data.draw``) would be reported in the ``arguments`` field of our :doc:`observability output <observability>`. Now, all values are reported.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1342,7 +1342,7 @@ class StateForActualGivenExecution:
                     "coverage": None,  # Not recorded when we're replaying the MFE
                     "metadata": {
                         "traceback": tb,
-                        "predicates": ran_example._observability_predicates,
+                        "predicates": dict(ran_example._observability_predicates),
                         **_system_metadata(),
                     },
                 }

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -2531,7 +2531,10 @@ class ConjectureData:
                     in_gctime = gc_cumulative_time() - gc_start_time
                     self.draw_times[key] = time.perf_counter() - start_time - in_gctime
             except Exception as err:
-                add_note(err, f"while generating {key[9:]!r} from {strategy!r}")
+                add_note(
+                    err,
+                    f"while generating {key.removeprefix('generate:')!r} from {strategy!r}",
+                )
                 raise
             if TESTCASE_CALLBACKS:
                 self._observability_args[key] = to_jsonable(v)

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -63,7 +63,9 @@ def make_testcase(
         }[data.status],
         "status_reason": status_reason,
         "representation": string_repr,
-        "arguments": arguments or {},
+        "arguments": {
+            k.removeprefix("generate:"): v for k, v in (arguments or {}).items()
+        },
         "how_generated": how_generated,  # iid, mutation, etc.
         "features": {
             **{

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -74,7 +74,7 @@ def make_testcase(
         "timing": timing,
         "metadata": {
             "traceback": getattr(data.extra_information, "_expected_traceback", None),
-            "predicates": data._observability_predicates,
+            "predicates": dict(data._observability_predicates),
             "backend": backend_metadata or {},
             **_system_metadata(),
         },

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2113,13 +2113,13 @@ class DataObject:
     def draw(self, strategy: SearchStrategy[Ex], label: Any = None) -> Ex:
         check_strategy(strategy, "strategy")
         self.count += 1
-        printer = RepresentationPrinter(context=current_build_context())
         desc = f"Draw {self.count}{'' if label is None else f' ({label})'}"
         with deprecate_random_in_strategy("{}from {!r}", desc, strategy):
             result = self.conjecture_data.draw(strategy, observe_as=f"generate:{desc}")
 
         # optimization to avoid needless printer.pretty
         if should_note():
+            printer = RepresentationPrinter(context=current_build_context())
             printer.text(f"{desc}: ")
             printer.pretty(result)
             note(printer.getvalue())

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -85,7 +85,6 @@ from hypothesis.internal.conjecture.utils import (
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
 from hypothesis.internal.floats import float_of
-from hypothesis.internal.observability import TESTCASE_CALLBACKS
 from hypothesis.internal.reflection import (
     define_function_signature,
     get_pretty_function_description,
@@ -139,11 +138,7 @@ from hypothesis.strategies._internal.strings import (
     TextStrategy,
     _check_is_single_character,
 )
-from hypothesis.strategies._internal.utils import (
-    cacheable,
-    defines_strategy,
-    to_jsonable,
-)
+from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 from hypothesis.utils.conventions import not_set
 from hypothesis.vendor.pretty import RepresentationPrinter
 
@@ -2119,15 +2114,13 @@ class DataObject:
         check_strategy(strategy, "strategy")
         self.count += 1
         printer = RepresentationPrinter(context=current_build_context())
-        desc = f"Draw {self.count}{'' if label is None else f' ({label})'}: "
+        desc = f"Draw {self.count}{'' if label is None else f' ({label})'}"
         with deprecate_random_in_strategy("{}from {!r}", desc, strategy):
             result = self.conjecture_data.draw(strategy, observe_as=f"generate:{desc}")
-        if TESTCASE_CALLBACKS:
-            self.conjecture_data._observability_args[desc] = to_jsonable(result)
 
         # optimization to avoid needless printer.pretty
         if should_note():
-            printer.text(desc)
+            printer.text(f"{desc}: ")
             printer.pretty(result)
             note(printer.getvalue())
         return result

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -80,10 +80,10 @@ def test_capture_unnamed_arguments():
     test_cases = [tc for tc in observations if tc["type"] == "test_case"]
     for test_case in test_cases:
         assert list(test_case["arguments"].keys()) == [
-            "generate:v1",
-            "generate:v2",
-            "generate:data",
-            "generate:Draw 1",
+            "v1",
+            "v2",
+            "data",
+            "Draw 1",
         ], test_case
 
 
@@ -98,10 +98,10 @@ def test_capture_named_arguments():
     test_cases = [tc for tc in observations if tc["type"] == "test_case"]
     for test_case in test_cases:
         assert list(test_case["arguments"].keys()) == [
-            "generate:named1",
-            "generate:named2",
-            "generate:data",
-            "generate:Draw 1",
+            "named1",
+            "named2",
+            "data",
+            "Draw 1",
         ], test_case
 
 

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -69,6 +69,42 @@ def test_observability():
             )
 
 
+def test_capture_unnamed_arguments():
+    @given(st.integers(), st.floats(), st.data())
+    def f(v1, v2, data):
+        data.draw(st.booleans())
+
+    with capture_observations() as observations:
+        f()
+
+    test_cases = [tc for tc in observations if tc["type"] == "test_case"]
+    for test_case in test_cases:
+        assert list(test_case["arguments"].keys()) == [
+            "generate:v1",
+            "generate:v2",
+            "generate:data",
+            "generate:Draw 1",
+        ], test_case
+
+
+def test_capture_named_arguments():
+    @given(named1=st.integers(), named2=st.floats(), data=st.data())
+    def f(named1, named2, data):
+        data.draw(st.booleans())
+
+    with capture_observations() as observations:
+        f()
+
+    test_cases = [tc for tc in observations if tc["type"] == "test_case"]
+    for test_case in test_cases:
+        assert list(test_case["arguments"].keys()) == [
+            "generate:named1",
+            "generate:named2",
+            "generate:data",
+            "generate:Draw 1",
+        ], test_case
+
+
 def test_assume_has_status_reason():
     @given(st.booleans())
     def f(b):


### PR DESCRIPTION
This regressed at some point, probably when we were moving things around for alternative backends.