### PR TITLE
Revert Refactor of `BundleReferenceStrategy` into `Bundle`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release brings back the old representation of :class:`hypothesis.stateful.Bundle`, reverting most changes of `PR #4124 <https://github.com/HypothesisWorks/hypothesis/pull/4124>`_.

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -24,6 +24,7 @@ from hypothesis import (
     reproduce_failure,
     seed,
     settings as Settings,
+    strategies as st,
 )
 from hypothesis.control import current_build_context
 from hypothesis.database import ExampleDatabase
@@ -1336,6 +1337,27 @@ def test_flatmap():
         @rule(bun=buns)
         def use_directly(self, bun):
             assert isinstance(bun, int)
+
+    Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_use_bundle_within_other_strategies():
+    class Class:
+        def __init__(self, value):
+            self.value = value
+
+    class Machine(RuleBasedStateMachine):
+        my_bundle = Bundle("my_bundle")
+
+        @initialize(target=my_bundle)
+        def set_initial(self, /) -> str:
+            return "sample text"
+
+        @rule(instance=st.builds(Class, my_bundle))
+        def check(self, instance):
+            assert isinstance(instance, Class)
+            assert isinstance(instance.value, str)
 
     Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
     run_state_machine_as_test(Machine)


### PR DESCRIPTION
After reviewing, closes #4181, I realize there isn't a really "hypothesis-like" way to differentiate between the `Bundle` calls from the internal `run_state_machine` and those from other strategies, so the best way to solve this seems to be to revert most of it (there's two areas about printing but it didn't seem to affect the tests, so leaving that in). Hopefully it wasn't too much trouble for the users! At the very least there's some improvement in the testbase.

I'll also have to do a bit of refactor #4084 but I think that'll be fine.

Original PR: #4124