### PR TITLE
Fully move to the typed choice sequence cache

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improves our internal caching logic for test cases.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -489,7 +489,7 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs, original_s
 
         with local_settings(state.settings):
             fragments_reported = []
-            empty_data = ConjectureData.for_buffer(b"")
+            empty_data = ConjectureData.for_choices([])
             try:
                 execute_example = partial(
                     state.execute_once,
@@ -1334,9 +1334,7 @@ class StateForActualGivenExecution:
             info = falsifying_example.extra_information
             fragments = []
 
-            ran_example = runner.new_conjecture_data_for_buffer(
-                falsifying_example.buffer
-            )
+            ran_example = runner.new_conjecture_data_ir(falsifying_example.choices)
             ran_example.slice_comments = falsifying_example.slice_comments
             tb = None
             origin = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1737,19 +1737,12 @@ class ConjectureData:
             debug_report(f"overrun because hit {self.max_length_ir=}")
             self.mark_overrun()
 
-        if self.ir_prefix is not None and observe:
-            if self.index_ir < len(self.ir_prefix):
-                choice = self._pop_choice(ir_type, kwargs, forced=forced)
-            else:
-                try:
-                    choice = (
-                        forced
-                        if forced is not None
-                        else draw_choice(ir_type, kwargs, random=self.__random)
-                    )
-                except StopTest:
-                    debug_report("overrun because draw_choice overran")
-                    self.mark_overrun()
+        if (
+            observe
+            and self.ir_prefix is not None
+            and self.index_ir < len(self.ir_prefix)
+        ):
+            choice = self._pop_choice(ir_type, kwargs, forced=forced)
 
             if forced is None:
                 forced = choice
@@ -2261,7 +2254,7 @@ class ConjectureData:
         elif self._bytes_drawn < len(self.__prefix):
             index = self._bytes_drawn
             buf = self.__prefix[index : index + n_bytes]
-            if len(buf) < n_bytes:
+            if len(buf) < n_bytes:  # pragma: no cover # removing soon
                 assert self.__random is not None
                 buf += uniform(self.__random, n_bytes - len(buf))
         else:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1757,7 +1757,7 @@ class ConjectureData:
             getattr(self.observer, f"draw_{ir_type}")(
                 value, kwargs=kwargs, was_forced=was_forced
             )
-            size = ir_size([value])
+            size = 0 if self.provider.avoid_realization else ir_size([value])
             if self.length_ir + size > self.max_length_ir:
                 debug_report(
                     f"overrun because {self.length_ir=} + {size=} > {self.max_length_ir=}"
@@ -1964,14 +1964,18 @@ class ConjectureData:
             # node if the alternative is not "the entire data is an overrun".
             assert self.index_ir == len(self.ir_prefix) - 1
             if node.type == "simplest":
-                try:
-                    choice: ChoiceT = choice_from_index(0, ir_type, kwargs)
-                except ChoiceTooLarge:
-                    self.mark_overrun()
+                if isinstance(self.provider, HypothesisProvider):
+                    try:
+                        choice: ChoiceT = choice_from_index(0, ir_type, kwargs)
+                    except ChoiceTooLarge:
+                        self.mark_overrun()
+                else:
+                    # give alternative backends control over these draws
+                    choice = getattr(self.provider, f"draw_{ir_type}")(**kwargs)
             else:
                 raise NotImplementedError
 
-            node.size -= ir_size([choice])
+            node.size -= 0 if self.provider.avoid_realization else ir_size([choice])
             if node.size < 0:
                 self.mark_overrun()
             return choice

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 from sortedcontainers import SortedList
 
+from hypothesis.internal.conjecture.choice import choices_key
 from hypothesis.internal.conjecture.data import ConjectureData, ConjectureResult, Status
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
 from hypothesis.internal.conjecture.shrinker import sort_key_ir
@@ -300,7 +301,7 @@ class ParetoOptimiser:
             assert self.front
             i = min(i, len(self.front) - 1)
             target = self.front[i]
-            if target.buffer in seen:
+            if choices_key(target.choices) in seen:
                 i -= 1
                 continue
             assert target is not prev
@@ -328,7 +329,7 @@ class ParetoOptimiser:
                 return False
 
             shrunk = self.__engine.shrink(target, allow_transition=allow_transition)
-            seen.add(shrunk.buffer)
+            seen.add(choices_key(shrunk.choices))
 
             # Note that the front may have changed shape arbitrarily when
             # we ran the shrinker. If it didn't change shape then this is

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -1370,7 +1370,8 @@ class Shrinker:
         node2 = self.nodes[
             chooser.choose(
                 range(node1.index + 1, min(len(self.nodes), node1.index + 3 + 1)),
-                lambda i: self.nodes[i].ir_type == "integer",
+                lambda i: self.nodes[i].ir_type == "integer"
+                and not self.nodes[i].was_forced,
             )
         ]
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -216,7 +216,7 @@ def test_can_navigate_to_a_valid_example():
         data.mark_interesting()
 
     runner = ConjectureRunner(f, settings=settings(max_examples=5000, database=None))
-    with buffer_size_limit(2):
+    with buffer_size_limit(4):
         runner.run()
     assert runner.interesting_examples
 
@@ -1503,19 +1503,6 @@ def test_does_not_cache_extended_prefix_if_overrun():
         d2 = runner.cached_test_function_ir((b"",), extend=8)
         assert d1.status is Status.OVERRUN
         assert d2.status is Status.VALID
-
-
-def test_draw_bits_partly_from_prefix_and_partly_random():
-    # a draw_bits call which straddles the end of our prefix has a slightly
-    # different code branch.
-    def test(data):
-        # float consumes draw_bits(64)
-        data.draw_float()
-
-    with deterministic_PRNG():
-        runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        d = runner.cached_test_function(bytes(10), extend=100)
-        assert d.status == Status.VALID
 
 
 def test_can_be_set_to_ignore_limits():

--- a/hypothesis-python/tests/cover/test_fuzz_one_input.py
+++ b/hypothesis-python/tests/cover/test_fuzz_one_input.py
@@ -18,7 +18,7 @@ import pytest
 from hypothesis import Phase, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.conjecture.shrinker import sort_key
+from hypothesis.internal.conjecture.engine import shortlex
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ def test_fuzz_one_input(buffer_type):
     # recent seed that we tried or the pruned-and-canonicalised form of it.
     (saved_examples,) = db.data.values()
     assert len(saved_examples) == 1
-    assert sort_key(seeds[-1]) >= sort_key(next(iter(saved_examples)))
+    assert shortlex(seeds[-1]) >= shortlex(next(iter(saved_examples)))
 
     # Now that we have a failure in `db`, re-running our test is sufficient to
     # reproduce it, *and shrink to a minimal example*.


### PR DESCRIPTION
Also moves a few more usages off the buffer.

This causes crosshair test failures, where crosshair cannot find a `!= 123456` failure. Crosshair appears to be claiming the test case is verified, due to this line:

```
        zero_data = self.cached_test_function_ir(
            (NodeTemplate("simplest", size=BUFFER_SIZE),)
        )
```

because the `NodeTemplate` forcefully inserts a simplest-valued choice, bypassing the usual `draw_*` request logic. I believe Crosshair therefore thinks the test case requests zero choices and has an empty decision tree, which is trivially verified.

* We could add a `draw_node_template` hook or similar which backends can override, but I'm a bit nervous about committing this implementation detail to the interface when I'm not confident `NodeTemplate` will stick around in its current form forever. 
* Another option is adding `index_hint: Optional[int] = None` to every `draw_*` method, which backends could ignore but HypothesisProvider would return `choice_from_index(0)` for (and `assert index_hint is None or index_hint == 0`, for now).

@Zac-HD any thoughts? Also cc @pschanely, though I don't think this is a problem on Crosshair's side.

Shrinking benchmark is neutral (a bit disappointing, I was hoping the cache would be a shrinking win):

![shrinking](https://github.com/user-attachments/assets/57c180ce-3af8-42bc-91a2-fb3f106ba515)
