### PR TITLE
Use `shrink_key` to avoid shrinking work in more places

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve how the shrinker checks for unnecessary work, leading to 10% less time spent shrinking on average, with no reduction in quality.

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -26,6 +26,7 @@ from hypothesis.internal.conjecture.shrinking.common import Shrinker as Shrinker
 from hypothesis.internal.conjecture.utils import Sampler
 from hypothesis.internal.floats import MAX_PRECISE_INTEGER
 
+from tests.common.debug import minimal
 from tests.conjecture.common import (
     SOME_LABEL,
     float_kw,
@@ -655,3 +656,15 @@ def test_lower_duplicated_characters_across_choices(start, expected, gap):
 
     shrinker.fixate_shrink_passes(["lower_duplicated_characters"])
     assert shrinker.choices == (expected[0],) + (0,) * gap + (expected[1],)
+
+
+def test_shrinking_one_of_with_same_shape():
+    # This is a covering test for our one_of shrinking logic for the case when
+    # the choice sequence *doesn't* change shape in the newly chosen one_of branch.
+    #
+    # There are relatively few tests in our suite that cover this (and previously
+    # none in the covering subset). I chose the simplest one to copy here, but
+    # haven't yet put time into extracting the essence of a test case that
+    # covers this case, which is why we're using st.permutations here instead of
+    # something more fundamental / obviously testing what we want.
+    minimal(st.permutations(list(range(5))), lambda x: x[0] != 0)

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -26,7 +26,6 @@ from hypothesis.internal.conjecture.shrinking.common import Shrinker as Shrinker
 from hypothesis.internal.conjecture.utils import Sampler
 from hypothesis.internal.floats import MAX_PRECISE_INTEGER
 
-from tests.common.debug import minimal
 from tests.conjecture.common import (
     SOME_LABEL,
     float_kw,
@@ -661,10 +660,12 @@ def test_lower_duplicated_characters_across_choices(start, expected, gap):
 def test_shrinking_one_of_with_same_shape():
     # This is a covering test for our one_of shrinking logic for the case when
     # the choice sequence *doesn't* change shape in the newly chosen one_of branch.
-    #
-    # There are relatively few tests in our suite that cover this (and previously
-    # none in the covering subset). I chose the simplest one to copy here, but
-    # haven't yet put time into extracting the essence of a test case that
-    # covers this case, which is why we're using st.permutations here instead of
-    # something more fundamental / obviously testing what we want.
-    minimal(st.permutations(list(range(5))), lambda x: x[0] != 0)
+    @shrinking_from([1, 0])
+    def shrinker(data: ConjectureData):
+        n = data.draw_integer(0, 1)
+        data.draw_integer()
+        if n == 1:
+            data.mark_interesting()
+
+    shrinker.initial_coarse_reduction()
+    assert shrinker.choices == (1, 0)


### PR DESCRIPTION
`consider_new_nodes` checks `sort_key`, but `cached_test_function` doesn't, so the shrinker does unnecessary work sometimes. This moves those checks into `cached_test_function`.

Benchmark (10% improvement):

![shrinking](https://github.com/user-attachments/assets/967da61f-20c2-4c09-af74-e51b0c84102e)
