### PR TITLE
Unwrap nested `one_of` strategies

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,9 +1,18 @@
 RELEASE_TYPE: patch
 
-We now provide a better string representation for :func:`~hypothesis.strategies.one_of` strategies, by flattening nested :func:`~hypothesis.strategies.one_of` instances. For instance:
+We now provide a better string representation for :func:`~hypothesis.strategies.one_of` strategies, by flattening consecutive ``|`` combinations. For instance:
 
 .. code-block:: pycon
 
     >>> st.integers() | st.text() | st.booleans()
     # previously: one_of(one_of(integers(), text()), booleans())
     one_of(integers(), text(), booleans())
+
+Explicit calls to :func:`~hypothesis.strategies.one_of` remain unflattened, in order to make tracking down complicated :func:`~hypothesis.strategies.one_of` constructions easier:
+
+.. code-block:: pycon
+
+    >>> st.one_of(st.integers(), st.one_of(st.text(), st.booleans()))
+    one_of(integers(), one_of(text(), booleans()))
+
+We print ``one_of`` in reprs (rather than ``integers() | text() | ...``) for consistency with reprs containing ``.filter`` or ``.map`` calls, which uses the full ``one_of`` to avoid ambiguity.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+We now provide a better string representation for :func:`~hypothesis.strategies.one_of` strategies, by flattening nested :func:`~hypothesis.strategies.one_of` instances. For instance:
+
+.. code-block:: pycon
+
+    >>> st.integers() | st.text() | st.booleans()
+    # previously: one_of(one_of(integers(), text()), booleans())
+    one_of(integers(), text(), booleans())

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1342,7 +1342,7 @@ class StateForActualGivenExecution:
         for falsifying_example in self.falsifying_examples:
             fragments = []
 
