### PR TITLE
Shrink NaN to canonical form

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve shrinking of non-standard NaN float values (:issue:`4277`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/choice.py
@@ -417,7 +417,7 @@ def choice_to_index(choice: ChoiceT, kwargs: ChoiceKwargsT) -> int:
             to_order=intervals.index_from_char_in_shrink_order,
         )
     elif isinstance(choice, float):
-        sign = int(sign_aware_lte(choice, -0.0))
+        sign = int(math.copysign(1.0, choice) < 0)
         return (sign << 64) | float_to_lex(abs(choice))
     else:
         raise NotImplementedError

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -110,7 +110,8 @@ class Shrinker:
     def consider(self, value):
         """Try using ``value`` as a possible candidate improvement.
 
-        Return True if self.current is canonically equal to self.current after the call.
+        Return True if self.current is canonically equal to value after the call, either because
+        the value was incorporated as an improvement or because it had that value already.
         """
         value = self.make_immutable(value)
         if value == self.current:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -34,7 +34,7 @@ class Shrinker:
         self.name = name
 
         self.__predicate = predicate
-        self.__seen = set()
+        self.__seen = {self.make_canonical(self.current)}
         self.debugging_enabled = debug
 
     @property

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/common.py
@@ -114,13 +114,12 @@ class Shrinker:
         the value was incorporated as an improvement or because it had that value already.
         """
         value = self.make_immutable(value)
-        if value == self.current:
-            # shortcut for the simple (non-canonical) equality case, not required for correctness
-            return True
         self.debug(f"considering {value!r}")
         canonical = self.make_canonical(value)
+        if canonical == self.make_canonical(self.current):
+            return True
         if canonical in self.__seen:
-            return canonical == self.make_canonical(self.current)
+            return False
         self.__seen.add(canonical)
         self.check_invariants(value)
         if not self.left_is_better(value, self.current):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -14,24 +14,23 @@ import sys
 from hypothesis.internal.conjecture.floats import float_to_lex
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
-from hypothesis.internal.floats import MAX_PRECISE_INTEGER
+from hypothesis.internal.floats import MAX_PRECISE_INTEGER, float_to_int
 
 
 class Float(Shrinker):
     def setup(self):
-        self.NAN = math.nan
         self.debugging_enabled = True
 
-    def make_immutable(self, f):
-        f = float(f)
+    def make_canonical(self, f):
         if math.isnan(f):
-            # Always use the same NAN so it works properly in self.seen
-            f = self.NAN
+            # Distinguish different NaN bit patterns, while making each equal to itself
+            # To avoid accidental collision w/ a valid (large) float, convert to str.
+            return hex(float_to_int(f))
         return f
 
     def check_invariants(self, value):
-        # We only handle positive floats because we encode the sign separately
-        # anyway.
+        # We only handle positive floats (including NaN) because we encode the sign
+        # separately anyway.
         assert not (value < 0)
 
     def left_is_better(self, left, right):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -9,12 +9,13 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
+import struct
 import sys
 
 from hypothesis.internal.conjecture.floats import float_to_lex
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
-from hypothesis.internal.floats import MAX_PRECISE_INTEGER, float_to_int
+from hypothesis.internal.floats import MAX_PRECISE_INTEGER
 
 
 class Float(Shrinker):
@@ -23,9 +24,10 @@ class Float(Shrinker):
 
     def make_canonical(self, f):
         if math.isnan(f):
-            # Distinguish different NaN bit patterns, while making each equal to itself
-            # To avoid accidental collision w/ a valid (large) float, convert to str.
-            return hex(float_to_int(f))
+            # Distinguish different NaN bit patterns, while making each equal to itself.
+            # Returning bytes instead of integer (float_to_int) avoids accidental
+            # equality with valid large floats.
+            return struct.pack("d", f)
         return f
 
     def check_invariants(self, value):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinking/floats.py
@@ -9,13 +9,12 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
-import struct
 import sys
 
 from hypothesis.internal.conjecture.floats import float_to_lex
 from hypothesis.internal.conjecture.shrinking.common import Shrinker
 from hypothesis.internal.conjecture.shrinking.integer import Integer
-from hypothesis.internal.floats import MAX_PRECISE_INTEGER
+from hypothesis.internal.floats import MAX_PRECISE_INTEGER, float_to_int
 
 
 class Float(Shrinker):
@@ -25,9 +24,8 @@ class Float(Shrinker):
     def make_canonical(self, f):
         if math.isnan(f):
             # Distinguish different NaN bit patterns, while making each equal to itself.
-            # Returning bytes instead of integer (float_to_int) avoids accidental
-            # equality with valid large floats.
-            return struct.pack("d", f)
+            # Wrap in tuple to avoid potential collision with (huge) finite floats.
+            return ("nan", float_to_int(f))
         return f
 
     def check_invariants(self, value):

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
-import struct
 import sys
 
 import pytest
@@ -18,7 +17,7 @@ from hypothesis import HealthCheck, assume, example, given, settings, strategies
 from hypothesis.internal.compat import ceil, extract_bits, floor
 from hypothesis.internal.conjecture import floats as flt
 from hypothesis.internal.conjecture.engine import ConjectureRunner
-from hypothesis.internal.floats import float_to_int
+from hypothesis.internal.floats import SIGNALING_NAN, float_to_int
 
 EXPONENTS = list(range(flt.MAX_EXPONENT + 1))
 assert len(EXPONENTS) == 2**11
@@ -204,9 +203,7 @@ def test_reject_out_of_bounds_floats_while_shrinking():
     assert g == 103.0
 
 
-@pytest.mark.parametrize(
-    "nan", [-math.nan, struct.unpack("d", struct.pack("Q", 0xFFF8000000000001))[0]]
-)
+@pytest.mark.parametrize("nan", [-math.nan, SIGNALING_NAN, -SIGNALING_NAN])
 def test_shrinks_to_canonical_nan(nan):
     shrunk = minimal_from(nan, math.isnan)
     assert float_to_int(shrunk) == float_to_int(math.nan)

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -17,11 +17,8 @@ import pytest
 from hypothesis import HealthCheck, assume, example, given, settings, strategies as st
 from hypothesis.internal.compat import ceil, extract_bits, floor
 from hypothesis.internal.conjecture import floats as flt
-from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import float_to_int
-
-from tests.conjecture.common import shrinking_from
 
 EXPONENTS = list(range(flt.MAX_EXPONENT + 1))
 assert len(EXPONENTS) == 2**11
@@ -208,16 +205,8 @@ def test_reject_out_of_bounds_floats_while_shrinking():
 
 
 @pytest.mark.parametrize(
-    "nan",
-    [math.nan, -math.nan, struct.unpack('d', struct.pack('Q', 0xfff8000000000001))[0]]
+    "nan", [-math.nan, struct.unpack("d", struct.pack("Q", 0xFFF8000000000001))[0]]
 )
 def test_shrinks_to_canonical_nan(nan):
-    @shrinking_from([nan])
-    def shrinker(data: ConjectureData):
-        value = data.draw_float()
-        if math.isnan(value):
-            data.mark_interesting()
-
-    shrinker.shrink()
-    assert len(shrinker.choices) == 1
-    assert float_to_int(shrinker.choices[0]) == float_to_int(math.nan)
+    shrunk = minimal_from(nan, math.isnan)
+    assert float_to_int(shrunk) == float_to_int(math.nan)

--- a/hypothesis-python/tests/cover/test_shrink_budgeting.py
+++ b/hypothesis-python/tests/cover/test_shrink_budgeting.py
@@ -20,7 +20,7 @@ from hypothesis.internal.conjecture.shrinking import Integer, Ordering
     [
         (Integer, 2**16),
         (Integer, int(sys.float_info.max)),
-        (Ordering, [[100] * 10]),
+        (Ordering, [(100,) * 10]),
         (Ordering, [i * 100 for i in (range(5))]),
         (Ordering, [i * 100 for i in reversed(range(5))]),
     ],

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -58,7 +58,7 @@ def test_shrinks_to_canonical_nan(s):
     @seed(s)
     def sort_is_reversible(l):
         # fmt: off
-        assert sorted(l, reverse=True) == list(reversed(sorted(l)))
+        assert sorted(l, reverse=True) == list(reversed(sorted(l)))  # noqa: C413
         # fmt: on
 
     try:

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -8,17 +8,12 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import math
-import struct
-
 import pytest
 
-from hypothesis import example, given, seed, strategies as st
+from hypothesis import example, given, strategies as st
 from hypothesis.internal.compat import ceil
-from hypothesis.internal.conjecture.data import ConjectureData
 
 from tests.common.debug import minimal
-from tests.conjecture.common import shrinking_from
 
 
 def test_shrinks_to_simple_floats():
@@ -50,22 +45,3 @@ def test_shrinks_downwards_to_integers_when_fractional(b):
         ).filter(lambda x: int(x) != x)
     )
     assert g == b + 0.5
-
-
-@pytest.mark.parametrize("nan",
-    [
-        math.nan,
-        -math.nan,
-        struct.unpack('d', struct.pack('Q', 0xfff8000000000001))[0]
-    ]
-)
-def test_shrinks_to_canonical_nan(nan):
-    @shrinking_from([nan])
-    def shrinker(data: ConjectureData):
-        value = data.draw_float()
-        if math.isnan(value):
-            data.mark_interesting()
-
-    shrinker.shrink()
-    assert len(shrinker.choices) == 1
-    assert struct.pack("d", shrinker.choices[0]) == struct.pack("d", math.nan)

--- a/hypothesis-python/tests/quality/test_float_shrinking.py
+++ b/hypothesis-python/tests/quality/test_float_shrinking.py
@@ -50,10 +50,17 @@ def test_shrinks_downwards_to_integers_when_fractional(b):
 @pytest.mark.parametrize("s", range(10))
 def test_shrinks_to_canonical_nan(s):
     # Regression test for #4277. A more reliable and minimal example could probably be found.
-    @given(st.lists(st.just(0)|st.floats().filter(lambda a: a != a), min_size=2, max_size=2))
+    @given(
+        st.lists(
+            st.just(0) | st.floats().filter(lambda a: a != a), min_size=2, max_size=2
+        )
+    )
     @seed(s)
     def sort_is_reversible(l):
+        # fmt: off
         assert sorted(l, reverse=True) == list(reversed(sorted(l)))
+        # fmt: on
+
     try:
         sort_is_reversible()
     except AssertionError as e:


### PR DESCRIPTION
Closes #4277.

The first issue (`-nan`) is a one-liner, switching from `sign_aware_lte` to `math.copysign` to detect the sign of a choice.

Second issue (`struct.unpack('d', struct.pack('Q', 0xfff8000000000001))[0]`) requires distinguishing NaNs in float shrinking, so that code is reshuffled a bit to separate out the "immutable" value for the shrinker from the "hashable" value for tracking of seen values.