### PR TITLE
Don't extend during the target phase

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch tweaks the performance of the :ref:`target phase <phases>`, avoiding aborting some test cases when it would be better to finish generating them.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -331,16 +331,7 @@ class Shrinker:
 
         # Because the shrinker is also used to `pareto_optimise` in the target phase,
         # we sometimes want to allow extending buffers instead of aborting at the end.
-        if in_target_phase:  # pragma: no cover
-            # TODO_IR: this is no longer used, but it should be. See
-            # https://github.com/HypothesisWorks/hypothesis/commit/91c63bb76c970effd6cf3c013d8ed98788cf0527
-            # we'll need to adjust for the new notion of size in terms of nodes,
-            # and change self.cached_test_function_ir.
-            from hypothesis.internal.conjecture.engine import BUFFER_SIZE
-
-            self.__extend = BUFFER_SIZE
-        else:
-            self.__extend = 0
+        self.__extend = "full" if in_target_phase else 0
         self.should_explain = explain
 
     @derived_value  # type: ignore
@@ -399,7 +390,9 @@ class Shrinker:
             if not choice_permitted(node.value, node.kwargs):
                 return None
 
-        result = self.engine.cached_test_function_ir([n.value for n in nodes])
+        result = self.engine.cached_test_function_ir(
+            [n.value for n in nodes], extend=self.__extend
+        )
         self.incorporate_test_data(result)
         self.check_calls()
         return result


### PR DESCRIPTION
In the pareto optimiser, left dominates right if it is better in every way, including sort_key and all target scores. The optimiser shrinks by allowing transitions where left dominates right, which means it will never allow transitions where the attempt is larger than the current data in terms of sort_key. Because of this, I think allowing the target phase to extend is actually not beneficial, because ParetoOptimiser will reject these anyway. 

@Zac-HD would appreciate a sanity check if I'm correct here. We changed this in https://github.com/HypothesisWorks/hypothesis/pull/3862 (and at the time I also thought this was a good change and agreed with the reasoning, but no longer believe that). 

To go back to the original issue #3827, this isn't going to make Tyche's life any easier, because it will bring back "gave up" statuses in the target phase. But that's a separate problem that observability will have to figure out how to deal with IMO. I suggested setting status_reason for gave_up in #3862, and continue to think this is a good idea which will help Tyche distinguish between "gave ups which I care about" (failed an assume or filter, etc) and "gave ups which I don't" (gave up because we know this example cannot be better than the current).