### PR TITLE
Rename `Example` to `Span`

### DIFF
--- a/guides/strategies-that-shrink.rst
+++ b/guides/strategies-that-shrink.rst
@@ -254,7 +254,7 @@ Explicit example boundaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This is almost always handled implicitly, e.g. by ``cu.many``, but *sometimes*
 it can be useful to explicitly insert boundaries around draws that should be
-deleted simultaneously using ``data.start_example``.  This is used to group
+deleted simultaneously using ``data.start_span``.  This is used to group
 the value and sign of floating-point numbers, for example, which we split up
 in order to provide a more natural shrinking order.
 

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Rename a few internal classes for clarity.

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -183,12 +183,12 @@ class LarkStrategy(st.SearchStrategy):
             draw_state.append(data.draw(strategy))
         else:
             assert isinstance(symbol, NonTerminal)
-            data.start_example(self.rule_label(symbol.name))
+            data.start_span(self.rule_label(symbol.name))
             expansion = data.draw(self.nonterminal_strategies[symbol.name])
             for e in expansion:
                 self.draw_symbol(data, e, draw_state)
                 self.gen_ignore(data, draw_state)
-            data.stop_example()
+            data.stop_span()
 
     def gen_ignore(self, data: ConjectureData, draw_state: list[str]) -> None:
         if self.ignored_symbols and data.draw_boolean(1 / 4):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -132,69 +132,67 @@ def structural_coverage(label: int) -> StructuralCoverageTag:
 POOLED_KWARGS_CACHE = LRUCache(4096)
 
 
-class Example:
-    """Examples track the hierarchical structure of draws from the byte stream,
-    within a single test run.
+class Span:
+    """A span tracks the hierarchical structure of choices within a single test run.
 
-    Examples are created to mark regions of the byte stream that might be
-    useful to the shrinker, such as:
-    - The bytes used by a single draw from a strategy.
-    - Useful groupings within a strategy, such as individual list elements.
-    - Strategy-like helper functions that aren't first-class strategies.
-    - Each lowest-level draw of bits or bytes from the byte stream.
-    - A single top-level example that spans the entire input.
+    Spans are created to mark regions of the choice sequence that that are
+    logically related to each other. For instance, Hypothesis tracks:
+    - A single top-level span for the entire choice sequence
+    - A span for the choices made by each strategy
+    - Some strategies define additional spans within their choices. For instance,
+      st.lists() tracks the "should add another element" choice and the "add
+      another element" choices as separate spans.
 
-    Example-tracking allows the shrinker to try "high-level" transformations,
-    such as rearranging or deleting the elements of a list, without having
-    to understand their exact representation in the byte stream.
+    Spans provide useful information to the shrinker, mutator, targeted PBT,
+    and other subsystems of Hypothesis.
 
-    Rather than store each ``Example`` as a rich object, it is actually
-    just an index into the ``Examples`` class defined below. This has two
-    purposes: Firstly, for most properties of examples we will never need
+    Rather than store each ``Span`` as a rich object, it is actually
+    just an index into the ``Spans`` class defined below. This has two
+    purposes: Firstly, for most properties of spans we will never need
     to allocate storage at all, because most properties are not used on
-    most examples. Secondly, by storing the properties as compact lists
+    most spans. Secondly, by storing the spans as compact lists
     of integers, we save a considerable amount of space compared to
     Python's normal object size.
 
     This does have the downside that it increases the amount of allocation
     we do, and slows things down as a result, in some usage patterns because
-    we repeatedly allocate the same Example or int objects, but it will
+    we repeatedly allocate the same Span or int objects, but it will
     often dramatically reduce our memory usage, so is worth it.
     """
 
     __slots__ = ("index", "owner")
 
-    def __init__(self, owner: "Examples", index: int) -> None:
+    def __init__(self, owner: "Spans", index: int) -> None:
         self.owner = owner
         self.index = index
 
     def __eq__(self, other: object) -> bool:
         if self is other:
             return True
-        if not isinstance(other, Example):
+        if not isinstance(other, Span):
             return NotImplemented
         return (self.owner is other.owner) and (self.index == other.index)
 
     def __ne__(self, other: object) -> bool:
         if self is other:
             return False
-        if not isinstance(other, Example):
+        if not isinstance(other, Span):
             return NotImplemented
         return (self.owner is not other.owner) or (self.index != other.index)
 
     def __repr__(self) -> str:
-        return f"examples[{self.index}]"
+        return f"spans[{self.index}]"
 
     @property
     def label(self) -> int:
-        """A label is an opaque value that associates each example with its
+        """A label is an opaque value that associates each span with its
         approximate origin, such as a particular strategy class or a particular
         kind of draw."""
         return self.owner.labels[self.owner.label_indices[self.index]]
 
     @property
     def parent(self) -> Optional[int]:
-        """The index of the example that this one is nested directly within."""
+        """The index of the span that this one is nested directly within."""
         if self.index == 0:
             return None
         return self.owner.parentage[self.index]
