### PR TITLE
Teach from_type to build with posonly args

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.from_type` can now handle constructors with
+required positional-only arguments if they have type annotations.  Previously,
+we only passed arguments by keyword.

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -1224,3 +1224,16 @@ def test_custom_strategy_function_resolves_types_conditionally():
         assert_all_examples(st.from_type(A), lambda example: type(example) == C)
         assert_all_examples(st.from_type(B), lambda example: example is sentinel)
         assert_all_examples(st.from_type(C), lambda example: type(example) == C)
+
+
+class CustomInteger(int):
+    def __init__(self, value: int, /) -> None:
+        if not isinstance(value, int):
+            raise TypeError
+
+
+@given(...)
+def test_from_type_resolves_required_posonly_args(n: CustomInteger):
+    # st.builds() does not infer for positional arguments, but st.from_type()
+    # does.  See e.g. https://stackoverflow.com/q/79199376/ for motivation.
+    assert isinstance(n, CustomInteger)


### PR DESCRIPTION
Which allows the answer to [this StackOverflow question](https://stackoverflow.com/questions/79199376/hypothesis-cannot-build-from-type-when-type-is-int-subclass) to be "subclasses of `int` must have pos-only args, fix that and it'll work".