### PR TITLE
Add possibility to generate nasty strings

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,7 @@
 RELEASE_TYPE: minor
 
-:func:`~hypothesis.strategies.text` now occasionally generates from a preselected list of strings which are likely to find bugs. These include ligatures, right-to-left and top-to-bottom text, emojis, emoji modifiers, strings like ``"Infinity"``, ``"None"``, and ``"FALSE"``, and other terrible things.
+:func:`~hypothesis.strategies.text` now occasionally generates from a preselected list of strings which are likely to find bugs. These include ligatures, right-to-left and top-to-bottom text, emojis, emoji modifiers, strings like ``"Infinity"``, ``"None"``, and ``"FALSE"``, and other interesting things. This is especially useful when testing the full unicode range, where the search space is too large for uniform sampling to be very effective.
 
-This is especially useful when testing the full unicode range, where the search space is too large for uniform sampling to be very effective.
+Of course, examples generated this way shrink just like they normally would. It was always possible for Hypothesis to generate these strings; it is just more likely after this change. From the outside, it is as if Hypothesis generated the example completely randomly.
 
 Many thanks to the `Big List of Naughty Strings <https://github.com/minimaxir/big-list-of-naughty-strings>`_, `Text Rendering Hates You <https://faultlore.com/blah/text-hates-you/>`_, and `Text Editing Hates You Too <https://lord.io/text-editing-hates-you-too/>`_ for forming the basis of this list.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.text` now occasionally generates from a preselected list of strings which are likely to find bugs. These include ligatures, right-to-left and top-to-bottom text, emojis, emoji modifiers, strings like ``"Infinity"``, ``"None"``, and ``"FALSE"``, and other terrible things.
+
+This is especially useful when testing the full unicode range, where the search space is too large for uniform sampling to be very effective.
+
+Many thanks to the `Big List of Naughty Strings <https://github.com/minimaxir/big-list-of-naughty-strings>`_, `Text Rendering Hates You <https://faultlore.com/blah/text-hates-you/>`_, and `Text Editing Hates You Too <https://lord.io/text-editing-hates-you-too/>`_ for forming the basis of this list.

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -372,3 +372,7 @@ for i in range(4):
 test_long_duplicates_strings = define_test(
     tuples(text(), text()), lambda s: len(s[0]) >= 5 and s[0] == s[1]
 )
+
+test_can_produce_nasty_strings = define_test(
+    text(), lambda s: s in {"NaN", "Inf", "undefined"}, p=0.01
+)

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -526,3 +526,11 @@ def test_minimize_duplicated_characters_within_a_choice():
         )
         == "0001"
     )
+
+
+def test_nasty_string_shrinks():
+    # failures found via NASTY_STRINGS should shrink like normal
+    assert (
+        minimal(st.text(), lambda s: "𝕿𝖍𝖊" in s, settings=settings(max_examples=10000))
+        == "𝕿𝖍𝖊"
+    )


### PR DESCRIPTION
First part of https://github.com/HypothesisWorks/hypothesis/issues/3127. I'd still like to walk the ast to extract constant strings, but that's for a future pull 😄

I'm happy to make adjustments to what values we include here. I basically just scrolled through the three linked posts and added strings that I thought were relevant. I avoided including a bunch of sections of the big list of naughty strings in particular, because I don't think we want to be actively vulnerability hunting (xss, sql injection, etc). Most everything from the other two made it in.

I also intentionally left off the EICAR string. I haven't tried it, but I think odds are good that the Hypothesis library/source code itself would be detected as malware by some users, even if we made it past pypi. We could rot13 it, but antivirus scanners may still pick it up in memory once decoded. I just don't think it's worth messing around with it.