### PR TITLE
Implement and use `sort_key_ir`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-The shrinker now uses the `typed choice sequence` (:issue:`3921`) to determine counterexample complexity. We expect this to mostly match the previous ordering, but it may result in reporting different counterexamples in some cases.
+The shrinker now uses the typed choice sequence (:issue:`3921`) when ordering failing examples. As a result, Hypothesis may now report a different minimal failing example for some tests. We expect most cases to remain unchanged.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The shrinker now uses the `typed choice sequence` (:issue:`3921`) to determine counterexample complexity. We expect this to mostly match the previous ordering, but it may result in reporting different counterexamples in some cases.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -85,7 +85,7 @@ from hypothesis.internal.conjecture.junkdrawer import (
     ensure_free_stackframes,
     gc_cumulative_time,
 )
-from hypothesis.internal.conjecture.shrinker import sort_key
+from hypothesis.internal.conjecture.shrinker import sort_key, sort_key_ir
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
     InterestingOrigin,
@@ -1226,7 +1226,7 @@ class StateForActualGivenExecution:
         if runner.interesting_examples:
             self.falsifying_examples = sorted(
                 runner.interesting_examples.values(),
-                key=lambda d: sort_key(d.buffer),
+                key=lambda d: sort_key_ir(d.ir_nodes),
                 reverse=True,
             )
         else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -74,7 +74,7 @@ from hypothesis.internal.conjecture.junkdrawer import (
     startswith,
 )
 from hypothesis.internal.conjecture.pareto import NO_SCORE, ParetoFront, ParetoOptimiser
-from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key
+from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key, sort_key_ir
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report, report
 
@@ -562,8 +562,8 @@ class ConjectureRunner:
                 if v < existing_score:
                     continue
 
-                if v > existing_score or sort_key(data.buffer) < sort_key(
-                    existing_example.buffer
+                if v > existing_score or sort_key_ir(data.ir_nodes) < sort_key_ir(
+                    existing_example.ir_nodes
                 ):
                     data_as_result = data.as_result()
                     assert not isinstance(data_as_result, _Overrun)
@@ -619,7 +619,7 @@ class ConjectureRunner:
                 if self.first_bug_found_at is None:
                     self.first_bug_found_at = self.call_count
             else:
-                if sort_key(data.buffer) < sort_key(existing.buffer):
+                if sort_key_ir(data.ir_nodes) < sort_key_ir(existing.ir_nodes):
                     self.shrinks += 1
                     self.downgrade_buffer(existing.buffer)
                     self.__data_cache.unpin(existing.buffer)
@@ -1376,7 +1376,7 @@ class ConjectureRunner:
         self.finish_shrinking_deadline = time.perf_counter() + MAX_SHRINKING_SECONDS
 
         for prev_data in sorted(
-            self.interesting_examples.values(), key=lambda d: sort_key(d.buffer)
+            self.interesting_examples.values(), key=lambda d: sort_key_ir(d.ir_nodes)
         ):
             assert prev_data.status == Status.INTERESTING
             data = self.new_conjecture_data_ir(prev_data.ir_nodes)
@@ -1393,7 +1393,7 @@ class ConjectureRunner:
                     for k, v in self.interesting_examples.items()
                     if k not in self.shrunk_examples
                 ),
-                key=lambda kv: (sort_key(kv[1].buffer), sort_key(repr(kv[0]))),
+                key=lambda kv: (sort_key_ir(kv[1].ir_nodes), sort_key(repr(kv[0]))),
             )
             self.debug(f"Shrinking {target!r}: {data.choices}")
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -80,7 +80,7 @@ def sort_key(buffer: SortKeyT) -> tuple[int, SortKeyT]:
     return (len(buffer), buffer)
 
 
