### PR TITLE
Add small integer representation

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release improves the internal representation of integers. This should have relatively
+little user visible difference, but will improve performance of both generation and shrinking
+in some cases, and also will improve shrink quality in a few others. In particular code like
+``st.one_of(st.integers(), st.text())`` should now reliably prefer ``0`` over ``""``.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -744,7 +744,14 @@ def ir_to_bytes(ir: Iterable[IRType], /) -> bytes:
             elem = struct.pack("!d", elem)
         elif isinstance(elem, int):
             tag = 2 << 5
-            elem = elem.to_bytes(1 + elem.bit_length() // 8, "big", signed=True)
+            # We represent zero specially as zero bytes wide to
+            # make sure shrinking order makes sense. It's also
+            # a small space saving but we don't really care about
+            # that.
+            if elem != 0:
+                elem = elem.to_bytes(1 + elem.bit_length() // 8, "big", signed=True)
+            else:
+                elem = b""
         elif isinstance(elem, bytes):
             tag = 3 << 5
         else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1770,6 +1770,31 @@ class HypothesisProvider(PrimitiveProvider):
         self, *, forced: Optional[int] = None, fake_forced: bool = False
     ) -> int:
         assert self._cd is not None
+
+        max_small_integer = 50
+        if forced is None:
+            small_forced = None
+        elif abs(forced) > max_small_integer:
+            small_forced = max_small_integer * 2 + 2
+        elif forced == 0:
+            small_forced = 0
+        else:
+            small_forced = abs(forced) << 1
+            if forced < 0:
+                small_forced |= 1
+
+        small_integer_bits = self._cd.draw_bits(
+            8, forced=small_forced, fake_forced=fake_forced
+        )
+        if small_integer_bits == 0:
+            return 0
+        if small_integer_bits <= (max_small_integer * 2 + 1):
+            value = small_integer_bits >> 1
+            if small_integer_bits & 1:
+                return -value
+            else:
+                return value
+
         forced_i = None
         if forced is not None:
             # Using any bucket large enough to contain this integer would be a

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -221,7 +221,11 @@ class Sampler:
 
 
 INT_SIZES = (8, 16, 32, 64, 128)
-INT_SIZES_SAMPLER = Sampler((4.0, 8.0, 1.0, 1.0, 0.5), observe=False)
+# We relatively rarely draw an 8-bit integer because most of the 8-bit integers
+# we draw are from our special case for integers with absolute value <= 50.
+# We allow some small number both for shrinking purposes and to get better
+# coverage of the interval [51, 256]
+INT_SIZES_SAMPLER = Sampler((1.0, 8.0, 1.0, 1.0, 0.5), observe=False)
 
 
 class many:

--- a/hypothesis-python/tests/cover/test_replay_logic.py
+++ b/hypothesis-python/tests/cover/test_replay_logic.py
@@ -124,6 +124,7 @@ def test_will_shrink_if_the_previous_example_does_not_look_right():
     def test(data):
         nonlocal last
         m = data.draw(st.integers())
+        print(m)
         last = m
         if first_test:
             data.draw(st.integers())

--- a/hypothesis-python/tests/nocover/test_integer_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_integer_shrinking.py
@@ -1,0 +1,64 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from random import Random
+
+from hypothesis import assume, example, given, strategies as st
+from hypothesis.errors import StopTest
+from hypothesis.internal.conjecture.data import ConjectureData, Status
+from hypothesis.internal.conjecture.engine import ConjectureRunner
+
+
+@st.composite
+def integer_buffer(draw):
+    for _ in range(100):
+        buf = draw(st.binary(min_size=8))
+        try:
+            data = ConjectureData.for_buffer(buf)
+            data.draw_integer()
+            return bytes(data.buffer)
+        except StopTest:
+            continue
+    assume(False)
+
+
+@example(
+    n=-46,
+    buffer=b"f\x00\x01\x01\x01",
+)
+@given(st.integers(), integer_buffer())
+def test_will_always_shrink_an_integer_to_a_boundary(n, buffer):
+    if n > 0:
+
+        def test_function(data):
+            if data.draw_integer() >= n:
+                data.mark_interesting()
+
+    elif n < 0:
+
+        def test_function(data):
+            if data.draw_integer() <= n:
+                data.mark_interesting()
+
+    else:
+
+        def test_function(data):
+            data.draw_integer()
+            data.mark_interesting()
+
+    runner = ConjectureRunner(test_function, random=Random(0))
+    assume(runner.cached_test_function(buffer).status == Status.INTERESTING)
+
+    runner.shrink_interesting_examples()
+
+    (shrunk,) = runner.interesting_examples.values()
+
+    result = ConjectureData.for_buffer(shrunk.buffer).draw_integer()
+    assert result == n

--- a/hypothesis-python/tests/nocover/test_minimal_representations.py
+++ b/hypothesis-python/tests/nocover/test_minimal_representations.py
@@ -1,0 +1,27 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import hypothesis.strategies as st
+from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.engine import BUFFER_SIZE
+from hypothesis.strategies import SearchStrategy
+
+
+def minimal_buffer_for(strategy: SearchStrategy) -> bytes:
+    data = ConjectureData.for_buffer(bytes(BUFFER_SIZE))
+    # TODO: Not all strategies will actually produce a valid result
+    # for all zero bytes. When we have one we want to test this
+    # will require updating to use the shrinker.
+    data.draw(strategy)
+    return bytes(data.buffer)
+
+
+def test_integers_have_a_one_byte_representation():
+    assert len(minimal_buffer_for(st.integers())) == 1


### PR DESCRIPTION
Long-standing Hypothesis shrinking advice is that when you write `one_of(x, y)` then you should make sure that `x` is simpler than `y` so as to get good shrinking behaviour.

But, uh, what does "simpler" mean? Well it means "has smaller representations in the Hypothesis internal shrink order". Fair enough.

Well it turns out that this secretly means two different things:

1. Which of these is *typically* smaller?
2. Which of these is smaller *once shrunk*?

Which of these do we mean?

Well, uh, unfortunately we mean both. The former is important to get good shrinking performance/behaviour, the latter is important to to get good results once fully shrunk.

Sure would be a shame if there were common pairs of strategies where these gave different answers, huh?

Anyway `one_of(integers(), text())` is such an example. `integers()` are typically (and sortof logically should be) smaller than text, but `0` is actually larger than `''` in both the new and old representations.

This PR adds a small-integer optimisation that fixes both. It gives us a single-byte representation of small integers in the old buffer-based implementation, and adds a special case for zero in the serialisation format of the new IR representation (non-zero integers don't need special casing here, because in the new representation this is only a problem for `0`. Any string of length > 0 will be at least two bytes, so the IR already handles the sizing of small non-zero integers correctly.