### PR TITLE
Support "T" and "V" dtypes in `from_dtype`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.extra.numpy.from_dtype` now supports the :obj:`numpy.dtypes.VoidDType` (``"V``) dtype, as well as the new :obj:`numpy:numpy.dtypes.StringDType` (``"T"``) dtype in NumPy 2.0.

--- a/hypothesis-python/tests/numpy/test_from_dtype.py
+++ b/hypothesis-python/tests/numpy/test_from_dtype.py
@@ -42,6 +42,7 @@ STANDARD_TYPES = [
         "complex128",
         "datetime64",
         "timedelta64",
+        "void",
         bool,
         str,
         bytes,
@@ -103,6 +104,14 @@ def test_unicode_string_dtypes_generate_unicode_strings(data):
     assert isinstance(result, str)
 
 
+@given(st.data())
+def test_void_dtype_generates_void(data):
+    dtype = data.draw(nps.void_dtypes())
+    value = data.draw(nps.from_dtype(dtype))
+    assert isinstance(value, np.void)
+    assert isinstance(value.tobytes(), bytes)
+
+
 @given(nps.arrays(dtype="U99", shape=(10,)))
 def test_can_unicode_strings_without_decode_error(arr):
     # See https://github.com/numpy/numpy/issues/15363
@@ -129,6 +138,7 @@ def test_byte_string_dtypes_generate_unicode_strings(data):
 
 
 skipif_np2 = pytest.mark.skipif(np_version >= (2, 0), reason="removed in new version")
+skipif_np1 = pytest.mark.skipif(np_version < (2, 0), reason="added in new version")
 
 
 @pytest.mark.parametrize(
@@ -251,6 +261,16 @@ def test_arrays_gives_useful_error_on_inconsistent_time_unit():
         ("U", {"min_size": 1, "max_size": 2}, lambda x: 1 <= len(x) <= 2),
         ("U4", {"min_size": 1, "max_size": 2}, lambda x: 1 <= len(x) <= 2),
         ("U", {"alphabet": "abc"}, lambda x: set(x).issubset("abc")),
+        pytest.param(
+            "T", {"alphabet": "abc"}, lambda x: set(x).issubset("abc"), marks=skipif_np1
+        ),
+        pytest.param(
+            "T",
+            {"min_size": 1, "max_size": 2},
+            lambda x: 1 <= len(x) <= 2,
+            marks=skipif_np1,
+        ),
+        ("V", {"min_size": 1, "max_size": 2}, lambda x: 1 <= len(x.tobytes()) <= 2),
     ],
 )
 @given(data=st.data())

--- a/hypothesis-python/tests/numpy/test_from_type.py
+++ b/hypothesis-python/tests/numpy/test_from_type.py
@@ -32,7 +32,7 @@ def test_resolves_dtype_type(dtype):
     assert isinstance(dtype, np.dtype)
 
 
-@pytest.mark.parametrize("typ", [np.object_, np.void])
+@pytest.mark.parametrize("typ", [np.object_])
 def test_does_not_resolve_nonscalar_types(typ):
     # Comparing the objects directly fails on Windows,
     # so compare their reprs instead.
@@ -42,7 +42,9 @@ def test_does_not_resolve_nonscalar_types(typ):
 @pytest.mark.parametrize("typ", STANDARD_TYPES_TYPE)
 def test_resolves_and_varies_numpy_scalar_type(typ):
     # Check that we find an instance that is not equal to the default
-    x = find_any(from_type(typ), lambda x: x != type(x)())
+    # (except for void, which does not have a default)
+    cond = lambda _: True if typ is np.void else lambda x: x != type(x)()
+    x = find_any(from_type(typ), cond)
     assert isinstance(x, typ)
 
 


### PR DESCRIPTION
(probably) resolves https://github.com/HypothesisWorks/hypothesis/issues/4039. I did look around for what it would take to support user-defined dtypes, but found...little documentation on the topic in the numpy docs 😅. I found along the way that we don't support the [void dtype](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.void), so this pull adds support for that too.

I have some local work on accepting dtype-coercible strings in `from_dtype` (`dtype: Union[np.dtype, str]`) - would that change be welcome as well? `nps.from_dtype(np.dtype("int8"))` feels a bit cumbersome, but I also understand wanting to keep the api surface tight.