### PR TITLE
Add subtree mutations

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,22 @@
+RELEASE_TYPE: patch
+
+For strategies which draw make recursive draws, including :func:`~hypothesis.strategies.recursive` and :func:`~hypothesis.strategies.deferred`, we now generate examples with duplicated subtrees more often. This tends to uncover interesting behavior in tests.
+
+For instance, we might now generate a tree like this more often (though the details depend on the strategy):
+
+.. code-block:: none
+
+                 ┌─────┐
+          ┌──────┤  a  ├──────┐
+          │      └─────┘      │
+       ┌──┴──┐             ┌──┴──┐
+       │  b  │             │  a  │
+       └──┬──┘             └──┬──┘
+     ┌────┴────┐         ┌────┴────┐
+  ┌──┴──┐   ┌──┴──┐   ┌──┴──┐   ┌──┴──┐
+  │  c  │   │  d  │   │  b  │   │ ... │
+  └─────┘   └─────┘   └──┬──┘   └─────┘
+                    ┌────┴────┐
+                 ┌──┴──┐   ┌──┴──┐
+                 │  c  │   │  d  │
+                 └─────┘   └─────┘

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -38,6 +38,10 @@ def calc_label_from_cls(cls: type) -> int:
     return calc_label_from_name(cls.__qualname__)
 
 
+def calc_label_from_hash(obj: object) -> int:
+    return calc_label_from_name(str(hash(obj)))
+
+
 def combine_labels(*labels: int) -> int:
     label = 0
     for l in labels:

--- a/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/misc.py
@@ -13,7 +13,7 @@ from hypothesis.strategies._internal.strategies import (
     SampledFromStrategy,
     SearchStrategy,
     T,
-    is_simple_data,
+    is_hashable,
 )
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 
@@ -45,7 +45,7 @@ class JustStrategy(SampledFromStrategy):
         return f"just({get_pretty_function_description(self.value)}){suffix}"
 
     def calc_is_cacheable(self, recur):
-        return is_simple_data(self.value)
+        return is_hashable(self.value)
 
     def do_filtered_draw(self, data):
         # The parent class's `do_draw` implementation delegates directly to

--- a/hypothesis-python/tests/conjecture/test_mutations.py
+++ b/hypothesis-python/tests/conjecture/test_mutations.py
@@ -1,0 +1,48 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from hypothesis import strategies as st
+
+from tests.common.debug import find_any
+
+tree = st.deferred(lambda: st.tuples(st.integers(), tree, tree)) | st.just(None)
+
+
+def test_can_find_duplicated_subtree():
+    # look for an example of the form
+    #
+    #                  ┌─────┐
+    #           ┌──────┤  a  ├──────┐
+    #           │      └─────┘      │
+    #        ┌──┴──┐             ┌──┴──┐
+    #        │  b  │             │  a  │
+    #        └──┬──┘             └──┬──┘
+    #      ┌────┴────┐         ┌────┴────┐
+    #   ┌──┴──┐   ┌──┴──┐   ┌──┴──┐   ┌──┴──┐
+    #   │  c  │   │  d  │   │  b  │   │ ... │
+    #   └─────┘   └─────┘   └──┬──┘   └─────┘
+    #                     ┌────┴────┐
+    #                  ┌──┴──┐   ┌──┴──┐
+    #                  │  c  │   │  d  │
+    #                  └─────┘   └─────┘
+    #
+    # If we just checked that (b, c, d) was duplicated somewhere, this could have
+    # happened as a result of normal mutation. Checking for the a parent node as
+    # well is unlikely to have been generated without tree mutation, however.
+    find_any(
+        tree,
+        (
+            lambda v: v is not None
+            and v[1] is not None
+            and v[2] is not None
+            and v[0] == v[2][0]
+            and v[1] == v[2][1]
+        ),
+    )

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -106,6 +106,11 @@ def test_combine_labels_is_distinct():
     assert cu.combine_labels(x, y) not in (x, y)
 
 
+@given(st.integers())
+def test_combine_labels_is_identity_for_single_argument(n):
+    assert cu.combine_labels(n) == n
+
+
 @pytest.mark.skipif(np is None, reason="requires Numpy")
 def test_invalid_numpy_sample():
     with pytest.raises(InvalidArgument):

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -15,7 +15,7 @@ import operator
 
 import pytest
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import bit_count
 from hypothesis.strategies._internal.strategies import SampledFromStrategy
@@ -131,12 +131,7 @@ def test_flags_minimizes_bit_count():
 
 
 def test_flags_finds_all_bits_set():
-    assert find_any(
-        st.sampled_from(LargeFlag),
-        lambda f: f == ~LargeFlag(0),
-        # see https://github.com/HypothesisWorks/hypothesis/pull/4295
-        settings=settings(max_examples=10000),
-    )
+    assert find_any(st.sampled_from(LargeFlag), lambda f: f == ~LargeFlag(0))
 
 
 def test_sample_unnamed_alias():

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -15,7 +15,7 @@ import operator
 
 import pytest
 
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import bit_count
 from hypothesis.strategies._internal.strategies import SampledFromStrategy
@@ -131,7 +131,12 @@ def test_flags_minimizes_bit_count():
 
 
 def test_flags_finds_all_bits_set():
-    assert find_any(st.sampled_from(LargeFlag), lambda f: f == ~LargeFlag(0))
+    assert find_any(
+        st.sampled_from(LargeFlag),
+        lambda f: f == ~LargeFlag(0),
+        # see https://github.com/HypothesisWorks/hypothesis/pull/4295
+        settings=settings(max_examples=10000),
+    )
 
 
 def test_sample_unnamed_alias():

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -36,8 +36,8 @@ class PoisonedTree(SearchStrategy):
             return data.draw(self) + data.draw(self)
         else:
             # We draw n as two separate calls so that it doesn't show up as a
-            # single block. If it did, the heuristics that allow us to move
-            # blocks around would fire and it would move right, which would
+            # single choice. If it did, the heuristics that allow us to move
+            # choices around would fire and it would move right, which would
             # then allow us to shrink it more easily.
             n1 = data.draw_integer(0, 2**16 - 1) << 16
             n2 = data.draw_integer(0, 2**16 - 1)


### PR DESCRIPTION
Adds repeated subtree mutation, in the style of [nautilus](https://wcventure.github.io/FuzzingPaper/Paper/NDSS19_Nautilus.pdf). (I didn't take this mutation from them, it's just the obvious thing to do and I noticed afterwards that they were the same. Though who knows, maybe this was only in my brain after reading that paper).

This adds a bit of unwanted mutation to `st.sampled_from(Flag)`, because that uses a recursive `sampled_from` in its own implementation. `calc_label_from_name` doesn't use strategy kwargs to distinguish labels; maybe it should? It's just the class name right now, so every `sampled_from` has the same label. Adding kwargs would make labels useful as a true marker of recursive structure. I haven't checked whether doing this breaks anything. Requiring every strategy to define the kwargs that are relevant for label calculation could also go along nicely with providing those kwargs to providers in `span_start`.