### PR TITLE
More correct type hints for filter and map

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+Fix a type-hinting regression from :ref:`version 6.125.1 <v6.125.1>`, where we would no longer guarantee the type of the argument to ``.filter`` predicates (:issue:`4269`).
+
+.. code-block:: python
+
+  # x was previously Unknown, but is now correctly guaranteed to be int
+  st.integers().filter(lambda x: x > 0)

--- a/whole_repo_tests/revealed_types.py
+++ b/whole_repo_tests/revealed_types.py
@@ -37,6 +37,10 @@ REVEALED_TYPES = [
         "tuples(text(), text(), text(), text(), text(), text())",
         "tuple[Any, ...]",
     ),
+    ("lists(none())", "list[None]"),
+    ("integers().filter(lambda x: x > 0)", "int"),
+    ("booleans().filter(lambda x: x)", "bool"),
+    ("integers().map(bool).filter(lambda x: x)", "bool"),
 ]
 
 NUMPY_REVEALED_TYPES = [

--- a/whole_repo_tests/test_mypy.py
+++ b/whole_repo_tests/test_mypy.py
@@ -114,7 +114,6 @@ def assert_mypy_errors(fname, expected, python_version=None):
     "val,expect",
     [
         *REVEALED_TYPES,  # shared with Pyright
-        ("lists(none())", "list[None]"),
         ("data()", "hypothesis.strategies._internal.core.DataObject"),
         ("none() | integers()", "Union[None, int]"),
         ("recursive(integers(), lists)", "Union[list[Any], int]"),

--- a/whole_repo_tests/test_pyright.py
+++ b/whole_repo_tests/test_pyright.py
@@ -178,7 +178,6 @@ def test_numpy_arrays_strategy(tmp_path: Path):
     "val,expect",
     [
         *REVEALED_TYPES,  # shared with Mypy
-        ("lists(none())", "list[None]"),
         ("dictionaries(integers(), datetimes())", "dict[int, datetime]"),
         ("data()", "DataObject"),
         ("none() | integers()", "int | None"),


### PR DESCRIPTION
Closes #4269.

Using `PredicateT` was not correctly capturing the `Ex` TypeVar in `def filter(self, condition: PredicateT)`. I've replaced all of the type alias usages with explicit ones, which resolves this issue and probably several others we hadn't found yet.