### PR TITLE
Use `ConjectureData.for_choices`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch improves shrinking involving long strings or byte sequences whose value is not relevant to the failure.
+Internal code refactoring for the typed choice sequence (:issue:`3921`). May have some neutral effect on shrinking.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -765,17 +765,17 @@ class DataTree:
                         or any(not v.is_exhausted for v in branch.children.values())
                     )
 
-    def rewrite(self, nodes):
+    def rewrite(self, choices):
         """Use previously seen ConjectureData objects to return a tuple of
         the rewritten choice sequence and the status we would get from running
         that with the test function. If the status cannot be predicted
         from the existing values it will be None."""
-        data = ConjectureData.for_ir_tree(nodes)
+        data = ConjectureData.for_choices(choices)
         try:
             self.simulate_test_function(data)
-            return (data.ir_nodes, data.status)
+            return (data.choices, data.status)
         except PreviouslyUnseenBehaviour:
-            return (nodes, None)
+            return (choices, None)
 
     def simulate_test_function(self, data):
         """Run a simulated version of the test function recorded by

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -17,7 +17,7 @@ from hypothesis.internal.conjecture.data import (
     Status,
     _Overrun,
     bits_to_bytes,
-    ir_size_nodes,
+    ir_size,
     ir_value_permitted,
 )
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR, ConjectureRunner
@@ -176,7 +176,7 @@ class Optimiser:
                     )
                     attempt = self.engine.cached_test_function_ir(
                         attempt_nodes,
-                        extend=BUFFER_SIZE_IR - ir_size_nodes(attempt_nodes),
+                        extend=BUFFER_SIZE_IR - ir_size(attempt_nodes),
                     )
 
                     if self.consider_new_data(attempt):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -21,7 +21,7 @@ from hypothesis.internal.conjecture.data import (
     ConjectureResult,
     IRNode,
     Status,
-    ir_size_nodes,
+    ir_size,
     ir_to_buffer,
     ir_value_equal,
     ir_value_key,
@@ -586,7 +586,7 @@ class Shrinker:
 
                 attempt = nodes[:start] + tuple(replacement) + nodes[end:]
                 result = self.engine.cached_test_function_ir(
-                    attempt, extend=BUFFER_SIZE_IR - ir_size_nodes(attempt)
+                    attempt, extend=BUFFER_SIZE_IR - ir_size(attempt)
                 )
 
                 # Turns out this was a variable-length part, so grab the infix...

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/collection.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/collection.py
@@ -15,7 +15,7 @@ from hypothesis.internal.conjecture.utils import identity
 
 class Collection(Shrinker):
     def setup(
-        self, *, ElementShrinker, to_order=identity, from_order=identity, min_size
+        self, *, ElementShrinker, min_size, to_order=identity, from_order=identity
     ):
         self.ElementShrinker = ElementShrinker
         self.to_order = to_order
@@ -27,9 +27,7 @@ class Collection(Shrinker):
 
     def short_circuit(self):
         zero = self.from_order(0)
-        success = self.consider([zero] * len(self.current))
-        # we could still simplify by deleting elements (unless we're minimal size).
-        return success and len(self.current) == self.min_size
+        return self.consider([zero] * self.min_size)
 
     def left_is_better(self, left, right):
         if len(left) < len(right):
@@ -47,6 +45,11 @@ class Collection(Shrinker):
         return False
 
     def run_step(self):
+        # try all-zero first; we already considered all-zero-and-smallest in
+        # short_circuit.
+        zero = self.from_order(0)
+        self.consider([zero] * len(self.current))
+
         # try deleting each element in turn, starting from the back
         # TODO_BETTER_SHRINK: adaptively delete here by deleting larger chunks at once
         # if early deletes succeed. use find_integer. turns O(n) into O(log(n))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -160,7 +160,7 @@ class Shrinker:
         If this returns True, the ``run`` method will terminate early
         without doing any more work.
         """
