### PR TITLE
Handle Pyodide and pyodide-build unvendoring, and update Pyodide CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,7 +228,7 @@ jobs:
   test-pyodide:
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 18
+      NODE_VERSION: 22
       # Note that the versions below are updated by `update_pyodide_versions()` in our weekly cronjob.
       # The versions of pyodide-build and the Pyodide runtime may differ.
       PYODIDE_VERSION: 0.27.5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,10 +255,6 @@ jobs:
         run: |
           pip install pyodide-build==$PYODIDE_BUILD_VERSION
           pyodide xbuildenv install $PYODIDE_VERSION
-      - name: Build
-        run: |
-          cd hypothesis-python/
-          CFLAGS=-g2 LDFLAGS=-g2 pyodide build
       - name: Set up Pyodide venv and install dependencies
         run: |
           pip install --upgrade setuptools pip wheel==0.45.1 build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,6 +251,10 @@ jobs:
         uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
+      - name: Install pyodide-build and Pyodide cross-build environment
+        run: |
+          pip install pyodide-build==$PYODIDE_BUILD_VERSION
+          pyodide xbuildenv install $PYODIDE_VERSION
       - name: Build
         run: |
           cd hypothesis-python/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,9 +229,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 18
-      # Note that the versions below must be updated in sync; we've automated
-      # that with `update_pyodide_versions()` in our weekly cronjob.
-      PYODIDE_VERSION: 0.27.3
+      # Note that the versions below are updated by `update_pyodide_versions()` in our weekly cronjob.
+      # The versions of pyodide-build and the Pyodide runtime may differ.
+      PYODIDE_VERSION: 0.27.5
+      PYODIDE_BUILD_VERSION: 0.30.0
       PYTHON_VERSION: 3.12.7
       EMSCRIPTEN_VERSION: 3.1.58
     steps:
@@ -252,9 +253,6 @@ jobs:
           version: ${{ env.EMSCRIPTEN_VERSION }}
       - name: Build
         run: |
-          # TODO remove https://github.com/pyodide/pyodide/issues/5585
-          pip install -U wheel==0.45.1
-          pip install pyodide-build==$PYODIDE_VERSION
           cd hypothesis-python/
           CFLAGS=-g2 LDFLAGS=-g2 pyodide build
       - name: Set up Pyodide venv and install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,7 +234,6 @@ jobs:
       PYODIDE_VERSION: 0.27.5
       PYODIDE_BUILD_VERSION: 0.30.0
       PYTHON_VERSION: 3.12.7
-      EMSCRIPTEN_VERSION: 3.1.58
     steps:
       - uses: actions/checkout@v3
         with:
@@ -247,10 +246,6 @@ jobs:
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Set up Emscripten
-        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
       - name: Install pyodide-build and Pyodide cross-build environment
         run: |
           pip install pyodide-build==$PYODIDE_BUILD_VERSION

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
     - name: Run tests
       run: TASK=${{ matrix.task }} ./build.sh
 
-  # See https://pyodide.org/en/stable/development/building-and-testing-packages.html#testing-packages-against-pyodide
+  # See https://pyodide.org/en/stable/usage/building-and-testing-packages.html
   # and https://github.com/numpy/numpy/blob/9a650391651c8486d8cb8b27b0e75aed5d36033e/.github/workflows/emscripten.yml
   test-pyodide:
     runs-on: ubuntu-latest

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ their individual contributions.
 * `Adam Sven Johnson <https://www.github.com/pkqk>`_
 * `Afrida Tabassum <https://github.com/oxfordhalfblood>`_ (afrida@gmail.com)
 * `Afonso Silva <https://github.com/ajcerejeira>`_ (ajcerejeira@gmail.com)
+* `Agrya Khetarpal <https://github.com/agriyakhetarpal>`_
 * `Agustín Covarrubias <https://github.com/agucova>`_ (gh@agucova.dev)
 * `Akash Suresh <https://www.github.com/akash-suresh>`_ (akashsuresh36@gmail.com)
 * `Alex Gaynor <https://github.com/alex>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,7 +14,7 @@ their individual contributions.
 * `Adam Sven Johnson <https://www.github.com/pkqk>`_
 * `Afrida Tabassum <https://github.com/oxfordhalfblood>`_ (afrida@gmail.com)
 * `Afonso Silva <https://github.com/ajcerejeira>`_ (ajcerejeira@gmail.com)
