### PR TITLE
Extend `redistribute_integer_pairs` to floats

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The shrinker contains a pass aimed at integers which are required to sum to a value. This patch extends that pass to floats as well.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1256,10 +1256,10 @@ class Shrinker:
             and node1.index < node.index <= node1.index + 4,
         )
 
-        m = node1.value
-        n = node2.value
+        m: Union[int, float] = node1.value
+        n: Union[int, float] = node2.value
 
-        def boost(k):
+        def boost(k: int):
             if k > m:
                 return False
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1394,7 +1394,7 @@ class Shrinker:
         m: Union[int, float] = node1.value
         n: Union[int, float] = node2.value
 
-        def boost(k: int):
+        def boost(k: int) -> bool:
             if k > m:
                 return False
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -14,8 +14,7 @@ import sys
 from hypothesis.internal.conjecture.floats import float_to_lex
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
-
-MAX_PRECISE_INTEGER = 2**53
+from hypothesis.internal.floats import MAX_PRECISE_INTEGER
 
 
 class Float(Shrinker):

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -219,5 +219,6 @@ def clamp(lower: float, value: float, upper: float) -> float:
 
 SMALLEST_SUBNORMAL = next_up(0.0)
 SIGNALING_NAN = int_to_float(0x7FF8_0000_0000_0001)  # nonzero mantissa
+MAX_PRECISE_INTEGER = 2**53
 assert math.isnan(SIGNALING_NAN)
 assert math.copysign(1, SIGNALING_NAN) == 1

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -356,10 +356,11 @@ def draw_value(ir_type, kwargs):
 
 
 @st.composite
-def ir_nodes(draw, *, was_forced=None, ir_type=None):
-    if ir_type is None:
+def ir_nodes(draw, *, was_forced=None, ir_types=None):
+    if ir_types is None:
         (ir_type, kwargs) = draw(ir_types_and_kwargs())
     else:
+        ir_type = draw(st.sampled_from(ir_types))
         kwargs = draw(kwargs_strategy(ir_type))
     # ir nodes don't include forced in their kwargs. see was_forced attribute
     del kwargs["forced"]

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -579,7 +579,7 @@ def _draw(data, node, *, forced=None):
     return getattr(data, f"draw_{node.ir_type}")(**node.kwargs, forced=forced)
 
 
-@given(ir_nodes(was_forced=True, ir_type="float"))
+@given(ir_nodes(was_forced=True, ir_types=["float"]))
 def test_simulate_forced_floats(node):
     tree = DataTree()
 

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -505,7 +505,7 @@ def test_can_simultaneously_lower_non_duplicated_nearby_blocks(n_gap):
     assert shrinker.choices == (1, 0) + (0,) * n_gap + (1,)
 
 
-def test_redistribute_integer_pairs_with_forced_node():
+def test_redistribute_pairs_with_forced_node_integer():
     @shrinking_from(ir(15, 10))
     def shrinker(data: ConjectureData):
         n1 = data.draw_integer(0, 100)
@@ -513,8 +513,8 @@ def test_redistribute_integer_pairs_with_forced_node():
         if n1 + n2 > 20:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["redistribute_integer_pairs"])
-    # redistribute_integer_pairs shouldn't try modifying forced nodes while
+    shrinker.fixate_shrink_passes(["redistribute_numeric_pairs"])
+    # redistribute_numeric_pairs shouldn't try modifying forced nodes while
     # shrinking. Since the second draw is forced, this isn't possible to shrink
     # with just this pass.
     assert shrinker.choices == (15, 10)

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -343,13 +343,29 @@ def test_lists_forced_near_top(n):
     ) == [0] * (n + 2)
 
 
-def test_sum_of_pair():
+def test_sum_of_pair_int():
     assert minimal(
         tuples(integers(0, 1000), integers(0, 1000)), lambda x: sum(x) > 1000
     ) == (1, 1000)
 
 
-def test_sum_of_pair_separated():
+def test_sum_of_pair_float():
+    assert minimal(
+        tuples(st.floats(0, 1000), st.floats(0, 1000)), lambda x: sum(x) > 1000
+    ) == (1.0, 1000.0)
+
+
+def test_sum_of_pair_mixed():
+    # check both orderings
+    assert minimal(
+        tuples(st.floats(0, 1000), st.integers(0, 1000)), lambda x: sum(x) > 1000
+    ) == (1.0, 1000.0)
+    assert minimal(
+        tuples(st.integers(0, 1000), st.floats(0, 1000)), lambda x: sum(x) > 1000
+    ) == (1.0, 1000.0)
+
+
+def test_sum_of_pair_separated_int():
     @st.composite
     def separated_sum(draw):
         n1 = draw(st.integers(0, 1000))
@@ -358,6 +374,19 @@ def test_sum_of_pair_separated():
         draw(st.integers())
         n2 = draw(st.integers(0, 1000))
         return (n1, n2)
+
+    assert minimal(separated_sum(), lambda x: sum(x) > 1000) == (1, 1000)
+
+
+def test_sum_of_pair_separated_float():
+    @st.composite
+    def separated_sum(draw):
+        f1 = draw(st.floats(0, 1000))
+        draw(st.text())
+        draw(st.booleans())
+        draw(st.integers())
+        f2 = draw(st.floats(0, 1000))
+        return (f1, f2)
 
     assert minimal(separated_sum(), lambda x: sum(x) > 1000) == (1, 1000)
 

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -359,10 +359,10 @@ def test_sum_of_pair_mixed():
     # check both orderings
     assert minimal(
         tuples(st.floats(0, 1000), st.integers(0, 1000)), lambda x: sum(x) > 1000
-    ) == (1.0, 1000.0)
+    ) == (1.0, 1000)
     assert minimal(
         tuples(st.integers(0, 1000), st.floats(0, 1000)), lambda x: sum(x) > 1000
-    ) == (1.0, 1000.0)
+    ) == (1, 1000.0)
 
 
 def test_sum_of_pair_separated_int():


### PR DESCRIPTION
also addresses a TODO in `minimize_duplicated_nodes`.