@@ -209,99 +207,100 @@ class Example:
 
     @property
     def depth(self) -> int:
-        """Depth of this example in the example tree. The top-level example has a
-        depth of 0."""
+        """
+        Depth of this span in the span tree. The top-level span has a depth of 0.
+        """
         return self.owner.depths[self.index]
 
     @property
     def discarded(self) -> bool:
-        """True if this is example's ``stop_example`` call had ``discard`` set to
+        """True if this is span's ``stop_span`` call had ``discard`` set to
         ``True``. This means we believe that the shrinker should be able to delete
-        this example completely, without affecting the value produced by its enclosing
+        this span completely, without affecting the value produced by its enclosing
         strategy. Typically set when a rejection sampler decides to reject a
         generated value and try again."""
         return self.index in self.owner.discarded
 
     @property
     def choice_count(self) -> int:
-        """The number of choices in this example."""
+        """The number of choices in this span."""
         return self.end - self.start
 
     @property
-    def children(self) -> "list[Example]":
-        """The list of all examples with this as a parent, in increasing index
+    def children(self) -> "list[Span]":
+        """The list of all spans with this as a parent, in increasing index
         order."""
         return [self.owner[i] for i in self.owner.children[self.index]]
 
 
-class ExampleProperty:
-    """There are many properties of examples that we calculate by
+class SpanProperty:
+    """There are many properties of spans that we calculate by
     essentially rerunning the test case multiple times based on the
-    calls which we record in ExampleRecord.
+    calls which we record in SpanProperty.
 
     This class defines a visitor, subclasses of which can be used
     to calculate these properties.
     """
 
-    def __init__(self, examples: "Examples"):
-        self.example_stack: list[int] = []
-        self.examples = examples
-        self.example_count = 0
+    def __init__(self, spans: "Spans"):
+        self.span_stack: list[int] = []
+        self.spans = spans
+        self.span_count = 0
         self.choice_count = 0
 
     def run(self) -> Any:
         """Rerun the test case with this visitor and return the
         results of ``self.finish()``."""
-        for record in self.examples.trail:
+        for record in self.spans.trail:
             if record == CHOICE_RECORD:
                 self.choice_count += 1
-            elif record >= START_EXAMPLE_RECORD:
-                self.__push(record - START_EXAMPLE_RECORD)
+            elif record >= START_SPAN_RECORD:
+                self.__push(record - START_SPAN_RECORD)
             else:
                 assert record in (
-                    STOP_EXAMPLE_DISCARD_RECORD,
-                    STOP_EXAMPLE_NO_DISCARD_RECORD,
+                    STOP_SPAN_DISCARD_RECORD,
+                    STOP_SPAN_NO_DISCARD_RECORD,
                 )
-                self.__pop(discarded=record == STOP_EXAMPLE_DISCARD_RECORD)
+                self.__pop(discarded=record == STOP_SPAN_DISCARD_RECORD)
         return self.finish()
 
     def __push(self, label_index: int) -> None:
-        i = self.example_count
-        assert i < len(self.examples)
-        self.start_example(i, label_index=label_index)
-        self.example_count += 1
-        self.example_stack.append(i)
+        i = self.span_count
+        assert i < len(self.spans)
+        self.start_span(i, label_index=label_index)
+        self.span_count += 1
+        self.span_stack.append(i)
 
     def __pop(self, *, discarded: bool) -> None:
-        i = self.example_stack.pop()
-        self.stop_example(i, discarded=discarded)
+        i = self.span_stack.pop()
+        self.stop_span(i, discarded=discarded)
 
-    def start_example(self, i: int, label_index: int) -> None:
-        """Called at the start of each example, with ``i`` the
-        index of the example and ``label_index`` the index of
-        its label in ``self.examples.labels``."""
+    def start_span(self, i: int, label_index: int) -> None:
+        """Called at the start of each span, with ``i`` the
+        index of the span and ``label_index`` the index of
+        its label in ``self.spans.labels``."""
 
-    def stop_example(self, i: int, *, discarded: bool) -> None:
-        """Called at the end of each example, with ``i`` the
-        index of the example and ``discarded`` being ``True`` if ``stop_example``
+    def stop_span(self, i: int, *, discarded: bool) -> None:
+        """Called at the end of each span, with ``i`` the
+        index of the span and ``discarded`` being ``True`` if ``stop_span``
         was called with ``discard=True``."""
 
     def finish(self) -> Any:
         raise NotImplementedError
 
 
-STOP_EXAMPLE_DISCARD_RECORD = 1
-STOP_EXAMPLE_NO_DISCARD_RECORD = 2
-START_EXAMPLE_RECORD = 3
+STOP_SPAN_DISCARD_RECORD = 1
+STOP_SPAN_NO_DISCARD_RECORD = 2
+START_SPAN_RECORD = 3
 
 CHOICE_RECORD = calc_label_from_name("ir draw record")
 
 
