### PR TITLE
Improve shrinking for collections with duplicate elements, and duplicate characters across string choices

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves shrinking behavior for values from :func:`~hypothesis.strategies.text` and :func:`~hypothesis.strategies.binary` which contain duplicate elements, like ``"zzzabc"``. It also improves shrinking for  bugs which require the same character to be drawn from two different :func:`~hypothesis.strategies.text` strategies to trigger.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -635,8 +635,8 @@ class Shrinker:
                 node_program("X" * 1),
                 "pass_to_descendant",
                 "reorder_examples",
-                "minimize_duplicated_nodes",
-                "minimize_individual_nodes",
+                "minimize_duplicated_choices",
+                "minimize_individual_choices",
                 "redistribute_numeric_pairs",
                 "lower_integers_together",
             ]
@@ -1259,8 +1259,8 @@ class Shrinker:
         return list(duplicates.values())
 
     @defines_shrink_pass()
-    def minimize_duplicated_nodes(self, chooser):
-        """Find blocks that have been duplicated in multiple places and attempt
+    def minimize_duplicated_choices(self, chooser):
+        """Find choices that have been duplicated in multiple places and attempt
         to minimize all of the duplicates simultaneously.
 
         This lets us handle cases where two values can't be shrunk
@@ -1480,8 +1480,8 @@ class Shrinker:
             self.consider_new_nodes(prefix + new_replacement + suffix)
 
     @defines_shrink_pass()
-    def minimize_individual_nodes(self, chooser):
-        """Attempt to minimize each node in sequence.
+    def minimize_individual_choices(self, chooser):
+        """Attempt to minimize each choice in sequence.
 
         This is the pass that ensures that e.g. each integer we draw is a
         minimum value. So it's the part that guarantees that if we e.g. do
@@ -1491,7 +1491,7 @@ class Shrinker:
 
         then in our shrunk example, x = 10 rather than say 97.
 
-        If we are unsuccessful at minimizing a node of interest we then
+        If we are unsuccessful at minimizing a choice of interest we then
         check if that's because it's changing the size of the test case and,
         if so, we also make an attempt to delete parts of the test case to
         see if that fixes it.

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -849,7 +849,7 @@ def test_dependent_block_pairs_can_lower_to_zero():
         if n == 1:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.choices == (False, 1)
 
 
@@ -862,7 +862,7 @@ def test_handle_size_too_large_during_dependent_lowering():
         else:
             data.draw_integer(0, 2**8 - 1)
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
 
 
 def test_block_may_grow_during_lexical_shrinking():
@@ -876,7 +876,7 @@ def test_block_may_grow_during_lexical_shrinking():
             data.draw_integer(0, 2**16 - 1)
         data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.choices == (0, 0)
 
 

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -46,7 +46,7 @@ def test_can_shrink_variable_draws_with_just_deletion(n):
         if any(b):
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.choices == (1, 1)
 
 
@@ -54,7 +54,7 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
     monkeypatch.setattr(
         Shrinker,
         "shrink",
-        lambda self: self.fixate_shrink_passes(["minimize_individual_nodes"]),
+        lambda self: self.fixate_shrink_passes(["minimize_individual_choices"]),
     )
     monkeypatch.setattr(
         ConjectureRunner,
@@ -82,7 +82,7 @@ def test_duplicate_nodes_that_go_away():
         if len(set(b)) <= 1:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_duplicated_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_duplicated_choices"])
     assert shrinker.shrink_target.choices == (0, 0)
 
 
@@ -99,7 +99,7 @@ def test_accidental_duplication():
         if len(set(b)) == 1:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_duplicated_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_duplicated_choices"])
     print(shrinker.choices)
     assert shrinker.choices == (5, 5, *([b"\x00"] * 5))
 
@@ -240,7 +240,7 @@ def test_dependent_block_pairs_is_up_to_shrinking_integers():
         if result >= 32768 and cap == 1:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.choices == (1, True, 65536, 1)
 
 
@@ -331,7 +331,7 @@ def test_zig_zags_quickly():
         if abs(m - n) <= 10:
             data.mark_interesting(interesting_origin(1))
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.engine.valid_examples <= 100
     assert shrinker.choices == (1, 1)
 
@@ -364,7 +364,7 @@ def test_zig_zags_quickly_with_shrink_towards(
         if abs(m - n) <= 1:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.engine.valid_examples <= 40
     assert shrinker.choices == expected
 
@@ -539,7 +539,7 @@ def test_can_quickly_shrink_to_trivial_collection(n):
         if len(b) >= n:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_nodes"])
+    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
     assert shrinker.choices == (b"\x00" * n,)
     assert shrinker.calls < 10
 

--- a/hypothesis-python/tests/cover/test_debug_information.py
+++ b/hypothesis-python/tests/cover/test_debug_information.py
@@ -32,7 +32,7 @@ def test_reports_passes():
 
     value = out.getvalue()
 
-    assert "minimize_individual_nodes" in value
+    assert "minimize_individual_choices" in value
     assert "calls" in value
     assert "shrinks" in value
 

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -8,7 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from collections import OrderedDict, namedtuple
+from collections import Counter, OrderedDict, namedtuple
 from fractions import Fraction
 from functools import reduce
 
@@ -473,3 +473,56 @@ def test_lowering_together_mixed(gap):
 def test_lowering_together_with_gap(gap):
     s = st.tuples(st.integers(-10, 10), st.text(), st.floats(), st.integers(-10, 10))
     assert minimal(s, lambda x: x[0] + gap == x[3]) == (0, "", 0.0, gap)
+
+
+def test_run_length_encoding():
+    # extracted from https://github.com/HypothesisWorks/hypothesis/issues/4286,
+    # as well as our docs
+
+    def decode(table: list[tuple[int, str]]) -> str:
+        out = ""
+        for count, char in table:
+            out += count * char
+        return out
+
+    def encode(s: str) -> list[tuple[int, str]]:
+        count = 1
+        prev = ""
+        out = []
+
+        if not s:
+            return []
+
+        for char in s:
+            if char != prev:
+                if prev:
+                    entry = (count, prev)
+                    out.append(entry)
+                # BUG:
+                # count = 1
+                prev = char
+            else:
+                count += 1
+
+        entry = (count, char)
+        out.append(entry)
+        return out
+
+    assert minimal(st.text(), lambda s: decode(encode(s)) != s) == "001"
+
+
+def test_minimize_duplicated_characters_within_a_choice():
+    # look for strings which have at least 3 of the same character, and also at
+    # least two different characters (to avoid the trivial shrink of replacing
+    # everything with "0" from working).
+
+    # we should test this for st.binary too, but it's difficult to get it
+    # to satisfy this precondition in the first place (probably worth improving
+    # our generation here to duplicate binary elements in generate_mutations_from)
+    assert (
+        minimal(
+            st.text(min_size=1),
+            lambda v: Counter(v).most_common()[0][1] > 2 and len(set(v)) > 1,
+        )
+        == "0001"
+    )


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4286. The changes to `collection.py` are what actually addresses that issue. `lower_duplicated_characters` is a bonus which I came across while investigating.