### PR TITLE
Add a crosshair realization test and improve docs

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Improve an additional interaction between the :pypi:`hypothesis-crosshair`
+:ref:`backend <alternative-backends>` and :ref:`our observability tools <observability>`.

--- a/hypothesis-python/docs/redirect.html.template
+++ b/hypothesis-python/docs/redirect.html.template
@@ -6,7 +6,29 @@
     </noscript>
     <script>
       var target = "${to_uri}";
-      if (window.location.hash) {
+
+      var manualRedirects = {
+        "details.html#thread-safety-policy": "supported.html#thread-safety-policy",
+        "details.html#hypothesis.given": "reference/api.html#hypothesis.given",
+        "details.html#targeted-example-generation": "reference/api.html#targeted-property-based-testing",
+        "details.html#custom-function-execution": "reference/api.html#custom-function-execution",
+        // TODO_DOCS when we figure out a home for this page
+        // "details.html#type-annotations-in-hypothesis": ""
+        "details.html#the-hypothesis-pytest-plugin": "reference/integrations.html#the-hypothesis-pytest-plugin",
+        "details.html#use-with-external-fuzzers": "reference/api.html#use-with-external-fuzzers",
+        "details.html#making-assumptions": "reference/api.html#hypothesis.assume",
+        "details.html#hypothesis.event": "reference/api.html#hypothesis.event",
+        "details.html#hypothesis.assume": "reference/api.html#hypothesis.assume",
+        "details.html#hypothesis.given": "reference/api.html#hypothesis.given",
+        "details.html#hypothesis.target": "reference/api.html#hypothesis.target",
+        "details.html#hypothesis.register_random": "reference/strategies.html#hypothesis.register_random",
+        "details.html#hypothesis.strategies.SearchStrategy": "reference/strategies.html#hypothesis.strategies.SearchStrategy",
+      };
+      var redirect = manualRedirects[window.location.pathname.split('/').pop() + window.location.hash];
+
+      if (redirect) {
+        window.location.replace(redirect);
+      } else if (window.location.hash) {
         window.location.replace(target + window.location.hash);
       } else {
         window.location.replace(target);

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -165,7 +165,7 @@ def to_jsonable(obj: object, *, avoid_realization: bool) -> object:
     known types.
     """
     if isinstance(obj, (str, int, float, bool, type(None))):
-        if isinstance(obj, int) and abs(obj) >= 2**63:
+        if isinstance(obj, int) and not isinstance(obj, bool) and abs(obj) >= 2**63:
             # Silently clamp very large ints to max_float, to avoid OverflowError when
             # casting to float.  (but avoid adding more constraints to symbolic values)
             if avoid_realization:

--- a/hypothesis-python/tests/crosshair/test_crosshair.py
+++ b/hypothesis-python/tests/crosshair/test_crosshair.py
@@ -8,10 +8,15 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+from contextlib import nullcontext
+
+import crosshair
 import pytest
 
-from hypothesis import Verbosity, given, settings, strategies as st
+from hypothesis import Phase, Verbosity, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
+
+from tests.common.utils import capture_observations
 
 
 @pytest.mark.parametrize("verbosity", list(Verbosity))
@@ -53,4 +58,47 @@ def test_hypothesis_realizes_on_fatal_error():
         raise BaseException("marker")
 
     with pytest.raises(BaseException, match="marker"):
+        f()
+
+
+@pytest.mark.parametrize(
+    "strategy, use_observability, expected_choices",
+    [
+        (st.integers(), False, 1),
+        # we add an additional path constraint to ints in to_jsonable.
+        (st.integers(), True, 2),
+        (st.text(), False, 1),
+        (st.text(), True, 1),
+        (st.booleans(), False, 2),
+        (st.booleans(), True, 2),
+        (st.floats(), False, 6),
+        (st.floats(), True, 6),
+        (st.binary(), False, 1),
+        (st.binary(), True, 1),
+    ],
+)
+def test_no_path_constraints_are_added_to_symbolic_values(
+    strategy, use_observability, expected_choices
+):
+    # check that we don't interact with the returned crosshair symbolics in a
+    # way that would add path constraints.
+    #
+    # For most of the five choice sequence types, crosshair represents them as a
+    # single decision. Floats uses a more complicated z3 representation. But
+    # I have no idea why booleans use 2 choices instead of 1.
+
+    # limit to one example to prevent crosshair from raising e.g.
+    # BackendCannotProceed(scope="verified") and switching to the hypothesis
+    # provider
+    @given(strategy)
+    @settings(
+        backend="crosshair", database=None, phases={Phase.generate}, max_examples=1
+    )
+    def f(value):
+        assert (
+            len(crosshair.statespace.context_statespace().choices_made)
+            == expected_choices
+        )
+
+    with capture_observations() if use_observability else nullcontext():
         f()

--- a/hypothesis-python/tests/crosshair/test_crosshair.py
+++ b/hypothesis-python/tests/crosshair/test_crosshair.py
@@ -8,15 +8,17 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from contextlib import nullcontext
-
 import crosshair
 import pytest
+from hypothesis_crosshair_provider.crosshair_provider import CrossHairPrimitiveProvider
 
 from hypothesis import Phase, Verbosity, given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.internal.conjecture.providers import COLLECTION_DEFAULT_MAX_SIZE
+from hypothesis.internal.intervalsets import IntervalSet
 
 from tests.common.utils import capture_observations
+from tests.conjecture.common import float_kw, integer_kw, string_kw
 
 
 @pytest.mark.parametrize("verbosity", list(Verbosity))
@@ -61,31 +63,49 @@ def test_hypothesis_realizes_on_fatal_error():
         f()
 
 
+def count_choices_for(choice_type, kwargs):
+    # returns the number of choices that crosshair makes for this draw, before
+    # hypothesis ever has a chance to interact with it.
+    provider = CrossHairPrimitiveProvider()
+    with provider.per_test_case_context_manager():
+        assert len(crosshair.statespace.context_statespace().choices_made) == 0
+        getattr(provider, f"draw_{choice_type}")(**kwargs)
+        return len(crosshair.statespace.context_statespace().choices_made)
+
+
 @pytest.mark.parametrize(
-    "strategy, use_observability, expected_choices",
+    "strategy, expected_choices",
     [
-        (st.integers(), False, 1),
-        # we add an additional path constraint to ints in to_jsonable.
-        (st.integers(), True, 2),
-        (st.text(), False, 1),
-        (st.text(), True, 1),
-        (st.booleans(), False, 2),
-        (st.booleans(), True, 2),
-        (st.floats(), False, 6),
-        (st.floats(), True, 6),
-        (st.binary(), False, 1),
-        (st.binary(), True, 1),
+        (st.integers(), lambda: count_choices_for("integer", integer_kw())),
+        (st.floats(), lambda: count_choices_for("float", float_kw())),
+        (
+            st.binary(),
+            lambda: count_choices_for(
+                "bytes", {"min_size": 0, "max_size": COLLECTION_DEFAULT_MAX_SIZE}
+            ),
+        ),
+        # crosshair's symbolic mapping implementation performs an `is` check under
+        # certain circumstances, which adds a choice to the symbolic bool when we
+        # execute test(*args, **kwargs), since kwargs is a symbolic mapping
+        # containing the symbolic boolean.
+        #
+        # I think this only affects bool since no other crosshair type has an
+        # override for `is`.
+        (st.booleans(), lambda: count_choices_for("boolean", {}) + 1),
+        (
+            st.text(),
+            lambda: count_choices_for(
+                "string", string_kw(IntervalSet.from_string("a"))
+            ),
+        ),
     ],
 )
-def test_no_path_constraints_are_added_to_symbolic_values(
-    strategy, use_observability, expected_choices
-):
-    # check that we don't interact with the returned crosshair symbolics in a
-    # way that would add path constraints.
-    #
-    # For most of the five choice sequence types, crosshair represents them as a
-    # single decision. Floats uses a more complicated z3 representation. But
-    # I have no idea why booleans use 2 choices instead of 1.
+def test_no_path_constraints_are_added_to_symbolic_values(strategy, expected_choices):
+    # check that we don't interact with returned symbolics from the crosshair
+    # provider in a way that would add decisions to crosshair's state space (ie
+    # add path constraints).
+
+    expected_choices = expected_choices()
 
     # limit to one example to prevent crosshair from raising e.g.
     # BackendCannotProceed(scope="verified") and switching to the hypothesis
@@ -95,10 +115,57 @@ def test_no_path_constraints_are_added_to_symbolic_values(
         backend="crosshair", database=None, phases={Phase.generate}, max_examples=1
     )
     def f(value):
-        assert (
-            len(crosshair.statespace.context_statespace().choices_made)
-            == expected_choices
+        # if this test ever fails, we will replay it without crosshair, in which
+        # case the statespace is None.
+        statespace = crosshair.statespace.optional_context_statespace()
+        assert statespace is not None, "this test failed under crosshair"
+        assert len(statespace.choices_made) == expected_choices
+
+    f()
+
+
+@pytest.mark.parametrize(
+    "strategy, extra_observability",
+    [
+        # we add an additional path constraint to ints in to_jsonable.
+        (st.integers(), 1),
+        (st.text(), 0),
+        (st.booleans(), 0),
+        (st.floats(), 0),
+        (st.binary(), 0),
+    ],
+)
+def test_observability_and_verbosity_dont_add_choices(strategy, extra_observability):
+    choices = {}
+
+    @given(strategy)
+    @settings(backend="crosshair", database=None, max_examples=1)
+    def f_normal(value):
+        choices["normal"] = len(crosshair.statespace.context_statespace().choices_made)
+
+    @given(strategy)
+    @settings(backend="crosshair", database=None, max_examples=1)
+    def f_observability(value):
+        choices["observability"] = len(
+            crosshair.statespace.context_statespace().choices_made
         )
 
-    with capture_observations() if use_observability else nullcontext():
-        f()
+    @given(strategy)
+    @settings(
+        backend="crosshair", database=None, max_examples=1, verbosity=Verbosity.debug
+    )
+    def f_verbosity(value):
+        choices["verbosity"] = len(
+            crosshair.statespace.context_statespace().choices_made
+        )
+
+    f_normal()
+    f_verbosity()
+    with capture_observations():
+        f_observability()
+
+    assert (
+        choices["normal"]
+        == (choices["observability"] - extra_observability)
+        == choices["verbosity"]
+    )


### PR DESCRIPTION
- Adds back a missing docs section https://github.com/HypothesisWorks/hypothesis/pull/4300#issuecomment-2749046732
- Adds a test that we don't add choices to symbolics from crosshair
  - crosshair makes two choices for bools, but I'm assuming that's not on our side?
  - everything else is 1 choice except floats, which I expected since crosshair mimics actual f64 semantics in z3
- Adds some manual redirects for the old `details.html` page. Ideally I'd build some way to specify hash redirects in the plugin, but hacking them into the redirect template was easier.