### PR TITLE
Share `belongs_to` cache

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improves sharing of some internal cache behavior.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -25,6 +25,7 @@ import zlib
 from collections import defaultdict
 from collections.abc import Coroutine, Generator, Hashable, Iterable, Sequence
 from functools import partial
+from inspect import Parameter
 from random import Random
 from typing import (
     TYPE_CHECKING,
@@ -633,7 +634,13 @@ class Stuff:
     given_kwargs: dict = attr.ib(factory=dict)
 
 
-def process_arguments_to_given(wrapped_test, arguments, kwargs, given_kwargs, params):
+def process_arguments_to_given(
+    wrapped_test: Any,
+    arguments: Sequence[object],
+    kwargs: dict[str, object],
+    given_kwargs: dict[str, SearchStrategy],
+    params: dict[str, Parameter],
+) -> tuple[Sequence[object], dict[str, object], Stuff]:
     selfy = None
     arguments, kwargs = convert_positional_arguments(wrapped_test, arguments, kwargs)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -37,6 +37,7 @@ from hypothesis.internal.compat import NotRequired, TypeAlias, TypedDict, ceil, 
 from hypothesis.internal.conjecture.choice import (
     ChoiceKeyT,
     ChoiceKwargsT,
+    ChoiceNode,
     ChoiceT,
     ChoiceTemplate,
     choices_key,
@@ -45,7 +46,6 @@ from hypothesis.internal.conjecture.data import (
     ConjectureData,
     ConjectureResult,
     DataObserver,
-    IRNode,
     Overrun,
     Status,
     _Overrun,
@@ -495,7 +495,7 @@ class ConjectureRunner:
                             "integer": int,
                             "boolean": bool,
                             "bytes": bytes,
-                        }[node.ir_type]
+                        }[node.type]
                         if type(value) is not expected_type:
                             raise HypothesisException(
                                 f"expected {expected_type} from "
@@ -1431,8 +1431,8 @@ class ConjectureRunner:
         )
 
     def passing_choice_sequences(
-        self, prefix: Sequence[IRNode] = ()
-    ) -> frozenset[tuple[IRNode, ...]]:
+        self, prefix: Sequence[ChoiceNode] = ()
+    ) -> frozenset[tuple[ChoiceNode, ...]]:
         """Return a collection of choice sequence nodes which cause the test to pass.
         Optionally restrict this by a certain prefix, which is useful for explain mode.
         """

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -108,14 +108,14 @@ class Optimiser:
             # we can only (sensibly & easily) define hill climbing for
             # numeric-style nodes. It's not clear hill-climbing a string is
             # useful, for instance.
-            if node.ir_type not in {"integer", "float", "bytes", "boolean"}:
+            if node.type not in {"integer", "float", "bytes", "boolean"}:
                 continue
 
             def attempt_replace(k: int) -> bool:
                 """
                 Try replacing the current node in the current best test case
                 with a value which is "k times larger", where the exact notion
-                of "larger" depends on the ir_type.
+                of "larger" depends on the choice_type.
 
                 Note that we use the *current* best and not the one we started with.
                 This helps ensure that if we luck into a good draw when making
@@ -131,10 +131,10 @@ class Optimiser:
                     return False  # pragma: no cover
 
                 new_choice: ChoiceT
-                if node.ir_type in {"integer", "float"}:
+                if node.type in {"integer", "float"}:
                     assert isinstance(node.value, (int, float))
                     new_choice = node.value + k
-                elif node.ir_type == "boolean":
+                elif node.type == "boolean":
                     assert isinstance(node.value, bool)
                     if abs(k) > 1:
                         return False
@@ -145,7 +145,7 @@ class Optimiser:
                     if k == 0:  # pragma: no cover
                         new_choice = node.value
                 else:
-                    assert node.ir_type == "bytes"
+                    assert node.type == "bytes"
                     assert isinstance(node.value, bytes)
                     v = int_from_bytes(node.value)
                     # can't go below zero for bytes

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -32,12 +32,13 @@ def belongs_to(package: ModuleType) -> Callable[[str], bool]:
         return lambda filepath: False
 
     assert package.__file__ is not None
-    FILE_CACHE[package] = {}
+    FILE_CACHE.setdefault(package, {})
+    cache = FILE_CACHE[package]
     root = Path(package.__file__).resolve().parent
 
     def accept(filepath: str) -> bool:
         try:
-            return FILE_CACHE[package][filepath]
+            return cache[filepath]
         except KeyError:
             pass
         try:
@@ -45,7 +46,7 @@ def belongs_to(package: ModuleType) -> Callable[[str], bool]:
             result = True
         except Exception:
             result = False
-        FILE_CACHE[package][filepath] = result
+        cache[filepath] = result
         return result
 
     accept.__name__ = f"is_{package.__name__}_file"

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 import types
 import warnings
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Sequence
 from functools import partial, wraps
 from io import StringIO
 from keyword import iskeyword
@@ -214,7 +214,9 @@ def convert_keyword_arguments(function, args, kwargs):
     return bound.args, bound.kwargs
 
 
-def convert_positional_arguments(function, args, kwargs):
+def convert_positional_arguments(
+    function: Any, args: Sequence[object], kwargs: dict[str, object]
+) -> tuple[tuple[object, ...], dict[str, object]]:
     """Return a tuple (new_args, new_kwargs) where all possible arguments have
     been moved to kwargs.
 

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -252,9 +252,9 @@ def test_backend_can_shrink_floats():
 # mostly a shoehorned coverage test until the shrinker is migrated to the ir
 # and calls cached_test_function_ir with backends consistently.
 @given(nodes())
