### PR TITLE
Improve pprinting of stateful examples

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,19 @@
+RELEASE_TYPE: patch
+
+Improve the clarity of printing counterexamples in :doc:`stateful testing <stateful>`, by avoiding confusing :class:`~hypothesis.stateful.Bundle` references with equivalent values drawn from a regular strategy.
+
+For example, we now print:
+
+.. code-block: python
+
+  a_0 = state.add_to_bundle(a=0)
+  state.unrelated(value=0)
+
+instead of
+
+.. code-block: python
+
+  a_0 = state.add_to_bundle(a=0)
+  state.unrelated(value=a_0)
+
+if the ``unrelated`` rule draws from a regular strategy such as :func:`~hypothesis.strategies.integers` instead of the ``a`` bundle.


### PR DESCRIPTION
`singleton_printers` does unconditional id-based replacement, which is not always correct (see tests). `test_unrelated_rule_does_not_use_var_reference_repr` fails on master with:

```python
state = UnrelatedCall()
a_0 = state.add_a(a=0)
state.unrelated(value=a_0) # should be value=0
```

I think the main use case for the singleton printers is addressed with `VarReference`, and any remaining effects are imo net-negative, though they can sometimes be more readable even if not strictly correct.