### PR TITLE
Add DRMacIver as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Engine changes need to be approved by Zac-HD, as per
 # https://github.com/HypothesisWorks/hypothesis/blob/master/guides/review.rst#engine-changes
-/hypothesis-python/src/hypothesis/internal/conjecture/ @Zac-HD
+/hypothesis-python/src/hypothesis/internal/conjecture/ @DRMacIver @Zac-HD 
 
 # Changes to the paper also need to be approved by DRMacIver or Zac, as authors
 /paper.md @DRMacIver @Zac-HD


### PR DESCRIPTION
I was going to review https://github.com/HypothesisWorks/hypothesis/pull/4217 and realised I couldn't actually approve it as I'm not listed as a code owner for conjecture. Seemed appropriate to fix this given that I'm getting more involved in Hypothesis again.