### PR TITLE
Fix some flaky reporting corner cases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch improves certain corner cases for reporting of flaky errors
+(:issue:`4183` and :issue:`4228`).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1125,9 +1125,14 @@ class StateForActualGivenExecution:
             # of treating it as a test failure.
             if isinstance(e, BaseExceptionGroup) and len(e.exceptions) == 1:
                 # When a naked exception is implicitly wrapped in an ExceptionGroup
-                # due to a re-raising "except*", the ExceptionGroup is constructed
-                # in the caller stack frame (see #4183).
-                tb = e.exceptions[0].__traceback__
+                # due to a re-raising "except*", the ExceptionGroup is constructed in
+                # the caller's stack frame (see #4183). This workaround is specifically
+                # for implicit wrapping of naked exceptions by "except*", since explicit
+                # raising of ExceptionGroup gets the proper traceback in the first place
+                # - there's no need to handle hierarchical groups here, at least if no
+                # such implicit wrapping happens inside hypothesis code (we only care
+                # about the hypothesis-or-not distinction).
+                tb = e.exceptions[0].__traceback__ or e.__traceback__
             else:
                 tb = e.__traceback__
             filepath = traceback.extract_tb(tb)[-1][0]

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -8,11 +8,14 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
+
 import pytest
 
 from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
 from hypothesis.core import StateForActualGivenExecution
 from hypothesis.errors import Flaky, FlakyFailure, Unsatisfiable, UnsatisfiedAssumption
+from hypothesis.internal.compat import ExceptionGroup
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.internal.scrutineer import Tracer
 from hypothesis.strategies import booleans, composite, integers, lists, random_module
@@ -61,28 +64,33 @@ def test_fails_differently_is_flaky():
     with pytest.raises(FlakyFailure, match="Inconsistent results from replaying") as e:
         rude()
     exceptions = e.value.exceptions
-    assert set(map(type, exceptions)) == set([Nope, DifferentNope])
+    assert len(exceptions) == 2
+    assert set(map(type, exceptions)) == {Nope, DifferentNope}
 
 
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="except* syntax")
 def test_exceptiongroup_wrapped_naked_exception_is_flaky():
-    first_call = True
 
-    @given(integers())
-    def rude(x):
-        nonlocal first_call
-        if first_call:
-            first_call = False
-            try:
-                raise Nope
-            except* Nope:
-                raise
+    # Defer parsing until runtime, as "except*" is syntax error pre 3.11
+    rude_def = """
+first_call = True
+def rude_fn(x):
+    global first_call
+    if first_call:
+        first_call = False
+        try:
+            raise Nope
+        except* Nope:
+            raise
+    """
+    exec(rude_def, globals())
+    rude = given(integers())(rude_fn)  # noqa: F821 # defined by exec()
 
     with pytest.raises(FlakyFailure, match="Falsified on the first call but") as e:
         rude()
     exceptions = e.value.exceptions
-    assert set(map(type, exceptions)) == set([ExceptionGroup])
-    assert set(map(type, exceptions[0].exceptions)) == set([Nope])
-
+    assert list(map(type, exceptions)) == [ExceptionGroup]
+    assert list(map(type, exceptions[0].exceptions)) == [Nope]
 
 
 def test_gives_flaky_error_if_assumption_is_flaky():


### PR DESCRIPTION
Closes #4183 
Closes #4228 

Two corner cases in reporting of flaky errors.

One of them is a straightforward missing handling of flakiness at `mark_interesting` time.

The other deals with a surprising aspect of how a naked exception is wrapped in an `ExceptionGroup` when caught and reraised by `except*` — the group's traceback points not to where the naked exception is raised, nor to the location of the `except*` block, but instead to the _caller_ one frame above the `except*`:
```
def wrapped():
    try:
        raise Exception  # innermost frame of EceptionGroup.exceptions[0]
    except* Exception:
        raise

def naked():
    raise Exception  # innermost frame of Exception

if __name__ == "__main__":
    import traceback
    try:
        naked()
    except Exception as e:
        print("naked:", traceback.format_tb(e.__traceback__)[-1])
    try:
        wrapped()  # innermost frame of ExceptionGroup
    except Exception as e:
        print("wrapper:", traceback.format_tb(e.__traceback__)[-1])
        print("wrapped:", traceback.format_tb(e.exceptions[0].__traceback__)[-1])
```

I'm not sure if this is consistent between python implementations, so the final commit adds a check. Will revert once CI results are in.