### PR TITLE
Add a `URandomProvider` for use by Antithesis

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds an :ref:`alternative backend <alternative-backends>` which draws randomness from ``/dev/urandom``. This is useful for users of `Antithesis <https://antithesis.com/>`_ who also have Hypothesis tests, allowing Antithesis mutation of ``/dev/urandom`` to drive Hypothesis generation.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 This patch adds an :ref:`alternative backend <alternative-backends>` which draws randomness from ``/dev/urandom``. This is useful for users of `Antithesis <https://antithesis.com/>`_ who also have Hypothesis tests, allowing Antithesis mutation of ``/dev/urandom`` to drive Hypothesis generation.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,5 @@
 RELEASE_TYPE: minor
 
-This patch adds an :ref:`alternative backend <alternative-backends>` which draws randomness from ``/dev/urandom``. This is useful for users of `Antithesis <https://antithesis.com/>`_ who also have Hypothesis tests, allowing Antithesis mutation of ``/dev/urandom`` to drive Hypothesis generation.
+This release adds a ``"hypothesis-urandom"`` :ref:`backend <alternative-backends>`, which draws randomness from ``/dev/urandom`` instead of Python's PRNG. This is useful for users of `Antithesis <https://antithesis.com/>`_ who also have Hypothesis tests, allowing Antithesis mutation of ``/dev/urandom`` to drive Hypothesis generation. We expect it to be strictly slower than the default backend for everyone else.
+
+It can be enabled with ``@settings(backend="hypothesis-urandom")``.

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -258,7 +258,8 @@ hypothesis-urandom
     using `Antithesis <https://antithesis.com/>`_, in which case this enables Antithesis
     mutations to drive Hypothesis generation.
 
-    Not available on windows.
+    ``/dev/urandom`` is not available on Windows, so we emit a warning and fall back to the
+    hypothesis backend there.
 crosshair
     Generates examples using SMT solvers like z3, which is particularly effective at satisfying
     difficult checks in your code, like ``if`` or ``==`` statements.

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -253,10 +253,10 @@ Hypothesis includes the following backends:
 hypothesis
     The default backend.
 hypothesis-urandom
-    The same same as the default backend, but uses ``/dev/urandom`` to back the randomness
-    behind its PRNG. The only reason to use this backend is if you are also using
-    `Antithesis <https://antithesis.com/>`_, in which case this enables Antithesis mutations
-    to drive Hypothesis generation.
+    The same as the default backend, but uses ``/dev/urandom`` to back the randomness
+    behind its PRNG. The only reason to use this backend over the default is if you are also
+    using `Antithesis <https://antithesis.com/>`_, in which case this enables Antithesis
+    mutations to drive Hypothesis generation.
 
     Not available on windows.
 crosshair

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -241,25 +241,44 @@ Alternative backends for Hypothesis
 
 .. warning::
 
-   EXPERIMENTAL AND UNSTABLE.
+   Alternative backends are experimental and not yet part of the public API.
+   We may continue to make breaking changes as we finalize the interface.
 
-The importable name of a backend which Hypothesis should use to generate primitive
-types.  We aim to support heuristic-random, solver-based, and fuzzing-based backends.
+Hypothesis supports alternative backends, which tells Hypothesis how to generate primitive
+types. This enables powerful generation techniques which are compatible with all parts of
+Hypothesis, including the database and shrinking.
 
-See :issue:`3086` for details, e.g. if you're interested in writing your own backend.
-(note that there is *no stable interface* for this; you'd be helping us work out
-what that should eventually look like, and we're likely to make regular breaking
-changes for some time to come)
+Hypothesis includes the following backends:
 
-Using the prototype :pypi:`crosshair-tool` backend via :pypi:`hypothesis-crosshair`,
-a solver-backed test might look something like:
+hypothesis
+    The default backend.
+hypothesis-urandom
+    The same same as the default backend, but uses ``/dev/urandom`` to back the randomness
+    behind its PRNG. The only reason to use this backend is if you are also using
+    `Antithesis <https://antithesis.com/>`_, in which case this enables Antithesis mutations
+    to drive Hypothesis generation.
+
+    Not available on windows.
+crosshair
+    Generates examples using SMT solvers like z3, which is particularly effective at satisfying
+    difficult checks in your code, like ``if`` or ``==`` statements.
+
+    Requires ``pip install hypothesis[crosshair]``.
+
+You can change the backend for a test with the ``backend`` setting. For instance, after
+``pip install hypothesis[crosshair]``, you can use :pypi:`crosshair <crosshair-tool>` to
+generate examples with SMT via the :pypi:`hypothesis-crosshair` backend:
 
 .. code-block:: python
 
     from hypothesis import given, settings, strategies as st
 
 
