### PR TITLE
Define `extend: int = 0` and `NodeTemplate` in terms of choice count

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Some Hypothesis internals now use the number of choices as a yardstick of input size, rather than the entropy consumed by those choices. We don't expect this to cause significant behavioral changes.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1334,7 +1334,9 @@ class StateForActualGivenExecution:
             info = falsifying_example.extra_information
             fragments = []
 
-            ran_example = runner.new_conjecture_data_ir(falsifying_example.choices)
+            ran_example = runner.new_conjecture_data_ir(
+                falsifying_example.choices, max_length=len(falsifying_example.choices)
+            )
             ran_example.slice_comments = falsifying_example.slice_comments
             tb = None
             origin = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -18,16 +18,7 @@ from contextlib import contextmanager, suppress
 from datetime import timedelta
 from enum import Enum
 from random import Random, getrandbits
-from typing import (
-    Callable,
-    Final,
-    List,
-    Literal,
-    NoReturn,
-    Optional,
-    Union,
-    cast,
-)
+from typing import Callable, Final, List, Literal, NoReturn, Optional, Union, cast
 
 import attr
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -18,7 +18,16 @@ from contextlib import contextmanager, suppress
 from datetime import timedelta
 from enum import Enum
 from random import Random, getrandbits
-from typing import Callable, Final, List, Literal, NoReturn, Optional, Union, cast
+from typing import (
+    Callable,
+    Final,
+    List,
+    Literal,
+    NoReturn,
+    Optional,
+    Union,
+    cast,
+)
 
 import attr
 
