### PR TITLE
Reorganize code for the typed choice sequence

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Registration of experimental :ref:`alternative-backends` is now done via ``hypothesis.internal.conjecture.providers.AVAILABLE_PROVIDERS`` instead of ``hypothesis.internal.conjecture.data.AVAILABLE_PROVIDERS``.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -39,6 +39,7 @@ from hypothesis.errors import (
     InvalidArgument,
     InvalidState,
 )
+from hypothesis.internal.conjecture.providers import AVAILABLE_PROVIDERS
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.internal.validation import check_type, try_convert
 from hypothesis.utils.conventions import not_set
@@ -296,8 +297,6 @@ class settings(metaclass=settingsMeta):
         raise AttributeError("settings objects are immutable")
 
     def __repr__(self) -> str:
-        from hypothesis.internal.conjecture.data import AVAILABLE_PROVIDERS
-
         bits = sorted(
             f"{name}={getattr(self, name)!r}"
             for name in all_settings
@@ -731,8 +730,6 @@ If set to ``True``, Hypothesis will print code for failing examples that can be 
 
 
 def _backend_validator(value: str) -> str:
-    from hypothesis.internal.conjecture.data import AVAILABLE_PROVIDERS
-
     if value not in AVAILABLE_PROVIDERS:
         if value == "crosshair":  # pragma: no cover
             install = '`pip install "hypothesis[crosshair]"` and try again.'

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -775,8 +775,8 @@ def _unpack_uleb128(buffer: bytes) -> tuple[int, int]:
     return (i + 1, value)
 
 
-def ir_to_bytes(ir: Iterable[ChoiceT], /) -> bytes:
-    """Serialize a list of IR elements to a bytestring.  Inverts ir_from_bytes."""
+def choices_to_bytes(ir: Iterable[ChoiceT], /) -> bytes:
+    """Serialize a list of IR elements to a bytestring.  Inverts choices_from_bytes."""
     # We use a custom serialization format for this, which might seem crazy - but our
     # data is a flat sequence of elements, and standard tools like protobuf or msgpack
     # don't deal well with e.g. nonstandard bit-pattern-NaNs, or invalid-utf8 unicode.
@@ -815,7 +815,7 @@ def ir_to_bytes(ir: Iterable[ChoiceT], /) -> bytes:
     return b"".join(parts)
 
 
-def _ir_from_bytes(buffer: bytes, /) -> tuple[ChoiceT, ...]:
+def _choices_from_bytes(buffer: bytes, /) -> tuple[ChoiceT, ...]:
     # See above for an explanation of the format.
     parts: list[ChoiceT] = []
     idx = 0
@@ -846,15 +846,15 @@ def _ir_from_bytes(buffer: bytes, /) -> tuple[ChoiceT, ...]:
     return tuple(parts)
 
 
-def ir_from_bytes(buffer: bytes, /) -> Optional[tuple[ChoiceT, ...]]:
+def choices_from_bytes(buffer: bytes, /) -> Optional[tuple[ChoiceT, ...]]:
     """
-    Deserialize a bytestring to a tuple of choices. Inverts ir_to_bytes.
+    Deserialize a bytestring to a tuple of choices. Inverts choices_to_bytes.
 
     Returns None if the given bytestring is not a valid serialization of choice
     sequences.
     """
     try:
-        return _ir_from_bytes(buffer)
+        return _choices_from_bytes(buffer)
     except Exception:
         # deserialization error, eg because our format changed or someone put junk
         # data in the db.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -20,6 +20,8 @@ from typing import (
     Union,
     cast,
 )
+
+import attr
 
 from hypothesis.errors import ChoiceTooLarge
 from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
@@ -70,6 +72,16 @@ ChoiceNameT: "TypeAlias" = Literal["integer", "string", "boolean", "float", "byt
 ChoiceKeyT: "TypeAlias" = Union[
     int, str, bytes, tuple[Literal["bool"], bool], tuple[Literal["float"], int]
 ]
+
+
+@attr.s(slots=True)
+class ChoiceTemplate:
+    type: Literal["simplest"] = attr.ib()
+    count: Optional[int] = attr.ib()
+
+    def __attrs_post_init__(self) -> None:
+        if self.count is not None:
+            assert self.count > 0
 
 
 def _size_to_index(size: int, *, alphabet_size: int) -> int:
@@ -494,3 +506,9 @@ def choice_kwargs_key(ir_type, kwargs):
             kwargs["shrink_towards"],
         )
     return tuple(kwargs[key] for key in sorted(kwargs))
+
+
+def choices_size(choices: Iterable[ChoiceT]) -> int:
+    from hypothesis.database import choices_to_bytes
+
+    return len(choices_to_bytes(choices))

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -8,8 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import abc
-import contextlib
 import math
 import time
 from collections import defaultdict
@@ -17,20 +15,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from enum import IntEnum
 from functools import cached_property
 from random import Random
-from sys import float_info
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Literal,
-    NoReturn,
-    Optional,
-    TypedDict,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, TypeVar, Union, cast
 
 import attr
 
