### PR TITLE
Sort scrutineer reported lines

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+When reporting the always-passing, never-failing lines from the |Phase.explain| phase, we now sort the reported lines so that local code shows up first, then third-party library code, then standard library code.

--- a/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py
+++ b/hypothesis-python/tests/ghostwriter/try-writing-for-installed.py
@@ -19,10 +19,10 @@ Some have import-time side effects or errors so we skip them; others
 just have such weird semantics that we don't _want_ to support them.
 """
 
-import distutils.sysconfig as sysconfig
 import multiprocessing
 import os
 import subprocess
+import sysconfig
 
 skip = (
     "idlelib curses antigravity pip prompt_toolkit IPython .popen_ django. .test. "


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/3551

Also, `LIB_DIR = str(Path(sys.executable).parent / "lib")` was incorrect, it needed another `.parent`:

```python
>>> str(Path(sys.executable).parent / "lib")
'/opt/homebrew/opt/python@3.12/bin/lib'
```