@@ -52,7 +61,6 @@ from hypothesis.internal.conjecture.data import (
     PrimitiveProvider,
     Status,
     _Overrun,
-    ir_size,
 )
 from hypothesis.internal.conjecture.datatree import (
     DataTree,
@@ -195,17 +203,16 @@ StatisticsDict = TypedDict(
 )
 
 
-def truncate_choices_to_size(
-    choices: Sequence[ChoiceT], size: int
-) -> tuple[ChoiceT, ...]:
-    s = 0
-    i = 0
+def choice_count(choices: Sequence[Union[ChoiceT, NodeTemplate]]) -> Optional[int]:
+    count = 0
     for choice in choices:
-        s += ir_size([choice])
-        if s > size:
-            break
-        i += 1
-    return tuple(choices[:i])
+        if isinstance(choice, NodeTemplate):
+            if choice.count is None:
+                return None
+            count += choice.count
+        else:
+            count += 1
+    return count
 
 
 class ConjectureRunner:
@@ -356,7 +363,7 @@ class ConjectureRunner:
         choices: Sequence[Union[ChoiceT, NodeTemplate]],
         *,
         error_on_discard: bool = False,
-        extend: int = 0,
+        extend: Union[int, Literal["full"]] = 0,
     ) -> Union[ConjectureResult, _Overrun]:
         """
         If ``error_on_discard`` is set to True this will raise ``ContainsDiscard``
@@ -382,7 +389,12 @@ class ConjectureRunner:
             except KeyError:
                 pass
 
-        max_length = min(BUFFER_SIZE_IR, ir_size(choices) + extend)
+        if extend == "full":
+            max_length = None
+        elif (count := choice_count(choices)) is None:
+            max_length = None
+        else:
+            max_length = count + extend
 
         # explicitly use a no-op DataObserver here instead of a TreeRecordingObserver.
         # The reason is we don't expect simulate_test_function to explore new choices
@@ -856,7 +868,7 @@ class ConjectureRunner:
                     # clear out any keys which fail deserialization
                     self.settings.database.delete(self.database_key, existing)
                     continue
-                data = self.cached_test_function_ir(choices, extend=BUFFER_SIZE)
+                data = self.cached_test_function_ir(choices, extend="full")
                 if data.status != Status.INTERESTING:
                     self.settings.database.delete(self.database_key, existing)
                     self.settings.database.delete(self.secondary_key, existing)
@@ -891,7 +903,7 @@ class ConjectureRunner:
                     if choices is None:
                         self.settings.database.delete(self.pareto_key, existing)
                         continue
-                    data = self.cached_test_function_ir(choices, extend=BUFFER_SIZE)
+                    data = self.cached_test_function_ir(choices, extend="full")
                     if data not in self.pareto_front:
                         self.settings.database.delete(self.pareto_key, existing)
                     if data.status == Status.INTERESTING:
@@ -954,7 +966,7 @@ class ConjectureRunner:
 
         assert self.should_generate_more()
         zero_data = self.cached_test_function_ir(
-            (NodeTemplate("simplest", size=BUFFER_SIZE),)
+            (NodeTemplate("simplest", count=None),)
         )
         if zero_data.status > Status.OVERRUN:
             assert isinstance(zero_data, ConjectureResult)
@@ -1034,27 +1046,21 @@ class ConjectureRunner:
             # not whatever is specified by the backend. We can improve this
             # once more things are on the ir.
             if not self.using_hypothesis_backend:
-                data = self.new_conjecture_data_ir([], max_length=BUFFER_SIZE)
+                data = self.new_conjecture_data_ir([])
                 with suppress(BackendCannotProceed):
                     self.test_function(data)
                 continue
 
             self._current_phase = "generate"
             prefix = self.generate_novel_prefix()
-            # it is possible, if unlikely, to generate a > BUFFER_SIZE novel prefix,
-            # as nodes in the novel tree may be variable sized due to eg integer
-            # probe retries.
-            prefix = truncate_choices_to_size(prefix, BUFFER_SIZE_IR)
             if (
                 self.valid_examples <= small_example_cap
                 and self.call_count <= 5 * small_example_cap
                 and not self.interesting_examples
                 and consecutive_zero_extend_is_invalid < 5
             ):
-                prefix_size = ir_size(prefix)
                 minimal_example = self.cached_test_function_ir(
-                    prefix
-                    + (NodeTemplate("simplest", size=BUFFER_SIZE_IR - prefix_size),)
+                    prefix + (NodeTemplate("simplest", count=None),)
                 )
 
                 if minimal_example.status < Status.VALID:
@@ -1065,8 +1071,8 @@ class ConjectureRunner:
                 # ConjectureResult object.
                 assert isinstance(minimal_example, ConjectureResult)
                 consecutive_zero_extend_is_invalid = 0
-                minimal_extension = ir_size(minimal_example.ir_nodes) - prefix_size
-                max_length = min(prefix_size + minimal_extension * 10, BUFFER_SIZE_IR)
+                minimal_extension = len(minimal_example.choices) - len(prefix)
+                max_length = len(prefix) + minimal_extension * 5
 
                 # We could end up in a situation where even though the prefix was
                 # novel when we generated it, because we've now tried zero extending
@@ -1096,14 +1102,14 @@ class ConjectureRunner:
 
                 prefix = trial_data.choices
             else:
-                max_length = BUFFER_SIZE_IR
+                max_length = None
 
             data = self.new_conjecture_data_ir(prefix, max_length=max_length)
             self.test_function(data)
 
             if (
                 data.status is Status.OVERRUN
-                and max_length < BUFFER_SIZE_IR
+                and max_length is not None
                 and "invalid because" not in data.events
             ):
                 data.events["invalid because"] = (
@@ -1298,7 +1304,7 @@ class ConjectureRunner:
 
     def new_conjecture_data_ir(
         self,
-        choices: Sequence[Union[ChoiceT, NodeTemplate]],
+        prefix: Sequence[Union[ChoiceT, NodeTemplate]],
         *,
         observer: Optional[DataObserver] = None,
         max_length: Optional[int] = None,
@@ -1310,11 +1316,13 @@ class ConjectureRunner:
         if not self.using_hypothesis_backend:
             observer = DataObserver()
 
-        return ConjectureData.for_choices(
-            choices,
+        return ConjectureData(
+            BUFFER_SIZE,
+            prefix=b"",
+            ir_prefix=prefix,
             observer=observer,
             provider=provider,
-            max_length=max_length,
+            max_length_ir=max_length,
             random=self.random,
         )
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -17,9 +17,8 @@ from hypothesis.internal.conjecture.data import (
     Status,
     _Overrun,
     bits_to_bytes,
-    ir_size,
 )
-from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR, ConjectureRunner
+from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.junkdrawer import find_integer
 from hypothesis.internal.conjecture.pareto import NO_SCORE
 
@@ -174,8 +173,7 @@ class Optimiser:
                         + choices[node.index + 1 :]
                     )
                     attempt = self.engine.cached_test_function_ir(
-                        attempt_choices,
-                        extend=BUFFER_SIZE_IR - ir_size(attempt_choices),
+                        attempt_choices, extend="full"
                     )
 
                     if self.consider_new_data(attempt):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -28,7 +28,6 @@ from hypothesis.internal.conjecture.data import (
     IRNode,
     Status,
     draw_choice,
-    ir_size,
 )
 from hypothesis.internal.conjecture.junkdrawer import (
     endswith,
@@ -486,7 +485,6 @@ class Shrinker:
         self.explain()
 
     def explain(self):
-        from hypothesis.internal.conjecture.engine import BUFFER_SIZE_IR
 
         if not self.should_explain or not self.shrink_target.arg_slices:
             return
@@ -541,9 +539,7 @@ class Shrinker:
                     replacement.append(node.value)
 
                 attempt = choices[:start] + tuple(replacement) + choices[end:]
-                result = self.engine.cached_test_function_ir(
-                    attempt, extend=BUFFER_SIZE_IR - ir_size(attempt)
-                )
+                result = self.engine.cached_test_function_ir(attempt, extend="full")
 
                 # Turns out this was a variable-length part, so grab the infix...
                 if result.status is Status.OVERRUN:
@@ -744,7 +740,7 @@ class Shrinker:
         examples = self.examples_starting_at[i]
         for _ in range(3):
             random_attempt = self.engine.cached_test_function_ir(
-                [n.value for n in prefix], extend=len(nodes) * 2
+                [n.value for n in prefix], extend=len(nodes)
             )
             if random_attempt.status < Status.VALID:
                 continue

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -50,8 +50,7 @@ from hypothesis.internal.reflection import (
 from hypothesis.strategies._internal.utils import defines_strategy
 from hypothesis.utils.conventions import UniqueIdentifier
 
-# TODO: Use `(3, 13)` once Python 3.13 is released.
-if sys.version_info >= (3, 13, 0, "final"):
+if sys.version_info >= (3, 13):
     Ex = TypeVar("Ex", covariant=True, default=Any)
 elif TYPE_CHECKING:
     from typing_extensions import TypeVar  # type: ignore[assignment]

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -55,7 +55,7 @@ if sys.version_info >= (3, 13):
 elif TYPE_CHECKING:
     from typing_extensions import TypeVar  # type: ignore[assignment]
 
-    Ex = TypeVar("Ex", covariant=True, default=Any)  # type: ignore[call-arg,misc]
+    Ex = TypeVar("Ex", covariant=True, default=Any)
 else:
     Ex = TypeVar("Ex", covariant=True)
 

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -128,18 +128,10 @@ def test_novel_prefixes_are_novel():
     runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
     for _ in range(100):
         prefix = runner.tree.generate_novel_prefix(runner.random)
-        extension = prefix + (NodeTemplate("simplest", size=100),)
+        extension = prefix + (NodeTemplate("simplest", count=100),)
         assert runner.tree.rewrite(extension)[1] is None
         result = runner.cached_test_function_ir(extension)
         assert runner.tree.rewrite(extension)[0] == result.choices
-
-
-def test_overruns_if_not_enough_bytes_for_block():
-    runner = ConjectureRunner(
-        lambda data: data.draw_bytes(2, 2), settings=TEST_SETTINGS, random=Random(0)
-    )
-    runner.cached_test_function_ir((b"\0\0",))
-    assert runner.tree.rewrite((b"\0",))[1] is Status.OVERRUN
 
 
 def test_overruns_if_prefix():

--- a/hypothesis-python/tests/cover/test_deadline.py
+++ b/hypothesis-python/tests/cover/test_deadline.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import gc
+import re
 import time
 
 import pytest
@@ -119,7 +120,11 @@ def test_gives_a_deadline_specific_flaky_error_message():
     with pytest.raises(FlakyFailure) as err:
         slow_once()
     assert "Unreliable test timing" in "\n".join(err.value.__notes__)
-    assert "took 2" in "\n".join(err.value.__notes__)
+    # this used to be "took 2", but we saw that flake (on pypy, though unsure if
+    # that means anything) with "took 199.59ms". It's possible our gc accounting
+    # is incorrect, or we could just be running into rare non-guarantees of
+    # time.sleep.
+    assert re.search(r"took \d", "\n".join(err.value.__notes__))
 
 
 @pytest.mark.parametrize("slow_strategy", [False, True])

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -32,14 +32,15 @@ from tests.common.utils import capture_observations
 
 
 @seed("deterministic so we don't miss some combination of features")
-@example(a=0, x=4, data=None)
+@example(l=[1], a=0, x=4, data=None)
 # explicitly set max_examples=100 to override our lower example limit for coverage tests.
 @settings(database=InMemoryExampleDatabase(), deadline=None, max_examples=100)
-@given(st.integers(), st.integers(), st.data())
-def do_it_all(a, x, data):
+@given(st.lists(st.integers()), st.integers(), st.integers(), st.data())
+def do_it_all(l, a, x, data):
     event(f"{x%2=}")
     target(x % 5, label="x%5")
     assume(a % 9)
+    assume(len(l) > 0)
     if data:
         data.draw(st.text("abcdef", min_size=a % 3), label="interactive")
     1 / ((x or 1) % 7)

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -103,9 +103,9 @@ def test_errors_with_did_not_reproduce_if_the_shape_changes():
     n = len(b)
 
     @reproduce_failure(__version__, encode_failure([b]))
-    @given(st.binary(min_size=n + 1, max_size=n + 1))
-    def test(x):
-        assert x == b
+    @given(st.binary(min_size=n, max_size=n) | st.integers())
+    def test(v):
+        assert v == b
 
     with pytest.raises(DidNotReproduce):
         test()

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1074,7 +1074,7 @@ def test_uses_seed(capsys):
 
 
 def test_reproduce_failure_works():
-    @reproduce_failure(__version__, encode_failure([0, 1]))
+    @reproduce_failure(__version__, encode_failure([False, 0, True]))
     class TrivialMachine(RuleBasedStateMachine):
         @rule()
         def oops(self):
@@ -1085,7 +1085,7 @@ def test_reproduce_failure_works():
 
 
 def test_reproduce_failure_fails_if_no_error():
-    @reproduce_failure(__version__, encode_failure([0, 1]))
+    @reproduce_failure(__version__, encode_failure([False, 0, True]))
     class TrivialMachine(RuleBasedStateMachine):
         @rule()
         def ok(self):

--- a/hypothesis-python/tests/crosshair/test_crosshair.py
+++ b/hypothesis-python/tests/crosshair/test_crosshair.py
@@ -13,6 +13,7 @@ import pytest
 from hypothesis import Verbosity, given, settings, strategies as st
 
 
+@pytest.mark.xfail(reason="temporarily ignoring crosshair churn")
 @pytest.mark.parametrize("verbosity", list(Verbosity))
 def test_crosshair_works_for_all_verbosities(verbosity):
     # check that we aren't realizing symbolics early in debug prints and killing
@@ -26,6 +27,7 @@ def test_crosshair_works_for_all_verbosities(verbosity):
         f()
 
 
+@pytest.mark.xfail(reason="temporarily ignoring crosshair churn")
 @pytest.mark.parametrize("verbosity", list(Verbosity))
 def test_crosshair_works_for_all_verbosities_data(verbosity):
     # data draws have their own print path

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -74,7 +74,7 @@ def test_can_discard(monkeypatch):
     def nodes(data):
         seen = set()
         while len(seen) < n:
-            seen.add(data.draw_bytes(1, 1))
+            seen.add(data.draw_bytes())
         data.mark_interesting()
 
     assert len(nodes) == n

--- a/hypothesis-python/tests/nocover/test_targeting.py
+++ b/hypothesis-python/tests/nocover/test_targeting.py
@@ -71,7 +71,9 @@ def test_targeting_can_be_disabled():
         @given(strat)
         def test(ls):
             nonlocal result
-            score = float(sum(ls))
+            # cap the score to avoid long test times by unbounded driving of list
+            # length upwards
+            score = min(sum(ls), 10_000)
             result = max(result, score)
             target(score)
 


### PR DESCRIPTION
This is a bit of an RFC; I'm not sure this is the correct semantics. The argument is that the number of nodes is more often the most relevant piece of information (as e.g. the primary ordering for `sort_key`), and not the choice size, so our internal api should reflect this. In this pull, there are two ways for a `ConjectureData` to overrun: by overrunning `BUFFER_SIZE` via `ir_size` as normal, or by drawing more than `max_length` choices. If `max_length` is not passed, then the former is the only way to overrun. There is currently no way to decrease the maximum `buffer_size` for a particular data, though in principle we could add this interaction.

 A secondary argument is this lets us get rid of lots of `ir_size` calls, which makes it easier (or possible at all, really) to require that `ir_size` take a `kwargs: ChoiceKwargsT` when calculating size. `ir_size` is only used in one place after this.