### PR TITLE
Use typed choice sequence in database

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,3 +21,5 @@ python:
       - path: hypothesis-python/
         extra_requirements:
            - all
+sphinx:
+   configuration: hypothesis-python/docs/conf.py

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
-The :doc:`Hypothesis example database <database>` now uses a new internal format to store examples. The new format is not compatible with the previous format, so any old stored counterexamples will be silently discarded.
+The :doc:`Hypothesis example database <database>` now uses a new internal format to store examples. This new format is not compatible with the previous format, so stored entries will not carry over.
 
-If you are replaying counterexamples using an external database such as :class:`~hypothesis.database.GitHubArtifactDatabase`, this means the counterexample must have been found after this version in the external database to successfully replay locally. In short, the Hypothesis versions of the local and remote databases should be both before or both after this version.
+The database is best thought of as a cache that may be invalidated at times. Instead of relying on it for correctness, we recommend using :obj:`@example <hypothesis.example>` to specify explicit examples. When using databases across environments (such as connecting a :class:`~hypothesis.database.GitHubArtifactDatabase` database in CI to your local environment), we recommend using the same version of Hypothesis for each where possible, for maximum reproducibility.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+The :doc:`Hypothesis example database <database>` now uses a new internal format to store examples. The new format is not compatible with the previous format, so any old stored counterexamples will be silently discarded.
+
+If you are replaying counterexamples using an external database such as :class:`~hypothesis.database.GitHubArtifactDatabase`, this means the counterexample must have been found after this version in the external database to successfully replay locally. In short, the Hypothesis versions of the local and remote databases should be both before or both after this version.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -87,7 +87,7 @@ from hypothesis.internal.conjecture.junkdrawer import (
     ensure_free_stackframes,
     gc_cumulative_time,
 )
-from hypothesis.internal.conjecture.shrinker import sort_key, sort_key_ir
+from hypothesis.internal.conjecture.shrinker import sort_key_ir
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import (
     InterestingOrigin,
@@ -352,9 +352,8 @@ def decode_failure(blob: bytes) -> Sequence[ChoiceT]:
             f"Could not decode blob {blob!r}: Invalid start byte {prefix!r}"
         )
 
-    try:
-        choices = ir_from_bytes(decoded)
-    except Exception:
+    choices = ir_from_bytes(decoded)
+    if choices is None:
         raise InvalidArgument(f"Invalid serialized choice sequence for blob {blob!r}")
 
     return choices
