### PR TITLE
Add short-circuit for trivial collections

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves shrinking involving long strings or byte sequences whose value is not relevant to the failure.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
@@ -69,8 +69,14 @@ def collection_index(choice, *, min_size, alphabet_size, to_order=identity):
     # We then add each element c to the index, starting from the end (so "ab" is
     # simpler than "ba"). Each loop takes c at position i in the sequence and
     # computes the number of sequences of size i which come before it in the ordering.
-    for i, c in enumerate(reversed(choice)):
-        index += (alphabet_size**i) * to_order(c)
+
+    # this running_exp computation is equivalent to doing
+    #   index += (alphabet_size**i) * n
+    # but reuses intermediate exponentiation steps for efficiency.
+    running_exp = 1
+    for c in reversed(choice):
+        index += running_exp * to_order(c)
+        running_exp *= alphabet_size
     return index
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1362,12 +1362,14 @@ class Shrinker:
             Bytes.shrink(
                 value,
                 lambda val: self.try_shrinking_nodes(nodes, val),
+                min_size=kwargs["min_size"],
             )
         elif ir_type == "string":
             String.shrink(
                 value,
                 lambda val: self.try_shrinking_nodes(nodes, val),
                 intervals=kwargs["intervals"],
+                min_size=kwargs["min_size"],
             )
         else:
             raise NotImplementedError

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/collection.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/collection.py
@@ -14,13 +14,22 @@ from hypothesis.internal.conjecture.utils import identity
 
 
 class Collection(Shrinker):
-    def setup(self, *, ElementShrinker, to_order=identity, from_order=identity):
+    def setup(
+        self, *, ElementShrinker, to_order=identity, from_order=identity, min_size
+    ):
         self.ElementShrinker = ElementShrinker
         self.to_order = to_order
         self.from_order = from_order
+        self.min_size = min_size
 
     def make_immutable(self, value):
         return tuple(value)
+
+    def short_circuit(self):
+        zero = self.from_order(0)
+        success = self.consider([zero] * len(self.current))
+        # we could still simplify by deleting elements (unless we're minimal size).
+        return success and len(self.current) == self.min_size
 
     def left_is_better(self, left, right):
         if len(left) < len(right):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -160,7 +160,7 @@ class Shrinker:
         If this returns True, the ``run`` method will terminate early
         without doing any more work.
         """
-        return False
+        return False  # pragma: no cover
 
     def left_is_better(self, left, right):
         """Returns True if the left is strictly simpler than the right

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -200,13 +200,6 @@ def test_variadic_draw():
 
 
 def test_draw_to_overrun(monkeypatch):
-    # TODO_BETTER_SHRINK: sometimes we can get unlucky and fail to shrink the
-    # initial size draw d to 2 before shrinking the 128 * d bytes, but I'm not
-    # sure why.
-    #
-    # If we do get unlucky in such a way then we need more than 500 shrinks to finish.
-    monkeypatch.setattr(engine_module, "MAX_SHRINKS", 1000)
-
     @run_to_nodes
     def nodes(data):
         d = (data.draw_bytes(1, 1)[0] - 8) & 0xFF

--- a/hypothesis-python/tests/conjecture/test_minimizer.py
+++ b/hypothesis-python/tests/conjecture/test_minimizer.py
@@ -72,7 +72,9 @@ def test_can_sort_bytes_by_reordering_partially_not_cross_stationary_element():
     ],
 )
 def test_shrink_strings(initial, predicate, intervals, expected):
-    assert String.shrink(initial, predicate, intervals=intervals) == tuple(expected)
+    assert String.shrink(
+        initial, predicate, intervals=intervals, min_size=len(expected)
+    ) == tuple(expected)
 
 
 @pytest.mark.parametrize(
@@ -85,9 +87,11 @@ def test_shrink_strings(initial, predicate, intervals, expected):
     ],
 )
 def test_shrink_bytes(initial, predicate, expected):
-    assert bytes(Bytes.shrink(initial, predicate)) == expected
+    assert bytes(Bytes.shrink(initial, predicate, min_size=len(expected))) == expected
 
 
 def test_collection_left_is_better():
-    shrinker = Collection([1, 2, 3], lambda v: True, ElementShrinker=Integer)
+    shrinker = Collection(
+        [1, 2, 3], lambda v: True, ElementShrinker=Integer, min_size=3
+    )
     assert not shrinker.left_is_better([1, 2, 3], [1, 2, 3])

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -518,3 +518,16 @@ def test_redistribute_integer_pairs_with_forced_node():
     # shrinking. Since the second draw is forced, this isn't possible to shrink
     # with just this pass.
     assert shrinker.choices == (15, 10)
+
+
+@pytest.mark.parametrize("n", [10, 50, 100, 200])
+def test_can_quickly_shrink_to_trivial_collection(n):
+    @shrinking_from(ir(b"\x01" * n))
+    def shrinker(data: ConjectureData):
+        b = data.draw_bytes()
+        if len(b) >= n:
+            data.mark_interesting()
+
+    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    assert shrinker.choices == (b"\x00" * n,)
+    assert shrinker.calls < 10


### PR DESCRIPTION
Significantly speeds up `test_draw_to_overrun`, and seems generally appropriate.

Benchmark (no change):

![shrinking](https://github.com/user-attachments/assets/655d2d89-bb15-4a73-a7f2-f5e2d6211a9a)
