### PR TITLE
Triage slow crosshair tests

### DIFF
--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -619,7 +619,10 @@ class Tree:
         return f"Tree({self.left}, {self.right})"
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~19 mins")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~19 mins; datastructure explosion https://github.com/pschanely/hypothesis-crosshair/issues/27",
+)
 @given(tree=st.builds(Tree))
 def test_resolving_recursive_type(tree):
     assert isinstance(tree, Tree)
@@ -983,7 +986,7 @@ def test_no_byteswarning(_):
 
 @pytest.mark.skipif(
     settings._current_profile == "crosshair",
-    reason="Crosshair doesn't generate the Decimal('snan'), so this runs for hours",
+    reason="Crosshair is too much slower at hashing values",
 )
 def test_hashable_type_unhashable_value():
     # Decimal("snan") is not hashable; we should be able to generate it.

--- a/hypothesis-python/tests/cover/test_lookup_py38.py
+++ b/hypothesis-python/tests/cover/test_lookup_py38.py
@@ -126,7 +126,10 @@ class Node:
     right: typing.Union["Node", int]
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~11 mins")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~11 mins; datastructure explosion: https://github.com/pschanely/hypothesis-crosshair/issues/27",
+)
 @given(st.builds(Node))
 def test_can_resolve_recursive_dataclass(val):
     assert isinstance(val, Node)

--- a/hypothesis-python/tests/cover/test_provisional_strategies.py
+++ b/hypothesis-python/tests/cover/test_provisional_strategies.py
@@ -56,7 +56,10 @@ def test_invalid_domain_arguments(max_length, max_element_length):
         )
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~300s each")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~300s each; the `sampled_from(get_top_level_domains())` decision is realized via iterative comparisons https://github.com/pschanely/CrossHair/issues/332",
+)
 @pytest.mark.parametrize("max_length", [None, 4, 8, 255])
 @pytest.mark.parametrize("max_element_length", [None, 1, 2, 4, 8, 63])
 def test_valid_domains_arguments(max_length, max_element_length):

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -328,7 +328,10 @@ def test_randbytes_have_right_length(rnd, n):
     assert len(rnd.randbytes(n)) == n
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes hours")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes hours; may get faster after https://github.com/pschanely/CrossHair/issues/332",
+)
 @given(any_random)
 def test_can_manage_very_long_ranges_with_step(rnd):
     i = rnd.randrange(0, 2**256, 3)

--- a/hypothesis-python/tests/cover/test_regex.py
+++ b/hypothesis-python/tests/cover/test_regex.py
@@ -104,7 +104,10 @@ def test_matching(category, predicate, invert, is_unicode):
     _test_matching_pattern(category, isvalidchar=pred, is_unicode=is_unicode)
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~30s each")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~30s each; CrossHair strings just aren't fast enough",
+)
 @pytest.mark.parametrize(
     "pattern",
     [
@@ -191,7 +194,10 @@ def test_any_with_dotall_generate_newline_binary(pattern):
     find_any(st.from_regex(pattern), lambda s: s == b"\n", settings(max_examples=10**6))
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~30s each")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~30s each; CrossHair strings just aren't fast enough",
+)
 @pytest.mark.parametrize(
     "pattern",
     ["\\d", "[\\d]", "[^\\D]", "\\w", "[\\w]", "[^\\W]", "\\s", "[\\s]", "[^\\S]"],

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -101,7 +101,7 @@ def test_efficient_dicts_with_sampled_keys(x):
 
 @pytest.mark.skipif(
     settings._current_profile == "crosshair",
-    reason="takes ~10 mins and raises Unsatisfiable",
+    reason="takes ~10 mins and raises Unsatisfiable; first barrier is symbolic subscripting https://github.com/pschanely/CrossHair/issues/332",
 )
 @given(
     st.lists(

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1333,7 +1333,10 @@ class LotsOfEntropyPerStepMachine(RuleBasedStateMachine):
         assert data
 
 
-@pytest.mark.skipif(Settings._current_profile == "crosshair", reason="takes hours")
+@pytest.mark.skipif(
+    Settings._current_profile == "crosshair",
+    reason="takes hours; too much symbolic data",
+)
 def test_lots_of_entropy():
     run_state_machine_as_test(LotsOfEntropyPerStepMachine)
 

--- a/hypothesis-python/tests/nocover/test_characters.py
+++ b/hypothesis-python/tests/nocover/test_characters.py
@@ -52,7 +52,10 @@ lots_of_encodings = sorted(x for x in set(aliases).union(aliases.values()) if _e
 assert len(lots_of_encodings) > 100  # sanity-check
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes 2000s")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes 2000s; large & slow symbolic strings",
+)
 @given(data=st.data(), codec=st.sampled_from(lots_of_encodings))
 def test_can_constrain_characters_to_codec(data, codec):
     s = data.draw(st.text(st.characters(codec=codec), min_size=100))

--- a/hypothesis-python/tests/nocover/test_emails.py
+++ b/hypothesis-python/tests/nocover/test_emails.py
@@ -14,7 +14,11 @@ from hypothesis import given, settings
 from hypothesis.strategies import emails, just
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~7 mins")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~7 mins; first barrier: the `sampled_from(get_top_level_domains())` decision is "
+    "realized via iterative comparisons; see https://github.com/pschanely/CrossHair/issues/332",
+)
 @given(emails())
 def test_is_valid_email(address: str):
     local, at_, domain = address.rpartition("@")

--- a/hypothesis-python/tests/nocover/test_flatmap.py
+++ b/hypothesis-python/tests/nocover/test_flatmap.py
@@ -84,7 +84,10 @@ def test_flatmap_has_original_strategy_repr():
     assert repr(ints) in repr(ints_up)
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~6 mins")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~6 mins in CI, but ~7 sec in isolation. Unsure why",
+)
 def test_mixed_list_flatmap():
     s = lists(booleans().flatmap(lambda b: booleans() if b else text()))
 

--- a/hypothesis-python/tests/nocover/test_from_type_recipe.py
+++ b/hypothesis-python/tests/nocover/test_from_type_recipe.py
@@ -8,9 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
-
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, strategies as st
 from hypothesis.strategies._internal.types import _global_type_lookup
 
 from tests.common.debug import find_any
@@ -34,7 +32,6 @@ def everything_except(excluded_types):
     )
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~250s")
 @given(
     excluded_types=st.lists(
         st.sampled_from(TYPES), min_size=1, max_size=3, unique=True

--- a/hypothesis-python/tests/nocover/test_health_checks.py
+++ b/hypothesis-python/tests/nocover/test_health_checks.py
@@ -20,7 +20,9 @@ from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.strategies._internal.lazy import LazyStrategy
 
-pytestmark = pytest.mark.skipif(settings._current_profile == "crosshair", reason="slow")
+pytestmark = pytest.mark.skipif(
+    settings._current_profile == "crosshair", reason="slow - large number of symbolics"
+)
 
 large_strategy = st.binary(min_size=7000, max_size=7000)
 too_large_strategy = st.tuples(large_strategy, large_strategy)

--- a/hypothesis-python/tests/nocover/test_lstar.py
+++ b/hypothesis-python/tests/nocover/test_lstar.py
@@ -22,7 +22,10 @@ def byte_order(draw):
     return ls[:n]
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes 300s")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes 300s; may get faster after https://github.com/pschanely/CrossHair/issues/332",
+)
 @example({0}, [1])
 @given(st.sets(st.integers(0, 255)), byte_order())
 # This test doesn't even use targeting at all, but for some reason the

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -131,7 +131,10 @@ def test_flags_minimizes_bit_count():
     )
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="takes ~10 mins")
+@pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="takes ~10 mins; path tree is too large",
+)
 def test_flags_finds_all_bits_set():
     assert find_any(st.sampled_from(LargeFlag), lambda f: f == ~LargeFlag(0))
 