-    @settings(backend="crosshair")  # pip install hypothesis[crosshair]
+    # requires pip install hypothesis[crosshair]
+    @settings(backend="crosshair")
     @given(st.integers())
     def test_needs_solver(x):
         assert x != 123456789
+
+Failures found by alternative backends are saved to the database and shrink just like normally
+generated examples, and in general interact with every feature of Hypothesis as you would expect.

--- a/hypothesis-python/docs/strategies.rst
+++ b/hypothesis-python/docs/strategies.rst
@@ -274,8 +274,7 @@ generate examples with SMT via the :pypi:`hypothesis-crosshair` backend:
     from hypothesis import given, settings, strategies as st
 
 
-    # requires pip install hypothesis[crosshair]
-    @settings(backend="crosshair")
+    @settings(backend="crosshair")  # pip install hypothesis[crosshair]
     @given(st.integers())
     def test_needs_solver(x):
         assert x != 123456789

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -868,7 +868,7 @@ class URandomProvider(HypothesisProvider):
 
     def __init__(self, conjecturedata: Optional["ConjectureData"], /):
         super().__init__(conjecturedata)
-        if WINDOWS:
+        if WINDOWS:  # pragma: no branch
             warnings.warn(
                 "/dev/urandom is not available on windows. Falling back to "
                 'standard PRNG generation (equivalent to backend="hypothesis").',

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -868,7 +868,7 @@ class URandomProvider(HypothesisProvider):
 
     def __init__(self, conjecturedata: Optional["ConjectureData"], /):
         super().__init__(conjecturedata)
-        if WINDOWS:  # pragma: no branch
+        if WINDOWS:  # pragma: no cover
             warnings.warn(
                 "/dev/urandom is not available on windows. Falling back to "
                 'standard PRNG generation (equivalent to backend="hypothesis").',

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -60,15 +60,19 @@ _Lifetime: "TypeAlias" = Literal["test_case", "test_function"]
 COLLECTION_DEFAULT_MAX_SIZE = 10**10  # "arbitrarily large"
 
 
-# The set of available `PrimitiveProvider`s, by name.  Other libraries, such as
-# crosshair, can implement this interface and add themselves; at which point users
-# can configure which backend to use via settings.   Keys are the name of the library,
-# which doubles as the backend= setting, and values are importable class names.
+# The available `PrimitiveProvider`s, and therefore also the available backends
+# for use by @settings(backend=...). The key is the name to be used in the backend=
+# value, and the value is the importable path to a subclass of PrimitiveProvider.
 #
-# NOTE: this is a temporary interface.  We DO NOT promise to continue supporting it!
-#       (but if you want to experiment and don't mind breakage, here you go)
+# See also
+# https://hypothesis.readthedocs.io/en/latest/strategies.html#alternative-backends-for-hypothesis.
+#
+# NOTE: the PrimitiveProvider interface is not yet stable. We may continue to
+# make breaking changes to it. (but if you want to experiment and don't mind
+# breakage, here you go!)
 AVAILABLE_PROVIDERS = {
     "hypothesis": "hypothesis.internal.conjecture.providers.HypothesisProvider",
+    "hypothesis-urandom": "hypothesis.internal.conjecture.providers.URandomProvider",
 }
 FLOAT_INIT_LOGIC_CACHE = LRUCache(4096)
 STRING_SAMPLER_CACHE = LRUCache(64)

--- a/hypothesis-python/tests/common/arguments.py
+++ b/hypothesis-python/tests/common/arguments.py
@@ -10,7 +10,7 @@
 
 import pytest
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.errors import InvalidArgument
 
 
@@ -30,7 +30,11 @@ def argument_validation_test(bad_args):
         ("function", "args", "kwargs"), bad_args, ids=list(map(e_to_str, bad_args))
     )
     def test_raise_invalid_argument(function, args, kwargs):
+        # some invalid argument tests may find multiple distinct invalid inputs,
+        # which hypothesis raises as an exception group (and is not caught by
+        # pytest.raises).
         @given(function(*args, **kwargs))
+        @settings(report_multiple_bugs=False)
         def test(x):
             pass
 

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -603,6 +603,14 @@ def test_available_providers_deprecation():
     "strategy", [st.integers(), st.text(), st.floats(), st.booleans(), st.binary()]
 )
 def test_can_generate_from_all_available_providers(backend, strategy):
