### PR TITLE
Reduce example generation batch size

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,4 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-When a user requests an interactive input via ``strategy.example``, we generate and cache a batch of 100 inputs and return the first one. As this initial batch can be expensive for large strategies, this patch reduces the batch size to 10.
+* This release changes our input distribution for low ``max_examples``. Previously, we capped the size of inputs when generating at least the first 10 inputs, with the reasoning that early inputs to a property should be small. However, this meant properties with ``max_examples=10`` would consistent entirely of small inputs. This patch removes the hard lower bound so that inputs to these properties are more representative of the input space.
+* When a user requests an interactive input via ``strategy.example``, we generate and cache a batch of 100 inputs, returning the first one. This can be expensive for large strategies or when only a few examples are needed. This release improves the speed of ``strategy.example`` by lowering the batch size to 10.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+When a user requests an interactive input via ``strategy.example``, we generate and cache a batch of 100 inputs and return the first one. As this initial batch can be expensive for large strategies, this patch reduces the batch size to 10.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -335,7 +335,10 @@ class SearchStrategy(Generic[Ex]):
         @given(self)
         @settings(
             database=None,
-            max_examples=100,
+            # generate only a few examples at a time to avoid slow interactivity
+            # for large strategies. The overhead of @given is very small relative
+            # to generation, so a small batch size is fine.
+            max_examples=10,
             deadline=None,
             verbosity=Verbosity.quiet,
             phases=(Phase.generate,),


### PR DESCRIPTION
Ran into this in the wild myself and decided to do something about it 😄. See also https://github.com/HypothesisWorks/hypothesis/issues/3790#issuecomment-1811657344. I think the downsides to a lower batch size are small; people really shouldn't be using `.example` for large n, and even if they do the overhead of smaller batches is pretty small.