-class ExampleRecord:
-    """Records the series of ``start_example``, ``stop_example``, and
-    ``draw_bits`` calls so that these may be stored in ``Examples`` and
+class SpanRecord:
+    """Records the series of ``start_span``, ``stop_span``, and
+    ``draw_bits`` calls so that these may be stored in ``Spans`` and
     replayed when we need to know about the structure of individual
-    ``Example`` objects.
+    ``Span`` objects.
 
     Note that there is significant similarity between this class and
     ``DataObserver``, and the plan is to eventually unify them, but
@@ -320,123 +319,123 @@ class ExampleRecord:
     def record_choice(self) -> None:
         self.trail.append(CHOICE_RECORD)
 
-    def start_example(self, label: int) -> None:
+    def start_span(self, label: int) -> None:
         assert self.__index_of_labels is not None
         try:
             i = self.__index_of_labels[label]
         except KeyError:
             i = self.__index_of_labels.setdefault(label, len(self.labels))
             self.labels.append(label)
-        self.trail.append(START_EXAMPLE_RECORD + i)
+        self.trail.append(START_SPAN_RECORD + i)
 
-    def stop_example(self, *, discard: bool) -> None:
+    def stop_span(self, *, discard: bool) -> None:
         if discard:
-            self.trail.append(STOP_EXAMPLE_DISCARD_RECORD)
+            self.trail.append(STOP_SPAN_DISCARD_RECORD)
         else:
-            self.trail.append(STOP_EXAMPLE_NO_DISCARD_RECORD)
+            self.trail.append(STOP_SPAN_NO_DISCARD_RECORD)
 
 
-class _starts_and_ends(ExampleProperty):
-    def __init__(self, examples: "Examples") -> None:
-        super().__init__(examples)
-        self.starts = IntList.of_length(len(self.examples))
-        self.ends = IntList.of_length(len(self.examples))
+class _starts_and_ends(SpanProperty):
+    def __init__(self, spans: "Spans") -> None:
+        super().__init__(spans)
+        self.starts = IntList.of_length(len(self.spans))
+        self.ends = IntList.of_length(len(self.spans))
 
-    def start_example(self, i: int, label_index: int) -> None:
+    def start_span(self, i: int, label_index: int) -> None:
         self.starts[i] = self.choice_count
 
-    def stop_example(self, i: int, *, discarded: bool) -> None:
+    def stop_span(self, i: int, *, discarded: bool) -> None:
         self.ends[i] = self.choice_count
 
     def finish(self) -> tuple[IntList, IntList]:
         return (self.starts, self.ends)
 
 
-class _discarded(ExampleProperty):
-    def __init__(self, examples: "Examples") -> None:
-        super().__init__(examples)
+class _discarded(SpanProperty):
+    def __init__(self, spans: "Spans") -> None:
+        super().__init__(spans)
         self.result: set[int] = set()
 
     def finish(self) -> frozenset[int]:
         return frozenset(self.result)
 
-    def stop_example(self, i: int, *, discarded: bool) -> None:
+    def stop_span(self, i: int, *, discarded: bool) -> None:
         if discarded:
             self.result.add(i)
 
 
-class _parentage(ExampleProperty):
-    def __init__(self, examples: "Examples") -> None:
-        super().__init__(examples)
-        self.result = IntList.of_length(len(self.examples))
+class _parentage(SpanProperty):
+    def __init__(self, spans: "Spans") -> None:
+        super().__init__(spans)
+        self.result = IntList.of_length(len(self.spans))
 
-    def stop_example(self, i: int, *, discarded: bool) -> None:
+    def stop_span(self, i: int, *, discarded: bool) -> None:
         if i > 0:
-            self.result[i] = self.example_stack[-1]
+            self.result[i] = self.span_stack[-1]
 
     def finish(self) -> IntList:
         return self.result
 
 
-class _depths(ExampleProperty):
-    def __init__(self, examples: "Examples") -> None:
-        super().__init__(examples)
-        self.result = IntList.of_length(len(self.examples))
+class _depths(SpanProperty):
+    def __init__(self, spans: "Spans") -> None:
+        super().__init__(spans)
+        self.result = IntList.of_length(len(self.spans))
 
-    def start_example(self, i: int, label_index: int) -> None:
-        self.result[i] = len(self.example_stack)
+    def start_span(self, i: int, label_index: int) -> None:
+        self.result[i] = len(self.span_stack)
 
     def finish(self) -> IntList:
         return self.result
 
 
-class _label_indices(ExampleProperty):
-    def __init__(self, examples: "Examples") -> None:
-        super().__init__(examples)
-        self.result = IntList.of_length(len(self.examples))
+class _label_indices(SpanProperty):
+    def __init__(self, spans: "Spans") -> None:
+        super().__init__(spans)
+        self.result = IntList.of_length(len(self.spans))
 
-    def start_example(self, i: int, label_index: int) -> None:
+    def start_span(self, i: int, label_index: int) -> None:
         self.result[i] = label_index
 
     def finish(self) -> IntList:
         return self.result
 
 
