### PR TITLE
More type hinting, move some things to `choice.py`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Internal code refactoring for the typed choice sequence (:issue:`3921`). May have some neutral effect on shrinking.
+Internal type hint additions and refactorings.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -76,9 +76,9 @@ from hypothesis.internal.compat import (
     get_type_hints,
     int_from_bytes,
 )
+from hypothesis.internal.conjecture.choice import ChoiceT
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
-    IRType,
     PrimitiveProvider,
     Status,
 )
@@ -331,7 +331,7 @@ def encode_failure(choices):
     return base64.b64encode(blob)
 
 
-def decode_failure(blob: bytes) -> Sequence[IRType]:
+def decode_failure(blob: bytes) -> Sequence[ChoiceT]:
     try:
         decoded = base64.b64decode(blob)
     except Exception:

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1129,7 +1129,7 @@ class StateForActualGivenExecution:
                 if interesting_origin[0] == DeadlineExceeded:
                     self.failed_due_to_deadline = True
                     self.explain_traces.clear()
-                data.mark_interesting(interesting_origin)  # type: ignore  # mypy bug?
+                data.mark_interesting(interesting_origin)
         finally:
             # Conditional here so we can save some time constructing the payload; in
             # other cases (without coverage) it's cheap enough to do that regardless.

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -31,7 +31,7 @@ from zipfile import BadZipFile, ZipFile
 
 from hypothesis.configuration import storage_directory
 from hypothesis.errors import HypothesisException, HypothesisWarning