-def test_new_conjecture_data_ir_with_backend(node):
+def test_new_conjecture_data_with_backend(node):
     def test(data):
-        getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
+        getattr(data, f"draw_{node.type}")(**node.kwargs)
 
     with temp_register_backend("prng", PrngProvider):
         runner = ConjectureRunner(test, settings=settings(backend="prng"))

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1523,12 +1523,12 @@ def test_too_slow_report():
 
 
 def _draw(cd, node):
-    return getattr(cd, f"draw_{node.ir_type}")(**node.kwargs)
+    return getattr(cd, f"draw_{node.type}")(**node.kwargs)
 
 
 @given(nodes(was_forced=False))
 def test_overruns_with_extend_are_not_cached(node):
-    assume(compute_max_children(node.ir_type, node.kwargs) > 100)
+    assume(compute_max_children(node.type, node.kwargs) > 100)
 
     def test(cd):
         _draw(cd, node)

--- a/hypothesis-python/tests/conjecture/test_forced.py
+++ b/hypothesis-python/tests/conjecture/test_forced.py
@@ -19,7 +19,7 @@ from hypothesis.internal.conjecture.choice import choice_equal
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.floats import SIGNALING_NAN, SMALLEST_SUBNORMAL
 
-from tests.conjecture.common import fresh_data, ir_types_and_kwargs
+from tests.conjecture.common import choice_types_kwargs, fresh_data
 
 
 @given(st.data())
@@ -130,11 +130,11 @@ def test_forced_many(data):
         {"min_value": -1 * math.inf, "max_value": -1 * math.inf, "forced": math.nan},
     )
 )
-@given(ir_types_and_kwargs(use_forced=True))
-def test_forced_values(ir_type_and_kwargs):
-    (ir_type, kwargs) = ir_type_and_kwargs
+@given(choice_types_kwargs(use_forced=True))
+def test_forced_values(choice_type_and_kwargs):
+    (choice_type, kwargs) = choice_type_and_kwargs
 
-    if ir_type == "float":
+    if choice_type == "float":
         # TODO intentionally avoid triggering a bug with forcing nan values
         # while both min and max value have the opposite sign.
         # Once we fix the aforementioned bug we can remove this intentional
@@ -143,13 +143,13 @@ def test_forced_values(ir_type_and_kwargs):
 
     forced = kwargs["forced"]
     data = fresh_data()
-    assert choice_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
+    assert choice_equal(getattr(data, f"draw_{choice_type}")(**kwargs), forced)
 
     # now make sure the written buffer reproduces the forced value, even without
     # specifying forced=.
     del kwargs["forced"]
     data = ConjectureData.for_choices(data.choices)
-    assert choice_equal(getattr(data, f"draw_{ir_type}")(**kwargs), forced)
+    assert choice_equal(getattr(data, f"draw_{choice_type}")(**kwargs), forced)
 
 
 @pytest.mark.parametrize("sign", [1, -1])

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -13,8 +13,8 @@ import math
 import pytest
 
 from hypothesis import assume, example, given, settings
-from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.choice import ChoiceNode
+from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.datatree import compute_max_children
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -13,7 +13,8 @@ import math
 import pytest
 
 from hypothesis import assume, example, given, settings
