### PR TITLE
Write atomically in `DirectoryBasedExampleDatabase`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+:class:`~hypothesis.database.DirectoryBasedExampleDatabase` now creates files representing database entries atomically, avoiding a very brief intermediary state where a file could be created but not yet written to.


### PR DESCRIPTION
Discovered while investigating test failures in https://github.com/Zac-HD/hypofuzz/pull/47.