### PR TITLE
Freeze in `BackendCannotProceed`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes a bug caused by :ref:`alternative backends <alternative-backends>` raising ``hypothesis.errors.BackendCannotProceed`` in certain cases.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -484,6 +484,7 @@ class ConjectureRunner:
                     self._switch_to_hypothesis_provider = True
             # skip the post-test-case tracking; we're pretending this never happened
             interrupted = True
+            data.freeze()
             return
         except BaseException:
             self.save_buffer(data.buffer)


### PR DESCRIPTION
root cause of exceptions in https://github.com/HypothesisWorks/hypothesis/pull/4034. No test because it requires taking the zero_data code path, and any test may well be obviated by imminent typed choice sequence work.