-from hypothesis.internal.conjecture.data import IRNode, Status
+from hypothesis.internal.conjecture.data import Status
+from hypothesis.internal.conjecture.choice import ChoiceNode
 from hypothesis.internal.conjecture.datatree import compute_max_children
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -226,16 +227,16 @@ def test_optimiser_when_test_grows_buffer_to_overflow():
 
 @given(nodes())
 @example(
-    IRNode(
-        ir_type="bytes",
+    ChoiceNode(
+        type="bytes",
         value=b"\xb1",
         kwargs={"min_size": 1, "max_size": 1},
         was_forced=False,
     )
 )
 @example(
-    IRNode(
-        ir_type="string",
+    ChoiceNode(
+        type="string",
         value="aaaa",
         kwargs={
             "min_size": 0,
@@ -246,10 +247,10 @@ def test_optimiser_when_test_grows_buffer_to_overflow():
     )
 )
 @example(
-    IRNode(ir_type="integer", value=1, kwargs=integer_kw(0, 200), was_forced=False)
+    ChoiceNode(type="integer", value=1, kwargs=integer_kw(0, 200), was_forced=False)
 )
 def test_optimising_all_nodes(node):
-    assume(compute_max_children(node.ir_type, node.kwargs) > 50)
+    assume(compute_max_children(node.type, node.kwargs) > 50)
     size_function = {
         "integer": lambda n: n,
         "float": lambda f: f if math.isfinite(f) else 0,
@@ -260,8 +261,8 @@ def test_optimising_all_nodes(node):
     with deterministic_PRNG():
 
         def test(data):
-            v = getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
-            data.target_observations["v"] = size_function[node.ir_type](v)
+            v = getattr(data, f"draw_{node.type}")(**node.kwargs)
+            data.target_observations["v"] = size_function[node.type](v)
 
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, max_examples=50)

--- a/hypothesis-python/tests/conjecture/test_provider_contract.py
+++ b/hypothesis-python/tests/conjecture/test_provider_contract.py
@@ -20,9 +20,9 @@ from hypothesis.internal.conjecture.providers import BytestringProvider
 from hypothesis.internal.intervalsets import IntervalSet
 
 from tests.conjecture.common import (
+    choice_types_kwargs,
     float_kw,
     integer_kw,
-    ir_types_and_kwargs,
     nodes,
     string_kw,
 )
@@ -41,8 +41,8 @@ from tests.conjecture.common import (
 @example(b"\x00" * 100, [("float", float_kw())])
 @example(b"\x00" * 100, [("bytes", {"min_size": 0, "max_size": 10})])
 @example(b"\x00", [("integer", integer_kw())])
-@given(st.binary(min_size=200), st.lists(ir_types_and_kwargs()))
-def test_provider_contract_bytestring(bytestring, ir_type_and_kwargs):
+@given(st.binary(min_size=200), st.lists(choice_types_kwargs()))
+def test_provider_contract_bytestring(bytestring, choice_type_and_kwargs):
     data = ConjectureData(
         random=None,
         observer=None,
@@ -50,16 +50,16 @@ def test_provider_contract_bytestring(bytestring, ir_type_and_kwargs):
         provider_kw={"bytestring": bytestring},
     )
 
-    for ir_type, kwargs in ir_type_and_kwargs:
+    for choice_type, kwargs in choice_type_and_kwargs:
         try:
-            value = getattr(data, f"draw_{ir_type}")(**kwargs)
+            value = getattr(data, f"draw_{choice_type}")(**kwargs)
         except StopTest:
             return
 
         assert choice_permitted(value, kwargs)
-        kwargs["forced"] = choice_from_index(0, ir_type, kwargs)
+        kwargs["forced"] = choice_from_index(0, choice_type, kwargs)
         assert choice_equal(
-            kwargs["forced"], getattr(data, f"draw_{ir_type}")(**kwargs)
+            kwargs["forced"], getattr(data, f"draw_{choice_type}")(**kwargs)
         )
 
 
@@ -67,5 +67,5 @@ def test_provider_contract_bytestring(bytestring, ir_type_and_kwargs):
 def test_provider_contract_hypothesis(nodes, random):
     data = ConjectureData(random=random)
     for node in nodes:
-        value = getattr(data, f"draw_{node.ir_type}")(**node.kwargs)
+        value = getattr(data, f"draw_{node.type}")(**node.kwargs)
         assert choice_permitted(value, node.kwargs)

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -87,7 +87,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
     nodes = [
         node
         for node in data.nodes
-        if node.ir_type == "integer" and node.kwargs["max_value"] == 2**16 - 1
+        if node.type == "integer" and node.kwargs["max_value"] == 2**16 - 1
     ]
     assert len(nodes) % 2 == 0
 


### PR DESCRIPTION
Also renames all (?) remaining references to `ir_`. `ChoiceNode(type="integer")` is maybe a bit weird but `ChoiceNode(choice_type="integer")` felt too verbose. I think of `choice` as "a single typed value" and `ChoiceNode` as "a value plus the context in which it was drawn (kwargs/etc)".

Things were looking pretty hairy for a while when we were in the thick of the migration, api-design and naming-wise 😅 I'm pretty happy with where we've ended up in `choice.py` now though.