-class _mutator_groups(ExampleProperty):
-    def __init__(self, examples: "Examples") -> None:
-        super().__init__(examples)
+class _mutator_groups(SpanProperty):
+    def __init__(self, spans: "Spans") -> None:
+        super().__init__(spans)
         self.groups: dict[int, set[tuple[int, int]]] = defaultdict(set)
 
-    def start_example(self, i: int, label_index: int) -> None:
+    def start_span(self, i: int, label_index: int) -> None:
         # TODO should we discard start == end cases? occurs for eg st.data()
         # which is conditionally or never drawn from. arguably swapping
         # nodes with the empty list is a useful mutation enabled by start == end?
-        key = (self.examples[i].start, self.examples[i].end)
+        key = (self.spans[i].start, self.spans[i].end)
         self.groups[label_index].add(key)
 
     def finish(self) -> Iterable[set[tuple[int, int]]]:
-        # Discard groups with only one example, since the mutator can't
+        # Discard groups with only one span, since the mutator can't
         # do anything useful with them.
         return [g for g in self.groups.values() if len(g) >= 2]
 
 
-class Examples:
-    """A lazy collection of ``Example`` objects, derived from
-    the record of recorded behaviour in ``ExampleRecord``.
+class Spans:
+    """A lazy collection of ``Span`` objects, derived from
+    the record of recorded behaviour in ``SpanRecord``.
 
-    Behaves logically as if it were a list of ``Example`` objects,
+    Behaves logically as if it were a list of ``Span`` objects,
     but actually mostly exists as a compact store of information
     for them to reference into. All properties on here are best
