### PR TITLE
Fix `from_type` error on certain protocols

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where :func:`~hypothesis.strategies.from_type` would error on certain types involving :class:`~python:typing.Protocol` (:issue:`4194`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -541,7 +541,9 @@ def from_typing_type(thing):
         else:
             union_elems = ()
         if not any(
-            isinstance(T, type) and issubclass(int, get_origin(T) or T)
+            # see https://github.com/HypothesisWorks/hypothesis/issues/4194 for
+            # try_issubclass.
+            isinstance(T, type) and try_issubclass(int, get_origin(T) or T)
             for T in [*union_elems, elem_type]
         ):
             mapping.pop(bytes, None)


### PR DESCRIPTION
Closes #4194. 

Continuing from there - we actually do support drawing from non-runtime-checkable protocols, *iff* they have a corresponding registered strategy.`IsDataclass` did have such a strategy in this case, so erroring here is a bug. 

The bug in this case was running logic involving `issubclass` on a thing which cannot be subclass-checked - but we only checked this sometimes, due to short circuiting. This explains the `int` heisenbug. 