### PR TITLE
Use the typed choice sequence for `@reproduce_failure`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Internal code refactoring for the typed choice sequence (:issue:`3921`). May have some neutral effect on shrinking.
+:func:`@reproduce_failure() <hypothesis.reproduce_failure>` now represents failures using the typed choice sequence (:issue:`3921`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-:func:`@reproduce_failure() <hypothesis.reproduce_failure>` now represents failures using the typed choice sequence (:issue:`3921`).
+:func:`@reproduce_failure() <hypothesis.reproduce_failure>` now uses a newer internal interface to represent failures. As a reminder, this representation is not intended to be stable across versions or with respect to changes in the test.

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -26,20 +26,25 @@ from hypothesis import (
 )
 from hypothesis.core import decode_failure, encode_failure
 from hypothesis.errors import DidNotReproduce, InvalidArgument, UnsatisfiedAssumption
+from hypothesis.internal.conjecture.data import ir_value_equal
 
 from tests.common.utils import capture_out, no_shrink
+from tests.conjecture.common import ir_nodes
 
 
-@example(bytes(20))  # shorter compressed
-@example(bytes(3))  # shorter uncompressed
-@given(st.binary() | st.binary(min_size=100))
-def test_encoding_loop(b):
-    assert decode_failure(encode_failure(b)) == b
+@given(st.lists(ir_nodes()))
+def test_encoding_loop(nodes):
+    choices = [n.value for n in nodes]
+    looped = decode_failure(encode_failure(choices))
+    assert len(choices) == len(looped)
+    for i, node in enumerate(nodes):
+        assert ir_value_equal(node.ir_type, choices[i], looped[i])
 
 
 @example(base64.b64encode(b"\2\3\4"))
 @example(b"\t")
 @example(base64.b64encode(b"\1\0"))  # zlib error
+@example(base64.b64encode(b"\1" + zlib.compress(b"\xFF")))  # ir_from_bytes error
 @given(st.binary())
 def test_decoding_may_fail(t):
     try:
@@ -63,13 +68,13 @@ def test_reproduces_the_failure():
     b = b"hello world"
     n = len(b)
 
-    @reproduce_failure(__version__, encode_failure(b))
+    @reproduce_failure(__version__, encode_failure([b]))
     @given(st.binary(min_size=n, max_size=n))
     def test_outer(x):
         assert x != b
 
     @given(st.binary(min_size=n, max_size=n))
-    @reproduce_failure(__version__, encode_failure(b))
+    @reproduce_failure(__version__, encode_failure([b]))
     def test_inner(x):
         assert x != b
 
@@ -83,7 +88,7 @@ def test_errors_if_provided_example_does_not_reproduce_failure():
     b = b"hello world"
     n = len(b)
 
-    @reproduce_failure(__version__, encode_failure(b))
+    @reproduce_failure(__version__, encode_failure([b]))
     @given(st.binary(min_size=n, max_size=n))
     def test(x):
         assert x == b
@@ -96,7 +101,7 @@ def test_errors_with_did_not_reproduce_if_the_shape_changes():
     b = b"hello world"
     n = len(b)
 
-    @reproduce_failure(__version__, encode_failure(b))
+    @reproduce_failure(__version__, encode_failure([b]))
     @given(st.binary(min_size=n + 1, max_size=n + 1))
     def test(x):
         assert x == b
@@ -109,7 +114,7 @@ def test_errors_with_did_not_reproduce_if_rejected():
     b = b"hello world"
     n = len(b)
 
-    @reproduce_failure(__version__, encode_failure(b))
+    @reproduce_failure(__version__, encode_failure([b]))
     @given(st.binary(min_size=n, max_size=n))
     def test(x):
         reject()
@@ -204,7 +209,7 @@ def test_raises_invalid_if_wrong_version():
     b = b"hello world"
     n = len(b)
 
-    @reproduce_failure("1.0.0", encode_failure(b))
+    @reproduce_failure("1.0.0", encode_failure([b]))
     @given(st.binary(min_size=n, max_size=n))
     def test(x):
         pass

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -29,9 +29,10 @@ from hypothesis.errors import DidNotReproduce, InvalidArgument, UnsatisfiedAssum
 from hypothesis.internal.conjecture.data import ir_value_equal
 
 from tests.common.utils import capture_out, no_shrink
-from tests.conjecture.common import ir_nodes
+from tests.conjecture.common import ir, ir_nodes
 
 
+@example(ir("0" * 100))  # shorter compressed than not
 @given(st.lists(ir_nodes()))
 def test_encoding_loop(nodes):
     choices = [n.value for n in nodes]

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import base64
 import re
 from collections import defaultdict
 from typing import ClassVar
@@ -27,6 +26,7 @@ from hypothesis import (
     strategies as st,
 )
 from hypothesis.control import current_build_context
+from hypothesis.core import encode_failure
 from hypothesis.database import ExampleDatabase
 from hypothesis.errors import DidNotReproduce, Flaky, InvalidArgument, InvalidDefinition
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -1074,7 +1074,7 @@ def test_uses_seed(capsys):
 
 
 def test_reproduce_failure_works():
-    @reproduce_failure(__version__, base64.b64encode(b"\x00\x00\x01\x00\x00\x00"))
+    @reproduce_failure(__version__, encode_failure([0, 1]))
     class TrivialMachine(RuleBasedStateMachine):
         @rule()
         def oops(self):
@@ -1085,7 +1085,7 @@ def test_reproduce_failure_works():
 
 
 def test_reproduce_failure_fails_if_no_error():
-    @reproduce_failure(__version__, base64.b64encode(b"\x00\x00\x01\x00\x00\x00"))
+    @reproduce_failure(__version__, encode_failure([0, 1]))
     class TrivialMachine(RuleBasedStateMachine):
         @rule()
         def ok(self):


### PR DESCRIPTION
Depends on #4219 for `ConjectureData.for_choices`. 2e01109a3c1d136e778af2faf442237ad4f05dc6 is the additional commit in this pull.