### PR TITLE
Fix code blocks in changelog

### DIFF
--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -1891,8 +1891,11 @@ Previously, this did nothing at all.
     class TestMyStatefulMachine(MyStatefulMachine.TestCase):
         settings = settings(max_examples=10000)
 
+
     # the old way still works, but it's more verbose.
     MyStateMachine.TestCase.settings = settings(max_examples=10000)
+
+
     class TestMyStatefulMachine(MyStatefulMachine.TestCase):
         pass
 
@@ -1912,7 +1915,9 @@ This has never had any effect, and it should be used as a decorator instead:
 
     class BadMachine(RuleBasedStateMachine):
         """This doesn't do anything, and is now an error!"""
+
         settings = settings(derandomize=True)
+
 
     @settings(derandomize=True)
     class GoodMachine(RuleBasedStateMachine):

--- a/hypothesis-python/docs/changes.rst
+++ b/hypothesis-python/docs/changes.rst
@@ -28,14 +28,14 @@ Improve the clarity of printing counterexamples in :doc:`stateful testing <state
 
 For example, we now print:
 
-.. code-block: python
+.. code-block:: python
 
   a_0 = state.add_to_bundle(a=0)
   state.unrelated(value=0)
 
 instead of
 
-.. code-block: python
+.. code-block:: python
 
   a_0 = state.add_to_bundle(a=0)
   state.unrelated(value=a_0)
@@ -1885,7 +1885,7 @@ This patch supports assigning ``settings = settings(...)`` as a class attribute
 on a subclass of a ``.TestCase`` attribute of a :class:`~hypothesis.stateful.RuleBasedStateMachine`.
 Previously, this did nothing at all.
 
-.. code-block: python
+.. code-block:: python
 
     # works as of this release
     class TestMyStatefulMachine(MyStatefulMachine.TestCase):
@@ -1908,7 +1908,7 @@ This release makes it an error to assign ``settings = settings(...)``
 as a class attribute on a :class:`~hypothesis.stateful.RuleBasedStateMachine`.
 This has never had any effect, and it should be used as a decorator instead:
 
-.. code-block: python
+.. code-block:: python
 
     class BadMachine(RuleBasedStateMachine):
         """This doesn't do anything, and is now an error!"""

--- a/tooling/src/hypothesistooling/releasemanagement.py
+++ b/tooling/src/hypothesistooling/releasemanagement.py
@@ -17,7 +17,7 @@ like a nice tidy reusable set of functionality.
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 import hypothesistooling as tools
 
@@ -30,7 +30,7 @@ def release_date_string():
     through a release."""
     global __RELEASE_DATE_STRING
     if __RELEASE_DATE_STRING is None:
-        __RELEASE_DATE_STRING = datetime.utcnow().strftime("%Y-%m-%d")
+        __RELEASE_DATE_STRING = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     return __RELEASE_DATE_STRING
 
 

--- a/whole_repo_tests/test_rst_is_valid.py
+++ b/whole_repo_tests/test_rst_is_valid.py
@@ -9,6 +9,8 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import os
+import re
+from pathlib import Path
 
 import hypothesistooling as tools
 from hypothesistooling.projects import hypothesispython as hp
@@ -30,6 +32,17 @@ ALL_RST = [
 
 def test_passes_rst_lint():
     pip_tool("rst-lint", *(f for f in ALL_RST if not is_sphinx(f)))
+
+
+def test_rst_code_blocks():
+    # has bitten us before https://github.com/HypothesisWorks/hypothesis/pull/4273
+    pattern = re.compile(r"^\.\.\s+code-block:\s+", re.MULTILINE)
+    for f in ALL_RST:
+        matches = pattern.search(Path(f).read_text())
+        assert not matches, (
+            f"incorrect code block syntax in {f}. Use `.. code-block::` "
+            "instead of `.. code-block:`"
+        )
 
 
 def disabled_test_passes_flake8():


### PR DESCRIPTION
`.. code-block: python` is a comment; `.. code-block:: python` is a code block 😅. Affects some old changelogs as well.