### PR TITLE
Refactor some stateful internals

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactoring to make some stateful internals easier to access.


### PR DESCRIPTION
For https://github.com/Zac-HD/hypofuzz/pull/51.

Continuing discussion from there:

> Rather than attaching a magic attribute - which could be confused by mocks or whatever - let's define a subclass of TestCase in hypothesis.stateful and then [inherit from it here](https://github.com/HypothesisWorks/hypothesis/blob/eaa0852472ff4830782bfabb9043b914ef989332/hypothesis-python/src/hypothesis/stateful.py#L428-L443), so we have a principled way to identify it on the Hypofuzz side.

I like this in principle, but hypofuzz still needs a way to access the actual defining `RuleBasedStateMachine` class, not just recognizing if it is a stateful test or not. Do you think we should *also* add the custom `TestCase` subclass, in addition to the magic attribute? And use the former for checking stateful test existence, and the latter for implementing it.