### PR TITLE
Support xdist in shrinking benchmark (via the filesystem)

### DIFF
--- a/hypothesis-python/benchmark/README.md
+++ b/hypothesis-python/benchmark/README.md
@@ -4,8 +4,8 @@ The plotting script (but not collecting benchmark data) requires additional depe
 
 To run a benchmark:
 
-- `pytest tests/ --hypothesis-benchmark-shrinks new --hypothesis-benchmark-output data.json` (starting on the newer version)
-- `pytest tests/ --hypothesis-benchmark-shrinks old --hypothesis-benchmark-output data.json` (after switching to the old version)
+- `pytest tests/ -n auto --hypothesis-benchmark-shrinks new --hypothesis-benchmark-output data.json` (starting on the newer version)
+- `pytest tests/ -n auto --hypothesis-benchmark-shrinks old --hypothesis-benchmark-output data.json` (after switching to the old version)
   - Use the same `data.json` path, the benchmark will append data. You can append `-k ...` for both commands to subset the benchmark.
 - `python benchmark/graph.py data.json shrinking.png`
 

--- a/hypothesis-python/benchmark/graph.py
+++ b/hypothesis-python/benchmark/graph.py
@@ -74,7 +74,11 @@ def _process_benchmark_data(data):
     for node_id in old_calls:
         old = old_calls[node_id]
         new = new_calls[node_id]
-        if set(old) | set(new) == {0} or len(old) != len(new):
+        if (
+            set(old) | set(new) == {0}
+            or len(old) != len(new)
+            or len(old) == len(new) == 0
+        ):
             print(f"skipping {node_id}")
             continue
 


### PR DESCRIPTION
I tried getting xdist to serialize this information from worker -> controller in memory, but I'm not sure it's possible. (You can do controller -> worker, though). Ended up just writing to disk.

I expect I'm about the only person who cares about this benchmark, but 8x speedup will be really nice for me! And also enables increasing the trials-per-test from 5 in the future, for tighter confidence intervals.