@@ -1873,13 +1872,13 @@ def given(
                 except (StopTest, UnsatisfiedAssumption):
                     return None
                 except BaseException:
-                    buffer = bytes(data.buffer)
                     known = minimal_failures.get(data.interesting_origin)
                     if settings.database is not None and (
-                        known is None or sort_key(buffer) <= sort_key(known)
+                        known is None
+                        or sort_key_ir(data.ir_nodes) <= sort_key_ir(known)
                     ):
-                        settings.database.save(database_key, buffer)
-                        minimal_failures[data.interesting_origin] = buffer
+                        settings.database.save(database_key, ir_to_bytes(data.choices))
+                        minimal_failures[data.interesting_origin] = data.ir_nodes
                     raise
                 return bytes(data.buffer)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
@@ -465,7 +465,8 @@ def choices_key(choices: Sequence[ChoiceT]) -> tuple[ChoiceKeyT, ...]:
 
 def choice_key(choice: ChoiceT) -> ChoiceKeyT:
     if isinstance(choice, float):
-        # distinguish -0.0/0.0, signaling/nonsignaling nans, etc.
+        # float_to_int to distinguish -0.0/0.0, signaling/nonsignaling nans, etc,
+        # and then add a "float" key to avoid colliding with actual integers.
         return ("float", float_to_int(choice))
     if isinstance(choice, bool):
         # avoid choice_key(0) == choice_key(False)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -345,7 +345,7 @@ class ConjectureRunner:
                     # correct engine.
                     raise
 
-    def _cache_key(self, choices: Sequence[ChoiceT]) -> tuple[ChoiceT, ...]:
+    def _cache_key(self, choices: Sequence[ChoiceT]) -> tuple[ChoiceKeyT, ...]:
         return choices_key(choices)
 
     def _cache(self, data: ConjectureData) -> None:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -44,7 +44,7 @@ from hypothesis.errors import (
 )
 from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.internal.compat import NotRequired, TypeAlias, TypedDict, ceil, override
-from hypothesis.internal.conjecture.choice import ChoiceKwargsT, ChoiceT
+from hypothesis.internal.conjecture.choice import ChoiceKwargsT, ChoiceT, choices_key
 from hypothesis.internal.conjecture.data import (
     AVAILABLE_PROVIDERS,
     ConjectureData,
@@ -58,7 +58,6 @@ from hypothesis.internal.conjecture.data import (
     Status,
     _Overrun,
     ir_size,
-    ir_value_key,
 )
 from hypothesis.internal.conjecture.datatree import (
     DataTree,
@@ -346,8 +345,8 @@ class ConjectureRunner:
                     # correct engine.
                     raise
 
-    def _cache_key(self, choices: Sequence[ChoiceT]) -> tuple[int, ...]:
-        return tuple(ir_value_key(choice) for choice in choices)
+    def _cache_key(self, choices: Sequence[ChoiceT]) -> tuple[ChoiceT, ...]:
+        return choices_key(choices)
 
     def _cache(self, data: ConjectureData) -> None:
         result = data.as_result()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -81,7 +81,7 @@ def sort_key(buffer: SortKeyT) -> tuple[int, SortKeyT]:
        result, so it makes sense to prioritise reducing earlier values over
        later ones. This makes the lexicographic order the more natural choice.
     """
-    return (len(buffer), buffer)
+    return (len(buffer), buffer)  # pragma: no cover # removing soon
 
 
 def sort_key_ir(nodes: Sequence[IRNode]) -> tuple[int, tuple[int, ...]]:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -16,7 +16,9 @@ from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 import attr
 
 from hypothesis.internal.conjecture.choice import (
+    choice_equal,
     choice_from_index,
+    choice_key,
     choice_permitted,
     choice_to_index,
 )
@@ -27,8 +29,6 @@ from hypothesis.internal.conjecture.data import (
     Status,
     draw_choice,
     ir_size,
-    ir_value_equal,
-    ir_value_key,
 )
 from hypothesis.internal.conjecture.junkdrawer import (
     endswith,
@@ -1082,7 +1082,7 @@ class Shrinker:
             assert len(prev_nodes) == len(new_nodes)
             for i, (n1, n2) in enumerate(zip(prev_nodes, new_nodes)):
                 assert n1.ir_type == n2.ir_type
-                if not ir_value_equal(n1.value, n2.value):
+                if not choice_equal(n1.value, n2.value):
                     self.__all_changed_nodes.add(i)
 
         return self.__all_changed_nodes
@@ -1295,7 +1295,7 @@ class Shrinker:
         """Returns a list of nodes grouped (ir_type, value)."""
         duplicates = defaultdict(list)
         for node in self.nodes:
-            duplicates[(node.ir_type, ir_value_key(node.value))].append(node)
+            duplicates[(node.ir_type, choice_key(node.value))].append(node)
         return list(duplicates.values())
 
     @defines_shrink_pass()
@@ -1437,7 +1437,7 @@ class Shrinker:
         # same operation on both basically just works.
         kwargs = nodes[0].kwargs
         assert all(
-            node.ir_type == ir_type and ir_value_equal(node.value, value)
+            node.ir_type == ir_type and choice_equal(node.value, value)
             for node in nodes
         )
 

--- a/hypothesis-python/tests/conjecture/test_forced.py
+++ b/hypothesis-python/tests/conjecture/test_forced.py
@@ -15,7 +15,8 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, assume, example, given, settings
 from hypothesis.internal.conjecture import utils as cu
-from hypothesis.internal.conjecture.data import ConjectureData, ir_value_equal
+from hypothesis.internal.conjecture.choice import choice_equal
+from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.floats import SIGNALING_NAN, SMALLEST_SUBNORMAL
 
 from tests.conjecture.common import fresh_data, ir_types_and_kwargs
@@ -142,13 +143,13 @@ def test_forced_values(ir_type_and_kwargs):
 
     forced = kwargs["forced"]
     data = fresh_data()
-    assert ir_value_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
+    assert choice_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
 
     # now make sure the written buffer reproduces the forced value, even without
     # specifying forced=.
     del kwargs["forced"]
     data = ConjectureData.for_choices(data.choices)
-    assert ir_value_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
+    assert choice_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
 
 
 @pytest.mark.parametrize("sign", [1, -1])

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -29,6 +29,7 @@ from hypothesis.internal.conjecture.choice import (
     choice_from_index,
     choice_permitted,
     choice_to_index,
+    choices_key,
 )
 from hypothesis.internal.conjecture.data import (
     COLLECTION_DEFAULT_MAX_SIZE,
@@ -884,3 +885,26 @@ def test_draw_directly_explicit():
         )
         == 10
     )
+
+
+@pytest.mark.parametrize(
+    "choices1, choices2",
+    [
+        [(True,), (1,)],
+        [(False,), (0,)],
+        [(0.0,), (-0.0,)],
+    ],
+)
+def test_choices_key_distinguishes_weird_cases(choices1, choices2):
+    assert choices_key(choices1) != choices_key(choices2)
+
+
+@given(st.lists(ir_nodes()), st.lists(ir_nodes()))
+def test_choices_key_respects_inequality(nodes1, nodes2):
+    choices1 = [n.value for n in nodes1]
+    choices2 = [n.value for n in nodes2]
+    if choices_key(choices1) != choices_key(choices2):
+        assert set(choices1) != set(choices2)
+
+    # note that the other direction is not necessarily true: {False} == {0},
+    # but choices_key([False]) != choices_key([0]).

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -897,14 +897,3 @@ def test_draw_directly_explicit():
 )
 def test_choices_key_distinguishes_weird_cases(choices1, choices2):
     assert choices_key(choices1) != choices_key(choices2)
-
-
-@given(st.lists(ir_nodes()), st.lists(ir_nodes()))
-def test_choices_key_respects_inequality(nodes1, nodes2):
-    choices1 = [n.value for n in nodes1]
-    choices2 = [n.value for n in nodes2]
-    if choices_key(choices1) != choices_key(choices2):
-        assert set(choices1) != set(choices2)
-
-    # note that the other direction is not necessarily true: {False} == {0},
-    # but choices_key([False]) != choices_key([0]).

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -891,7 +891,10 @@ def test_draw_directly_explicit():
     "choices1, choices2",
     [
         [(True,), (1,)],
+        [(True,), (1.0,)],
         [(False,), (0,)],
+        [(False,), (0.0,)],
+        [(False,), (-0.0,)],
         [(0.0,), (-0.0,)],
     ],
 )

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -478,7 +478,7 @@ def test_background_write_database():
 @example(ir("a"))
 @example(ir(b"a"))
 @example(ir(b"a" * 50))
-def test_ir_nodes_rountrips(nodes1):
+def test_ir_nodes_roundtrips(nodes1):
     s1 = ir_to_bytes([n.value for n in nodes1])
     assert isinstance(s1, bytes)
     ir2 = ir_from_bytes(s1)

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -35,7 +35,7 @@ from hypothesis.database import (
 )
 from hypothesis.errors import HypothesisWarning
 from hypothesis.internal.compat import WINDOWS
-from hypothesis.internal.conjecture.data import ir_value_equal
+from hypothesis.internal.conjecture.choice import choice_equal
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
 from hypothesis.strategies import binary, lists, tuples
 from hypothesis.utils.conventions import not_set
@@ -485,7 +485,7 @@ def test_ir_nodes_rountrips(nodes1):
     assert len(nodes1) == len(ir2)
 
     for n1, v2 in zip(nodes1, ir2):
-        assert ir_value_equal(n1.value, v2)
+        assert choice_equal(n1.value, v2)
 
     s2 = ir_to_bytes(ir2)
     assert s1 == s2

--- a/hypothesis-python/tests/cover/test_float_utils.py
+++ b/hypothesis-python/tests/cover/test_float_utils.py
@@ -14,7 +14,7 @@ from sys import float_info
 import pytest
 
 from hypothesis import example, given, strategies as st
-from hypothesis.internal.conjecture.data import ir_value_equal
+from hypothesis.internal.conjecture.choice import choice_equal
 from hypothesis.internal.floats import (
     count_between_floats,
     float_permitted,
@@ -103,4 +103,4 @@ def test_float_clamper(kwargs, input_value):
         allow_nan=allow_nan,
         smallest_nonzero_magnitude=smallest_nonzero_magnitude,
     ):
-        assert ir_value_equal(input_value, clamped)
+        assert choice_equal(input_value, clamped)

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -26,7 +26,7 @@ from hypothesis import (
 )
 from hypothesis.core import decode_failure, encode_failure
 from hypothesis.errors import DidNotReproduce, InvalidArgument, UnsatisfiedAssumption
-from hypothesis.internal.conjecture.data import ir_value_equal
+from hypothesis.internal.conjecture.choice import choice_equal
 
 from tests.common.utils import capture_out, no_shrink
 from tests.conjecture.common import ir, ir_nodes
@@ -39,7 +39,7 @@ def test_encoding_loop(nodes):
     looped = decode_failure(encode_failure(choices))
     assert len(choices) == len(looped)
     for pre, post in zip(choices, looped):
-        assert ir_value_equal(pre, post)
+        assert choice_equal(pre, post)
 
 
 @example(base64.b64encode(b"\2\3\4"))

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from hypothesis import given, settings, strategies as st
-from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.database import InMemoryExampleDatabase, ir_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import Shrinker, node_program
@@ -53,7 +53,8 @@ def test_saves_data_while_shrinking(monkeypatch):
     runner.run()
     assert runner.interesting_examples
     assert len(seen) == n
-    in_db = non_covering_examples(db)
+
+    in_db = {ir_from_bytes(b)[0] for b in non_covering_examples(db)}
     assert in_db.issubset(seen)
     assert in_db == seen
 


### PR DESCRIPTION
The database now stores entries as `(sort_key_ir(data.ir_nodes), data.choices)`, letting us sort entries by shrink ordering. If `ir_from_bytes` deserialization fails, return None. Caller is responsible for handling this case (usually by clearing the bad entry from the db). 

I think it's worth storing the choice complexity in the db, for better sorting. The case of interest is when serialization is large but the complexity is low. This happens mainly via `min_size=` or `shrink_towards`. I'm not certain how big of a problem this is - probably most issues require storing some (small + high complexity) or (large + low complexity) value, then changing the test case to add or remove a min_size, changing the relative complexity baseline. I think the worst this would manifest as is us repeatedly trying clearly-suboptimal examples from the database, or rejecting possible-shrinks from the secondary corpus as "too complex" when they aren't. We'd still like to avoid these though.

Also bundles c0f89798528ea3e0194e899b82b61408b45d5284, which is an independent cleanup commit.