### PR TITLE
Fix test_clean_source for python 3.13.2

### DIFF
--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -659,8 +659,9 @@ def test_param_called_within_defaults_on_error():
 
 def _prep_source(*pairs):
     return [
-        pytest.param(dedent(x).strip(), dedent(y).strip().encode(), id=f"case-{i}")
-        for i, (x, y) in enumerate(pairs)
+        pytest.param(dedent(x).strip(), dedent(y).strip().encode(),
+                     id=f"case-{i}", marks=marks)
+        for i, (x, y, *marks) in enumerate(pairs)
     ]
 
 
@@ -687,6 +688,20 @@ def _prep_source(*pairs):
                 assert x
                 "Had some blank lines above"
             """,
+        ),
+        (
+            """
+            def      \\
+                f(): pass
+            """,
+            """
+            def\\
+                f(): pass
+            """,
+            pytest.mark.skipif(
+                sys.version_info >= (3, 12),
+                reason="untokenize() does not round-trip for code with line breaks, gh-125553",
+            ),
         ),
         (
             """

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -690,16 +690,6 @@ def _prep_source(*pairs):
         ),
         (
             """
-            def      \\
-                f(): pass
-            """,
-            """
-            def\\
-                f(): pass
-            """,
-        ),
-        (
-            """
             @dec
             async def f():
                 pass


### PR DESCRIPTION
In python 3.13.2 untokenize() does not round-trip for code containing line breaks (\ + \n). This patch removes the test case for the space removal before line break.

https://github.com/python/cpython/issues/125553