### PR TITLE
fix: avoid race condition during loop over `sys.modules`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+Prevent an unlikely but possible ``RuntimeError`` that can occur if
+:func:`~hypothesis.internal.constants_ast.local_modules` is called while
+:py:data:`sys.modules` is simultaneously modified, e.g. as a side effect
+of imports executed from another thread.
+

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,9 @@
 RELEASE_TYPE: patch
 
-Prevent an unlikely but possible ``RuntimeError`` that can occur if
-:func:`~hypothesis.internal.constants_ast.local_modules` is called while
-:py:data:`sys.modules` is simultaneously modified, e.g. as a side effect
-of imports executed from another thread.
+Fixes a rare internal error where new code from :ref:`version 6.131.1 <v6.131.1>`
+could fail if :py:data:`sys.modules` is simultaneously modified, e.g. as a side
+effect of imports executed from another thread.  Our :ref:`thread-safety-policy`
+does not promise that this is supported, but we're happy to take reasonable
+fixes.
 
+Thanks to Tony Li for reporting and fixing this issue.

--- a/hypothesis-python/docs/compatibility.rst
+++ b/hypothesis-python/docs/compatibility.rst
@@ -114,6 +114,9 @@ The supported versions of optional packages, for strategies in ``hypothesis.extr
 are listed in the documentation for that extra.  Our general goal is to support
 all versions that are supported upstream.
 
+
+.. _thread-safety-policy:
+
 --------------------
 Thread-Safety Policy
 --------------------

--- a/hypothesis-python/src/hypothesis/internal/constants_ast.py
+++ b/hypothesis-python/src/hypothesis/internal/constants_ast.py
@@ -153,9 +153,14 @@ def local_modules() -> tuple[ModuleType, ...]:
         # ModuleLocation for pyodide instead of this.
         return ()
 
+    # Prevents a `RuntimeError` that can occur when looping over `sys.modules`
+    # if it's simultaneously modified as a side effect of code in another thread.
+    # See: https://docs.python.org/3/library/sys.html#sys.modules
+    modules = tuple(sys.modules.values())
+
     return tuple(
         module
-        for module in sys.modules.values()
+        for module in modules
         if (
             getattr(module, "__file__", None) is not None
             and _is_local_module_file(module.__file__)

--- a/hypothesis-python/src/hypothesis/internal/constants_ast.py
+++ b/hypothesis-python/src/hypothesis/internal/constants_ast.py
@@ -156,7 +156,7 @@ def local_modules() -> tuple[ModuleType, ...]:
     # Prevents a `RuntimeError` that can occur when looping over `sys.modules`
     # if it's simultaneously modified as a side effect of code in another thread.
     # See: https://docs.python.org/3/library/sys.html#sys.modules
-    modules = tuple(sys.modules.values())
+    modules = sys.modules.copy().values()
 
     return tuple(
         module


### PR DESCRIPTION
Minor fix to prevent an unlikely but possible `RuntimeError` when `local_modules()` is called (in `hypothesis.internal.constants_ast`).

The error occurs while looping through `sys.modules.values()`, if its size is modified during iteration, e.g. by code from another thread.  This PR addresses the issue by pulling out out a copy of `sys.modules.values()` before iterating over it.

Example traceback:
```
    .0 = <dict_valueiterator object at ...>

        return tuple(
            module
    >       for module in sys.modules.values()
            if (
                getattr(module, "__file__", None) is not None
                and _is_local_module_file(module.__file__)
            )
        )
    E   RuntimeError: dictionary changed size during iteration

    .../site-packages/hypothesis/internal/constants_ast.py:147: RuntimeError
```