### PR TITLE
Add 2024.12 to allowed array API versions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+Add 2024.12 to the list of recognized Array API versions in
+``hypothesis.extra.array_api``.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -63,10 +63,10 @@ __all__ = [
 ]
 
 
-RELEASED_VERSIONS = ("2021.12", "2022.12", "2023.12")
+RELEASED_VERSIONS = ("2021.12", "2022.12", "2023.12", "2024.12")
 NOMINAL_VERSIONS = (*RELEASED_VERSIONS, "draft")
 assert sorted(NOMINAL_VERSIONS) == list(NOMINAL_VERSIONS)  # sanity check
-NominalVersion = Literal["2021.12", "2022.12", "2023.12", "draft"]
+NominalVersion = Literal["2021.12", "2022.12", "2023.12", "2024.12", "draft"]
 assert get_args(NominalVersion) == NOMINAL_VERSIONS  # sanity check
 
 


### PR DESCRIPTION
This is a bit pre-emptive: 2024.12 Array API spec is not released yet :-).

However, the story goes like this:

The 2024.12 release is in the works and is expected "soon" (tm);
We would like to release array-api-compat and array-api-strict with 2024.12 support quickly once the spec itself is finalized;
Testing of array-api-compat across Array API provider libraries (numpy, pytorch, jax.numpy, dask) relies on array-api-tests;
array-api-tests relies on hypothesis.extra.array_api module;
if hypothesis.extra.array_api does not recognize 2024.12 as an allowed version, we cannot even start testing anything against the new spec version.

<s>So I'm wondering what would you think about merging this one-line change and cutting a new hypothesis release? I fully realize it might sound a bit preposterous to ask for a release because of an unrelated change in a far far corner of your userspace. Still I've got to ask :-).</s>

EDIT: now that I actually read the release policy, am adding the RELEASE.rst snippet.  I'd guess there's not much need to precisely time this PR: hypothesis full well can recognize an upcoming array API version.