--- a/hypothesis-python/tests/nocover/test_simple_strings.py
+++ b/hypothesis-python/tests/nocover/test_simple_strings.py
@@ -17,7 +17,8 @@ from hypothesis.strategies import text
 
 
 @pytest.mark.skipif(
-    settings._current_profile == "crosshair", reason="takes ~10 minutes"
+    settings._current_profile == "crosshair",
+    reason="takes ~10 minutes; many-valued realization is slow",
 )
 @given(text(min_size=1, max_size=1))
 @settings(max_examples=2000)

--- a/hypothesis-python/tests/nocover/test_targeting.py
+++ b/hypothesis-python/tests/nocover/test_targeting.py
@@ -87,7 +87,8 @@ def test_targeting_can_be_disabled():
 
 
 @pytest.mark.skipif(
-    settings._current_profile == "crosshair", reason="takes ~15 minutes"
+    settings._current_profile == "crosshair",
+    reason="takes ~15 minutes, mostly just unrolling the rejection sampling loop",
 )
 def test_issue_2395_regression():
     @given(d=st.floats().filter(lambda x: abs(x) < 1000))

--- a/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/nocover/test_type_lookup_forward_ref.py
@@ -20,7 +20,10 @@ from tests.common import utils
 # Mutually-recursive types
 # See https://github.com/HypothesisWorks/hypothesis/issues/2722
 
-pytestmark = pytest.mark.skipif(settings._current_profile == "crosshair", reason="slow")
+pytestmark = pytest.mark.skipif(
+    settings._current_profile == "crosshair",
+    reason="slow with recursive strustures: https://github.com/pschanely/hypothesis-crosshair/issues/27",
+)
 
 
 @given(st.data())

--- a/hypothesis-python/tests/nocover/test_unusual_settings_configs.py
+++ b/hypothesis-python/tests/nocover/test_unusual_settings_configs.py
@@ -8,8 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
-
 from hypothesis import HealthCheck, Verbosity, assume, given, settings, strategies as st
 
 
@@ -19,7 +17,6 @@ def test_single_example(n):
     pass
 
 
-@pytest.mark.skipif(settings._current_profile == "crosshair", reason="hangs/crashes")
 @settings(
     max_examples=1,
     database=None,


### PR DESCRIPTION
Add triage reasons & issue links for the CrossHair tests that are skipped due to poor performance.
Also removed a couple of the skips entirely.

Resolves https://github.com/pschanely/CrossHair/issues/301 (and part of #3914).