+    if backend == "crosshair":
+        # TODO running into a 'not in statespace' issue which is fixed in
+        # https://github.com/HypothesisWorks/hypothesis/pull/4034. Remove
+        # this skip when that is merged"
+        pytest.skip(
+            "temp, fixed in https://github.com/HypothesisWorks/hypothesis/pull/4034"
+        )
+
     if backend == "hypothesis-urandom" and WINDOWS:
         pytest.skip("/dev/urandom not available on windows")
 

--- a/hypothesis-python/tests/conjecture/test_provider_contract.py
+++ b/hypothesis-python/tests/conjecture/test_provider_contract.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import pytest
+
 from hypothesis import example, given, strategies as st
 from hypothesis.errors import StopTest
 from hypothesis.internal.conjecture.choice import (
@@ -16,7 +18,11 @@ from hypothesis.internal.conjecture.choice import (
     choice_permitted,
 )
 from hypothesis.internal.conjecture.data import ConjectureData
-from hypothesis.internal.conjecture.providers import BytestringProvider
+from hypothesis.internal.conjecture.providers import (
+    BytestringProvider,
+    HypothesisProvider,
+    URandomProvider,
+)
 from hypothesis.internal.intervalsets import IntervalSet
 
 from tests.conjecture.common import (
@@ -63,9 +69,10 @@ def test_provider_contract_bytestring(bytestring, choice_type_and_kwargs):
         )
 
 
+@pytest.mark.parametrize("provider", [URandomProvider, HypothesisProvider])
 @given(st.lists(nodes()), st.randoms())
-def test_provider_contract_hypothesis(nodes, random):
-    data = ConjectureData(random=random)
+def test_provider_contract(provider, nodes, random):
+    data = ConjectureData(random=random, provider=provider)
     for node in nodes:
         value = getattr(data, f"draw_{node.type}")(**node.kwargs)
         assert choice_permitted(value, node.kwargs)

--- a/hypothesis-python/tests/conjecture/test_provider_contract.py
+++ b/hypothesis-python/tests/conjecture/test_provider_contract.py
@@ -12,6 +12,7 @@ import pytest
 
 from hypothesis import example, given, strategies as st
 from hypothesis.errors import StopTest
+from hypothesis.internal.compat import WINDOWS
 from hypothesis.internal.conjecture.choice import (
     choice_equal,
     choice_from_index,
@@ -69,7 +70,18 @@ def test_provider_contract_bytestring(bytestring, choice_type_and_kwargs):
         )
 
 
-@pytest.mark.parametrize("provider", [URandomProvider, HypothesisProvider])
+@pytest.mark.parametrize(
+    "provider",
+    [
+        pytest.param(
+            URandomProvider,
+            marks=pytest.mark.skipif(
+                WINDOWS, reason="/dev/urandom not available on windows"
+            ),
+        ),
+        HypothesisProvider,
+    ],
+)
 @given(st.lists(nodes()), st.randoms())
 def test_provider_contract(provider, nodes, random):
     data = ConjectureData(random=random, provider=provider)


### PR DESCRIPTION
[Antithesis](https://antithesis.com/) is a fuzzer which uses `/dev/urandom` as its source of randomness to mutate. This pull adds a `class URandomProvider(HypothesisProvider)` which backs its random draws using `/dev/urandom`, giving Antithesis control over choices made during Hypothesis tests.

(Zac and I are attending [Antithesis' BugBash](https://bugbash.antithesis.com/#about) in April—Zac as a speaker—and would love to be able to say that Hypothesis has great integration with Antithesis!)

- [x] Check whether we need to override `random.random()` too (e: we do)