@@ -43,6 +28,7 @@ from hypothesis.internal.conjecture.choice import (
     ChoiceKwargsT,
     ChoiceNameT,
     ChoiceT,
+    ChoiceTemplate,
     FloatKWargs,
     IntegerKWargs,
     StringKWargs,
@@ -52,25 +38,20 @@ from hypothesis.internal.conjecture.choice import (
     choice_kwargs_equal,
     choice_kwargs_key,
     choice_permitted,
+    choices_size,
 )
-from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
 from hypothesis.internal.conjecture.junkdrawer import IntList, gc_cumulative_time
-from hypothesis.internal.conjecture.utils import (
-    INT_SIZES,
-    INT_SIZES_SAMPLER,
-    Sampler,
-    calc_label_from_name,
-    many,
+from hypothesis.internal.conjecture.providers import (
+    COLLECTION_DEFAULT_MAX_SIZE,
+    HypothesisProvider,
+    PrimitiveProvider,
 )
+from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import (
-    SIGNALING_NAN,
     SMALLEST_SUBNORMAL,
     float_to_int,
     int_to_float,
-    make_float_clamper,
-    next_down,
-    next_up,
     sign_aware_lte,
 )
 from hypothesis.internal.intervalsets import IntervalSet
@@ -79,26 +60,35 @@ from hypothesis.reporting import debug_report
 if TYPE_CHECKING:
     from typing import TypeAlias
 
-    from typing_extensions import dataclass_transform
-
     from hypothesis.strategies import SearchStrategy
     from hypothesis.strategies._internal.strategies import Ex
-else:
-
-    def dataclass_transform():
-        def wrapper(tp):
-            return tp
-
-        return wrapper
 
 
-TOP_LABEL = calc_label_from_name("top")
-TargetObservations = dict[str, Union[int, float]]
+def __getattr__(name: str) -> Any:
+    if name == "AVAILABLE_PROVIDERS":
+        from hypothesis._settings import note_deprecation
+        from hypothesis.internal.conjecture.providers import AVAILABLE_PROVIDERS
+
+        note_deprecation(
+            "hypothesis.internal.conjecture.data.AVAILABLE_PROVIDERS has been moved to "
+            "hypothesis.internal.conjecture.providers.AVAILABLE_PROVIDERS.",
+            since="2025-01-25",
+            has_codemod=False,
+            stacklevel=1,
+        )
+        return AVAILABLE_PROVIDERS
+
+    raise AttributeError(
+        f"Module 'hypothesis.internal.conjecture.data' has no attribute {name}"
+    )
+
 
 T = TypeVar("T")
-
+TargetObservations = dict[str, Union[int, float]]
 # index, ir_type, kwargs, forced
 MisalignedAt: "TypeAlias" = tuple[int, ChoiceNameT, ChoiceKwargsT, Optional[ChoiceT]]
+
+TOP_LABEL = calc_label_from_name("top")
 
 
 class ExtraInformation:
@@ -124,7 +114,6 @@ class Status(IntEnum):
         return f"Status.{self.name}"
 
 
-@dataclass_transform()
 @attr.s(slots=True, frozen=True)
 class StructuralCoverageTag:
     label: int = attr.ib()
@@ -140,43 +129,9 @@ def structural_coverage(label: int) -> StructuralCoverageTag:
         return STRUCTURAL_COVERAGE_CACHE.setdefault(label, StructuralCoverageTag(label))
 
 
-NASTY_FLOATS = sorted(
-    [
-        0.0,
-        0.5,
-        1.1,
-        1.5,
-        1.9,
-        1.0 / 3,
-        10e6,
-        10e-6,
-        1.175494351e-38,
-        next_up(0.0),
-        float_info.min,
-        float_info.max,
-        3.402823466e38,
-        9007199254740992,
-        1 - 10e-6,
-        2 + 10e-6,
-        1.192092896e-07,
-        2.2204460492503131e-016,
-    ]
-    + [2.0**-n for n in (24, 14, 149, 126)]  # minimum (sub)normals for float16,32
-    + [float_info.min / n for n in (2, 10, 1000, 100_000)]  # subnormal in float64
-    + [math.inf, math.nan] * 5
-    + [SIGNALING_NAN],
-    key=float_to_lex,
-)
-NASTY_FLOATS = list(map(float, NASTY_FLOATS))
-NASTY_FLOATS.extend([-x for x in NASTY_FLOATS])
-
-# These caches, especially the kwargs cache, can be quite hot and so we prefer
-# LRUCache over LRUReusedCache for performance. We lose scan resistance, but
-# that's probably fine here.
-FLOAT_INIT_LOGIC_CACHE = LRUCache(4096)
+# This cache can be quite hot and so we prefer LRUCache over LRUReusedCache for
+# performance. We lose scan resistance, but that's probably fine here.
 POOLED_KWARGS_CACHE = LRUCache(4096)
-
-COLLECTION_DEFAULT_MAX_SIZE = 10**10  # "arbitrarily large"
 
 
 class Example:
@@ -708,23 +663,6 @@ class IRNode:
 
 
 @attr.s(slots=True)
-class NodeTemplate:
-    type: Literal["simplest"] = attr.ib()
-    count: Optional[int] = attr.ib()
-
-    def __attrs_post_init__(self) -> None:
-        if self.count is not None:
-            assert self.count > 0
-
-
-def ir_size(ir: Iterable[ChoiceT]) -> int:
-    from hypothesis.database import ir_to_bytes
-
-    return len(ir_to_bytes(ir))
-
-
-@dataclass_transform()
-@attr.s(slots=True)
 class ConjectureResult:
     """Result class storing the parts of ConjectureData that we
     will care about after the original ConjectureData has outlived its
@@ -754,500 +692,11 @@ class ConjectureResult:
         return tuple(node.value for node in self.nodes)
 
 
-# Masks for masking off the first byte of an n-bit buffer.
-# The appropriate mask is stored at position n % 8.
-BYTE_MASKS = [(1 << n) - 1 for n in range(8)]
-BYTE_MASKS[0] = 255
-
-_Lifetime: "TypeAlias" = Literal["test_case", "test_function"]
-
-
-class _BackendInfoMsg(TypedDict):
-    type: str
-    title: str
-    content: Union[str, dict[str, Any]]
-
-
-class PrimitiveProvider(abc.ABC):
-    # This is the low-level interface which would also be implemented
-    # by e.g. CrossHair, by an Atheris-hypothesis integration, etc.
-    # We'd then build the structured tree handling, database and replay
-    # support, etc. on top of this - so all backends get those for free.
-    #
-    # See https://github.com/HypothesisWorks/hypothesis/issues/3086
-
-    # How long a provider instance is used for. One of test_function or
-    # test_case. Defaults to test_function.
-    #
-    # If test_function, a single provider instance will be instantiated and used
-    # for the entirety of each test function. I.e., roughly one provider per
-    # @given annotation. This can be useful if you need to track state over many
-    # executions to a test function.
-    #
-    # This lifetime will cause None to be passed for the ConjectureData object
-    # in PrimitiveProvider.__init__, because that object is instantiated per
-    # test case.
-    #
-    # If test_case, a new provider instance will be instantiated and used each
-    # time hypothesis tries to generate a new input to the test function. This
-    # lifetime can access the passed ConjectureData object.
-    #
-    # Non-hypothesis providers probably want to set a lifetime of test_function.
-    lifetime: ClassVar[_Lifetime] = "test_function"
-
-    # Solver-based backends such as hypothesis-crosshair use symbolic values
-    # which record operations performed on them in order to discover new paths.
-    # If avoid_realization is set to True, hypothesis will avoid interacting with
-    # symbolic choices returned by the provider in any way that would force the
-    # solver to narrow the range of possible values for that symbolic.
-    #
-    # Setting this to True disables some hypothesis features, such as
-    # DataTree-based deduplication, and some internal optimizations, such as
-    # caching kwargs. Only enable this if it is necessary for your backend.
-    avoid_realization: ClassVar[bool] = False
-
-    def __init__(self, conjecturedata: Optional["ConjectureData"], /) -> None:
-        self._cd = conjecturedata
-
-    def per_test_case_context_manager(self):
-        return contextlib.nullcontext()
-
-    def realize(self, value: T) -> T:
-        """
-        Called whenever hypothesis requires a concrete (non-symbolic) value from
-        a potentially symbolic value. Hypothesis will not check that `value` is
-        symbolic before calling `realize`, so you should handle the case where
-        `value` is non-symbolic.
-
-        The returned value should be non-symbolic.  If you cannot provide a value,
-        raise hypothesis.errors.BackendCannotProceed("discard_test_case")
-        """
-        return value
-
-    def observe_test_case(self) -> dict[str, Any]:
-        """Called at the end of the test case when observability mode is active.
-
-        The return value should be a non-symbolic json-encodable dictionary,
-        and will be included as `observation["metadata"]["backend"]`.
-        """
-        return {}
-
-    def observe_information_messages(
-        self, *, lifetime: _Lifetime
-    ) -> Iterable[_BackendInfoMsg]:
-        """Called at the end of each test case and again at end of the test function.
-
-        Return an iterable of `{type: info/alert/error, title: str, content: str|dict}`
-        dictionaries to be delivered as individual information messages.
-        (Hypothesis adds the `run_start` timestamp and `property` name for you.)
-        """
-        assert lifetime in ("test_case", "test_function")
-        yield from []
-
-    @abc.abstractmethod
-    def draw_boolean(
-        self,
-        p: float = 0.5,
-    ) -> bool:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def draw_integer(
-        self,
-        min_value: Optional[int] = None,
-        max_value: Optional[int] = None,
-        *,
-        # weights are for choosing an element index from a bounded range
-        weights: Optional[dict[int, float]] = None,
-        shrink_towards: int = 0,
-    ) -> int:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def draw_float(
-        self,
-        *,
-        min_value: float = -math.inf,
-        max_value: float = math.inf,
-        allow_nan: bool = True,
-        smallest_nonzero_magnitude: float,
-        # TODO: consider supporting these float widths at the IR level in the
-        # future.
-        # width: Literal[16, 32, 64] = 64,
-        # exclude_min and exclude_max handled higher up,
-    ) -> float:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def draw_string(
-        self,
-        intervals: IntervalSet,
-        *,
-        min_size: int = 0,
-        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
-    ) -> str:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def draw_bytes(
-        self,
-        min_size: int = 0,
-        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
-    ) -> bytes:
-        raise NotImplementedError
-
-    def span_start(self, label: int, /) -> None:  # noqa: B027  # non-abstract noop
-        """Marks the beginning of a semantically meaningful span.
-
-        Providers can optionally track this data to learn which sub-sequences
-        of draws correspond to a higher-level object, recovering the parse tree.
-        `label` is an opaque integer, which will be shared by all spans drawn
-        from a particular strategy.
-
-        This method is called from ConjectureData.start_example().
-        """
-
-    def span_end(self, discard: bool, /) -> None:  # noqa: B027  # non-abstract noop
-        """Marks the end of a semantically meaningful span.
-
-        `discard` is True when the draw was filtered out or otherwise marked as
-        unlikely to contribute to the input data as seen by the user's test.
-        Note however that side effects can make this determination unsound.
-
-        This method is called from ConjectureData.stop_example().
-        """
-
-
-class HypothesisProvider(PrimitiveProvider):
-    lifetime = "test_case"
-
-    def __init__(self, conjecturedata: Optional["ConjectureData"], /):
-        super().__init__(conjecturedata)
-
-    def draw_boolean(
-        self,
-        p: float = 0.5,
-    ) -> bool:
-        assert self._cd is not None
-        assert self._cd._random is not None
-
-        if p <= 0:
-            return False
-        if p >= 1:
-            return True
-
-        return self._cd._random.random() < p
-
-    def draw_integer(
-        self,
-        min_value: Optional[int] = None,
-        max_value: Optional[int] = None,
-        *,
-        weights: Optional[dict[int, float]] = None,
-        shrink_towards: int = 0,
-    ) -> int:
-        assert self._cd is not None
-
-        center = 0
-        if min_value is not None:
-            center = max(min_value, center)
-        if max_value is not None:
-            center = min(max_value, center)
-
-        if weights is not None:
-            assert min_value is not None
-            assert max_value is not None
-
-            # format of weights is a mapping of ints to p, where sum(p) < 1.
-            # The remaining probability mass is uniformly distributed over
-            # *all* ints (not just the unmapped ones; this is somewhat undesirable,
-            # but simplifies things).
-            #
-            # We assert that sum(p) is strictly less than 1 because it simplifies
-            # handling forced values when we can force into the unmapped probability
-            # mass. We should eventually remove this restriction.
-            sampler = Sampler(
-                [1.0 - sum(weights.values()), *weights.values()], observe=False
-            )
-            # if we're forcing, it's easiest to force into the unmapped probability
-            # mass and then force the drawn value after.
-            idx = sampler.sample(self._cd)
-
-            if idx == 0:
-                return self._draw_bounded_integer(min_value, max_value)
-            # implicit reliance on dicts being sorted for determinism
-            return list(weights)[idx - 1]
-
-        if min_value is None and max_value is None:
-            return self._draw_unbounded_integer()
-
-        if min_value is None:
-            assert max_value is not None
-            probe = max_value + 1
-            while max_value < probe:
-                probe = center + self._draw_unbounded_integer()
-            return probe
-
-        if max_value is None:
-            assert min_value is not None
-            probe = min_value - 1
-            while probe < min_value:
-                probe = center + self._draw_unbounded_integer()
-            return probe
-
-        return self._draw_bounded_integer(min_value, max_value)
-
-    def draw_float(
-        self,
-        *,
-        min_value: float = -math.inf,
-        max_value: float = math.inf,
-        allow_nan: bool = True,
-        smallest_nonzero_magnitude: float,
-        # TODO: consider supporting these float widths at the IR level in the
-        # future.
-        # width: Literal[16, 32, 64] = 64,
-        # exclude_min and exclude_max handled higher up,
-    ) -> float:
-        (
-            sampler,
-            clamper,
-            nasty_floats,
-        ) = self._draw_float_init_logic(
-            min_value=min_value,
-            max_value=max_value,
-            allow_nan=allow_nan,
-            smallest_nonzero_magnitude=smallest_nonzero_magnitude,
-        )
-
-        assert self._cd is not None
-
-        while True:
-            i = sampler.sample(self._cd) if sampler else 0
-            if i == 0:
-                result = self._draw_float()
-                if allow_nan and math.isnan(result):
-                    clamped = result  # pragma: no cover
-                else:
-                    clamped = clamper(result)
-                if clamped != result and not (math.isnan(result) and allow_nan):
-                    result = clamped
-            else:
-                result = nasty_floats[i - 1]
-            return result
-
-    def draw_string(
-        self,
-        intervals: IntervalSet,
-        *,
-        min_size: int = 0,
-        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
-    ) -> str:
-        assert self._cd is not None
-        assert self._cd._random is not None
-
-        average_size = min(
-            max(min_size * 2, min_size + 5),
-            0.5 * (min_size + max_size),
-        )
-
-        chars = []
-        elements = many(
-            self._cd,
-            min_size=min_size,
-            max_size=max_size,
-            average_size=average_size,
-            observe=False,
-        )
-        while elements.more():
-            if len(intervals) > 256:
-                if self.draw_boolean(0.2):
-                    i = self._cd._random.randint(256, len(intervals) - 1)
-                else:
-                    i = self._cd._random.randint(0, 255)
-            else:
-                i = self._cd._random.randint(0, len(intervals) - 1)
-
-            chars.append(intervals.char_in_shrink_order(i))
-
-        return "".join(chars)
-
-    def draw_bytes(
-        self,
-        min_size: int = 0,
-        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
-    ) -> bytes:
-        assert self._cd is not None
-        assert self._cd._random is not None
-
-        buf = bytearray()
-        average_size = min(
-            max(min_size * 2, min_size + 5),
-            0.5 * (min_size + max_size),
-        )
-        elements = many(
-            self._cd,
-            min_size=min_size,
-            max_size=max_size,
-            average_size=average_size,
-            observe=False,
-        )
-        while elements.more():
-            buf += self._cd._random.randbytes(1)
-
-        return bytes(buf)
-
-    def _draw_float(self) -> float:
-        assert self._cd is not None
-        assert self._cd._random is not None
-
-        f = lex_to_float(self._cd._random.getrandbits(64))
-        sign = 1 if self._cd._random.getrandbits(1) else -1
-        return sign * f
-
-    def _draw_unbounded_integer(self) -> int:
-        assert self._cd is not None
-        assert self._cd._random is not None
-
-        size = INT_SIZES[INT_SIZES_SAMPLER.sample(self._cd)]
-
-        r = self._cd._random.getrandbits(size)
-        sign = r & 1
-        r >>= 1
-        if sign:
-            r = -r
-        return r
-
-    def _draw_bounded_integer(
-        self,
-        lower: int,
-        upper: int,
-        *,
-        vary_size: bool = True,
-    ) -> int:
-        assert lower <= upper
-        assert self._cd is not None
-        assert self._cd._random is not None
-
-        if lower == upper:
-            return lower
-
-        bits = (upper - lower).bit_length()
-        if bits > 24 and vary_size and self._cd._random.random() < 7 / 8:
-            # For large ranges, we combine the uniform random distribution
-            # with a weighting scheme with moderate chance.  Cutoff at 2 ** 24 so that our
-            # choice of unicode characters is uniform but the 32bit distribution is not.
-            idx = INT_SIZES_SAMPLER.sample(self._cd)
-            cap_bits = min(bits, INT_SIZES[idx])
-            upper = min(upper, lower + 2**cap_bits - 1)
-            return self._cd._random.randint(lower, upper)
-
-        return self._cd._random.randint(lower, upper)
-
-    @classmethod
-    def _draw_float_init_logic(
-        cls,
-        *,
-        min_value: float,
-        max_value: float,
-        allow_nan: bool,
-        smallest_nonzero_magnitude: float,
-    ) -> tuple[
-        Optional[Sampler],
-        Callable[[float], float],
-        list[float],
-    ]:
-        """
-        Caches initialization logic for draw_float, as an alternative to
-        computing this for *every* float draw.
-        """
-        # float_to_int allows us to distinguish between e.g. -0.0 and 0.0,
-        # even in light of hash(-0.0) == hash(0.0) and -0.0 == 0.0.
-        key = (
-            float_to_int(min_value),
-            float_to_int(max_value),
-            allow_nan,
-            float_to_int(smallest_nonzero_magnitude),
-        )
-        if key in FLOAT_INIT_LOGIC_CACHE:
-            return FLOAT_INIT_LOGIC_CACHE[key]
-
-        result = cls._compute_draw_float_init_logic(
-            min_value=min_value,
-            max_value=max_value,
-            allow_nan=allow_nan,
-            smallest_nonzero_magnitude=smallest_nonzero_magnitude,
-        )
-        FLOAT_INIT_LOGIC_CACHE[key] = result
-        return result
-
-    @staticmethod
-    def _compute_draw_float_init_logic(
-        *,
-        min_value: float,
-        max_value: float,
-        allow_nan: bool,
-        smallest_nonzero_magnitude: float,
-    ) -> tuple[
-        Optional[Sampler],
-        Callable[[float], float],
-        list[float],
-    ]:
-        if smallest_nonzero_magnitude == 0.0:  # pragma: no cover
-            raise FloatingPointError(
-                "Got allow_subnormal=True, but we can't represent subnormal floats "
-                "right now, in violation of the IEEE-754 floating-point "
-                "specification.  This is usually because something was compiled with "
-                "-ffast-math or a similar option, which sets global processor state.  "
-                "See https://simonbyrne.github.io/notes/fastmath/ for a more detailed "
-                "writeup - and good luck!"
-            )
-
-        def permitted(f: float) -> bool:
-            if math.isnan(f):
-                return allow_nan
-            if 0 < abs(f) < smallest_nonzero_magnitude:
-                return False
-            return sign_aware_lte(min_value, f) and sign_aware_lte(f, max_value)
-
-        boundary_values = [
-            min_value,
-            next_up(min_value),
-            min_value + 1,
-            max_value - 1,
-            next_down(max_value),
-            max_value,
-        ]
-        nasty_floats = [f for f in NASTY_FLOATS + boundary_values if permitted(f)]
-        weights = [0.2 * len(nasty_floats)] + [0.8] * len(nasty_floats)
-        sampler = Sampler(weights, observe=False) if nasty_floats else None
-
-        clamper = make_float_clamper(
-            min_value,
-            max_value,
-            smallest_nonzero_magnitude=smallest_nonzero_magnitude,
-            allow_nan=allow_nan,
-        )
-        return (sampler, clamper, nasty_floats)
-
-
-# The set of available `PrimitiveProvider`s, by name.  Other libraries, such as
-# crosshair, can implement this interface and add themselves; at which point users
-# can configure which backend to use via settings.   Keys are the name of the library,
-# which doubles as the backend= setting, and values are importable class names.
-#
-# NOTE: this is a temporary interface.  We DO NOT promise to continue supporting it!
-#       (but if you want to experiment and don't mind breakage, here you go)
-AVAILABLE_PROVIDERS = {
-    "hypothesis": "hypothesis.internal.conjecture.data.HypothesisProvider",
-}
-
-
 class ConjectureData:
     @classmethod
     def for_choices(
         cls,
-        choices: Sequence[Union[NodeTemplate, ChoiceT]],
+        choices: Sequence[Union[ChoiceTemplate, ChoiceT]],
         *,
         observer: Optional[DataObserver] = None,
         provider: Union[type, PrimitiveProvider] = HypothesisProvider,
@@ -1269,7 +718,7 @@ class ConjectureData:
         random: Optional[Random],
         observer: Optional[DataObserver] = None,
         provider: Union[type, PrimitiveProvider] = HypothesisProvider,
-        prefix: Optional[Sequence[Union[NodeTemplate, ChoiceT]]] = None,
+        prefix: Optional[Sequence[Union[ChoiceTemplate, ChoiceT]]] = None,
         max_choices: Optional[int] = None,
         provider_kw: Optional[dict[str, Any]] = None,
     ) -> None:
@@ -1437,7 +886,7 @@ class ConjectureData:
             getattr(self.observer, f"draw_{ir_type}")(
                 value, kwargs=kwargs, was_forced=was_forced
             )
-            size = 0 if self.provider.avoid_realization else ir_size([value])
+            size = 0 if self.provider.avoid_realization else choices_size([value])
             if self.length + size > self.max_length:
                 debug_report(
                     f"overrun because {self.length=} + {size=} > {self.max_length=}"
@@ -1603,8 +1052,8 @@ class ConjectureData:
         assert self.index < len(self.prefix)
 
         value = self.prefix[self.index]
-        if isinstance(value, NodeTemplate):
-            node: NodeTemplate = value
+        if isinstance(value, ChoiceTemplate):
+            node: ChoiceTemplate = value
             if node.count is not None:
                 assert node.count >= 0
             # node templates have to be at the end for now, since it's not immediately
@@ -1909,13 +1358,6 @@ class ConjectureData:
 
     def mark_overrun(self) -> NoReturn:
         self.conclude_test(Status.OVERRUN)
-
-
-def bits_to_bytes(n: int) -> int:
-    """The number of bytes required to represent an n-bit number.
-    Equivalent to (n + 7) // 8, but slightly faster. This really is
-    called enough times that that matters."""
-    return (n + 7) >> 3
 
 
 def draw_choice(ir_type, kwargs, *, random):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -24,7 +24,7 @@ import attr
 
 from hypothesis import HealthCheck, Phase, Verbosity, settings as Settings
 from hypothesis._settings import local_settings
-from hypothesis.database import ExampleDatabase, ir_from_bytes, ir_to_bytes
+from hypothesis.database import ExampleDatabase, choices_from_bytes, choices_to_bytes
 from hypothesis.errors import (
     BackendCannotProceed,
     FlakyReplay,
@@ -38,18 +38,15 @@ from hypothesis.internal.conjecture.choice import (
     ChoiceKeyT,
     ChoiceKwargsT,
     ChoiceT,
+    ChoiceTemplate,
     choices_key,
 )
 from hypothesis.internal.conjecture.data import (
-    AVAILABLE_PROVIDERS,
     ConjectureData,
     ConjectureResult,
     DataObserver,
-    HypothesisProvider,
     IRNode,
-    NodeTemplate,
     Overrun,
-    PrimitiveProvider,
     Status,
     _Overrun,
 )
@@ -63,6 +60,11 @@ from hypothesis.internal.conjecture.junkdrawer import (
     startswith,
 )
 from hypothesis.internal.conjecture.pareto import NO_SCORE, ParetoFront, ParetoOptimiser
+from hypothesis.internal.conjecture.providers import (
+    AVAILABLE_PROVIDERS,
+    HypothesisProvider,
+    PrimitiveProvider,
+)
 from hypothesis.internal.conjecture.shrinker import Shrinker, ShrinkPredicateT, sort_key
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.healthcheck import fail_health_check
@@ -193,10 +195,10 @@ StatisticsDict = TypedDict(
 )
 
 
-def choice_count(choices: Sequence[Union[ChoiceT, NodeTemplate]]) -> Optional[int]:
+def choice_count(choices: Sequence[Union[ChoiceT, ChoiceTemplate]]) -> Optional[int]:
     count = 0
     for choice in choices:
-        if isinstance(choice, NodeTemplate):
+        if isinstance(choice, ChoiceTemplate):
             if choice.count is None:
                 return None
             count += choice.count
@@ -361,7 +363,7 @@ class ConjectureRunner:
 
     def cached_test_function_ir(
         self,
-        choices: Sequence[Union[ChoiceT, NodeTemplate]],
+        choices: Sequence[Union[ChoiceT, ChoiceTemplate]],
         *,
         error_on_discard: bool = False,
         extend: Union[int, Literal["full"]] = 0,
@@ -376,9 +378,9 @@ class ConjectureRunner:
         """
         # node templates represent a not-yet-filled hole and therefore cannot
         # be cached or retrieved from the cache.
-        if not any(isinstance(choice, NodeTemplate) for choice in choices):
+        if not any(isinstance(choice, ChoiceTemplate) for choice in choices):
             # this type cast is validated by the isinstance check above (ie, there
-            # are no NodeTemplate elements).
+            # are no ChoiceTemplate elements).
             choices = cast(Sequence[ChoiceT], choices)
             key = self._cache_key(choices)
             try:
@@ -597,7 +599,7 @@ class ConjectureRunner:
             else:
                 if sort_key(data.nodes) < sort_key(existing.nodes):
                     self.shrinks += 1
-                    self.downgrade_buffer(ir_to_bytes(existing.choices))
+                    self.downgrade_choices(existing.choices)
                     self.__data_cache.unpin(self._cache_key(existing.choices))
                     changed = True
 
@@ -647,7 +649,7 @@ class ConjectureRunner:
         self.record_for_health_check(data)
 
     def on_pareto_evict(self, data: ConjectureData) -> None:
-        self.settings.database.delete(self.pareto_key, ir_to_bytes(data.choices))
+        self.settings.database.delete(self.pareto_key, choices_to_bytes(data.choices))
 
     def generate_novel_prefix(self) -> tuple[ChoiceT, ...]:
         """Uses the tree to proactively generate a starting sequence of bytes
@@ -738,9 +740,10 @@ class ConjectureRunner:
             key = self.sub_key(sub_key)
             if key is None:
                 return
-            self.settings.database.save(key, ir_to_bytes(choices))
+            self.settings.database.save(key, choices_to_bytes(choices))
 
-    def downgrade_buffer(self, buffer: Union[bytes, bytearray]) -> None:
+    def downgrade_choices(self, choices: Sequence[ChoiceT]) -> None:
+        buffer = choices_to_bytes(choices)
         if self.settings.database is not None and self.database_key is not None:
             self.settings.database.move(self.database_key, self.secondary_key, buffer)
 
@@ -854,7 +857,7 @@ class ConjectureRunner:
             for i, existing in enumerate(corpus):
                 if i >= primary_corpus_size and found_interesting_in_primary:
                     break
-                choices = ir_from_bytes(existing)
+                choices = choices_from_bytes(existing)
                 if choices is None:
                     # clear out any keys which fail deserialization
                     self.settings.database.delete(self.database_key, existing)
@@ -890,7 +893,7 @@ class ConjectureRunner:
                 pareto_corpus.sort(key=shortlex)
 
                 for existing in pareto_corpus:
-                    choices = ir_from_bytes(existing)
+                    choices = choices_from_bytes(existing)
                     if choices is None:
                         self.settings.database.delete(self.pareto_key, existing)
                         continue
@@ -957,7 +960,7 @@ class ConjectureRunner:
 
         assert self.should_generate_more()
         zero_data = self.cached_test_function_ir(
-            (NodeTemplate("simplest", count=None),)
+            (ChoiceTemplate("simplest", count=None),)
         )
         if zero_data.status > Status.OVERRUN:
             assert isinstance(zero_data, ConjectureResult)
@@ -1051,7 +1054,7 @@ class ConjectureRunner:
                 and consecutive_zero_extend_is_invalid < 5
             ):
                 minimal_example = self.cached_test_function_ir(
-                    prefix + (NodeTemplate("simplest", count=None),)
+                    prefix + (ChoiceTemplate("simplest", count=None),)
                 )
 
                 if minimal_example.status < Status.VALID:
@@ -1295,7 +1298,7 @@ class ConjectureRunner:
 
     def new_conjecture_data_ir(
         self,
-        prefix: Sequence[Union[ChoiceT, NodeTemplate]],
+        prefix: Sequence[Union[ChoiceT, ChoiceTemplate]],
         *,
         observer: Optional[DataObserver] = None,
         max_choices: Optional[int] = None,
@@ -1379,12 +1382,13 @@ class ConjectureRunner:
                 self.settings.database.fetch(self.secondary_key), key=shortlex
             )
             for c in corpus:
-                choices = ir_from_bytes(c)
+                choices = choices_from_bytes(c)
                 if choices is None:
                     self.settings.database.delete(self.secondary_key, c)
                     continue
                 primary = {
-                    ir_to_bytes(v.choices) for v in self.interesting_examples.values()
+                    choices_to_bytes(v.choices)
+                    for v in self.interesting_examples.values()
                 }
                 cap = max(map(shortlex, primary))
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -472,3 +472,10 @@ def endswith(l1: Sequence[T], l2: Sequence[T]) -> bool:
     if len(l1) < len(l2):
         return False
     return all(v1 == v2 for v1, v2 in zip(l1[-len(l2) :], l2))
+
+
+def bits_to_bytes(n: int) -> int:
+    """The number of bytes required to represent an n-bit number.
+    Equivalent to (n + 7) // 8, but slightly faster. This really is
+    called enough times that that matters."""
+    return (n + 7) >> 3

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -12,14 +12,9 @@ from typing import Optional, Union
 
 from hypothesis.internal.compat import int_from_bytes, int_to_bytes
 from hypothesis.internal.conjecture.choice import ChoiceT, choice_permitted
-from hypothesis.internal.conjecture.data import (
-    ConjectureResult,
-    Status,
-    _Overrun,
-    bits_to_bytes,
-)
+from hypothesis.internal.conjecture.data import ConjectureResult, Status, _Overrun
 from hypothesis.internal.conjecture.engine import ConjectureRunner
-from hypothesis.internal.conjecture.junkdrawer import find_integer
+from hypothesis.internal.conjecture.junkdrawer import bits_to_bytes, find_integer
 from hypothesis.internal.conjecture.pareto import NO_SCORE
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -8,21 +8,567 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import abc
+import contextlib
 import math
-from typing import Optional
-
-from hypothesis.internal.compat import int_from_bytes
-from hypothesis.internal.conjecture.data import (
-    BYTE_MASKS,
-    COLLECTION_DEFAULT_MAX_SIZE,
-    ConjectureData,
-    PrimitiveProvider,
-    bits_to_bytes,
+from collections.abc import Iterable
+from sys import float_info
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    Optional,
+    TypedDict,
+    TypeVar,
+    Union,
 )
-from hypothesis.internal.conjecture.floats import lex_to_float
-from hypothesis.internal.conjecture.utils import many
-from hypothesis.internal.floats import make_float_clamper
+
+from hypothesis.internal.cache import LRUCache
+from hypothesis.internal.compat import int_from_bytes
+from hypothesis.internal.conjecture.floats import float_to_lex, lex_to_float
+from hypothesis.internal.conjecture.junkdrawer import bits_to_bytes
+from hypothesis.internal.conjecture.utils import (
+    INT_SIZES,
+    INT_SIZES_SAMPLER,
+    Sampler,
+    many,
+)
+from hypothesis.internal.floats import (
+    SIGNALING_NAN,
+    float_to_int,
+    make_float_clamper,
+    next_down,
+    next_up,
+    sign_aware_lte,
+)
 from hypothesis.internal.intervalsets import IntervalSet
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
+    from hypothesis.internal.conjecture.data import ConjectureData
+
+T = TypeVar("T")
+_Lifetime: "TypeAlias" = Literal["test_case", "test_function"]
+COLLECTION_DEFAULT_MAX_SIZE = 10**10  # "arbitrarily large"
+
+
+# The set of available `PrimitiveProvider`s, by name.  Other libraries, such as
+# crosshair, can implement this interface and add themselves; at which point users
+# can configure which backend to use via settings.   Keys are the name of the library,
+# which doubles as the backend= setting, and values are importable class names.
+#
+# NOTE: this is a temporary interface.  We DO NOT promise to continue supporting it!
+#       (but if you want to experiment and don't mind breakage, here you go)
+AVAILABLE_PROVIDERS = {
+    "hypothesis": "hypothesis.internal.conjecture.providers.HypothesisProvider",
+}
+FLOAT_INIT_LOGIC_CACHE = LRUCache(4096)
+
+NASTY_FLOATS = sorted(
+    [
+        0.0,
+        0.5,
+        1.1,
+        1.5,
+        1.9,
+        1.0 / 3,
+        10e6,
+        10e-6,
+        1.175494351e-38,
+        next_up(0.0),
+        float_info.min,
+        float_info.max,
+        3.402823466e38,
+        9007199254740992,
+        1 - 10e-6,
+        2 + 10e-6,
+        1.192092896e-07,
+        2.2204460492503131e-016,
+    ]
+    + [2.0**-n for n in (24, 14, 149, 126)]  # minimum (sub)normals for float16,32
+    + [float_info.min / n for n in (2, 10, 1000, 100_000)]  # subnormal in float64
+    + [math.inf, math.nan] * 5
+    + [SIGNALING_NAN],
+    key=float_to_lex,
+)
+NASTY_FLOATS = list(map(float, NASTY_FLOATS))
+NASTY_FLOATS.extend([-x for x in NASTY_FLOATS])
+
+# Masks for masking off the first byte of an n-bit buffer.
+# The appropriate mask is stored at position n % 8.
+BYTE_MASKS = [(1 << n) - 1 for n in range(8)]
+BYTE_MASKS[0] = 255
+
+
+class _BackendInfoMsg(TypedDict):
+    type: str
+    title: str
+    content: Union[str, dict[str, Any]]
+
+
+class PrimitiveProvider(abc.ABC):
+    # This is the low-level interface which would also be implemented
+    # by e.g. CrossHair, by an Atheris-hypothesis integration, etc.
+    # We'd then build the structured tree handling, database and replay
+    # support, etc. on top of this - so all backends get those for free.
+    #
+    # See https://github.com/HypothesisWorks/hypothesis/issues/3086
+
+    # How long a provider instance is used for. One of test_function or
+    # test_case. Defaults to test_function.
+    #
+    # If test_function, a single provider instance will be instantiated and used
+    # for the entirety of each test function. I.e., roughly one provider per
+    # @given annotation. This can be useful if you need to track state over many
+    # executions to a test function.
+    #
+    # This lifetime will cause None to be passed for the ConjectureData object
+    # in PrimitiveProvider.__init__, because that object is instantiated per
+    # test case.
+    #
+    # If test_case, a new provider instance will be instantiated and used each
+    # time hypothesis tries to generate a new input to the test function. This
+    # lifetime can access the passed ConjectureData object.
+    #
+    # Non-hypothesis providers probably want to set a lifetime of test_function.
+    lifetime: _Lifetime = "test_function"
+
+    # Solver-based backends such as hypothesis-crosshair use symbolic values
+    # which record operations performed on them in order to discover new paths.
+    # If avoid_realization is set to True, hypothesis will avoid interacting with
+    # symbolic choices returned by the provider in any way that would force the
+    # solver to narrow the range of possible values for that symbolic.
+    #
+    # Setting this to True disables some hypothesis features, such as
+    # DataTree-based deduplication, and some internal optimizations, such as
+    # caching kwargs. Only enable this if it is necessary for your backend.
+    avoid_realization = False
+
+    def __init__(self, conjecturedata: Optional["ConjectureData"], /) -> None:
+        self._cd = conjecturedata
+
+    def per_test_case_context_manager(self):
+        return contextlib.nullcontext()
+
+    def realize(self, value: T) -> T:
+        """
+        Called whenever hypothesis requires a concrete (non-symbolic) value from
+        a potentially symbolic value. Hypothesis will not check that `value` is
+        symbolic before calling `realize`, so you should handle the case where
+        `value` is non-symbolic.
+
+        The returned value should be non-symbolic.  If you cannot provide a value,
+        raise hypothesis.errors.BackendCannotProceed("discard_test_case")
+        """
+        return value
+
+    def observe_test_case(self) -> dict[str, Any]:
+        """Called at the end of the test case when observability mode is active.
+
+        The return value should be a non-symbolic json-encodable dictionary,
+        and will be included as `observation["metadata"]["backend"]`.
+        """
+        return {}
+
+    def observe_information_messages(
+        self, *, lifetime: _Lifetime
+    ) -> Iterable[_BackendInfoMsg]:
+        """Called at the end of each test case and again at end of the test function.
+
+        Return an iterable of `{type: info/alert/error, title: str, content: str|dict}`
+        dictionaries to be delivered as individual information messages.
+        (Hypothesis adds the `run_start` timestamp and `property` name for you.)
+        """
+        assert lifetime in ("test_case", "test_function")
+        yield from []
+
+    @abc.abstractmethod
+    def draw_boolean(
+        self,
+        p: float = 0.5,
+    ) -> bool:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def draw_integer(
+        self,
+        min_value: Optional[int] = None,
+        max_value: Optional[int] = None,
+        *,
+        # weights are for choosing an element index from a bounded range
+        weights: Optional[dict[int, float]] = None,
+        shrink_towards: int = 0,
+    ) -> int:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def draw_float(
+        self,
+        *,
+        min_value: float = -math.inf,
+        max_value: float = math.inf,
+        allow_nan: bool = True,
+        smallest_nonzero_magnitude: float,
+        # TODO: consider supporting these float widths at the IR level in the
+        # future.
+        # width: Literal[16, 32, 64] = 64,
+        # exclude_min and exclude_max handled higher up,
+    ) -> float:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def draw_string(
+        self,
+        intervals: IntervalSet,
+        *,
+        min_size: int = 0,
+        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
+    ) -> str:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def draw_bytes(
+        self,
+        min_size: int = 0,
+        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
+    ) -> bytes:
+        raise NotImplementedError
+
+    def span_start(self, label: int, /) -> None:  # noqa: B027  # non-abstract noop
+        """Marks the beginning of a semantically meaningful span.
+
+        Providers can optionally track this data to learn which sub-sequences
+        of draws correspond to a higher-level object, recovering the parse tree.
+        `label` is an opaque integer, which will be shared by all spans drawn
+        from a particular strategy.
+
+        This method is called from ConjectureData.start_example().
+        """
+
+    def span_end(self, discard: bool, /) -> None:  # noqa: B027, FBT001
+        """Marks the end of a semantically meaningful span.
+
+        `discard` is True when the draw was filtered out or otherwise marked as
+        unlikely to contribute to the input data as seen by the user's test.
+        Note however that side effects can make this determination unsound.
+
+        This method is called from ConjectureData.stop_example().
+        """
+
+
+class HypothesisProvider(PrimitiveProvider):
+    lifetime = "test_case"
+
+    def __init__(self, conjecturedata: Optional["ConjectureData"], /):
+        super().__init__(conjecturedata)
+
+    def draw_boolean(
+        self,
+        p: float = 0.5,
+    ) -> bool:
+        assert self._cd is not None
+        assert self._cd._random is not None
+
+        if p <= 0:
+            return False
+        if p >= 1:
+            return True
+
+        return self._cd._random.random() < p
+
+    def draw_integer(
+        self,
+        min_value: Optional[int] = None,
+        max_value: Optional[int] = None,
+        *,
+        weights: Optional[dict[int, float]] = None,
+        shrink_towards: int = 0,
+    ) -> int:
+        assert self._cd is not None
+
+        center = 0
+        if min_value is not None:
+            center = max(min_value, center)
+        if max_value is not None:
+            center = min(max_value, center)
+
+        if weights is not None:
+            assert min_value is not None
+            assert max_value is not None
+
+            # format of weights is a mapping of ints to p, where sum(p) < 1.
+            # The remaining probability mass is uniformly distributed over
+            # *all* ints (not just the unmapped ones; this is somewhat undesirable,
+            # but simplifies things).
+            #
+            # We assert that sum(p) is strictly less than 1 because it simplifies
+            # handling forced values when we can force into the unmapped probability
+            # mass. We should eventually remove this restriction.
+            sampler = Sampler(
+                [1 - sum(weights.values()), *weights.values()], observe=False
+            )
+            # if we're forcing, it's easiest to force into the unmapped probability
+            # mass and then force the drawn value after.
+            idx = sampler.sample(self._cd)
+
+            if idx == 0:
+                return self._draw_bounded_integer(min_value, max_value)
+            # implicit reliance on dicts being sorted for determinism
+            return list(weights)[idx - 1]
+
+        if min_value is None and max_value is None:
+            return self._draw_unbounded_integer()
+
+        if min_value is None:
+            assert max_value is not None
+            probe = max_value + 1
+            while max_value < probe:
+                probe = center + self._draw_unbounded_integer()
+            return probe
+
+        if max_value is None:
+            assert min_value is not None
+            probe = min_value - 1
+            while probe < min_value:
+                probe = center + self._draw_unbounded_integer()
+            return probe
+
+        return self._draw_bounded_integer(min_value, max_value)
+
+    def draw_float(
+        self,
+        *,
+        min_value: float = -math.inf,
+        max_value: float = math.inf,
+        allow_nan: bool = True,
+        smallest_nonzero_magnitude: float,
+        # TODO: consider supporting these float widths at the IR level in the
+        # future.
+        # width: Literal[16, 32, 64] = 64,
+        # exclude_min and exclude_max handled higher up,
+    ) -> float:
+        (
+            sampler,
+            clamper,
+            nasty_floats,
+        ) = self._draw_float_init_logic(
+            min_value=min_value,
+            max_value=max_value,
+            allow_nan=allow_nan,
+            smallest_nonzero_magnitude=smallest_nonzero_magnitude,
+        )
+
+        assert self._cd is not None
+
+        while True:
+            i = sampler.sample(self._cd) if sampler else 0
+            if i == 0:
+                result = self._draw_float()
+                if allow_nan and math.isnan(result):
+                    clamped = result  # pragma: no cover
+                else:
+                    clamped = clamper(result)
+                if clamped != result and not (math.isnan(result) and allow_nan):
+                    result = clamped
+            else:
+                result = nasty_floats[i - 1]
+            return result
+
+    def draw_string(
+        self,
+        intervals: IntervalSet,
+        *,
+        min_size: int = 0,
+        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
+    ) -> str:
+        assert self._cd is not None
+        assert self._cd._random is not None
+
+        average_size = min(
+            max(min_size * 2, min_size + 5),
+            0.5 * (min_size + max_size),
+        )
+
+        chars = []
+        elements = many(
+            self._cd,
+            min_size=min_size,
+            max_size=max_size,
+            average_size=average_size,
+            observe=False,
+        )
+        while elements.more():
+            if len(intervals) > 256:
+                if self.draw_boolean(0.2):
+                    i = self._cd._random.randint(256, len(intervals) - 1)
+                else:
+                    i = self._cd._random.randint(0, 255)
+            else:
+                i = self._cd._random.randint(0, len(intervals) - 1)
+
+            chars.append(intervals.char_in_shrink_order(i))
+
+        return "".join(chars)
+
+    def draw_bytes(
+        self,
+        min_size: int = 0,
+        max_size: int = COLLECTION_DEFAULT_MAX_SIZE,
+    ) -> bytes:
+        assert self._cd is not None
+        assert self._cd._random is not None
+
+        buf = bytearray()
+        average_size = min(
+            max(min_size * 2, min_size + 5),
+            0.5 * (min_size + max_size),
+        )
+        elements = many(
+            self._cd,
+            min_size=min_size,
+            max_size=max_size,
+            average_size=average_size,
+            observe=False,
+        )
+        while elements.more():
+            buf += self._cd._random.randbytes(1)
+
+        return bytes(buf)
+
+    def _draw_float(self) -> float:
+        assert self._cd is not None
+        assert self._cd._random is not None
+
+        f = lex_to_float(self._cd._random.getrandbits(64))
+        sign = 1 if self._cd._random.getrandbits(1) else -1
+        return sign * f
+
+    def _draw_unbounded_integer(self) -> int:
+        assert self._cd is not None
+        assert self._cd._random is not None
+
+        size = INT_SIZES[INT_SIZES_SAMPLER.sample(self._cd)]
+
+        r = self._cd._random.getrandbits(size)
+        sign = r & 1
+        r >>= 1
+        if sign:
+            r = -r
+        return r
+
+    def _draw_bounded_integer(
+        self,
+        lower: int,
+        upper: int,
+        *,
+        vary_size: bool = True,
+    ) -> int:
+        assert lower <= upper
+        assert self._cd is not None
+        assert self._cd._random is not None
+
+        if lower == upper:
+            return lower
+
+        bits = (upper - lower).bit_length()
+        if bits > 24 and vary_size and self._cd._random.random() < 7 / 8:
+            # For large ranges, we combine the uniform random distribution
+            # with a weighting scheme with moderate chance.  Cutoff at 2 ** 24 so that our
+            # choice of unicode characters is uniform but the 32bit distribution is not.
+            idx = INT_SIZES_SAMPLER.sample(self._cd)
+            cap_bits = min(bits, INT_SIZES[idx])
+            upper = min(upper, lower + 2**cap_bits - 1)
+            return self._cd._random.randint(lower, upper)
+
+        return self._cd._random.randint(lower, upper)
+
+    @classmethod
+    def _draw_float_init_logic(
+        cls,
+        *,
+        min_value: float,
+        max_value: float,
+        allow_nan: bool,
+        smallest_nonzero_magnitude: float,
+    ) -> tuple[
+        Optional[Sampler],
+        Callable[[float], float],
+        list[float],
+    ]:
+        """
+        Caches initialization logic for draw_float, as an alternative to
+        computing this for *every* float draw.
+        """
+        # float_to_int allows us to distinguish between e.g. -0.0 and 0.0,
+        # even in light of hash(-0.0) == hash(0.0) and -0.0 == 0.0.
+        key = (
+            float_to_int(min_value),
+            float_to_int(max_value),
+            allow_nan,
+            float_to_int(smallest_nonzero_magnitude),
+        )
+        if key in FLOAT_INIT_LOGIC_CACHE:
+            return FLOAT_INIT_LOGIC_CACHE[key]
+
+        result = cls._compute_draw_float_init_logic(
+            min_value=min_value,
+            max_value=max_value,
+            allow_nan=allow_nan,
+            smallest_nonzero_magnitude=smallest_nonzero_magnitude,
+        )
+        FLOAT_INIT_LOGIC_CACHE[key] = result
+        return result
+
+    @staticmethod
+    def _compute_draw_float_init_logic(
+        *,
+        min_value: float,
+        max_value: float,
+        allow_nan: bool,
+        smallest_nonzero_magnitude: float,
+    ) -> tuple[
+        Optional[Sampler],
+        Callable[[float], float],
+        list[float],
+    ]:
+        if smallest_nonzero_magnitude == 0.0:  # pragma: no cover
+            raise FloatingPointError(
+                "Got allow_subnormal=True, but we can't represent subnormal floats "
+                "right now, in violation of the IEEE-754 floating-point "
+                "specification.  This is usually because something was compiled with "
+                "-ffast-math or a similar option, which sets global processor state.  "
+                "See https://simonbyrne.github.io/notes/fastmath/ for a more detailed "
+                "writeup - and good luck!"
+            )
+
+        def permitted(f: float) -> bool:
+            if math.isnan(f):
+                return allow_nan
+            if 0 < abs(f) < smallest_nonzero_magnitude:
+                return False
+            return sign_aware_lte(min_value, f) and sign_aware_lte(f, max_value)
+
+        boundary_values = [
+            min_value,
+            next_up(min_value),
+            min_value + 1,
+            max_value - 1,
+            next_down(max_value),
+            max_value,
+        ]
+        nasty_floats = [f for f in NASTY_FLOATS + boundary_values if permitted(f)]
+        weights = [0.2 * len(nasty_floats)] + [0.8] * len(nasty_floats)
+        sampler = Sampler(weights, observe=False) if nasty_floats else None
+
+        clamper = make_float_clamper(
+            min_value,
+            max_value,
+            smallest_nonzero_magnitude=smallest_nonzero_magnitude,
+            allow_nan=allow_nan,
+        )
+        return (sampler, clamper, nasty_floats)
 
 
 class BytestringProvider(PrimitiveProvider):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from hypothesis.errors import HypothesisWarning, InvalidArgument
 from hypothesis.internal import charmap
-from hypothesis.internal.conjecture.data import COLLECTION_DEFAULT_MAX_SIZE
+from hypothesis.internal.conjecture.providers import COLLECTION_DEFAULT_MAX_SIZE
 from hypothesis.internal.filtering import max_len, min_len
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.internal.reflection import get_pretty_function_description

--- a/hypothesis-python/tests/common/setup.py
+++ b/hypothesis-python/tests/common/setup.py
@@ -13,7 +13,7 @@ from warnings import filterwarnings
 
 from hypothesis import HealthCheck, Phase, Verbosity, settings
 from hypothesis._settings import CI, is_in_ci, not_set
-from hypothesis.internal.conjecture.data import AVAILABLE_PROVIDERS
+from hypothesis.internal.conjecture.providers import AVAILABLE_PROVIDERS
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -19,13 +19,9 @@ from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import engine as engine_module
 from hypothesis.internal.conjecture.choice import ChoiceT
-from hypothesis.internal.conjecture.data import (
-    COLLECTION_DEFAULT_MAX_SIZE,
-    ConjectureData,
-    IRNode,
-    Status,
-)
+from hypothesis.internal.conjecture.data import ConjectureData, IRNode, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
+from hypothesis.internal.conjecture.providers import COLLECTION_DEFAULT_MAX_SIZE
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.escalation import InterestingOrigin

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -17,7 +17,15 @@ from typing import Optional
 
 import pytest
 
-from hypothesis import HealthCheck, Verbosity, assume, given, settings, strategies as st
+from hypothesis import (
+    HealthCheck,
+    Verbosity,
+    assume,
+    errors,
+    given,
+    settings,
+    strategies as st,
+)
 from hypothesis.control import current_build_context
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import (
@@ -28,13 +36,12 @@ from hypothesis.errors import (
     Unsatisfiable,
 )
 from hypothesis.internal.compat import int_to_bytes
-from hypothesis.internal.conjecture.data import (
+from hypothesis.internal.conjecture.data import ConjectureData, PrimitiveProvider
+from hypothesis.internal.conjecture.engine import ConjectureRunner
+from hypothesis.internal.conjecture.providers import (
     AVAILABLE_PROVIDERS,
     COLLECTION_DEFAULT_MAX_SIZE,
-    ConjectureData,
-    PrimitiveProvider,
 )
-from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import SIGNALING_NAN
 from hypothesis.internal.intervalsets import IntervalSet
 
@@ -581,3 +588,11 @@ def test_invalid_provider_kw():
             provider=TrivialProvider(None),
             provider_kw={"one": "two"},
         )
+
+
+def test_available_providers_deprecation():
+    with pytest.warns(errors.HypothesisDeprecationWarning):
+        from hypothesis.internal.conjecture.data import AVAILABLE_PROVIDERS  # noqa
+
+    with pytest.raises(ImportError):
+        from hypothesis.internal.conjecture.data import does_not_exist  # noqa

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -15,12 +15,8 @@ import pytest
 
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.errors import Flaky
-from hypothesis.internal.conjecture.data import (
-    ConjectureData,
-    NodeTemplate,
-    Status,
-    StopTest,
-)
+from hypothesis.internal.conjecture.choice import ChoiceTemplate
+from hypothesis.internal.conjecture.data import ConjectureData, Status, StopTest
 from hypothesis.internal.conjecture.datatree import (
     Branch,
     DataTree,
@@ -128,7 +124,7 @@ def test_novel_prefixes_are_novel():
     runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
     for _ in range(100):
         prefix = runner.tree.generate_novel_prefix(runner.random)
-        extension = prefix + (NodeTemplate("simplest", count=100),)
+        extension = prefix + (ChoiceTemplate("simplest", count=100),)
         assert runner.tree.rewrite(extension)[1] is None
         result = runner.cached_test_function_ir(extension)
         assert runner.tree.rewrite(extension)[0] == result.choices

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -13,7 +13,7 @@ import itertools
 import pytest
 
 from hypothesis import HealthCheck, Phase, settings, strategies as st
-from hypothesis.database import InMemoryExampleDatabase, ir_to_bytes
+from hypothesis.database import InMemoryExampleDatabase, choices_to_bytes
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -134,7 +134,7 @@ def test_clears_defunct_pareto_front():
         )
 
         for i in range(256):
-            db.save(runner.pareto_key, ir_to_bytes((i, 0)))
+            db.save(runner.pareto_key, choices_to_bytes((i, 0)))
 
         runner.run()
 
@@ -162,7 +162,7 @@ def test_down_samples_the_pareto_front():
         )
 
         for n1, n2 in itertools.product(range(256), range(256)):
-            db.save(runner.pareto_key, ir_to_bytes((n1, n2)))
+            db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
 
         with pytest.raises(RunIsComplete):
             runner.reuse_existing_examples()
@@ -192,7 +192,7 @@ def test_stops_loading_pareto_front_if_interesting():
         )
 
         for n1, n2 in itertools.product(range(256), range(256)):
-            db.save(runner.pareto_key, ir_to_bytes((n1, n2)))
+            db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
 
         runner.reuse_existing_examples()
 

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -32,8 +32,8 @@ from hypothesis.database import (
     ReadOnlyDatabase,
     _pack_uleb128,
     _unpack_uleb128,
-    ir_from_bytes,
-    ir_to_bytes,
+    choices_from_bytes,
+    choices_to_bytes,
 )
 from hypothesis.errors import HypothesisWarning
 from hypothesis.internal.compat import WINDOWS
@@ -482,15 +482,15 @@ def test_background_write_database():
 @example(ir(b"a" * 50))
 @example(ir(b"1" * 100_000))  # really long bytes
 def test_nodes_roundtrips(nodes1):
-    s1 = ir_to_bytes([n.value for n in nodes1])
+    s1 = choices_to_bytes([n.value for n in nodes1])
     assert isinstance(s1, bytes)
-    ir2 = ir_from_bytes(s1)
+    ir2 = choices_from_bytes(s1)
     assert len(nodes1) == len(ir2)
 
     for n1, v2 in zip(nodes1, ir2):
         assert choice_equal(n1.value, v2)
 
-    s2 = ir_to_bytes(ir2)
+    s2 = choices_to_bytes(ir2)
     assert s1 == s2
 
 

--- a/hypothesis-python/tests/cover/test_filter_rewriting.py
+++ b/hypothesis-python/tests/cover/test_filter_rewriting.py
@@ -21,7 +21,7 @@ import pytest
 
 from hypothesis import HealthCheck, given, settings, strategies as st
 from hypothesis.errors import HypothesisWarning, Unsatisfiable
-from hypothesis.internal.conjecture.data import COLLECTION_DEFAULT_MAX_SIZE
+from hypothesis.internal.conjecture.providers import COLLECTION_DEFAULT_MAX_SIZE
 from hypothesis.internal.filtering import max_len, min_len
 from hypothesis.internal.floats import next_down, next_up
 from hypothesis.internal.reflection import get_pretty_function_description

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -45,7 +45,7 @@ def test_encoding_loop(nodes):
 @example(base64.b64encode(b"\2\3\4"))
 @example(b"\t")
 @example(base64.b64encode(b"\1\0"))  # zlib error
-@example(base64.b64encode(b"\1" + zlib.compress(b"\xff")))  # ir_from_bytes error
+@example(base64.b64encode(b"\1" + zlib.compress(b"\xff")))  # choices_from_bytes error
 @given(st.binary())
 def test_decoding_may_fail(t):
     try:

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from hypothesis import given, settings, strategies as st
-from hypothesis.database import InMemoryExampleDatabase, ir_from_bytes
+from hypothesis.database import InMemoryExampleDatabase, choices_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.shrinker import Shrinker, node_program
@@ -54,7 +54,7 @@ def test_saves_data_while_shrinking(monkeypatch):
     assert runner.interesting_examples
     assert len(seen) == n
 
-    in_db = {ir_from_bytes(b)[0] for b in non_covering_examples(db)}
+    in_db = {choices_from_bytes(b)[0] for b in non_covering_examples(db)}
     assert in_db.issubset(seen)
     assert in_db == seen
 


### PR DESCRIPTION
* Move providers to `providers.py`, including `HypothesisProvider` and `PrimitiveProvider`. I'm trying to structure things better than sticking everything into `data.py`, which has become massive (2k lines)
* `AVAILABLE_PROVIDERS` has moved from `data.py` to `providers.py`, so (@pschanely) crosshair should update its registration code - or we could leave a compatibility alias in `data.py`?
* `NodeTemplate` -> `ChoiceTemplate`
* ...a few other obviously-correct renamings
* no actual behavioral changes