### PR TITLE
Reorder docs pages

### DIFF
--- a/hypothesis-python/docs/data.rst
+++ b/hypothesis-python/docs/data.rst
@@ -1,6 +1,6 @@
-=============================
-What you can generate and how
-=============================
+==========
+Strategies
+==========
 
 *Most things should be easy to generate and everything should be possible.*
 

--- a/hypothesis-python/docs/database.rst
+++ b/hypothesis-python/docs/database.rst
@@ -1,6 +1,6 @@
-===============================
-The Hypothesis example database
-===============================
+========
+Database
+========
 
 When Hypothesis finds a bug it stores enough information in its database to reproduce it. This
 enables you to have a classic testing workflow of find a bug, fix a bug, and be confident that

--- a/hypothesis-python/docs/development.rst
+++ b/hypothesis-python/docs/development.rst
@@ -1,6 +1,6 @@
-==============================
-Ongoing Hypothesis development
-==============================
+======================
+Hypothesis development
+======================
 
 Hypothesis development is managed by `David R. MacIver <https://www.drmaciver.com>`_
 and `Zac Hatfield-Dodds <https://zhd.dev>`_, respectively the first author and lead

--- a/hypothesis-python/docs/django.rst
+++ b/hypothesis-python/docs/django.rst
@@ -1,8 +1,8 @@
 .. _hypothesis-django:
 
-===========================
-Hypothesis for Django users
-===========================
+=====================
+Hypothesis for Django
+=====================
 
 Hypothesis offers a number of features specific for Django testing, available
 in the ``hypothesis[django]`` :doc:`extra </extras>`.  This is tested

--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -1,6 +1,6 @@
-==================
-Some more examples
-==================
+========================
+Some Hypothesis examples
+========================
 
 This is a collection of examples of how to use Hypothesis in interesting ways.
 It's small for now but will grow over time.

--- a/hypothesis-python/docs/ghostwriter.rst
+++ b/hypothesis-python/docs/ghostwriter.rst
@@ -1,6 +1,6 @@
-==========================
-Ghostwriting tests for you
-==========================
+===========
+Ghostwriter
+===========
 
 .. automodule:: hypothesis.extra.ghostwriter
    :members:

--- a/hypothesis-python/docs/index.rst
+++ b/hypothesis-python/docs/index.rst
@@ -57,27 +57,34 @@ check out some of the
 .. toctree::
   :maxdepth: 1
   :hidden:
+  :caption: Hypothesis
 
   quickstart
   details
-  settings
   data
-  extras
-  ghostwriter
-  django
-  numpy
+  settings
   database
   stateful
-  supported
+  reproducing
+  ghostwriter
   examples
-  community
+  extras
+  django
+  numpy
+  observability
+  supported
+  changes
+
+.. toctree::
+  :maxdepth: 1
+  :hidden:
+  :caption: Community
+
+  development
   manifesto
-  endorsements
   usage
   strategies
-  changes
-  development
-  support
   packaging
-  reproducing
-  observability
+  community
+  support
+  endorsements

--- a/hypothesis-python/docs/numpy.rst
+++ b/hypothesis-python/docs/numpy.rst
@@ -1,6 +1,6 @@
-===================================
-Hypothesis for the scientific stack
-===================================
+===========================
+Hypothesis for data science
+===========================
 
 .. _hypothesis-numpy:
 

--- a/hypothesis-python/docs/quickstart.rst
+++ b/hypothesis-python/docs/quickstart.rst
@@ -1,6 +1,6 @@
-=================
-Quick start guide
-=================
+==========
+Quickstart
+==========
 
 This document should talk you through everything you need to get started with
 Hypothesis.

--- a/hypothesis-python/docs/usage.rst
+++ b/hypothesis-python/docs/usage.rst
@@ -1,6 +1,6 @@
-=====================================
-Open source projects using Hypothesis
-=====================================
+=========================
+Projects using Hypothesis
+=========================
 
 The following is a non-exhaustive list of open source projects I know are
 using Hypothesis. If you're aware of any others please add them to the list!
@@ -8,10 +8,10 @@ The only inclusion criterion right now is that if it's a Python library
 then it should be available on PyPI.
 
 You can find hundreds more from `the Hypothesis page at libraries.io
-<https://libraries.io/pypi/hypothesis>`_, and :gh-file:`thousands on GitHub <network/dependents>`.
-Hypothesis has `over 100,000 downloads per week <https://pypistats.org/packages/hypothesis>`__,
-and was used by `more than 4% of Python users surveyed by the PSF in 2020
-<https://www.jetbrains.com/lp/python-developers-survey-2020/>`__.
+<https://libraries.io/pypi/hypothesis>`_, and `thousands on GitHub <https://github.com/HypothesisWorks/hypothesis/network/dependents>`__.
+Hypothesis has `over 8 million downloads per week <https://pypistats.org/packages/hypothesis>`__,
+and was used by `more than 5% of Python users surveyed by the PSF in 2023
+<https://lp.jetbrains.com/python-developers-survey-2023/>`__.
 
 * `aur <https://github.com/cdown/aur>`_
 * `argon2_cffi <https://github.com/hynek/argon2-cffi>`_


### PR DESCRIPTION
I've found the documentation sidebar quite confusing to navigate at times. Mostly that the titles are verbose or do not lean on hypothesis-specific terms (`strategies`), and that there is no clear delineation between the reference and the community pages. This is my subjective first pass at putting things in a more readable state 🙂 (with a lot of work on individual pages still remaining!)

| master | this pull | 
| --- | --- |
| <img width="296" alt="image" src="https://github.com/user-attachments/assets/b472d26d-45bb-4449-8b95-191ce8bc9cfe"> | <img width="279" alt="image" src="https://github.com/user-attachments/assets/d8bf68be-4686-424c-ba2a-4395638ae508"> |