-    understood as the backing storage for ``Example`` and are
+    understood as the backing storage for ``Span`` and are
     described there.
     """
 
-    def __init__(self, record: ExampleRecord) -> None:
+    def __init__(self, record: SpanRecord) -> None:
         self.trail = record.trail
         self.labels = record.labels
-        self.__length = self.trail.count(
-            STOP_EXAMPLE_DISCARD_RECORD
-        ) + record.trail.count(STOP_EXAMPLE_NO_DISCARD_RECORD)
+        self.__length = self.trail.count(STOP_SPAN_DISCARD_RECORD) + record.trail.count(
+            STOP_SPAN_NO_DISCARD_RECORD
+        )
         self.__children: Optional[list[Sequence[int]]] = None
 
     @cached_property
@@ -489,17 +488,17 @@ class Examples:
     def __len__(self) -> int:
         return self.__length
 
-    def __getitem__(self, i: int) -> Example:
+    def __getitem__(self, i: int) -> Span:
         n = self.__length
         if i < -n or i >= n:
             raise IndexError(f"Index {i} out of range [-{n}, {n})")
         if i < 0:
             i += n
-        return Example(self, i)
+        return Span(self, i)
 
     # not strictly necessary as we have len/getitem, but required for mypy.
     # https://github.com/python/mypy/issues/9737
-    def __iter__(self) -> Iterator[Example]:
+    def __iter__(self) -> Iterator[Span]:
         for i in range(len(self)):
             yield self[i]
 
@@ -581,7 +580,7 @@ class ConjectureResult:
     has_discards: bool = attr.ib()
     target_observations: TargetObservations = attr.ib()
     tags: frozenset[StructuralCoverageTag] = attr.ib()
-    examples: Examples = attr.ib(repr=False, eq=False)
+    spans: Spans = attr.ib(repr=False, eq=False)
     arg_slices: set[tuple[int, int]] = attr.ib(repr=False)
     slice_comments: dict[tuple[int, int], str] = attr.ib(repr=False)
     misaligned_at: Optional[MisalignedAt] = attr.ib(repr=False)
@@ -680,12 +679,12 @@ class ConjectureData:
         # Normally unpopulated but we need this in the niche case
         # that self.as_result() is Overrun but we still want the
         # examples for reporting purposes.
-        self.__examples: Optional[Examples] = None
+        self.__spans: Optional[Spans] = None
 
-        # We want the top level example to have depth 0, so we start
+        # We want the top level span to have depth 0, so we start
         # at -1.
         self.depth = -1
-        self.__example_record = ExampleRecord()
+        self.__span_record = SpanRecord()
 
         # Slice indices for discrete reportable parts that which-parts-matter can
         # try varying, to report if the minimal example always fails anyway.
@@ -706,7 +705,7 @@ class ConjectureData:
         self.prefix = prefix
         self.nodes: tuple[ChoiceNode, ...] = ()
         self.misaligned_at: Optional[MisalignedAt] = None
-        self.start_example(TOP_LABEL)
+        self.start_span(TOP_LABEL)
 
     def __repr__(self) -> str:
         return "ConjectureData(%s, %d choices%s)" % (
@@ -788,7 +787,7 @@ class ConjectureData:
                 was_forced=was_forced,
                 index=len(self.nodes),
             )
-            self.__example_record.record_choice()
+            self.__span_record.record_choice()
             self.nodes += (node,)
             self.length += size
 
@@ -1036,7 +1035,7 @@ class ConjectureData:
             self.__result = ConjectureResult(
                 status=self.status,
                 interesting_origin=self.interesting_origin,
-                examples=self.examples,
+                spans=self.spans,
                 nodes=self.nodes,
                 length=self.length,
                 output=self.output,
@@ -1103,7 +1102,7 @@ class ConjectureData:
         if label is None:
             assert isinstance(strategy.label, int)
             label = strategy.label
-        self.start_example(label=label)
+        self.start_span(label=label)
         try:
             if not at_top_level:
                 return strategy.do_draw(self)
@@ -1128,11 +1127,11 @@ class ConjectureData:
                 self._observability_args[key] = to_jsonable(v)
             return v
         finally:
-            self.stop_example()
+            self.stop_span()
 
-    def start_example(self, label: int) -> None:
+    def start_span(self, label: int) -> None:
         self.provider.span_start(label)
-        self.__assert_not_frozen("start_example")
+        self.__assert_not_frozen("start_span")
         self.depth += 1
         # Logically it would make sense for this to just be
         # ``self.depth = max(self.depth, self.max_depth)``, which is what it used to
@@ -1142,10 +1141,10 @@ class ConjectureData:
         # to fix with this check.
         if self.depth > self.max_depth:
             self.max_depth = self.depth
-        self.__example_record.start_example(label)
+        self.__span_record.start_span(label)
         self.labels_for_structure_stack.append({label})
 
-    def stop_example(self, *, discard: bool = False) -> None:
+    def stop_span(self, *, discard: bool = False) -> None:
         self.provider.span_end(discard)
         if self.frozen:
             return
@@ -1153,7 +1152,7 @@ class ConjectureData:
             self.has_discards = True
         self.depth -= 1
         assert self.depth >= -1
-        self.__example_record.stop_example(discard=discard)
+        self.__span_record.stop_span(discard=discard)
 
         labels_for_structure = self.labels_for_structure_stack.pop()
 
@@ -1164,10 +1163,10 @@ class ConjectureData:
                 self.tags.update([structural_coverage(l) for l in labels_for_structure])
 
         if discard:
-            # Once we've discarded an example, every test case starting with
+            # Once we've discarded a span, every test case starting with
             # this prefix contains discards. We prune the tree at that point so
             # as to avoid future test cases bothering with this region, on the
-            # assumption that some example that you could have used instead
+            # assumption that some span that you could have used instead
             # there would *not* trigger the discard. This greatly speeds up
             # test case generation in some cases, because it allows us to
             # ignore large swathes of the search space that are effectively
@@ -1191,11 +1190,11 @@ class ConjectureData:
             self.observer.kill_branch()
 
     @property
-    def examples(self) -> Examples:
+    def spans(self) -> Spans:
         assert self.frozen
-        if self.__examples is None:
-            self.__examples = Examples(record=self.__example_record)
-        return self.__examples
+        if self.__spans is None:
+            self.__spans = Spans(record=self.__span_record)
+        return self.__spans
 
     def freeze(self) -> None:
         if self.frozen:
@@ -1203,12 +1202,11 @@ class ConjectureData:
         self.finish_time = time.perf_counter()
         self.gc_finish_time = gc_cumulative_time()
 
-        # Always finish by closing all remaining examples so that we have a
-        # valid tree.
+        # Always finish by closing all remaining spans so that we have a valid tree.
         while self.depth >= 0:
-            self.stop_example()
+            self.stop_span()
 
-        self.__example_record.freeze()
+        self.__span_record.freeze()
         self.frozen = True
         self.observer.conclude_test(self.status, self.interesting_origin)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -805,8 +805,8 @@ class DataTree:
 
     def simulate_test_function(self, data: ConjectureData) -> None:
         """Run a simulated version of the test function recorded by
-        this tree. Note that this does not currently call ``stop_example``
-        or ``start_example`` as these are not currently recorded in the
+        this tree. Note that this does not currently call ``stop_span``
+        or ``start_span`` as these are not currently recorded in the
         tree. This will likely change in future."""
         node = self.root
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1157,7 +1157,7 @@ class ConjectureRunner:
                 and self.call_count <= initial_calls + 5
                 and failed_mutations <= 5
             ):
-                groups = data.examples.mutator_groups
+                groups = data.spans.mutator_groups
                 if not groups:
                     break
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/optimiser.py
@@ -181,12 +181,12 @@ class Optimiser:
                     if len(attempt.nodes) == len(self.current_data.nodes):
                         return False
 
-                    for j, ex in enumerate(self.current_data.examples):
+                    for j, ex in enumerate(self.current_data.spans):
                         if ex.start >= node.index + 1:
                             break  # pragma: no cover
                         if ex.end <= node.index:
                             continue
-                        ex_attempt = attempt.examples[j]
+                        ex_attempt = attempt.spans[j]
                         if ex.choice_count == ex_attempt.choice_count:
                             continue  # pragma: no cover
                         replacement = attempt.choices[ex_attempt.start : ex_attempt.end]

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -244,7 +244,7 @@ class PrimitiveProvider(abc.ABC):
         `label` is an opaque integer, which will be shared by all spans drawn
         from a particular strategy.
 
-        This method is called from ConjectureData.start_example().
+        This method is called from ConjectureData.start_span().
         """
 
     def span_end(self, discard: bool, /) -> None:  # noqa: B027, FBT001