-            ran_example = runner.new_conjecture_data_ir(
+            ran_example = runner.new_conjecture_data(
                 falsifying_example.choices, max_choices=len(falsifying_example.choices)
             )
             ran_example.slice_comments = falsifying_example.slice_comments

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -719,31 +719,14 @@ class ConjectureData:
     def choices(self) -> tuple[ChoiceT, ...]:
         return tuple(node.value for node in self.nodes)
 
-    # A bit of explanation of the `observe` and `fake_forced` arguments in our
-    # draw_* functions.
+    # draw_* functions might be called in one of two contexts: either "above" or
+    # "below" the choice sequence. For instance, draw_string calls draw_boolean
+    # from ``many`` when calculating the number of characters to return. We do
+    # not want these choices to get written to the choice sequence, because they
+    # are not true choices themselves.
     #
-    # There are two types of draws: sub-ir and super-ir. For instance, some ir
-    # nodes use `many`, which in turn calls draw_boolean. But some strategies
-    # also use many, at the super-ir level. We don't want to write sub-ir draws
-    # to the DataTree (and consequently use them when computing novel prefixes),
-    # since they are fully recorded by writing the ir node itself.
-    # But super-ir draws are not included in the ir node, so we do want to write
-    # these to the tree.
-    #
-    # `observe` formalizes this distinction. The draw will only be written to
-    # the DataTree if observe is True.
-    #
-    # `fake_forced` deals with a different problem. We use `forced=` to convert
-    # ir prefixes, which are potentially from other backends, into our backing
-    # bits representation. This works fine, except using `forced=` in this way
-    # also sets `was_forced=True` for all blocks, even those that weren't forced
-    # in the traditional way. The shrinker chokes on this due to thinking that
-    # nothing can be modified.
-    #
-    # Setting `fake_forced` to true says that yes, we want to force a particular
-    # value to be returned, but we don't want to treat that block as fixed for
-    # e.g. the shrinker.
-
+    # `observe` formalizes this. The choice will only be written to the choice
+    # sequence if observe is True.
     def _draw(self, choice_type, kwargs, *, observe, forced):
         # this is somewhat redundant with the length > max_length check at the
         # end of the function, but avoids trying to use a null self.random when

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -543,7 +543,7 @@ class DataTree:
 
     DataTree tracks the following:
 
-    - Drawn choices in the typed choice sequence
+    - Drawn choices in the choice sequence
       - ConjectureData.draw_integer()
       - ConjectureData.draw_float()
       - ConjectureData.draw_string()

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -361,7 +361,7 @@ class ConjectureRunner:
         key = self._cache_key(data.choices)
         self.__data_cache[key] = result
 
-    def cached_test_function_ir(
+    def cached_test_function(
         self,
         choices: Sequence[Union[ChoiceT, ChoiceTemplate]],
         *,
@@ -862,7 +862,7 @@ class ConjectureRunner:
                     # clear out any keys which fail deserialization
                     self.settings.database.delete(self.database_key, existing)
                     continue
-                data = self.cached_test_function_ir(choices, extend="full")
+                data = self.cached_test_function(choices, extend="full")
                 if data.status != Status.INTERESTING:
                     self.settings.database.delete(self.database_key, existing)
                     self.settings.database.delete(self.secondary_key, existing)
@@ -897,7 +897,7 @@ class ConjectureRunner:
                     if choices is None:
                         self.settings.database.delete(self.pareto_key, existing)
                         continue
-                    data = self.cached_test_function_ir(choices, extend="full")
+                    data = self.cached_test_function(choices, extend="full")
                     if data not in self.pareto_front:
                         self.settings.database.delete(self.pareto_key, existing)
                     if data.status == Status.INTERESTING:
@@ -959,9 +959,7 @@ class ConjectureRunner:
         self.debug("Generating new examples")
 
         assert self.should_generate_more()
-        zero_data = self.cached_test_function_ir(
-            (ChoiceTemplate("simplest", count=None),)
-        )
+        zero_data = self.cached_test_function((ChoiceTemplate("simplest", count=None),))
         if zero_data.status > Status.OVERRUN:
             assert isinstance(zero_data, ConjectureResult)
             self.__data_cache.pin(
@@ -1053,7 +1051,7 @@ class ConjectureRunner:
                 and not self.interesting_examples
                 and consecutive_zero_extend_is_invalid < 5
             ):
-                minimal_example = self.cached_test_function_ir(
+                minimal_example = self.cached_test_function(
                     prefix + (ChoiceTemplate("simplest", count=None),)
                 )
 
@@ -1193,7 +1191,7 @@ class ConjectureRunner:
                     # really matter. It may not achieve the desired result,
                     # but it's still a perfectly acceptable choice sequence
                     # to try.
-                    new_data = self.cached_test_function_ir(
+                    new_data = self.cached_test_function(
                         choices[:start1]
                         + replacement
                         + choices[end1:start2]
@@ -1395,7 +1393,7 @@ class ConjectureRunner:
                 if shortlex(c) > cap:
                     break
                 else:
-                    self.cached_test_function_ir(choices)
+                    self.cached_test_function(choices)
                     # We unconditionally remove c from the secondary key as it
                     # is either now primary or worse than our primary example
                     # of this reason for interestingness.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -408,7 +408,7 @@ class ConjectureRunner:
             trial_observer = DiscardObserver()
 
         try:
-            trial_data = self.new_conjecture_data_ir(
+            trial_data = self.new_conjecture_data(
                 choices, observer=trial_observer, max_choices=max_length
             )
             self.tree.simulate_test_function(trial_data)
@@ -433,7 +433,7 @@ class ConjectureRunner:
             except KeyError:
                 pass
 
-        data = self.new_conjecture_data_ir(choices, max_choices=max_length)
+        data = self.new_conjecture_data(choices, max_choices=max_length)
         # note that calling test_function caches `data` for us, for both an ir
         # tree key and a buffer key.
         self.test_function(data)
@@ -1038,7 +1038,7 @@ class ConjectureRunner:
             # not whatever is specified by the backend. We can improve this
             # once more things are on the ir.
             if not self.using_hypothesis_backend:
-                data = self.new_conjecture_data_ir([])
+                data = self.new_conjecture_data([])
                 with suppress(BackendCannotProceed):
                     self.test_function(data)
                 continue
@@ -1074,7 +1074,7 @@ class ConjectureRunner:
                 # running the test function for real here. If however we encounter
                 # some novel behaviour, we try again with the real test function,
                 # starting from the new novel prefix that has discovered.
-                trial_data = self.new_conjecture_data_ir(prefix, max_choices=max_length)
+                trial_data = self.new_conjecture_data(prefix, max_choices=max_length)
                 try:
                     self.tree.simulate_test_function(trial_data)
                     continue
@@ -1096,7 +1096,7 @@ class ConjectureRunner:
             else:
                 max_length = None
 
-            data = self.new_conjecture_data_ir(prefix, max_choices=max_length)
+            data = self.new_conjecture_data(prefix, max_choices=max_length)
             self.test_function(data)
 
             if (
@@ -1294,7 +1294,7 @@ class ConjectureRunner:
             self.shrink_interesting_examples()
         self.exit_with(ExitReason.finished)
 
-    def new_conjecture_data_ir(
+    def new_conjecture_data(
         self,
         prefix: Sequence[Union[ChoiceT, ChoiceTemplate]],
         *,
@@ -1333,7 +1333,7 @@ class ConjectureRunner:
             self.interesting_examples.values(), key=lambda d: sort_key(d.nodes)
         ):
             assert prev_data.status == Status.INTERESTING
-            data = self.new_conjecture_data_ir(prev_data.choices)
+            data = self.new_conjecture_data(prev_data.choices)
             self.test_function(data)
             if data.status != Status.INTERESTING:
                 self.exit_with(ExitReason.flaky)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -167,7 +167,7 @@ class Optimiser:
                         + (new_choice,)
                         + choices[node.index + 1 :]
                     )
-                    attempt = self.engine.cached_test_function_ir(
+                    attempt = self.engine.cached_test_function(
                         attempt_choices, extend="full"
                     )
 
@@ -191,7 +191,7 @@ class Optimiser:
                             continue  # pragma: no cover
                         replacement = attempt.choices[ex_attempt.start : ex_attempt.end]
                         if self.consider_new_data(
-                            self.engine.cached_test_function_ir(
+                            self.engine.cached_test_function(
                                 choices[: node.index]
                                 + replacement
                                 + self.current_data.choices[ex.end :]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -392,14 +392,14 @@ class Shrinker:
         if self.calls - self.calls_at_last_shrink >= self.max_stall:
             raise StopShrinking
 
-    def cached_test_function_ir(self, nodes):
+    def cached_test_function(self, nodes):
         # sometimes our shrinking passes try obviously invalid things. We handle
         # discarding them in one place here.
         for node in nodes:
             if not choice_permitted(node.value, node.kwargs):
                 return None
 
-        result = self.engine.cached_test_function_ir([n.value for n in nodes])
+        result = self.engine.cached_test_function([n.value for n in nodes])
         self.incorporate_test_data(result)
         self.check_calls()
         return result
@@ -414,7 +414,7 @@ class Shrinker:
             return False
 
         previous = self.shrink_target
-        self.cached_test_function_ir(nodes)
+        self.cached_test_function(nodes)
         return previous is not self.shrink_target
 
     def incorporate_test_data(self, data):
@@ -545,7 +545,7 @@ class Shrinker:
                     replacement.append(node.value)
 
                 attempt = choices[:start] + tuple(replacement) + choices[end:]
-                result = self.engine.cached_test_function_ir(attempt, extend="full")
+                result = self.engine.cached_test_function(attempt, extend="full")
 
                 # Turns out this was a variable-length part, so grab the infix...
                 if result.status is Status.OVERRUN:
@@ -569,7 +569,7 @@ class Shrinker:
                         choices[:start] + result.choices[start:res_end] + choices[end:]
                     )
                     chunks[(start, end)].append(result.choices[start:res_end])
-                    result = self.engine.cached_test_function_ir(attempt)
+                    result = self.engine.cached_test_function(attempt)
 
                     if result.status is Status.OVERRUN:
                         continue  # pragma: no cover  # flakily covered
@@ -608,7 +608,7 @@ class Shrinker:
                 new_choices.extend(self.random.choice(ls))
                 prev_end = end
 
-            result = self.engine.cached_test_function_ir(new_choices)
+            result = self.engine.cached_test_function(new_choices)
 
             # This *can't* be a shrink because none of the components were.
             assert shrink_target is self.shrink_target
@@ -704,7 +704,7 @@ class Shrinker:
                 # shape changes, as measured by either changing the number of subsequent
                 # nodes, or changing the nodes in such a way as to cause one of the
                 # previous values to no longer be valid in its position.
-                zero_attempt = self.cached_test_function_ir(
+                zero_attempt = self.cached_test_function(
                     nodes[:i] + (nodes[i].copy(with_value=0),) + nodes[i + 1 :]
                 )
                 if (
@@ -737,7 +737,7 @@ class Shrinker:
         while rerandomising and attempting to repair any subsequent
         changes to the shape of the test case that this causes."""
         nodes = self.shrink_target.nodes
-        initial_attempt = self.cached_test_function_ir(
+        initial_attempt = self.cached_test_function(
             nodes[:i] + (nodes[i].copy(with_value=v),) + nodes[i + 1 :]
         )
         if initial_attempt is self.shrink_target:
@@ -747,7 +747,7 @@ class Shrinker:
         initial = self.shrink_target
         examples = self.examples_starting_at[i]
         for _ in range(3):
-            random_attempt = self.engine.cached_test_function_ir(
+            random_attempt = self.engine.cached_test_function(
                 [n.value for n in prefix], extend=len(nodes)
             )
             if random_attempt.status < Status.VALID:
@@ -1094,7 +1094,7 @@ class Shrinker:
             [(node.index, node.index + 1, [node.copy(with_value=n)]) for node in nodes],
         )
 
-        attempt = self.cached_test_function_ir(initial_attempt)
+        attempt = self.cached_test_function(initial_attempt)
 
         if attempt is None:
             return False
@@ -1476,7 +1476,7 @@ class Shrinker:
             ]
         )
         suffix = nodes[ex.end :]
-        attempt = self.cached_test_function_ir(prefix + replacement + suffix)
+        attempt = self.cached_test_function(prefix + replacement + suffix)
 
         if self.shrink_target is not prev:
             return
@@ -1540,7 +1540,7 @@ class Shrinker:
             + (node.copy(with_value=node.value - 1),)
             + self.nodes[node.index + 1 :]
         )
-        attempt = self.cached_test_function_ir(lowered)
+        attempt = self.cached_test_function(lowered)
         if (
             attempt is None
             or attempt.status < Status.VALID

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -92,7 +92,7 @@ def shrinking_from(start):
                     phases=set(settings.default.phases) - {Phase.explain},
                 ),
             )
-            runner.cached_test_function_ir(start)
+            runner.cached_test_function(start)
             assert runner.interesting_examples
             (last_data,) = runner.interesting_examples.values()
             return runner.new_shrinker(

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -250,7 +250,7 @@ def test_backend_can_shrink_floats():
 
 
 # mostly a shoehorned coverage test until the shrinker is migrated to the ir
-# and calls cached_test_function_ir with backends consistently.
+# and calls cached_test_function with backends consistently.
 @given(nodes())
 def test_new_conjecture_data_with_backend(node):
     def test(data):
@@ -258,7 +258,7 @@ def test_new_conjecture_data_with_backend(node):
 
     with temp_register_backend("prng", PrngProvider):
         runner = ConjectureRunner(test, settings=settings(backend="prng"))
-        runner.cached_test_function_ir([node.value])
+        runner.cached_test_function([node.value])
 
 
 # trivial provider for tests which don't care about drawn distributions.

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -48,7 +48,7 @@ def runner_for(*examples):
         runner.exit_with = lambda reason: None
         ran_examples = []
         for choices in examples:
-            data = runner.cached_test_function_ir(choices)
+            data = runner.cached_test_function(choices)
             ran_examples.append((choices, data))
         for choices, d in ran_examples:
             rewritten, status = runner.tree.rewrite(choices)
@@ -126,7 +126,7 @@ def test_novel_prefixes_are_novel():
         prefix = runner.tree.generate_novel_prefix(runner.random)
         extension = prefix + (ChoiceTemplate("simplest", count=100),)
         assert runner.tree.rewrite(extension)[1] is None
-        result = runner.cached_test_function_ir(extension)
+        result = runner.cached_test_function(extension)
         assert runner.tree.rewrite(extension)[0] == result.choices
 
 
@@ -136,7 +136,7 @@ def test_overruns_if_prefix():
         settings=TEST_SETTINGS,
         random=Random(0),
     )
-    runner.cached_test_function_ir([False, False])
+    runner.cached_test_function([False, False])
     assert runner.tree.rewrite([False])[1] is Status.OVERRUN
 
 

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -115,7 +115,7 @@ def test_terminates_shrinks(n, monkeypatch):
     db = InMemoryExampleDatabase()
 
     def generate_new_examples(self):
-        self.cached_test_function_ir((255,) * 1000)
+        self.cached_test_function((255,) * 1000)
 
     monkeypatch.setattr(
         ConjectureRunner, "generate_new_examples", generate_new_examples
@@ -526,7 +526,7 @@ def test_debug_data(capsys):
             verbosity=Verbosity.debug,
         ),
     )
-    runner.cached_test_function_ir(choices)
+    runner.cached_test_function(choices)
     runner.run()
 
     out, _ = capsys.readouterr()
@@ -567,7 +567,7 @@ def test_clears_out_its_database_on_shrinking(
     initial_attempt, skip_target, monkeypatch
 ):
     def generate_new_examples(self):
-        self.cached_test_function_ir(initial_attempt)
+        self.cached_test_function(initial_attempt)
 
     monkeypatch.setattr(
         ConjectureRunner, "generate_new_examples", generate_new_examples
@@ -599,7 +599,7 @@ def test_clears_out_its_database_on_shrinking(
 
 def test_shrinks_both_interesting_examples(monkeypatch):
     def generate_new_examples(self):
-        self.cached_test_function_ir((1,))
+        self.cached_test_function((1,))
 
     monkeypatch.setattr(
         ConjectureRunner, "generate_new_examples", generate_new_examples
@@ -620,7 +620,7 @@ def test_discarding(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function_ir((False, True) * 10),
+        lambda runner: runner.cached_test_function((False, True) * 10),
     )
 
     @run_to_nodes
@@ -697,7 +697,7 @@ def test_shrinking_from_mostly_zero(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda self: self.cached_test_function_ir((0,) * 5 + (2,)),
+        lambda self: self.cached_test_function((0,) * 5 + (2,)),
     )
 
     @run_to_nodes
@@ -714,7 +714,7 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function_ir((False, False, True, True)),
+        lambda runner: runner.cached_test_function((False, False, True, True)),
     )
 
     @run_to_nodes
@@ -753,7 +753,7 @@ def test_database_clears_secondary_key():
     for i in range(10):
         database.save(runner.secondary_key, choices_to_bytes([i]))
 
-    runner.cached_test_function_ir((10,))
+    runner.cached_test_function((10,))
     assert runner.interesting_examples
 
     assert len(set(database.fetch(key))) == 1
@@ -785,7 +785,7 @@ def test_database_uses_values_from_secondary_key():
     for i in range(10):
         database.save(runner.secondary_key, choices_to_bytes([i]))
 
-    runner.cached_test_function_ir((10,))
+    runner.cached_test_function((10,))
     assert runner.interesting_examples
     assert len(set(database.fetch(key))) == 1
     assert len(set(database.fetch(runner.secondary_key))) == 10
@@ -923,7 +923,7 @@ def test_cached_test_function_returns_right_value():
         runner = ConjectureRunner(tf, settings=TEST_SETTINGS)
         for _ in range(2):
             for choices in ((0,), (1,)):
-                d = runner.cached_test_function_ir(choices)
+                d = runner.cached_test_function(choices)
                 assert d.status == Status.INTERESTING
                 assert d.choices == choices
         assert count == 2
@@ -942,10 +942,10 @@ def test_cached_test_function_does_not_reinvoke_on_prefix():
     with deterministic_PRNG():
         runner = ConjectureRunner(test_function, settings=TEST_SETTINGS)
 
-        data = runner.cached_test_function_ir((0, b"\0", 0))
+        data = runner.cached_test_function((0, b"\0", 0))
         assert data.status == Status.VALID
         for n in [2, 1, 0]:
-            d = runner.cached_test_function_ir(data.choices[:n])
+            d = runner.cached_test_function(data.choices[:n])
             assert d is Overrun
         assert call_count == 1
 
@@ -963,7 +963,7 @@ def test_will_evict_entries_from_the_cache(monkeypatch):
 
     for _ in range(3):
         for n in range(10):
-            runner.cached_test_function_ir((n,))
+            runner.cached_test_function((n,))
 
     # Because we exceeded the cache size, our previous
     # calls will have been evicted, so each call to
@@ -991,7 +991,7 @@ def test_branch_ending_in_write():
         for _ in range(100):
             prefix = runner.generate_novel_prefix()
             attempt = prefix + (False, False)
-            data = runner.cached_test_function_ir(attempt)
+            data = runner.cached_test_function(attempt)
             assert data.status is Status.VALID
             assert startswith(attempt, data.choices)
 
@@ -1072,7 +1072,7 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, report_multiple_bugs=False)
         )
-        runner.cached_test_function_ir((255, 255))
+        runner.cached_test_function((255, 255))
         runner.shrink_interesting_examples()
 
         results = {d.choices for d in runner.interesting_examples.values()}
@@ -1266,15 +1266,15 @@ def test_replaces_all_dominated():
         database_key=b"stuff",
     )
 
-    d1 = runner.cached_test_function_ir((0, 1)).as_result()
-    d2 = runner.cached_test_function_ir((1, 0)).as_result()
+    d1 = runner.cached_test_function((0, 1)).as_result()
+    d2 = runner.cached_test_function((1, 0)).as_result()
 
     assert len(runner.pareto_front) == 2
 
     assert runner.pareto_front[0] == d1
     assert runner.pareto_front[1] == d2
 
-    d3 = runner.cached_test_function_ir((0, 0)).as_result()
+    d3 = runner.cached_test_function((0, 0)).as_result()
     assert len(runner.pareto_front) == 1
 
     assert runner.pareto_front[0] == d3
@@ -1289,7 +1289,7 @@ def test_does_not_duplicate_elements():
         settings=settings(TEST_SETTINGS, database=InMemoryExampleDatabase()),
         database_key=b"stuff",
     )
-    d1 = runner.cached_test_function_ir((1,)).as_result()
+    d1 = runner.cached_test_function((1,)).as_result()
 
     assert len(runner.pareto_front) == 1
     # This can happen in practice if we e.g. reexecute a test because it has
@@ -1310,8 +1310,8 @@ def test_includes_right_hand_side_targets_in_dominance():
         database_key=b"stuff",
     )
 
-    d1 = runner.cached_test_function_ir((0,)).as_result()
-    d2 = runner.cached_test_function_ir((1,)).as_result()
+    d1 = runner.cached_test_function((0,)).as_result()
+    d2 = runner.cached_test_function((1,)).as_result()
 
     assert dominance(d1, d2) == DominanceRelation.NO_DOMINANCE
 
@@ -1327,8 +1327,8 @@ def test_smaller_interesting_dominates_larger_valid():
         database_key=b"stuff",
     )
 
-    d1 = runner.cached_test_function_ir((0,)).as_result()
-    d2 = runner.cached_test_function_ir((1,)).as_result()
+    d1 = runner.cached_test_function((0,)).as_result()
+    d2 = runner.cached_test_function((1,)).as_result()
     assert dominance(d1, d2) == DominanceRelation.LEFT_DOMINATES
 
 
@@ -1354,7 +1354,7 @@ def test_runs_optimisation_even_if_not_generating():
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, phases=[Phase.target])
         )
-        runner.cached_test_function_ir((0,))
+        runner.cached_test_function((0,))
         runner.run()
 
         assert runner.best_observed_targets["n"] == (2**16) - 1
@@ -1402,9 +1402,9 @@ def test_does_not_cache_extended_prefix():
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
 
-        d1 = runner.cached_test_function_ir((0,), extend=10)
+        d1 = runner.cached_test_function((0,), extend=10)
         assert runner.call_count == 1
-        d2 = runner.cached_test_function_ir((0,), extend=10)
+        d2 = runner.cached_test_function((0,), extend=10)
         assert runner.call_count == 2
         assert d1.status is d2.status is Status.VALID
 
@@ -1420,8 +1420,8 @@ def test_does_cache_if_extend_is_not_used():
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
 
-        d1 = runner.cached_test_function_ir((b"\0"), extend=8)
-        d2 = runner.cached_test_function_ir((b"\0"), extend=8)
+        d1 = runner.cached_test_function((b"\0"), extend=8)
+        d2 = runner.cached_test_function((b"\0"), extend=8)
         assert d1.status == d2.status == Status.VALID
         assert d1.choices == d2.choices
         assert calls == 1
@@ -1438,8 +1438,8 @@ def test_does_result_for_reuse():
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
 
-        d1 = runner.cached_test_function_ir((b"\0"), extend=8)
-        d2 = runner.cached_test_function_ir(d1.choices)
+        d1 = runner.cached_test_function((b"\0"), extend=8)
+        d2 = runner.cached_test_function(d1.choices)
         assert d1.status == d2.status == Status.VALID
         assert d1.nodes == d2.nodes
         assert calls == 1
@@ -1453,13 +1453,13 @@ def test_does_not_use_cached_overrun_if_extending():
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
 
-        data = runner.cached_test_function_ir((1,))
+        data = runner.cached_test_function((1,))
         assert data.status == Status.OVERRUN
         assert runner.call_count == 1
 
         # the choice sequence of (1,) maps to an overrun in the cache, but we
         # do not want to use this cache entry if we're extending.
-        data = runner.cached_test_function_ir((1,), extend=1)
+        data = runner.cached_test_function((1,), extend=1)
         assert data.status == Status.VALID
         assert runner.call_count == 2
 
@@ -1472,11 +1472,11 @@ def test_uses_cached_overrun_if_not_extending():
     with deterministic_PRNG():
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
 
-        data = runner.cached_test_function_ir((1,), extend=0)
+        data = runner.cached_test_function((1,), extend=0)
         assert data.status is Status.OVERRUN
         assert runner.call_count == 1
 
-        data = runner.cached_test_function_ir((1,), extend=0)
+        data = runner.cached_test_function((1,), extend=0)
         assert data.status is Status.OVERRUN
         assert runner.call_count == 1
 
@@ -1490,7 +1490,7 @@ def test_can_be_set_to_ignore_limits():
             test, settings=settings(TEST_SETTINGS, max_examples=1), ignore_limits=True
         )
         for c in range(256):
-            runner.cached_test_function_ir((c,))
+            runner.cached_test_function((c,))
 
         assert runner.tree.is_exhausted
 
@@ -1537,17 +1537,17 @@ def test_overruns_with_extend_are_not_cached(node):
     runner = ConjectureRunner(test)
     assert runner.call_count == 0
 
-    data = runner.cached_test_function_ir([node.value])
+    data = runner.cached_test_function([node.value])
     assert runner.call_count == 1
     assert data.status is Status.OVERRUN
 
     # cache hit
-    data = runner.cached_test_function_ir([node.value])
+    data = runner.cached_test_function([node.value])
     assert runner.call_count == 1
     assert data.status is Status.OVERRUN
 
     # cache miss
-    data = runner.cached_test_function_ir([node.value], extend="full")
+    data = runner.cached_test_function([node.value], extend="full")
     assert runner.call_count == 2
     assert data.status is Status.VALID
 
@@ -1562,15 +1562,15 @@ def test_simulate_to_evicted_data(monkeypatch):
         data.draw_integer()
 
     runner = ConjectureRunner(test)
-    runner.cached_test_function_ir([0])
+    runner.cached_test_function([0])
     # cache size is 1 so this evicts [0]
-    runner.cached_test_function_ir([1])
+    runner.cached_test_function([1])
     assert runner.call_count == 2
 
     # we dont throw PreviouslyUnseenBehavior when simulating, but the result
     # was evicted to the cache so we will still call through to the test function.
     runner.tree.simulate_test_function(ConjectureData.for_choices([0]))
-    runner.cached_test_function_ir([0])
+    runner.cached_test_function([0])
     assert runner.call_count == 3
 
 

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -130,7 +130,7 @@ def float_runner(start, condition, *, kwargs=None):
             data.mark_interesting()
 
     runner = ConjectureRunner(test_function)
-    runner.cached_test_function_ir((float(start),))
+    runner.cached_test_function((float(start),))
     assert runner.interesting_examples
     return runner
 

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -30,7 +30,7 @@ def test_optimises_to_maximum():
             data.target_observations["m"] = data.draw_integer(0, 2**8 - 1)
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.cached_test_function_ir((0,))
+        runner.cached_test_function((0,))
 
         try:
             runner.optimise_targets()
@@ -53,8 +53,8 @@ def test_optimises_multiple_targets():
             data.target_observations["m + n"] = m + n
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.cached_test_function_ir((200, 0))
-        runner.cached_test_function_ir((0, 200))
+        runner.cached_test_function((200, 0))
+        runner.cached_test_function((0, 200))
 
         try:
             runner.optimise_targets()
@@ -75,7 +75,7 @@ def test_optimises_when_last_element_is_empty():
             data.stop_example()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.cached_test_function_ir((250,))
+        runner.cached_test_function((250,))
 
         try:
             runner.optimise_targets()
@@ -98,7 +98,7 @@ def test_can_optimise_last_with_following_empty():
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, max_examples=100)
         )
-        runner.cached_test_function_ir((0,) * 101)
+        runner.cached_test_function((0,) * 101)
 
         with pytest.raises(RunIsComplete):
             runner.optimise_targets()
@@ -121,7 +121,7 @@ def test_can_find_endpoints_of_a_range(lower, upper, score_up):
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, max_examples=1000)
         )
-        runner.cached_test_function_ir(((lower + upper) // 2,))
+        runner.cached_test_function(((lower + upper) // 2,))
 
         try:
             runner.optimise_targets()
@@ -146,7 +146,7 @@ def test_targeting_can_drive_length_very_high():
         # extend here to ensure we get a valid (non-overrun) test case. The
         # outcome of the test case doesn't really matter as long as we have
         # something for the runner to optimize.
-        runner.cached_test_function_ir([], extend=50)
+        runner.cached_test_function([], extend=50)
 
         try:
             runner.optimise_targets()
@@ -167,7 +167,7 @@ def test_optimiser_when_test_grows_buffer_to_invalid():
                 data.mark_invalid()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        runner.cached_test_function_ir((0,) * 10)
+        runner.cached_test_function((0,) * 10)
 
         try:
             runner.optimise_targets()
@@ -192,7 +192,7 @@ def test_can_patch_up_examples():
                     data.mark_invalid()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-        d = runner.cached_test_function_ir((0, 0, 1, 2, 3, 4))
+        d = runner.cached_test_function((0, 0, 1, 2, 3, 4))
         assert d.status == Status.VALID
 
         try:
@@ -215,7 +215,7 @@ def test_optimiser_when_test_grows_buffer_to_overflow():
                     data.mark_invalid()
 
             runner = ConjectureRunner(test, settings=TEST_SETTINGS)
-            runner.cached_test_function_ir((0,) * 10)
+            runner.cached_test_function((0,) * 10)
 
             try:
                 runner.optimise_targets()
@@ -267,7 +267,7 @@ def test_optimising_all_nodes(node):
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, max_examples=50)
         )
-        runner.cached_test_function_ir([node.value])
+        runner.cached_test_function([node.value])
 
         try:
             runner.optimise_targets()

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -13,7 +13,11 @@ import itertools
 import pytest
 
 from hypothesis import HealthCheck, Phase, settings, strategies as st
-from hypothesis.database import InMemoryExampleDatabase, choices_to_bytes
+from hypothesis.database import (
+    InMemoryExampleDatabase,
+    choices_from_bytes,
+    choices_to_bytes,
+)
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.entropy import deterministic_PRNG
@@ -230,7 +234,7 @@ def test_optimises_the_pareto_front():
         settings=settings(max_examples=10000, database=InMemoryExampleDatabase()),
         database_key=b"stuff",
     )
-    runner.cached_test_function_ir([255] * 20 + [0])
+    runner.cached_test_function([255] * 20 + [0])
     runner.pareto_optimise()
 
     assert len(runner.pareto_front) == 6
@@ -251,7 +255,7 @@ def test_does_not_optimise_the_pareto_front_if_interesting():
         database_key=b"stuff",
     )
 
-    runner.cached_test_function_ir([0])
+    runner.cached_test_function([0])
     runner.pareto_optimise = None
     runner.optimise_targets()
 
@@ -273,7 +277,7 @@ def test_stops_optimising_once_interesting():
         database_key=b"stuff",
     )
 
-    data = runner.cached_test_function_ir([hi])
+    data = runner.cached_test_function([hi])
     assert data.status == Status.VALID
     runner.pareto_optimise()
     assert runner.call_count <= 20

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -68,10 +68,6 @@ def test_pareto_front_omits_invalid_examples():
         assert len(runner.pareto_front) == 0
 
 
-# at some point this test regressed. It's not clear how long ago, because it
-# happened to pass by chance on deterministic rng with seed 0 for at least
-# some amount of time.
-@pytest.mark.xfail(strict=False)
 def test_database_contains_only_pareto_front():
     with deterministic_PRNG():
 
@@ -105,11 +101,12 @@ def test_database_contains_only_pareto_front():
         assert len(values) == len(runner.pareto_front)
 
         for data in runner.pareto_front:
-            assert data.buffer in values
+            assert choices_to_bytes(data.choices) in values
             assert data in runner.pareto_front
 
-        for k in values:
-            assert runner.cached_test_function(k) in runner.pareto_front
+        for b in values:
+            choices = choices_from_bytes(b)
+            assert runner.cached_test_function(choices) in runner.pareto_front
 
 
 def test_clears_defunct_pareto_front():

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -59,7 +59,7 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function_ir((b"\0",) * 10),
+        lambda runner: runner.cached_test_function((b"\0",) * 10),
     )
 
     @run_to_nodes
@@ -196,7 +196,7 @@ def test_permits_but_ignores_raising_order(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function_ir((1,)),
+        lambda runner: runner.cached_test_function((1,)),
     )
 
     monkeypatch.setattr(Shrinker, "shrink", lambda self: self.consider_new_nodes(ir(2)))

--- a/hypothesis-python/tests/cover/test_one_of.py
+++ b/hypothesis-python/tests/cover/test_one_of.py
@@ -9,6 +9,8 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import re
+from collections.abc import Sequence
+from typing import Union
 
 import pytest
 
@@ -46,3 +48,18 @@ def test_one_of_without_strategies_suggests_sampled_from():
         match=re.escape("Did you mean st.sampled_from([1, 2, 3])?"),
     ):
         st.one_of(1, 2, 3)
+
+
+@pytest.mark.parametrize(
+    "strategy, count",
+    [
+        (st.one_of(st.integers(), st.integers(), st.integers()), 1),
+        (st.one_of(st.integers(), st.one_of(st.integers(), st.integers())), 2),
+        ((st.integers() | st.integers()) | st.integers(), 1),
+        (st.integers() | (st.integers() | st.integers()), 1),
+        (st.integers() | st.text() | st.booleans(), 1),
+        (st.from_type(Union[int, Sequence[int]]), 2),
+    ],
+)
+def test_one_of_unwrapping(strategy, count):
+    assert repr(strategy).count("one_of(") == count

--- a/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
+++ b/hypothesis-python/tests/ghostwriter/test_ghostwriter.py
@@ -127,7 +127,7 @@ def non_resolvable_arg(x: NotResolvable):
 
 def test_flattens_one_of_repr():
     strat = from_type(Union[int, Sequence[int]])
-    assert repr(strat).count("one_of(") > 1
+    assert repr(strat).count("one_of(") == 2
     assert ghostwriter._valid_syntax_repr(strat)[1].count("one_of(") == 1
 
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -39,7 +39,7 @@ def test_saves_data_while_shrinking(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function_ir([bytes([255] * 10)]),
+        lambda runner: runner.cached_test_function([bytes([255] * 10)]),
     )
 
     def f(data):
@@ -65,7 +65,7 @@ def test_can_discard(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
         "generate_new_examples",
-        lambda runner: runner.cached_test_function_ir(
+        lambda runner: runner.cached_test_function(
             tuple(bytes(v) for i in range(n) for v in [i, i])
         ),
     )
@@ -87,8 +87,8 @@ def test_cached_with_masked_byte_agrees_with_results(a, b):
 
     runner = ConjectureRunner(f)
 
-    cached_a = runner.cached_test_function_ir([a])
-    cached_b = runner.cached_test_function_ir([b])
+    cached_a = runner.cached_test_function([a])
+    cached_b = runner.cached_test_function([b])
 
     data_b = ConjectureData.for_choices([b], observer=runner.tree.new_observer())
     runner.test_function(data_b)

--- a/hypothesis-python/tests/nocover/test_precise_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_precise_shrinking.py
@@ -107,7 +107,7 @@ def precisely_shrink(
 
     runner = ConjectureRunner(test_function, random=random)
     try:
-        buf = runner.cached_test_function_ir(initial_choices)
+        buf = runner.cached_test_function(initial_choices)
         assert buf.status == Status.INTERESTING
         assert buf.choices == initial_choices
         assert runner.interesting_examples
@@ -238,7 +238,7 @@ def shrinks(strategy, nodes, *, allow_sloppy=True, seed=0):
             results[data.nodes] = value
 
         runner = ConjectureRunner(test_function, settings=settings(max_examples=10**9))
-        initial = runner.cached_test_function_ir(choices)
+        initial = runner.cached_test_function(choices)
         assert isinstance(initial, ConjectureResult)
         try:
             runner.shrink(initial, lambda x: x.choices == initial.choices)
@@ -260,7 +260,7 @@ def shrinks(strategy, nodes, *, allow_sloppy=True, seed=0):
                 results[key] = value
 
         runner = ConjectureRunner(test_function, settings=settings(max_examples=10**9))
-        initial = runner.cached_test_function_ir(initial_choices)
+        initial = runner.cached_test_function(initial_choices)
         assert len(results) == 1
         try:
             runner.shrink(initial, lambda x: x.choices == initial_choices)

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -109,7 +109,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
             test_function_with_poison, random=random, settings=TEST_SETTINGS
         )
         # replace n1 and n2 with 2**16 - 1 to insert a poison value here
-        runner.cached_test_function_ir(
+        runner.cached_test_function(
             data.choices[: node.index]
             + (2**16 - 1, 2**16 - 1)
             + (data.choices[node.index + 2 :])

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -89,7 +89,7 @@ def test_avoids_zig_zag_trap(p):
         random=Random(0),
     )
 
-    runner.cached_test_function_ir((m, m + 1, marker))
+    runner.cached_test_function((m, m + 1, marker))
     assert runner.interesting_examples
     runner.run()
     (v,) = runner.interesting_examples.values()


### PR DESCRIPTION
Purely aesthetic change I noticed when printing one_of. I'm open to this being shut down as not worthwhile / having unintended effects elsewhere - but I can't think of any.

This matches `typing`, FWIW:

```python
>>> Union[int, Union[str, bool]]
typing.Union[int, str, bool]
```