-from hypothesis.internal.conjecture.data import IRType
+from hypothesis.internal.conjecture.choice import ChoiceT
 from hypothesis.utils.conventions import not_set
 
 __all__ = [
@@ -723,7 +723,7 @@ class BackgroundWriteDatabase(ExampleDatabase):
         self._queue.put(("move", (src, dest, value)))
 
 
-def ir_to_bytes(ir: Iterable[IRType], /) -> bytes:
+def ir_to_bytes(ir: Iterable[ChoiceT], /) -> bytes:
     """Serialize a list of IR elements to a bytestring.  Inverts ir_from_bytes."""
     # We use a custom serialization format for this, which might seem crazy - but our
     # data is a flat sequence of elements, and standard tools like protobuf or msgpack
@@ -763,10 +763,10 @@ def ir_to_bytes(ir: Iterable[IRType], /) -> bytes:
     return b"".join(parts)
 
 
-def ir_from_bytes(buffer: bytes, /) -> list[IRType]:
+def ir_from_bytes(buffer: bytes, /) -> list[ChoiceT]:
     """Deserialize a bytestring to a list of IR elements. Inverts ir_to_bytes."""
     # See above for an explanation of the format.
-    parts: list[IRType] = []
+    parts: list[ChoiceT] = []
     idx = 0
     while idx < len(buffer):
         tag = buffer[idx] >> 5

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
@@ -10,7 +10,16 @@
 
 import math
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable, Optional, TypedDict, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Literal,
+    Optional,
+    TypedDict,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from hypothesis.errors import ChoiceTooLarge
 from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
@@ -57,6 +66,7 @@ ChoiceT: "TypeAlias" = Union[int, str, bool, float, bytes]
 ChoiceKwargsT: "TypeAlias" = Union[
     IntegerKWargs, FloatKWargs, StringKWargs, BytesKWargs, BooleanKWargs
 ]
+ChoiceNameT: "TypeAlias" = Literal["integer", "string", "boolean", "float", "bytes"]
 
 
 def _size_to_index(size: int, *, alphabet_size: int) -> int:
@@ -304,7 +314,9 @@ def choice_to_index(choice: ChoiceT, kwargs: ChoiceKwargsT) -> int:
         raise NotImplementedError
 
 
-def choice_from_index(index: int, ir_type: str, kwargs: ChoiceKwargsT) -> ChoiceT:
+def choice_from_index(
+    index: int, ir_type: ChoiceNameT, kwargs: ChoiceKwargsT
+) -> ChoiceT:
     assert index >= 0
     if ir_type == "integer":
         kwargs = cast(IntegerKWargs, kwargs)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -59,6 +59,7 @@ from hypothesis.internal.conjecture.utils import (
     calc_label_from_name,
     many,
 )
+from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import (
     SIGNALING_NAN,
     SMALLEST_SUBNORMAL,
@@ -90,9 +91,6 @@ else:
 
 
 TOP_LABEL = calc_label_from_name("top")
-InterestingOrigin = tuple[
-    type[BaseException], str, int, tuple[Any, ...], tuple[tuple[Any, ...], ...]
-]
 TargetObservations = dict[str, Union[int, float]]
 
 T = TypeVar("T")

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -843,7 +843,7 @@ class Blocks:
 
 
 class _Overrun:
-    status = Status.OVERRUN
+    status: Status = Status.OVERRUN
 
     def __repr__(self) -> str:
         return "Overrun"

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -39,6 +39,7 @@ from hypothesis.internal.conjecture.choice import (
     BooleanKWargs,
     BytesKWargs,
     ChoiceKwargsT,
+    ChoiceNameT,
     ChoiceT,
     FloatKWargs,
     IntegerKWargs,
@@ -95,9 +96,8 @@ TargetObservations = dict[str, Union[int, float]]
 
 T = TypeVar("T")
 
-IRTypeName: TypeAlias = Literal["integer", "string", "boolean", "float", "bytes"]
 # index, ir_type, kwargs, forced
-MisalignedAt: TypeAlias = tuple[int, IRTypeName, ChoiceKwargsT, Optional[ChoiceT]]
+MisalignedAt: TypeAlias = tuple[int, ChoiceNameT, ChoiceKwargsT, Optional[ChoiceT]]
 
 
 class ExtraInformation:
@@ -904,7 +904,7 @@ class DataObserver:
 
 @attr.s(slots=True, repr=False, eq=False)
 class IRNode:
-    ir_type: IRTypeName = attr.ib()
+    ir_type: ChoiceNameT = attr.ib()
     value: ChoiceT = attr.ib()
     kwargs: ChoiceKwargsT = attr.ib()
     was_forced: bool = attr.ib()
@@ -2283,7 +2283,7 @@ class ConjectureData:
             return kwargs
 
     def _pop_choice(
-        self, ir_type: IRTypeName, kwargs: ChoiceKwargsT, *, forced: Optional[ChoiceT]
+        self, ir_type: ChoiceNameT, kwargs: ChoiceKwargsT, *, forced: Optional[ChoiceT]
     ) -> ChoiceT:
         assert self.ir_prefix is not None
         # checked in _draw

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1006,7 +1006,7 @@ class NodeTemplate:
         assert self.size > 0
 
 
-def ir_size(ir: Iterable[ChoiceT]) -> int:
+def ir_size(ir: Iterable[Union[IRNode, NodeTemplate, ChoiceT]]) -> int:
     from hypothesis.database import ir_to_bytes
 
     size = 0

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -20,19 +20,21 @@ from hypothesis.errors import (
     StopTest,
 )
 from hypothesis.internal import floats as flt
-from hypothesis.internal.conjecture.choice import choice_from_index
-from hypothesis.internal.conjecture.data import (
+from hypothesis.internal.conjecture.choice import (
     BooleanKWargs,
     BytesKWargs,
-    ConjectureData,
-    DataObserver,
+    ChoiceKwargsT,
+    ChoiceT,
     FloatKWargs,
     IntegerKWargs,
-    IRKWargsType,
-    IRType,
+    StringKWargs,
+    choice_from_index,
+)
+from hypothesis.internal.conjecture.data import (
+    ConjectureData,
+    DataObserver,
     IRTypeName,
     Status,
-    StringKWargs,
 )
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import (
@@ -367,8 +369,8 @@ class TreeNode:
 
     # The kwargs, value, and ir_types of the nodes stored here. These always
     # have the same length. The values at index i belong to node i.
-    kwargs: list[IRKWargsType] = attr.ib(factory=list)
-    values: list[IRType] = attr.ib(factory=list)
+    kwargs: list[ChoiceKwargsT] = attr.ib(factory=list)
+    values: list[ChoiceT] = attr.ib(factory=list)
     ir_types: list[IRTypeName] = attr.ib(factory=list)
 
     # The indices of nodes which had forced values.
@@ -949,10 +951,10 @@ class TreeRecordingObserver(DataObserver):
     def draw_value(
         self,
         ir_type: IRTypeName,
-        value: IRType,
+        value: ChoiceT,
         *,
         was_forced: bool,
-        kwargs: IRKWargsType,
+        kwargs: ChoiceKwargsT,
     ) -> None:
         i = self.__index_in_current_node
         self.__index_in_current_node += 1

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -25,18 +25,14 @@ from hypothesis.internal.conjecture.choice import (
     BooleanKWargs,
     BytesKWargs,
     ChoiceKwargsT,
+    ChoiceNameT,
     ChoiceT,
     FloatKWargs,
     IntegerKWargs,
     StringKWargs,
     choice_from_index,
 )
-from hypothesis.internal.conjecture.data import (
-    ConjectureData,
-    DataObserver,
-    IRTypeName,
-    Status,
-)
+from hypothesis.internal.conjecture.data import ConjectureData, DataObserver, Status
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import (
     count_between_floats,
@@ -375,7 +371,7 @@ class TreeNode:
     # have the same length. The values at index i belong to node i.
     kwargs: list[ChoiceKwargsT] = attr.ib(factory=list)
     values: list[ChoiceT] = attr.ib(factory=list)
-    ir_types: list[IRTypeName] = attr.ib(factory=list)
+    ir_types: list[ChoiceNameT] = attr.ib(factory=list)
 
     # The indices of nodes which had forced values.
     #
@@ -954,7 +950,7 @@ class TreeRecordingObserver(DataObserver):
 
     def draw_value(
         self,
-        ir_type: IRTypeName,
+        ir_type: ChoiceNameT,
         value: ChoiceT,
         *,
         was_forced: bool,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -10,7 +10,7 @@
 
 import math
 from random import Random
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, AbstractSet, Optional, Union
 
 import attr
 
@@ -398,7 +398,7 @@ class TreeNode:
     is_exhausted: bool = attr.ib(default=False, init=False)
 
     @property
-    def forced(self) -> Union[set[int], frozenset[int]]:
+    def forced(self) -> AbstractSet[int]:
         if not self.__forced:
             return EMPTY
         return self.__forced

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -1048,7 +1048,9 @@ class TreeRecordingObserver(DataObserver):
         self.__index_in_current_node = 0
         self.__trail.append(self.__current_node)
 
-    def conclude_test(self, status, interesting_origin):
+    def conclude_test(
+        self, status: Status, interesting_origin: Optional[InterestingOrigin]
+    ) -> None:
         """Says that ``status`` occurred at node ``node``. This updates the
         node if necessary and checks for consistency."""
         if status == Status.OVERRUN:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -45,6 +45,7 @@ from hypothesis.errors import (
 )
 from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.compat import NotRequired, TypeAlias, TypedDict, ceil, override
+from hypothesis.internal.conjecture.choice import ChoiceKwargsT
 from hypothesis.internal.conjecture.data import (
     AVAILABLE_PROVIDERS,
     ConjectureData,
@@ -52,7 +53,6 @@ from hypothesis.internal.conjecture.data import (
     DataObserver,
     HypothesisProvider,
     InterestingOrigin,
-    IRKWargsType,
     IRNode,
     NodeTemplate,
     Overrun,
@@ -256,7 +256,7 @@ class ConjectureRunner:
             self.settings.backend
         )
 
-        self.best_observed_targets: "defaultdict[str, float]" = defaultdict(
+        self.best_observed_targets: defaultdict[str, float] = defaultdict(
             lambda: NO_SCORE
         )
         self.best_examples_of_observed_targets: dict[str, ConjectureResult] = {}
@@ -521,7 +521,7 @@ class ConjectureRunner:
                             )
 
                         kwargs = cast(
-                            IRKWargsType,
+                            ChoiceKwargsT,
                             {
                                 k: data.provider.realize(v)
                                 for k, v in node.kwargs.items()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -52,7 +52,6 @@ from hypothesis.internal.conjecture.data import (
     ConjectureResult,
     DataObserver,
     HypothesisProvider,
-    InterestingOrigin,
     IRNode,
     NodeTemplate,
     Overrun,
@@ -74,6 +73,7 @@ from hypothesis.internal.conjecture.junkdrawer import (
 )
 from hypothesis.internal.conjecture.pareto import NO_SCORE, ParetoFront, ParetoOptimiser
 from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key, sort_key_ir
+from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.reporting import base_report, report
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -228,6 +228,12 @@ class LazySequenceCopy(Generic[T]):
         self.__popped_indices.add(i)
         return v
 
+    def swap(self, i: int, j: int) -> None:
+        """Swap the elements ls[i], ls[j]."""
+        if i == j:
+            return
+        self[i], self[j] = self[j], self[i]
+
     def __getitem__(self, i: int) -> T:
         i = self.__underlying_index(i)
 
@@ -269,16 +275,9 @@ class LazySequenceCopy(Generic[T]):
         return i
 
     # even though we have len + getitem, mypyc requires iter.
-    def __iter__(self) -> Iterator[T]:
+    def __iter__(self) -> Iterable[T]:
         for i in range(len(self)):
             yield self[i]
-
-
-def swap(ls: LazySequenceCopy[T], i: int, j: int) -> None:
-    """Swap the elements ls[i], ls[j]."""
-    if i == j:
-        return
-    ls[i], ls[j] = ls[j], ls[i]
 
 
 def stack_depth_of_caller() -> int:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -124,7 +124,7 @@ class IntList(Sequence[int]):
             return IntList(self.__underlying[i])
         return self.__underlying[i]
 
-    def __delitem__(self, i: int) -> None:
+    def __delitem__(self, i: Union[int, slice]) -> None:
         del self.__underlying[i]
 
     def insert(self, i: int, v: int) -> None:
@@ -194,17 +194,17 @@ def uniform(random: Random, n: int) -> bytes:
     return random.getrandbits(n * 8).to_bytes(n, "big")
 
 
-class LazySequenceCopy:
+class LazySequenceCopy(Generic[T]):
     """A "copy" of a sequence that works by inserting a mask in front
     of the underlying sequence, so that you can mutate it without changing
     the underlying sequence. Effectively behaves as if you could do list(x)
     in O(1) time. The full list API is not supported yet but there's no reason
     in principle it couldn't be."""
 
-    def __init__(self, values: Sequence[int]):
+    def __init__(self, values: Sequence[T]):
         self.__values = values
         self.__len = len(values)
-        self.__mask: Optional[dict[int, int]] = None
+        self.__mask: Optional[dict[int, T]] = None
         self.__popped_indices: Optional[SortedList] = None
 
     def __len__(self) -> int:
@@ -212,7 +212,7 @@ class LazySequenceCopy:
             return self.__len
         return self.__len - len(self.__popped_indices)
 
-    def pop(self, i: int = -1) -> int:
+    def pop(self, i: int = -1) -> T:
         if len(self) == 0:
             raise IndexError("Cannot pop from empty list")
         i = self.__underlying_index(i)
@@ -228,7 +228,7 @@ class LazySequenceCopy:
         self.__popped_indices.add(i)
         return v
 
-    def __getitem__(self, i: int) -> int:
+    def __getitem__(self, i: int) -> T:
         i = self.__underlying_index(i)
 
         default = self.__values[i]
@@ -237,7 +237,7 @@ class LazySequenceCopy:
         else:
             return self.__mask.get(i, default)
 
-    def __setitem__(self, i: int, v: int) -> None:
+    def __setitem__(self, i: int, v: T) -> None:
         i = self.__underlying_index(i)
         if self.__mask is None:
             self.__mask = {}
@@ -268,8 +268,13 @@ class LazySequenceCopy:
                 i += 1
         return i
 
+    # even though we have len + getitem, mypyc requires iter.
+    def __iter__(self) -> Iterator[T]:
+        for i in range(len(self)):
+            yield self[i]
 
-def swap(ls: LazySequenceCopy, i: int, j: int) -> None:
+
+def swap(ls: LazySequenceCopy[T], i: int, j: int) -> None:
     """Swap the elements ls[i], ls[j]."""
     if i == j:
         return

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -11,14 +11,13 @@
 from typing import Union
 
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
+from hypothesis.internal.conjecture.choice import ChoiceT, choice_permitted
 from hypothesis.internal.conjecture.data import (
     ConjectureResult,
-    IRType,
     Status,
     _Overrun,
     bits_to_bytes,
     ir_size,
-    ir_value_permitted,
 )
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR, ConjectureRunner
 from hypothesis.internal.conjecture.junkdrawer import find_integer
@@ -137,7 +136,7 @@ class Optimiser:
                 if node.was_forced:
                     return False  # pragma: no cover
 
-                new_value: IRType
+                new_value: ChoiceT
                 if node.ir_type in {"integer", "float"}:
                     assert isinstance(node.value, (int, float))
                     new_value = node.value + k
@@ -164,7 +163,7 @@ class Optimiser:
                     size = max(len(node.value), bits_to_bytes(v.bit_length()))
                     new_value = int_to_bytes(v, size)
 
-                if not ir_value_permitted(new_value, node.ir_type, node.kwargs):
+                if not choice_permitted(new_value, node.kwargs):
                     return False
 
                 for _ in range(3):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -8,7 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from typing import Union
+from typing import Optional, Union
 
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.choice import ChoiceT, choice_permitted
@@ -97,7 +97,7 @@ class Optimiser:
 
         nodes_examined = set()
 
-        prev = None
+        prev: Optional[ConjectureResult] = None
         i = len(self.current_data.ir_nodes) - 1
         while i >= 0 and self.improvements <= self.max_improvements:
             if prev is not self.current_data:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -13,7 +13,7 @@ from enum import Enum
 from sortedcontainers import SortedList
 
 from hypothesis.internal.conjecture.data import ConjectureData, ConjectureResult, Status
-from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy, swap
+from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
 from hypothesis.internal.conjecture.shrinker import sort_key_ir
 
 NO_SCORE = float("-inf")
@@ -198,7 +198,7 @@ class ParetoFront:
             dominators = [data]
 
             while i >= 0 and len(dominators) < 10:
-                swap(front, i, self.__random.randint(0, i))
+                front.swap(i, self.__random.randint(0, i))
 
                 candidate = front[i]
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -15,7 +15,11 @@ from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 import attr
 
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
-from hypothesis.internal.conjecture.choice import choice_from_index, choice_to_index
+from hypothesis.internal.conjecture.choice import (
+    choice_from_index,
+    choice_permitted,
+    choice_to_index,
+)
 from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,
@@ -25,7 +29,6 @@ from hypothesis.internal.conjecture.data import (
     ir_to_buffer,
     ir_value_equal,
     ir_value_key,
-    ir_value_permitted,
 )
 from hypothesis.internal.conjecture.junkdrawer import (
     endswith,
@@ -394,7 +397,7 @@ class Shrinker:
         # sometimes our shrinking passes try obviously invalid things. We handle
         # discarding them in one place here.
         for node in tree:
-            if not ir_value_permitted(node.value, node.ir_type, node.kwargs):
+            if not choice_permitted(node.value, node.kwargs):
                 return None
 
         result = self.engine.cached_test_function_ir(tree)
@@ -761,8 +764,8 @@ class Shrinker:
                             orig_node = nodes[j]
                             if (
                                 zero_node.ir_type != orig_node.ir_type
-                                or not ir_value_permitted(
-                                    orig_node.value, zero_node.ir_type, zero_node.kwargs
+                                or not choice_permitted(
+                                    orig_node.value, zero_node.kwargs
                                 )
                             ):
                                 changed_shape = True

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -436,12 +436,12 @@ def extract_lambda_source(f):
     return source
 
 
-def get_pretty_function_description(f: Any) -> str:
+def get_pretty_function_description(f: object) -> str:
     if isinstance(f, partial):
         return pretty(f)
     if not hasattr(f, "__name__"):
         return repr(f)
-    name = f.__name__
+    name = f.__name__  # type: ignore # validated by hasattr above
     if name == "<lambda>":
         return extract_lambda_source(f)
     elif isinstance(f, (types.MethodType, types.BuiltinMethodType)):

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -436,7 +436,7 @@ def extract_lambda_source(f):
     return source
 
 
-def get_pretty_function_description(f):
+def get_pretty_function_description(f: Any) -> str:
     if isinstance(f, partial):
         return pretty(f)
     if not hasattr(f, "__name__"):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -465,7 +465,7 @@ class SearchStrategy(Generic[Ex]):
     def do_draw(self, data: ConjectureData) -> Ex:
         raise NotImplementedError(f"{type(self).__name__}.do_draw")
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
 

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -16,11 +16,11 @@ from hypothesis import HealthCheck, Phase, assume, settings, strategies as st
 from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import engine as engine_module
+from hypothesis.internal.conjecture.choice import ChoiceT
 from hypothesis.internal.conjecture.data import (
     COLLECTION_DEFAULT_MAX_SIZE,
     ConjectureData,
     IRNode,
-    IRType,
     Status,
 )
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE, ConjectureRunner
@@ -369,7 +369,7 @@ def ir_nodes(draw, *, was_forced=None, ir_type=None):
     return IRNode(ir_type=ir_type, value=value, kwargs=kwargs, was_forced=was_forced)
 
 
-def ir(*values: list[IRType]) -> list[IRNode]:
+def ir(*values: list[ChoiceT]) -> list[IRNode]:
     """
     For inline-creating an ir node or list of ir nodes, where you don't care about the
     kwargs. This uses maximally-permissable kwargs and infers the ir_type you meant

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -46,20 +46,16 @@ def interesting_origin(n: Optional[int] = None) -> InterestingOrigin:
     """
     Creates and returns an InterestingOrigin, parameterized by n, such that
     interesting_origin(n) == interesting_origin(m) iff n = m.
+
+    Since n=None may by chance concide with an explicitly-passed value of n, I
+    recommend not mixing interesting_origin() and interesting_origin(n) in the
+    same test.
     """
     try:
         int("not an int")
     except Exception as e:
         origin = InterestingOrigin.from_exception(e)
-        if n is None:
-            return origin
-        return InterestingOrigin(
-            exc_type=origin.exc_type,
-            filename=origin.filename,
-            lineno=n,
-            context=origin.context,
-            group_elems=origin.group_elems,
-        )
+        return origin._replace(lineno=n if n is not None else origin.lineno)
 
 
 def run_to_data(f):

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -29,7 +29,6 @@ from hypothesis.internal.conjecture.datatree import (
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.floats import float_to_int
 from hypothesis.internal.conjecture.junkdrawer import startswith
-
 from hypothesis.internal.floats import next_up
 from hypothesis.vendor import pretty
 

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -29,7 +29,7 @@ from hypothesis.internal.conjecture.datatree import (
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.floats import float_to_int
 from hypothesis.internal.conjecture.junkdrawer import startswith
-from hypothesis.internal.escalation import InterestingOrigin
+
 from hypothesis.internal.floats import next_up
 from hypothesis.vendor import pretty
 
@@ -37,6 +37,7 @@ from tests.conjecture.common import (
     boolean_kwargs,
     fresh_data,
     integer_kwargs,
+    interesting_origin,
     ir,
     ir_nodes,
     kwargs_strategy,
@@ -530,10 +531,7 @@ def test_can_generate_hard_floats():
 def test_datatree_repr(bool_kwargs, int_kwargs):
     tree = DataTree()
 
-    try:
-        int("not an int")
-    except ValueError as e:
-        origin = InterestingOrigin.from_exception(e)
+    origin = interesting_origin()
 
     observer = tree.new_observer()
     observer.draw_boolean(True, was_forced=False, kwargs=bool_kwargs)

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -58,6 +58,7 @@ from tests.conjecture.common import (
     TEST_SETTINGS,
     buffer_size_limit,
     integer_kw,
+    interesting_origin,
     ir,
     ir_nodes,
     run_to_nodes,
@@ -630,12 +631,12 @@ def test_shrinks_both_interesting_examples(monkeypatch):
 
     def f(data):
         n = data.draw_integer(0, 2**8 - 1)
-        data.mark_interesting(n & 1)
+        data.mark_interesting(interesting_origin(n & 1))
 
     runner = ConjectureRunner(f, database_key=b"key")
     runner.run()
-    assert runner.interesting_examples[0].choices == (0,)
-    assert runner.interesting_examples[1].choices == (1,)
+    assert runner.interesting_examples[interesting_origin(0)].choices == (0,)
+    assert runner.interesting_examples[interesting_origin(1)].choices == (1,)
 
 
 def test_discarding(monkeypatch):
@@ -1087,9 +1088,9 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
         n = data.draw_integer(0, 2**8 - 1)
 
         if m > 0:
-            data.mark_interesting(1)
+            data.mark_interesting(interesting_origin(1))
         if n > 5:
-            data.mark_interesting(2)
+            data.mark_interesting(interesting_origin(2))
 
     with deterministic_PRNG():
         runner = ConjectureRunner(

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -17,7 +17,7 @@ from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
 
-from tests.conjecture.common import ir
+from tests.conjecture.common import interesting_origin, ir
 
 
 def test_pareto_front_contains_different_interesting_reasons():
@@ -25,7 +25,8 @@ def test_pareto_front_contains_different_interesting_reasons():
 
         def test(data):
             data.target_observations[""] = 1
-            data.mark_interesting(data.draw_integer(0, 2**4 - 1))
+            n = data.draw_integer(0, 2**4 - 1)
+            data.mark_interesting(interesting_origin(n))
 
         runner = ConjectureRunner(
             test,

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -23,7 +23,13 @@ from hypothesis.internal.conjecture.shrinker import (
 from hypothesis.internal.conjecture.shrinking.common import Shrinker as ShrinkerPass
 from hypothesis.internal.conjecture.utils import Sampler
 
-from tests.conjecture.common import SOME_LABEL, ir, run_to_nodes, shrinking_from
+from tests.conjecture.common import (
+    SOME_LABEL,
+    interesting_origin,
+    ir,
+    run_to_nodes,
+    shrinking_from,
+)
 
 
 @pytest.mark.parametrize("n", [1, 5, 8, 15])
@@ -315,11 +321,11 @@ def test_zig_zags_quickly():
         if m == 0 or n == 0:
             data.mark_invalid()
         if abs(m - n) <= 1:
-            data.mark_interesting(0)
+            data.mark_interesting(interesting_origin(0))
         # Two different interesting origins for avoiding slipping in the
         # shrinker.
         if abs(m - n) <= 10:
-            data.mark_interesting(1)
+            data.mark_interesting(interesting_origin(1))
 
     shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
     assert shrinker.engine.valid_examples <= 100

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -25,6 +25,8 @@ from hypothesis.internal.conjecture.data import (
 )
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
+from tests.conjecture.common import interesting_origin
+
 
 @given(st.binary())
 def test_buffer_draws_as_self(buf):
@@ -253,17 +255,18 @@ def test_can_observe_draws():
     observer = LoggingObserver()
     x = ConjectureData.for_buffer(bytes([1, 2, 3]), observer=observer)
 
+    origin = interesting_origin()
     x.draw_boolean()
     x.draw_integer(0, 2**7 - 1, forced=10)
     x.draw_integer(0, 2**8 - 1)
     with pytest.raises(StopTest):
-        x.conclude_test(Status.INTERESTING, interesting_origin="neat")
+        x.conclude_test(Status.INTERESTING, interesting_origin=origin)
 
     assert observer.log == [
         ("draw_boolean", True, False),
         ("draw_integer", 10, True),
         ("draw_integer", 3, False),
-        ("concluded", Status.INTERESTING, "neat"),
+        ("concluded", Status.INTERESTING, origin),
     ]
 
 

--- a/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis-python/tests/nocover/test_explore_arbitrary_languages.py
@@ -26,6 +26,8 @@ from hypothesis import (
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
+from tests.conjecture.common import interesting_origin
+
 
 @attr.s()
 class Write:
@@ -89,7 +91,7 @@ def run_language_test_for(root, data, seed):
                     node = node.children.setdefault(c, data.draw(nodes))
         assert isinstance(node, Terminal)
         if node.status == Status.INTERESTING:
-            local_data.mark_interesting(node.payload)
+            local_data.mark_interesting(interesting_origin(node.payload))
         elif node.status == Status.INVALID:
             local_data.mark_invalid()
 


### PR DESCRIPTION
* `IRType` -> `ChoiceT` (and move to choice.py)
* `IRKwargsType` -> `ChoiceKwargsT` (and move to choice.py)
* `ir_value_permitted` -> `choice_permitted` (and move to choice.py)
* use actual `InterestingOrigin` instances in tests
* work some more on type hints

On the topic of type hints, I've been playing around with mypyc recently, and may work towards a serious push towards it in the near future, a la https://github.com/HypothesisWorks/hypothesis/issues/3074. I think most of the remaining work there is actually in conforming to a mypyc-approved subset (no nested classes, meaning `Examples` will need to be refactored!) rather than adding more type hints. Though there will certainly be some of the latter 😄 