-def sort_key_ir(nodes: list[IRNode]) -> tuple[int, tuple[int]]:
+def sort_key_ir(nodes: Sequence[IRNode]) -> tuple[int, tuple[int]]:
     return (
         len(nodes),
         tuple(choice_to_index(node.value, node.kwargs) for node in nodes),

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -80,7 +80,7 @@ def sort_key(buffer: SortKeyT) -> tuple[int, SortKeyT]:
     return (len(buffer), buffer)
 
 
-def sort_key_ir(nodes: Sequence[IRNode]) -> tuple[int, tuple[int]]:
+def sort_key_ir(nodes: Sequence[IRNode]) -> tuple[int, tuple[int, ...]]:
     return (
         len(nodes),
         tuple(choice_to_index(node.value, node.kwargs) for node in nodes),

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -481,13 +481,6 @@ class Shrinker:
         This method is "mostly idempotent" - calling it twice is unlikely to
         have any effect, though it has a non-zero probability of doing so.
         """
-        # We assume that if an all-trivial example is interesting then
-        # we're not going to do better than that. This might not technically be true:
-        # e.g. in tuples(booleans(), booleans()) | booleans() the simplest example
-        # is [1, False] but the all-trivial example is [0, False, False].
-        if all(node.trivial for node in self.nodes):
-            self.explain()
-            return
 
         try:
             self.greedy_shrink()

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -66,7 +66,7 @@ def test_raises_flaky_if_a_test_becomes_fast_on_rerun():
 
 
 def test_deadlines_participate_in_shrinking():
-    @settings(deadline=500, max_examples=1000)
+    @settings(deadline=500, max_examples=1000, database=None)
     @given(st.integers(min_value=0))
     def slow_if_large(i):
         if i >= 1000:

--- a/hypothesis-python/tests/nocover/test_duplication.py
+++ b/hypothesis-python/tests/nocover/test_duplication.py
@@ -52,11 +52,11 @@ def test_mostly_does_not_duplicate_blocks_even_when_failing(n):
         test()
     except ValueError:
         pass
-    # There are three circumstances in which a duplicate is allowed: We replay
-    # the failing test once to check for flakiness, once when shrinking to normalize
-    # to the minimal buffer, and then we replay the fully minimized failing test
-    # at the end to display the error. The complication comes from the fact that
-    # these may or may not be the same test case, so we can see either two test
-    # cases each run twice or one test case which has been run three times.
-    assert set(counts.values()) in ({1, 2, 3}, {1, 4})
+    # There are two circumstances in which a duplicate is allowed: We replay
+    # the failing test once to check for flakiness, and then we replay the
+    # fully minimized failing test at the end to display the error. The
+    # complication comes from the fact that these may or may not be the same
+    # test case, so we can see either two test cases each run twice or one
+    # test case which has been run three times.
+    assert set(counts.values()) in ({1, 2}, {1, 3})
     assert len([k for k, v in counts.items() if v > 1]) <= 2

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -10,14 +10,7 @@
 
 import pytest
 
-from hypothesis import (
-    HealthCheck,
-    Verbosity,
-    example,
-    given,
-    settings,
-    strategies as st,
-)
+from hypothesis import example, given, strategies as st
 from hypothesis.internal.compat import ceil
 
 from tests.common.debug import minimal
@@ -39,21 +32,16 @@ def test_can_shrink_in_variable_sized_context(n):
 @example(1.7976931348623157e308)
 @example(1.5)
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
-@settings(deadline=None, suppress_health_check=list(HealthCheck))
 def test_shrinks_downwards_to_integers(f):
-    g = minimal(
-        st.floats().filter(lambda x: x >= f),
-        settings=settings(verbosity=Verbosity.quiet, max_examples=10**6),
-    )
-    assert g == ceil(f)
+    assert minimal(st.floats(min_value=f)) == ceil(f)
 
 
 @example(1)
 @given(st.integers(1, 2**16 - 1))
-@settings(deadline=None, suppress_health_check=list(HealthCheck), max_examples=10)
 def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
-        st.floats().filter(lambda x: b < x < 2**53 and int(x) != x),
-        settings=settings(verbosity=Verbosity.quiet, max_examples=10**6),
+        st.floats(
+            min_value=b, max_value=2**53, exclude_min=True, exclude_max=True
+        ).filter(lambda x: int(x) != x)
     )
     assert g == b + 0.5


### PR DESCRIPTION
This uses `sort_key_ir` in place of `sort_key` for most things. We can't get rid of `sort_key` quite yet, but we're getting there.

This is a slight improvement in shrinking, probably because we've dropped the +1 shrink call per test to forced to the smallest buffer for compatibility with the buffer ordering. I think the stronger signal here is that nothing has gotten *worse*. ![shrinking](https://github.com/user-attachments/assets/9f5e1de3-5c37-464d-88ba-f7a3b06c45e9)