-* `Agrya Khetarpal <https://github.com/agriyakhetarpal>`_
+* `Agriya Khetarpal <https://github.com/agriyakhetarpal>`_
 * `Agustín Covarrubias <https://github.com/agucova>`_ (gh@agucova.dev)
 * `Akash Suresh <https://www.github.com/akash-suresh>`_ (akashsuresh36@gmail.com)
 * `Alex Gaynor <https://github.com/alex>`_

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -408,12 +408,11 @@ def update_pyodide_versions():
         f"pyodide_build-{vers_re}-py3-none-any.whl",  # excludes pre-releases
         requests.get("https://pypi.org/simple/pyodide-build/").text,
     )
-    pyodide_build_version = sorted(
+    pyodide_build_version = max(
         # Don't just pick the most recent version; find the highest stable version.
         set(all_pyodide_build_versions),
-        key=lambda version: tuple(int(x) for x in version.split(".")),
-        reverse=True,
-    )[0]
+        key=version_tuple,
+    )
 
     cross_build_environments_url = "https://raw.githubusercontent.com/pyodide/pyodide/refs/heads/main/pyodide-cross-build-environments.json"
     cross_build_environments_data = requests.get(cross_build_environments_url).json()
@@ -471,11 +470,10 @@ def update_pyodide_versions():
             f"No compatible Pyodide release found for pyodide-build {pyodide_build_version}"
         )
 
-    pyodide_release = sorted(
+    pyodide_release = max(
         compatible_releases,
-        key=lambda release: tuple(int(x) for x in release["version"].split(".")),
-        reverse=True,
-    )[0]
+        key=lambda release: version_tuple(release["version"]),
+    )
 
     pyodide_version = pyodide_release["version"]
     python_version = pyodide_release["python_version"]

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -455,7 +455,6 @@ def update_pyodide_versions():
 
     pyodide_version = pyodide_release["version"]
     python_version = pyodide_release["python_version"]
-    emscripten_version = pyodide_release["emscripten_version"]
 
     ci_file = tools.ROOT / ".github/workflows/main.yml"
     config = ci_file.read_text(encoding="utf-8")
@@ -463,7 +462,6 @@ def update_pyodide_versions():
         ("PYODIDE", pyodide_version),
         ("PYODIDE_BUILD", pyodide_build_version),
         ("PYTHON", python_version),
-        ("EMSCRIPTEN", emscripten_version),
     ]:
         config = re.sub(f"{name}_VERSION: {vers_re}", f"{name}_VERSION: {var}", config)
     ci_file.write_text(config, encoding="utf-8")

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -422,9 +422,7 @@ def update_pyodide_versions():
     stable_releases = [
         release
         for release in cross_build_environments_data["releases"].values()
-        if "a" not in release["version"]
-        and "b" not in release["version"]
-        and "rc" not in release["version"]
+        if re.fullmatch(vers_re, release["version"])
     ]
 
     compatible_releases = []


### PR DESCRIPTION
### Description

Closes https://github.com/pyodide/pyodide#5585

This PR refactors the `update_pyodide_versions()` function in `tooling/src/hypothesistooling/__main__.py` which generates the relevant versions for Pyodide and its build tooling in the `test-pyodide:` CI job. The previous logic did not account for the fact that we had unvendored `pyodide-build` and moved it to a separate package that is released separately of the Pyodide runtime during the Pyodide 0.27 release cycle.

### Summary

With these changes, the logic per the periodic updates will:
- use the PyPI Simple API to find out the latest stable version of `pyodide-build`, like before
- scan [the Pyodide cross-build environments metadata file](https://github.com/pyodide/pyodide/blob/d878eb2059b877fd4d25623d162c73872cdb4530/pyodide-cross-build-environments.json), and select a stable version for the Pyodide runtime that satisfies the minimum and maximum `pyodide-build` version constraints
- always use this identified Pyodide version through the `pyodide xbuildenv install` command

Other changes I've made:
- Dropped the Emscripten version installation step as it's not needed for pure Python packages
- Removed a redundant step through which we were building wheels twice
- Upgraded to a newer Node.js version (22) over the current 18

### Ancillary notes

- [x] I have gone through the [Copyright and Licensing section](https://github.com/HypothesisWorks/hypothesis/blob/6c024aaf0dc8bc13a63eade36891c41af2f1e038/CONTRIBUTING.rst#copyright-and-licensing), and I confirm that I am not performing this change on work time.
- [x] I have added my name to the AUTHORS.rst file.