@@ -254,7 +254,7 @@ class PrimitiveProvider(abc.ABC):
         unlikely to contribute to the input data as seen by the user's test.
         Note however that side effects can make this determination unsound.
 
-        This method is called from ConjectureData.stop_example().
+        This method is called from ConjectureData.stop_span().
         """
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -871,8 +871,8 @@ class Shrinker:
     @derived_value  # type: ignore
     def spans_by_label(self):
         """
-        An index of all spans grouped by their label, with the spans stored in
-        their normal index order.
+        A mapping of labels to a list of spans with that label. Spans in the list
+        are ordered by their normal index order.
         """
 
         spans_by_label = defaultdict(list)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -185,7 +185,7 @@ class Sampler:
         forced: Optional[int] = None,
     ) -> int:
         if self.observe:
-            data.start_example(SAMPLE_IN_SAMPLER_LABEL)
+            data.start_span(SAMPLE_IN_SAMPLER_LABEL)
         forced_choice = (  # pragma: no branch # https://github.com/nedbat/coveragepy/issues/1617
             None
             if forced is None
@@ -214,7 +214,7 @@ class Sampler:
             observe=self.observe,
         )
         if self.observe:
-            data.stop_example()
+            data.stop_span()
         if use_alternate:
             assert forced is None or alternate == forced, (forced, alternate)
             return alternate
@@ -263,23 +263,23 @@ class many:
         self.rejected = False
         self.observe = observe
 
-    def stop_example(self):
+    def stop_span(self):
         if self.observe:
-            self.data.stop_example()
+            self.data.stop_span()
 
-    def start_example(self, label):
+    def start_span(self, label):
         if self.observe:
-            self.data.start_example(label)
+            self.data.start_span(label)
 
     def more(self) -> bool:
         """Should I draw another element to add to the collection?"""
         if self.drawn:
-            self.stop_example()
+            self.stop_span()
 
         self.drawn = True
         self.rejected = False
 
-        self.start_example(ONE_FROM_MANY_LABEL)
+        self.start_span(ONE_FROM_MANY_LABEL)
         if self.min_size == self.max_size:
             # if we have to hit an exact size, draw unconditionally until that
             # point, and no further.
@@ -307,7 +307,7 @@ class many:
             self.count += 1
             return True
         else:
-            self.stop_example()
+            self.stop_span()
             return False
 
     def reject(self, why: Optional[str] = None) -> None:

--- a/hypothesis-python/src/hypothesis/provisional.py
+++ b/hypothesis-python/src/hypothesis/provisional.py
@@ -142,7 +142,7 @@ class DomainNameStrategy(st.SearchStrategy):
             # Generate a new valid subdomain using the regex strategy.
             sub_domain = data.draw(self.elem_strategy)
             if len(domain) + len(sub_domain) >= self.max_length:
-                data.stop_example(discard=True)
+                data.stop_span(discard=True)
                 break
             domain = sub_domain + "." + domain
         return domain

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -144,7 +144,7 @@ def get_state_machine_test(state_machine_factory, *, settings=None, _min_steps=0
                 # find a failing test case, so we stop with probability of
                 # 2 ** -16 during normal operation but force a stop when we've
                 # generated enough steps.
-                cd.start_example(STATE_MACHINE_RUN_LABEL)
+                cd.start_span(STATE_MACHINE_RUN_LABEL)
                 must_stop = None
                 if steps_run >= max_steps:
                     must_stop = True
@@ -227,7 +227,7 @@ def get_state_machine_test(state_machine_factory, *, settings=None, _min_steps=0
                         # then 'print_step' prints a multi-variable assignment.
                         output(machine._repr_step(rule, data_to_print, result))
                 machine.check_invariants(settings, output, cd._stateful_run_times)
-                cd.stop_example()
+                cd.stop_span()
         finally:
             output("state.teardown()")
             machine.teardown()

--- a/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
@@ -77,7 +77,7 @@ class FeatureFlags:
 
         data = self.__data
 
-        data.start_example(label=FEATURE_LABEL)
+        data.start_span(label=FEATURE_LABEL)
 
         # If we've already decided on this feature then we don't actually
         # need to draw anything, but we do write the same decision to the
@@ -99,7 +99,7 @@ class FeatureFlags:
         if name in oneof and not is_disabled:
             oneof.clear()
         oneof.discard(name)
-        data.stop_example()
+        data.stop_span()
         return not is_disabled
 
     def __repr__(self):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -897,14 +897,14 @@ class MappedStrategy(SearchStrategy[MappedTo], Generic[MappedFrom, MappedTo]):
                 warnings.simplefilter("ignore", BytesWarning)
             for _ in range(3):
                 try:
-                    data.start_example(MAPPED_SEARCH_STRATEGY_DO_DRAW_LABEL)
+                    data.start_span(MAPPED_SEARCH_STRATEGY_DO_DRAW_LABEL)
                     x = data.draw(self.mapped_strategy)
                     result = self.pack(x)
-                    data.stop_example()
+                    data.stop_span()
                     current_build_context().record_call(result, self.pack, [x], {})
                     return result
                 except UnsatisfiedAssumption:
-                    data.stop_example(discard=True)
+                    data.stop_span(discard=True)
         raise UnsatisfiedAssumption
 
     @property
@@ -1075,13 +1075,13 @@ class FilteredStrategy(SearchStrategy[Ex]):
 
     def do_filtered_draw(self, data: ConjectureData) -> Union[Ex, UniqueIdentifier]:
         for i in range(3):
-            data.start_example(FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL)
+            data.start_span(FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL)
             value = data.draw(self.filtered_strategy)
             if self.condition(value):
-                data.stop_example()
+                data.stop_span()
                 return value
             else:
-                data.stop_example(discard=True)
+                data.stop_span(discard=True)
                 if i == 0:
                     data.events[f"Retried draw from {self!r} to satisfy filter"] = ""
 

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -358,18 +358,18 @@ def test_will_generate_novel_prefix_to_avoid_exhausted_branches():
 def test_will_mark_changes_in_discard_as_flaky():
     tree = DataTree()
     data = ConjectureData.for_choices((1, 1), observer=tree.new_observer())
-    data.start_example(10)
+    data.start_span(10)
     data.draw_integer(0, 1)
-    data.stop_example()
+    data.stop_span()
     data.draw_integer(0, 1)
     data.freeze()
 
     data = ConjectureData.for_choices((1, 1), observer=tree.new_observer())
-    data.start_example(10)
+    data.start_span(10)
     data.draw_integer(0, 1)
 
     with pytest.raises(Flaky):
-        data.stop_example(discard=True)
+        data.stop_span(discard=True)
 
 
 def test_is_not_flaky_on_positive_zero_and_negative_zero():

--- a/hypothesis-python/tests/conjecture/test_ir.py
+++ b/hypothesis-python/tests/conjecture/test_ir.py
@@ -237,10 +237,10 @@ def test_nodes(random):
     data.draw_float(min_value=-10.0, max_value=10.0, forced=5.0)
     data.draw_boolean(forced=True)
 
-    data.start_example(42)
+    data.start_span(42)
     data.draw_string(IntervalSet.from_string("abcd"), forced="abbcccdddd")
     data.draw_bytes(8, 8, forced=bytes(8))
-    data.stop_example()
+    data.stop_span()
 
     data.draw_integer(0, 100, forced=50)
 

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -71,8 +71,8 @@ def test_optimises_when_last_element_is_empty():
 
         def test(data):
             data.target_observations["n"] = data.draw_integer(0, 2**8 - 1)
-            data.start_example(label=1)
-            data.stop_example()
+            data.start_span(label=1)
+            data.stop_span()
 
         runner = ConjectureRunner(test, settings=TEST_SETTINGS)
         runner.cached_test_function((250,))
@@ -92,8 +92,8 @@ def test_can_optimise_last_with_following_empty():
             for _ in range(100):
                 data.draw_integer(0, 3)
             data.target_observations[""] = data.draw_integer(0, 2**8 - 1)
-            data.start_example(1)
-            data.stop_example()
+            data.start_span(1)
+            data.stop_span()
 
         runner = ConjectureRunner(
             test, settings=settings(TEST_SETTINGS, max_examples=100)
@@ -181,12 +181,12 @@ def test_can_patch_up_examples():
     with deterministic_PRNG():
 
         def test(data):
-            data.start_example(42)
+            data.start_span(42)
             m = data.draw_integer(0, 2**6 - 1)
             data.target_observations["m"] = m
             for _ in range(m):
                 data.draw_boolean()
-            data.stop_example()
+            data.stop_span()
             for i in range(4):
                 if i != data.draw_integer(0, 2**8 - 1):
                     data.mark_invalid()

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -206,9 +206,9 @@ def test_uses_tags_in_calculating_pareto_front():
         def test(data):
             data.target_observations[""] = 1
             if data.draw_boolean():
-                data.start_example(11)
+                data.start_span(11)
                 data.draw_integer(0, 2**8 - 1)
-                data.stop_example()
+                data.stop_span()
 
         runner = ConjectureRunner(
             test,

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -108,11 +108,11 @@ def test_can_zero_subintervals():
     @shrinking_from((3, 0, 0, 0, 1) * 10)
     def shrinker(data: ConjectureData):
         for _ in range(10):
-            data.start_example(SOME_LABEL)
+            data.start_span(SOME_LABEL)
             n = data.draw_integer(0, 2**8 - 1)
             for _ in range(n):
                 data.draw_integer(0, 2**8 - 1)
-            data.stop_example()
+            data.stop_span()
             if data.draw_integer(0, 2**8 - 1) != 1:
                 return
         data.mark_interesting()
@@ -123,13 +123,13 @@ def test_can_zero_subintervals():
 
 def test_can_pass_to_an_indirect_descendant():
     def tree(data):
-        data.start_example(label=1)
+        data.start_span(label=1)
         n = data.draw_integer(0, 1)
         data.draw_integer(0, 2**8 - 1)
         if n:
             tree(data)
             tree(data)
-        data.stop_example(discard=True)
+        data.stop_span(discard=True)
 
     initial = (1, 10, 0, 0, 1, 0, 0, 10, 0, 0)
     target = (0, 10)
@@ -163,11 +163,11 @@ def test_handle_empty_draws():
     @run_to_nodes
     def nodes(data):
         while True:
-            data.start_example(SOME_LABEL)
+            data.start_span(SOME_LABEL)
             n = data.draw_integer(0, 1)
-            data.start_example(SOME_LABEL)
-            data.stop_example()
-            data.stop_example(discard=n > 0)
+            data.start_span(SOME_LABEL)
+            data.stop_span()
+            data.stop_span(discard=n > 0)
             if not n:
                 break
         data.mark_interesting()
@@ -175,20 +175,20 @@ def test_handle_empty_draws():
     assert tuple(n.value for n in nodes) == (0,)
 
 
-def test_can_reorder_examples():
+def test_can_reorder_spans():
     # grouped by iteration: (1, 1) (1, 1) (0) (0) (0)
     @shrinking_from((1, 1, 1, 1, 0, 0, 0))
     def shrinker(data: ConjectureData):
         total = 0
         for _ in range(5):
-            data.start_example(label=0)
+            data.start_span(label=0)
             if data.draw_integer(0, 2**8 - 1):
                 total += data.draw_integer(0, 2**9 - 1)
-            data.stop_example()
+            data.stop_span()
         if total == 2:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["reorder_examples"])
+    shrinker.fixate_shrink_passes(["reorder_spans"])
     assert shrinker.choices == (0, 0, 0, 1, 1, 1, 1)
 
 
@@ -251,14 +251,14 @@ def test_finding_a_minimal_balanced_binary_tree():
 
     def tree(data):
         # Returns height of a binary tree and whether it is height balanced.
-        data.start_example(label=0)
+        data.start_span(label=0)
         if not data.draw_boolean():
             result = (1, True)
         else:
             h1, b1 = tree(data)
             h2, b2 = tree(data)
             result = (1 + max(h1, h2), b1 and b2 and abs(h1 - h2) <= 1)
-        data.stop_example()
+        data.stop_span()
         return result
 
     # Starting from an unbalanced tree of depth six
@@ -304,13 +304,13 @@ def test_zero_contained_examples():
     @shrinking_from((1,) * 8)
     def shrinker(data: ConjectureData):
         for _ in range(4):
-            data.start_example(1)
+            data.start_span(1)
             if data.draw_integer(0, 2**8 - 1) == 0:
                 data.mark_invalid()
-            data.start_example(1)
+            data.start_span(1)
             data.draw_integer(0, 2**8 - 1)
-            data.stop_example()
-            data.stop_example()
+            data.stop_span()
+            data.stop_span()
         data.mark_interesting()
 
     shrinker.shrink()
@@ -372,15 +372,15 @@ def test_zig_zags_quickly_with_shrink_towards(
 def test_zero_irregular_examples():
     @shrinking_from((255,) * 6)
     def shrinker(data: ConjectureData):
-        data.start_example(1)
+        data.start_span(1)
         data.draw_integer(0, 2**8 - 1)
         data.draw_integer(0, 2**16 - 1)
-        data.stop_example()
-        data.start_example(1)
+        data.stop_span()
+        data.start_span(1)
         interesting = (
             data.draw_integer(0, 2**8 - 1) > 0 and data.draw_integer(0, 2**16 - 1) > 0
         )
-        data.stop_example()
+        data.stop_span()
         if interesting:
             data.mark_interesting()
 
@@ -425,17 +425,17 @@ def test_can_expand_deleted_region():
     @shrinking_from((1, 2, 3, 4, 0, 0))
     def shrinker(data: ConjectureData):
         def t():
-            data.start_example(1)
+            data.start_span(1)
 
-            data.start_example(1)
+            data.start_span(1)
             m = data.draw_integer(0, 2**8 - 1)
-            data.stop_example()
+            data.stop_span()
 
-            data.start_example(1)
+            data.start_span(1)
             n = data.draw_integer(0, 2**8 - 1)
-            data.stop_example()
+            data.stop_span()
 
-            data.stop_example()
+            data.stop_span()
             return (m, n)
 
         v1 = t()


### PR DESCRIPTION
Addresses part 1 of #4166. 

I was a bit concerned about having to leave a deprecated alias for `data.{start, stop}_example()`, but [grep.app doesn't know of any other consumers](https://grep.app/search?q=.start_example%28). Which doesn't mean there aren't any, of course 😅 