### PR TITLE
Remove `gc.collect()` before each test

### DIFF
--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -69,11 +69,6 @@ def warns_or_raises(request):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def _gc_before_each_test():
-    gc.collect()
-
-
-@pytest.fixture(scope="function", autouse=True)
 def _consistently_increment_time(monkeypatch):
     """Rather than rely on real system time we monkey patch time.time so that
     it passes at a consistent rate between calls.

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -161,7 +161,11 @@ def test_find_does_not_pollute_state():
     "ignore:It looks like `register_random` was passed an object that could be garbage collected"
 )
 def test_evil_prng_registration_nonsense():
-    gc_collect()
+    # my guess is that other tests may register randoms that are then marked for
+    # deletion (but not actually gc'd yet). Therefore, depending on the order tests
+    # are run, RANDOMS_TO_MANAGE may start with more entries than after a gc. To
+    # force a clean slate for this test, unconditionally gc.
+    gc.collect()
     # The first test to call deterministic_PRNG registers a new random instance.
     # If that's this test, it will throw off our n_registered count in the middle.
     # start with a no-op to ensure this registration has occurred.

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -162,6 +162,12 @@ def test_find_does_not_pollute_state():
 )
 def test_evil_prng_registration_nonsense():
     gc_collect()
+    # The first test to call deterministic_PRNG registers a new random instance.
+    # If that's this test, it will throw off our n_registered count in the middle.
+    # start with a no-op to ensure this registration has occurred.
+    with deterministic_PRNG(0):
+        pass
+
     n_registered = len(entropy.RANDOMS_TO_MANAGE)
     r1, r2, r3 = random.Random(1), random.Random(2), random.Random(3)
     s2 = r2.getstate()


### PR DESCRIPTION
I found this was adding ~50ms of overhead to every test. When multiplied by our 6500 tests, that's...a lot. Since [the commit which added this](https://github.com/HypothesisWorks/hypothesis/commit/cc8c93f21b9a46592f8d9dc943b0fc98c7ab6c9a) is 9 years old and pypy-specific, I'm hoping we can drop it without issues? @DRMacIver do you happen to remember the motivation for this change or any idea if it is still necessary?

To test, you can add the following to any test file

```python
@pytest.mark.parametrize("v", range(100))
def test_123456789(v):
    print("call", v)
```

and observe that `pytest -n 1 -k test_123456789 -s` takes ~7 seconds on master but 1.5 seconds on this branch (not zero due to test collection overhead).