-        return False  # pragma: no cover
+        return False
 
     def left_is_better(self, left, right):
         """Returns True if the left is strictly simpler than the right

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -28,6 +28,7 @@ from hypothesis.internal.conjecture.datatree import (
 )
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.floats import float_to_int
+from hypothesis.internal.conjecture.junkdrawer import startswith
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import next_up
 from hypothesis.vendor import pretty
@@ -56,9 +57,9 @@ def runner_for(*examples):
             data = runner.cached_test_function_ir(nodes)
             ran_examples.append((nodes, data))
         for nodes, d in ran_examples:
-            rewritten, status = runner.tree.rewrite(nodes)
+            rewritten, status = runner.tree.rewrite([n.value for n in nodes])
             assert status == d.status
-            assert rewritten == d.ir_nodes
+            assert rewritten == d.choices
         return runner
 
     return accept
@@ -129,10 +130,11 @@ def test_novel_prefixes_are_novel():
     runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
     for _ in range(100):
         prefix = runner.tree.generate_novel_prefix(runner.random)
+        prefix_choices = [n.value for n in prefix]
         extension = prefix + (NodeTemplate("simplest", size=100),)
-        assert runner.tree.rewrite(extension)[1] is None
+        assert runner.tree.rewrite(prefix_choices)[1] is None
         result = runner.cached_test_function_ir(extension)
-        assert runner.tree.rewrite(extension)[0] == result.ir_nodes
+        assert startswith(result.choices, runner.tree.rewrite(prefix_choices)[0])
 
 
 def test_overruns_if_not_enough_bytes_for_block():
@@ -140,7 +142,7 @@ def test_overruns_if_not_enough_bytes_for_block():
         lambda data: data.draw_bytes(2, 2), settings=TEST_SETTINGS, random=Random(0)
     )
     runner.cached_test_function_ir(ir(b"\0\0"))
-    assert runner.tree.rewrite(ir(b"\0"))[1] is Status.OVERRUN
+    assert runner.tree.rewrite([b"\0"])[1] is Status.OVERRUN
 
 
 def test_overruns_if_prefix():
@@ -150,7 +152,7 @@ def test_overruns_if_prefix():
         random=Random(0),
     )
     runner.cached_test_function_ir(ir(False, False))
-    assert runner.tree.rewrite(ir(False))[1] is Status.OVERRUN
+    assert runner.tree.rewrite([False])[1] is Status.OVERRUN
 
 
 def test_stores_the_tree_flat_until_needed():
@@ -206,58 +208,58 @@ def test_correctly_relocates_forced_nodes():
 
 def test_can_go_from_interesting_to_valid():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree([], observer=tree.new_observer())
+    data = ConjectureData.for_choices([], observer=tree.new_observer())
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree([], observer=tree.new_observer())
+    data = ConjectureData.for_choices([], observer=tree.new_observer())
     with pytest.raises(StopTest):
         data.conclude_test(Status.VALID)
 
 
 def test_going_from_interesting_to_invalid_is_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree([], observer=tree.new_observer())
+    data = ConjectureData.for_choices([], observer=tree.new_observer())
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree([], observer=tree.new_observer())
+    data = ConjectureData.for_choices([], observer=tree.new_observer())
     with pytest.raises(Flaky):
         data.conclude_test(Status.INVALID)
 
 
 def test_concluding_at_prefix_is_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(True), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True], observer=tree.new_observer())
     data.draw_boolean()
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree([], observer=tree.new_observer())
+    data = ConjectureData.for_choices([], observer=tree.new_observer())
     with pytest.raises(Flaky):
         data.conclude_test(Status.INVALID)
 
 
 def test_concluding_with_overrun_at_prefix_is_not_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(True), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True], observer=tree.new_observer())
     data.draw_boolean()
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree([], observer=tree.new_observer())
+    data = ConjectureData.for_choices([], observer=tree.new_observer())
     with pytest.raises(StopTest):
         data.conclude_test(Status.OVERRUN)
 
 
 def test_changing_n_bits_is_flaky_in_prefix():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(1), observer=tree.new_observer())
+    data = ConjectureData.for_choices([1], observer=tree.new_observer())
     data.draw_integer(0, 1)
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree(ir(1), observer=tree.new_observer())
+    data = ConjectureData.for_choices([1], observer=tree.new_observer())
     with pytest.raises(Flaky):
         data.draw_integer(0, 3)
 
@@ -266,24 +268,24 @@ def test_changing_n_bits_is_flaky_in_branch():
     tree = DataTree()
 
     for i in [0, 1]:
-        data = ConjectureData.for_ir_tree(ir(i), observer=tree.new_observer())
+        data = ConjectureData.for_choices([i], observer=tree.new_observer())
         data.draw_integer(0, 1)
         with pytest.raises(StopTest):
             data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree(ir(1), observer=tree.new_observer())
+    data = ConjectureData.for_choices([1], observer=tree.new_observer())
     with pytest.raises(Flaky):
         data.draw_integer(0, 3)
 
 
 def test_extending_past_conclusion_is_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(True), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True], observer=tree.new_observer())
     data.draw_boolean()
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree(ir(True, False), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True, False], observer=tree.new_observer())
     data.draw_boolean()
 
     with pytest.raises(Flaky):
@@ -292,12 +294,12 @@ def test_extending_past_conclusion_is_flaky():
 
 def test_changing_to_forced_is_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(True), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True], observer=tree.new_observer())
     data.draw_boolean()
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree(ir(True, False), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True, False], observer=tree.new_observer())
 
     with pytest.raises(Flaky):
         data.draw_boolean(forced=True)
@@ -305,12 +307,12 @@ def test_changing_to_forced_is_flaky():
 
 def test_changing_value_of_forced_is_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(True), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True], observer=tree.new_observer())
     data.draw_boolean(forced=True)
     with pytest.raises(StopTest):
         data.conclude_test(Status.INTERESTING)
 
-    data = ConjectureData.for_ir_tree(ir(True, False), observer=tree.new_observer())
+    data = ConjectureData.for_choices([True, False], observer=tree.new_observer())
 
     with pytest.raises(Flaky):
         data.draw_boolean(forced=False)
@@ -318,31 +320,31 @@ def test_changing_value_of_forced_is_flaky():
 
 def test_does_not_truncate_if_unseen():
     tree = DataTree()
-    nodes = ir(1, 2, 3, 4)
-    assert tree.rewrite(nodes) == (nodes, None)
+    choices = [1, 2, 3, 4]
+    assert tree.rewrite(choices) == (choices, None)
 
 
 def test_truncates_if_seen():
     tree = DataTree()
 
-    nodes = ir(1, 2, 3, 4)
+    choices = (1, 2, 3, 4)
 
-    data = ConjectureData.for_ir_tree(nodes, observer=tree.new_observer())
+    data = ConjectureData.for_choices(choices, observer=tree.new_observer())
     data.draw_integer()
     data.draw_integer()
     data.freeze()
 
-    assert tree.rewrite(nodes) == (nodes[:2], Status.VALID)
+    assert tree.rewrite(choices) == (choices[:2], Status.VALID)
 
 
 def test_child_becomes_exhausted_after_split():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(b"\0", b"\0"), observer=tree.new_observer())
+    data = ConjectureData.for_choices([b"\0", b"\0"], observer=tree.new_observer())
     data.draw_bytes(1, 1)
     data.draw_bytes(1, 1, forced=b"\0")
     data.freeze()
 
-    data = ConjectureData.for_ir_tree(ir(b"\1", b"\0"), observer=tree.new_observer())
+    data = ConjectureData.for_choices([b"\1", b"\0"], observer=tree.new_observer())
     data.draw_bytes(1, 1)
     data.draw_bytes(1, 1)
     data.freeze()
@@ -353,11 +355,11 @@ def test_child_becomes_exhausted_after_split():
 
 def test_will_generate_novel_prefix_to_avoid_exhausted_branches():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(1), observer=tree.new_observer())
+    data = ConjectureData.for_choices([1], observer=tree.new_observer())
     data.draw_integer(0, 1)
     data.freeze()
 
-    data = ConjectureData.for_ir_tree(ir(0, b"\1"), observer=tree.new_observer())
+    data = ConjectureData.for_choices([0, b"\1"], observer=tree.new_observer())
     data.draw_integer(0, 1)
     data.draw_bytes(1, 1)
     data.freeze()
@@ -370,14 +372,14 @@ def test_will_generate_novel_prefix_to_avoid_exhausted_branches():
 
 def test_will_mark_changes_in_discard_as_flaky():
     tree = DataTree()
-    data = ConjectureData.for_ir_tree(ir(1, 1), observer=tree.new_observer())
+    data = ConjectureData.for_choices([1, 1], observer=tree.new_observer())
     data.start_example(10)
     data.draw_integer(0, 1)
     data.stop_example()
     data.draw_integer(0, 1)
     data.freeze()
 
-    data = ConjectureData.for_ir_tree(ir(1, 1), observer=tree.new_observer())
+    data = ConjectureData.for_choices([1, 1], observer=tree.new_observer())
     data.start_example(10)
     data.draw_integer(0, 1)
 
@@ -391,13 +393,13 @@ def test_is_not_flaky_on_positive_zero_and_negative_zero():
     # draw.
     tree = DataTree()
 
-    data = ConjectureData.for_ir_tree(ir(0.0, False), observer=tree.new_observer())
+    data = ConjectureData.for_choices([0.0, False], observer=tree.new_observer())
     f = data.draw_float()
     assert float_to_int(f) == float_to_int(0.0)
     data.draw_boolean(forced=False)
     data.freeze()
 
-    data = ConjectureData.for_ir_tree(ir(-0.0, False), observer=tree.new_observer())
+    data = ConjectureData.for_choices([-0.0, False], observer=tree.new_observer())
     f = data.draw_float()
     assert float_to_int(f) == float_to_int(-0.0)
     data.draw_boolean(forced=True)
@@ -410,14 +412,8 @@ def test_is_not_flaky_on_positive_zero_and_negative_zero():
 
 
 def test_low_probabilities_are_still_explored():
-    @run_to_nodes
-    def false_ir(data):
-        data.draw_boolean(p=1e-10, forced=False)
-        data.mark_interesting()
-
     tree = DataTree()
-
-    data = ConjectureData.for_ir_tree(false_ir, observer=tree.new_observer())
+    data = ConjectureData.for_choices([False], observer=tree.new_observer())
     data.draw_boolean(p=1e-10)  # False
 
     v = tree.generate_novel_prefix(Random())
@@ -478,7 +474,7 @@ def test_can_generate_hard_values():
     max_value = 1000
     # set up `tree` such that [0, 999] have been drawn and only n=1000 remains.
     for i in range(max_value):
-        data = ConjectureData.for_ir_tree(ir(i), observer=tree.new_observer())
+        data = ConjectureData.for_choices([i], observer=tree.new_observer())
         data.draw_integer(min_value, max_value)
         data.freeze()
 
@@ -487,7 +483,7 @@ def test_can_generate_hard_values():
     # value once or twice.
     for _ in range(20):
         prefix = tree.generate_novel_prefix(Random())
-        data = ConjectureData.for_ir_tree(prefix)
+        data = ConjectureData.for_choices([n.value for n in prefix])
         assert data.draw_integer(min_value, max_value) == 1000
 
 
@@ -511,7 +507,9 @@ def test_can_generate_hard_floats():
             data.draw_float(min_value, max_value, forced=f, allow_nan=False)
             data.mark_interesting()
 
-        data = ConjectureData.for_ir_tree(nodes, observer=tree.new_observer())
+        data = ConjectureData.for_choices(
+            [n.value for n in nodes], observer=tree.new_observer()
+        )
         data.draw_float(min_value, max_value, allow_nan=False)
         data.freeze()
 
@@ -524,7 +522,7 @@ def test_can_generate_hard_floats():
     for _ in range(20):
         expected_value = next_up_n(min_value, 100)
         prefix = tree.generate_novel_prefix(Random())
-        data = ConjectureData.for_ir_tree(prefix)
+        data = ConjectureData.for_choices([n.value for n in prefix])
         assert data.draw_float(min_value, max_value, allow_nan=False) == expected_value
 
 
@@ -583,12 +581,12 @@ def _draw(data, node, *, forced=None):
 def test_simulate_forced_floats(node):
     tree = DataTree()
 
-    data = ConjectureData.for_ir_tree([node], observer=tree.new_observer())
+    data = ConjectureData.for_choices([node.value], observer=tree.new_observer())
     data.draw_float(**node.kwargs, forced=node.value)
     with pytest.raises(StopTest):
         data.conclude_test(Status.VALID)
 
-    data = ConjectureData.for_ir_tree([node], observer=tree.new_observer())
+    data = ConjectureData.for_choices([node.value], observer=tree.new_observer())
     tree.simulate_test_function(data)
     data.freeze()
     assert data.ir_nodes == (node,)

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -34,7 +34,7 @@ from hypothesis.internal.conjecture.data import (
     IRNode,
     Overrun,
     Status,
-    ir_size_nodes,
+    ir_size,
 )
 from hypothesis.internal.conjecture.datatree import compute_max_children
 from hypothesis.internal.conjecture.engine import (
@@ -194,7 +194,7 @@ def test_variadic_draw():
         if any(all(d) for d in draw_list(data)):
             data.mark_interesting()
 
-    ls = draw_list(ConjectureData.for_ir_tree(nodes))
+    ls = draw_list(ConjectureData.for_choices([n.value for n in nodes]))
     assert len(ls) == 1
     assert len(ls[0]) == 1
 
@@ -1612,7 +1612,7 @@ def test_overruns_with_extend_are_not_cached(node):
 
     # cache miss
     data = runner.cached_test_function_ir(
-        [node], extend=BUFFER_SIZE_IR - ir_size_nodes([node])
+        [node], extend=BUFFER_SIZE_IR - ir_size([node])
     )
     assert runner.call_count == 2
     assert data.status is Status.VALID
@@ -1638,7 +1638,7 @@ def test_simulate_to_evicted_data(monkeypatch):
 
     # we dont throw PreviouslyUnseenBehavior when simulating, but the result
     # was evicted to the cache so we will still call through to the test function.
-    runner.tree.simulate_test_function(ConjectureData.for_ir_tree([node_0]))
+    runner.tree.simulate_test_function(ConjectureData.for_choices([0]))
     runner.cached_test_function_ir([node_0])
     assert runner.call_count == 3
 

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -15,7 +15,6 @@ import pytest
 from hypothesis import HealthCheck, assume, example, given, settings, strategies as st
 from hypothesis.internal.compat import ceil, extract_bits, floor, int_to_bytes
 from hypothesis.internal.conjecture import floats as flt
-from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import float_to_int
 
@@ -138,15 +137,12 @@ def float_runner(start, condition, *, kwargs=None):
 
 
 def minimal_from(start, condition, *, kwargs=None):
-    kwargs = {} if kwargs is None else kwargs
-
     runner = float_runner(start, condition, kwargs=kwargs)
     runner.shrink_interesting_examples()
     (v,) = runner.interesting_examples.values()
-    data = ConjectureData.for_ir_tree(v.ir_nodes)
-    result = data.draw_float(**kwargs)
-    assert condition(result)
-    return result
+    f = v.choices[0]
+    assert condition(f)
+    return f
 
 
 INTERESTING_FLOATS = [0.0, 1.0, 2.0, sys.float_info.max, float("inf"), float("nan")]

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -20,6 +20,7 @@ from hypothesis.internal.conjecture.shrinker import (
     StopShrinking,
     node_program,
 )
+from hypothesis.internal.conjecture.shrinking.common import Shrinker as ShrinkerPass
 from hypothesis.internal.conjecture.utils import Sampler
 
 from tests.conjecture.common import SOME_LABEL, ir, run_to_nodes, shrinking_from
@@ -531,3 +532,17 @@ def test_can_quickly_shrink_to_trivial_collection(n):
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
     assert shrinker.choices == (b"\x00" * n,)
     assert shrinker.calls < 10
+
+
+class BadShrinker(ShrinkerPass):
+    """
+    A shrinker that really doesn't do anything at all. This is mostly a covering
+    test for the shrinker interface methods.
+    """
+
+    def run_step(self):
+        return
+
+
+def test_silly_shrinker_subclass():
+    assert BadShrinker.shrink(10, lambda _: True) == 10

--- a/hypothesis-python/tests/cover/test_filtered_strategy.py
+++ b/hypothesis-python/tests/cover/test_filtered_strategy.py
@@ -12,14 +12,12 @@ import hypothesis.strategies as st
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.strategies._internal.strategies import FilteredStrategy
 
-from tests.conjecture.common import ir
-
 
 def test_filter_iterations_are_marked_as_discarded():
     variable_equal_to_zero = 0  # non-local references disables filter-rewriting
     x = st.integers().filter(lambda x: x == variable_equal_to_zero)
 
-    data = ConjectureData.for_ir_tree(ir(1, 0))
+    data = ConjectureData.for_choices([1, 0])
     assert data.draw(x) == 0
     assert data.has_discards
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -89,7 +89,7 @@ def test_cached_with_masked_byte_agrees_with_results(a, b):
     cached_a = runner.cached_test_function_ir(ir(a))
     cached_b = runner.cached_test_function_ir(ir(b))
 
-    data_b = ConjectureData.for_ir_tree(ir(b), observer=runner.tree.new_observer())
+    data_b = ConjectureData.for_choices([b], observer=runner.tree.new_observer())
     runner.test_function(data_b)
 
     # If the cache found an old result, then it should match the real result.

--- a/hypothesis-python/tests/numpy/test_gen_data.py
+++ b/hypothesis-python/tests/numpy/test_gen_data.py
@@ -1164,6 +1164,7 @@ def test_basic_indices_can_generate_indices_not_covering_all_dims():
             (not isinstance(ix, tuple) and ix != Ellipsis)
             or (isinstance(ix, tuple) and Ellipsis not in ix and len(ix) < 3)
         ),
+        settings=settings(max_examples=5_000),
     )
 
 


### PR DESCRIPTION
Depends on #4217 (so `test_draw_to_overrun` finishes in a sane amount of time).

Here are three proposals for a replacement for `ConjectureData.for_buffer` on the typed choice sequence:

(1) pass the value of each choice:

```python
    @classmethod
    def for_choices(
        cls,
        choices: Sequence[NodeTemplate | IRType],
        ...
    ):
        ...
```

(2) pass the value of each choice and its complexity index:

```python
    @classmethod
    def for_choices(
        cls,
        choices: Sequence[NodeTemplate | tuple[IRType, int]],
        ...
    ):
        ...
```

(3) pass the value of each choice and its kwargs, noting that the complexity of a choice can be derived from its value + kwargs:

```python
    @classmethod
    def for_nodes(
        cls,
        nodes: Sequence[NodeTemplate | IRNode],
        ...
    ):
        ...
```

I am proposing we use (1) in this pull. The benefits of this is mainly a simplified and unified api. It also makes constructing a `ConjectureData` from a database entry possible, where we do not have choice complexity available. However, I am leaning towards encoding complexity alongside db values anyway, for more precise sorting, so this may be a nonissue. 

The downside of (1) is that we cannot use choice complexity during drawing, in particular misalignment. This leads to https://github.com/HypothesisWorks/hypothesis/commit/129da4b7f06d6df2bc4d6558b9cb01989a5b666c, which fills misalignments with the zero-index choice instead of using complexity as an intermediary. I think using `NodeTemplate` to opt-in to controlling this misalignment behavior in the shrinker could be a more clean path forward. In the mean time, the default and only behavior for correcting misalignments would be filling with the zero-index choice.

The shrinking benchmark is neutral:
![shrinking](https://github.com/user-attachments/assets/082a2899-2b0f-451e-a464-5182a072d939)

@DRMacIver if you have any thoughts on this from a shrinking perspective I'd definitely be curious to hear them.