### PR TITLE
Use `.for_choices` instead of `.for_buffer` in most tests, drop `ir_type` from  `ir_value_key`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal code refactoring.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -362,7 +362,7 @@ class ConjectureRunner:
         return tuple(
             (
                 node.ir_type,
-                ir_value_key(node.ir_type, node.value),
+                ir_value_key(node.value),
                 ir_kwargs_key(node.ir_type, node.kwargs),
             )
             for node in nodes

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1107,7 +1107,7 @@ class Shrinker:
             assert len(prev_nodes) == len(new_nodes)
             for i, (n1, n2) in enumerate(zip(prev_nodes, new_nodes)):
                 assert n1.ir_type == n2.ir_type
-                if not ir_value_equal(n1.ir_type, n1.value, n2.value):
+                if not ir_value_equal(n1.value, n2.value):
                     self.__all_changed_nodes.add(i)
 
         return self.__all_changed_nodes
@@ -1320,9 +1320,7 @@ class Shrinker:
         """Returns a list of nodes grouped (ir_type, value)."""
         duplicates = defaultdict(list)
         for node in self.nodes:
-            duplicates[(node.ir_type, ir_value_key(node.ir_type, node.value))].append(
-                node
-            )
+            duplicates[(node.ir_type, ir_value_key(node.value))].append(node)
         return list(duplicates.values())
 
     @defines_shrink_pass()
@@ -1460,7 +1458,7 @@ class Shrinker:
         # same operation on both basically just works.
         kwargs = nodes[0].kwargs
         assert all(
-            node.ir_type == ir_type and ir_value_equal(ir_type, node.value, value)
+            node.ir_type == ir_type and ir_value_equal(node.value, value)
             for node in nodes
         )
 

--- a/hypothesis-python/tests/conjecture/test_forced.py
+++ b/hypothesis-python/tests/conjecture/test_forced.py
@@ -142,13 +142,13 @@ def test_forced_values(ir_type_and_kwargs):
 
     forced = kwargs["forced"]
     data = fresh_data()
-    assert ir_value_equal(ir_type, getattr(data, f"draw_{ir_type}")(**kwargs), forced)
+    assert ir_value_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
 
     # now make sure the written buffer reproduces the forced value, even without
     # specifying forced=.
     del kwargs["forced"]
     data = ConjectureData.for_buffer(data.buffer)
-    assert ir_value_equal(ir_type, getattr(data, f"draw_{ir_type}")(**kwargs), forced)
+    assert ir_value_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
 
 
 @pytest.mark.parametrize("sign", [1, -1])

--- a/hypothesis-python/tests/conjecture/test_forced.py
+++ b/hypothesis-python/tests/conjecture/test_forced.py
@@ -46,7 +46,7 @@ def test_forced_many(data):
     assert not many.more()
 
     # ensure values written to the buffer do in fact generate the forced value
-    data = ConjectureData.for_buffer(data.buffer)
+    data = ConjectureData.for_choices(data.choices)
     many = cu.many(
         data,
         min_size=min_size,
@@ -147,7 +147,7 @@ def test_forced_values(ir_type_and_kwargs):
     # now make sure the written buffer reproduces the forced value, even without
     # specifying forced=.
     del kwargs["forced"]
-    data = ConjectureData.for_buffer(data.buffer)
+    data = ConjectureData.for_choices(data.choices)
     assert ir_value_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
 
 

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import traceback
+
 import pytest
 
 from hypothesis import given, settings, strategies as st
@@ -20,6 +22,12 @@ def fails_with_output(expected, error=AssertionError, **kw):
         def _new():
             with pytest.raises(error) as err:
                 settings(print_blob=False, derandomize=True, **kw)(f)()
+
+            if not hasattr(err.value, "__notes__"):
+                # something has gone deeply wrong in the internals
+                traceback.print_exception(err.value)
+                assert False
+
             got = "\n".join(err.value.__notes__).strip() + "\n"
             assert got == expected.strip() + "\n"
 

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -283,7 +283,7 @@ def test_copy_ir_node(node):
     new_value = draw_value(node.ir_type, node.kwargs)
     # if we drew the same value as before, the node should still be equal
     assert (node.copy(with_value=new_value) == node) is (
-        ir_value_equal(node.ir_type, new_value, node.value)
+        ir_value_equal(new_value, node.value)
     )
 
 
@@ -322,9 +322,9 @@ def test_data_with_changed_forced_value(node):
     draw_func = getattr(data, f"draw_{node.ir_type}")
     kwargs = deepcopy(node.kwargs)
     kwargs["forced"] = draw_value(node.ir_type, node.kwargs)
-    assume(not ir_value_equal(node.ir_type, kwargs["forced"], node.value))
+    assume(not ir_value_equal(kwargs["forced"], node.value))
 
-    assert ir_value_equal(node.ir_type, draw_func(**kwargs), kwargs["forced"])
+    assert ir_value_equal(draw_func(**kwargs), kwargs["forced"])
 
 
 # ensure we hit bare-minimum coverage for all ir types.
@@ -371,7 +371,7 @@ def test_data_with_same_forced_value_is_valid(node):
 
     kwargs = deepcopy(node.kwargs)
     kwargs["forced"] = node.value
-    assert ir_value_equal(node.ir_type, draw_func(**kwargs), kwargs["forced"])
+    assert ir_value_equal(draw_func(**kwargs), kwargs["forced"])
 
 
 @given(ir_types_and_kwargs())
@@ -562,7 +562,7 @@ def test_trivial_nodes(node):
         return getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
 
     # if we're trivial, then shrinking should produce the same value.
-    assert ir_value_equal(node.ir_type, minimal(values()), node.value)
+    assert ir_value_equal(minimal(values()), node.value)
 
 
 @pytest.mark.parametrize(
@@ -620,7 +620,7 @@ def test_nontrivial_nodes(node):
         return getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
 
     # if we're nontrivial, then shrinking should produce something different.
-    assert not ir_value_equal(node.ir_type, minimal(values()), node.value)
+    assert not ir_value_equal(minimal(values()), node.value)
 
 
 @pytest.mark.parametrize(
@@ -668,7 +668,7 @@ def test_conservative_nontrivial_nodes(node):
         data = draw(st.data()).conjecture_data
         return getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
 
-    assert ir_value_equal(node.ir_type, minimal(values()), node.value)
+    assert ir_value_equal(minimal(values()), float(node.value))
 
 
 @given(ir_nodes())
@@ -782,7 +782,7 @@ def test_choice_index_and_value_are_inverses(ir_type_and_kwargs):
     v = draw_value(ir_type, kwargs)
     index = choice_to_index(v, kwargs)
     note({"v": v, "index": index})
-    ir_value_equal(ir_type, choice_from_index(index, ir_type, kwargs), v)
+    ir_value_equal(choice_from_index(index, ir_type, kwargs), v)
 
 
 @pytest.mark.parametrize(
@@ -811,9 +811,7 @@ def test_choice_index_and_value_are_inverses(ir_type_and_kwargs):
 def test_choice_index_and_value_are_inverses_explicit(ir_type, kwargs, choices):
     for choice in choices:
         index = choice_to_index(choice, kwargs)
-        assert ir_value_equal(
-            ir_type, choice_from_index(index, ir_type, kwargs), choice
-        )
+        assert ir_value_equal(choice_from_index(index, ir_type, kwargs), choice)
 
 
 @pytest.mark.parametrize(

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -98,7 +98,7 @@ def test_drawing_an_exact_fraction_coin():
 
 
 def test_too_small_to_be_useful_coin():
-    data = ConjectureData.for_buffer([1])
+    data = ConjectureData.for_choices((True,))
     assert not data.draw_boolean(0.5**65)
 
 
@@ -198,10 +198,10 @@ def test_bounds_and_weights():
 
 
 def test_draw_string():
-    data = ConjectureData.for_buffer([0] * 10)
+    data = ConjectureData.for_choices(("0",))
     assert data.draw_string(IntervalSet([(0, 127)]), min_size=1) == "0"
 
-    data = ConjectureData.for_buffer([0] * 10)
+    data = ConjectureData.for_choices(("0",))
     assert data.draw_string(IntervalSet([(0, 1024)]), min_size=1) == "0"
 
 
@@ -254,7 +254,7 @@ def test_choice():
 
 def test_fixed_size_draw_many():
     many = cu.many(
-        ConjectureData.for_buffer([]), min_size=3, max_size=3, average_size=3
+        ConjectureData.for_choices([]), min_size=3, max_size=3, average_size=3
     )
     assert many.more()
     assert many.more()
@@ -265,14 +265,14 @@ def test_fixed_size_draw_many():
 def test_astronomically_unlikely_draw_many():
     # Our internal helper doesn't underflow to zero or negative, but nor
     # will we ever generate an element for such a low average size.
-    buffer = ConjectureData.for_buffer(1024 * [255])
-    many = cu.many(buffer, min_size=0, max_size=10, average_size=1e-5)
+    data = ConjectureData.for_choices((True,) * 1000)
+    many = cu.many(data, min_size=0, max_size=10, average_size=1e-5)
     assert not many.more()
 
 
 def test_rejection_eventually_terminates_many():
     many = cu.many(
-        ConjectureData.for_buffer([1] * 1000),
+        ConjectureData.for_choices((True,) * 1000),
         min_size=0,
         max_size=1000,
         average_size=100,
@@ -287,7 +287,7 @@ def test_rejection_eventually_terminates_many():
 
 
 def test_rejection_eventually_terminates_many_invalid_for_min_size():
-    data = ConjectureData.for_buffer([1] * 1000)
+    data = ConjectureData.for_choices((True,) * 1000)
     many = cu.many(data, min_size=1, max_size=1000, average_size=100)
 
     with pytest.raises(StopTest):
@@ -299,7 +299,10 @@ def test_rejection_eventually_terminates_many_invalid_for_min_size():
 
 def test_many_with_min_size():
     many = cu.many(
-        ConjectureData.for_buffer([0] * 10), min_size=2, average_size=10, max_size=1000
+        ConjectureData.for_choices((False,) * 5),
+        min_size=2,
+        average_size=10,
+        max_size=1000,
     )
     assert many.more()
     assert many.more()
@@ -308,7 +311,7 @@ def test_many_with_min_size():
 
 def test_many_with_max_size():
     many = cu.many(
-        ConjectureData.for_buffer([1] * 10), min_size=0, average_size=1, max_size=2
+        ConjectureData.for_choices((True,) * 5), min_size=0, average_size=1, max_size=2
     )
     assert many.more()
     assert many.more()

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -37,7 +37,7 @@ from tests.common.utils import capture_out
 
 
 def bc():
-    return BuildContext(ConjectureData.for_buffer(b""))
+    return BuildContext(ConjectureData.for_choices([]))
 
 
 def test_cannot_cleanup_with_no_context():

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -485,10 +485,7 @@ def test_ir_nodes_rountrips(nodes1):
     assert len(nodes1) == len(ir2)
 
     for n1, v2 in zip(nodes1, ir2):
-        v1 = n1.value
-        ir_type = n1.ir_type
-        assert type(v1) is type(v2)
-        assert ir_value_equal(ir_type, v1, v2)
+        assert ir_value_equal(n1.value, v2)
 
     s2 = ir_to_bytes(ir2)
     assert s1 == s2

--- a/hypothesis-python/tests/cover/test_float_utils.py
+++ b/hypothesis-python/tests/cover/test_float_utils.py
@@ -103,4 +103,4 @@ def test_float_clamper(kwargs, input_value):
         allow_nan=allow_nan,
         smallest_nonzero_magnitude=smallest_nonzero_magnitude,
     ):
-        assert ir_value_equal("float", input_value, clamped)
+        assert ir_value_equal(input_value, clamped)

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -38,8 +38,8 @@ def test_encoding_loop(nodes):
     choices = [n.value for n in nodes]
     looped = decode_failure(encode_failure(choices))
     assert len(choices) == len(looped)
-    for i, node in enumerate(nodes):
-        assert ir_value_equal(node.ir_type, choices[i], looped[i])
+    for i in range(choices):
+        assert ir_value_equal(choices[i], looped[i])
 
 
 @example(base64.b64encode(b"\2\3\4"))

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -157,7 +157,7 @@ def test_unsatisfiable_explicit_filteredstrategy_just(x):
 
 
 def test_transformed_just_strategy():
-    data = ConjectureData.for_buffer(bytes(100))
+    data = ConjectureData.for_choices([])
     s = JustStrategy([1]).map(lambda x: x * 2)
     assert s.do_draw(data) == 2
     sf = s.filter(lambda x: False)

--- a/hypothesis-python/tests/cover/test_searchstrategy.py
+++ b/hypothesis-python/tests/cover/test_searchstrategy.py
@@ -53,13 +53,13 @@ def test_just_strategy_uses_repr():
 
 
 def test_just_strategy_does_not_draw():
-    data = ConjectureData.for_buffer(b"")
+    data = ConjectureData.for_choices([])
     s = just("hello")
     assert s.do_draw(data) == "hello"
 
 
 def test_none_strategy_does_not_draw():
-    data = ConjectureData.for_buffer(b"")
+    data = ConjectureData.for_choices([])
     s = none()
     assert s.do_draw(data) is None
 

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -102,7 +102,7 @@ def test_can_restrict_to_ascii_only(s):
 def test_fixed_size_bytes_just_draw_bytes():
     from hypothesis.internal.conjecture.data import ConjectureData
 
-    x = ConjectureData.for_buffer(b"foo")
+    x = ConjectureData.for_choices([b"foo"])
     assert x.draw(binary(min_size=3, max_size=3)) == b"foo"
 
 

--- a/hypothesis-python/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis-python/tests/datetime/test_pytz_timezones.py
@@ -14,10 +14,9 @@ import warnings
 
 import pytest
 
-from hypothesis import assume, given
+from hypothesis import assume, given, strategies as st
 from hypothesis.errors import InvalidArgument, StopTest
-from hypothesis.internal.conjecture.data import ConjectureData
-from hypothesis.strategies import binary, data, datetimes, just, sampled_from, times
+from hypothesis.strategies import data, datetimes, just, sampled_from, times
 from hypothesis.strategies._internal.datetime import datetime_does_not_exist
 
 from tests.common.debug import assert_all_examples, find_any, minimal
@@ -112,15 +111,22 @@ def test_time_bounds_must_be_naive(name, val):
     ],
 )
 def test_can_trigger_error_in_draw_near_boundary(bound):
-    def test(buf):
-        data = ConjectureData.for_buffer(buf)
+    found = False
+
+    @given(st.data())
+    def f(data):
         try:
             data.draw(datetimes(**bound, timezones=timezones()))
         except StopTest:
             pass
-        return "Failed to draw a datetime" in data.events.get("invalid because", "")
+        if "Failed to draw a datetime" in data.conjecture_data.events.get(
+            "invalid because", ""
+        ):
+            nonlocal found
+            found = True
 
-    find_any(binary(), test)
+    f()
+    assert found
 
 
 @given(data(), datetimes(), datetimes())

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -82,5 +82,5 @@ def test_minimal_poisoned_containers(seed, size, p, strategy_class):
     )
     runner.run()
     (v,) = runner.interesting_examples.values()
-    result = ConjectureData.for_buffer(v.buffer).draw(strategy)
+    result = ConjectureData.for_choices(v.choices).draw(strategy)
     assert len(result) == 1


### PR DESCRIPTION
Former is a prerequisite to moving off the buffer and onto the typed choice sequence. The latter is me realizing that ir_type is a bit too annoying to pass everywhere, and thinking it's better to assert the passed types are equal and push the unequal case onto callers.