### PR TITLE
Don't pin zero data if backend cannot proceed

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes an internal error when certain :ref:`alternative backends <alternative-backends>` find a failure on their very first generated example.

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -248,6 +248,9 @@ class SmallSearchSpaceWarning(HypothesisWarning):
     in a meaningful way, for example by only creating default instances."""
 
 
+CannotProceedScopeT = Literal["verified", "exhausted", "discard_test_case", "other"]
+
+
 class BackendCannotProceed(HypothesisException):
     """UNSTABLE API
 
@@ -273,9 +276,5 @@ class BackendCannotProceed(HypothesisException):
             this backend.
     """
 
-    def __init__(
-        self,
-        scope: Literal["verified", "exhausted", "discard_test_case", "other"] = "other",
-        /,
-    ) -> None:
+    def __init__(self, scope: CannotProceedScopeT = "other", /) -> None:
         self.scope = scope

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -23,7 +23,14 @@ from typing import Optional
 
 import pytest
 
-from hypothesis import configuration, example, given, settings, strategies as st
+from hypothesis import (
+    HealthCheck,
+    configuration,
+    example,
+    given,
+    settings,
+    strategies as st,
+)
 from hypothesis.database import (
     BackgroundWriteDatabase,
     DirectoryBasedExampleDatabase,
@@ -656,6 +663,7 @@ def test_database_listener_background_write():
     _database_conforms_to_listener_api(
         lambda path: BackgroundWriteDatabase(InMemoryExampleDatabase()),
         flush=lambda db: db._join(),
+        parent_settings=settings(suppress_health_check=[HealthCheck.too_slow]),
     )
 
 

--- a/hypothesis-python/tests/crosshair/test_crosshair.py
+++ b/hypothesis-python/tests/crosshair/test_crosshair.py
@@ -13,7 +13,6 @@ import pytest
 from hypothesis import Verbosity, given, settings, strategies as st
 
 
-@pytest.mark.xfail(reason="temporarily ignoring crosshair churn")
 @pytest.mark.parametrize("verbosity", list(Verbosity))
 def test_crosshair_works_for_all_verbosities(verbosity):
     # check that we aren't realizing symbolics early in debug prints and killing
@@ -27,7 +26,6 @@ def test_crosshair_works_for_all_verbosities(verbosity):
         f()
 
 
-@pytest.mark.xfail(reason="temporarily ignoring crosshair churn")
 @pytest.mark.parametrize("verbosity", list(Verbosity))
 def test_crosshair_works_for_all_verbosities_data(verbosity):
     # data draws have their own print path


### PR DESCRIPTION
Pulling out source-code changes from https://github.com/HypothesisWorks/hypothesis/pull/4034 into its own pull, since this is an immediate improvement for users, and also the cause of one of our xfailing tests.