### PR TITLE
Improve constants collection speed

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,7 +1,4 @@
 RELEASE_TYPE: patch
 
-Improves several issues surrounding the code introduced in :ref:`version 6.131.1 <v6.131.1>`:
-
-* Improve speed of constants collection.
-* Cache constants to the ``.hypothesis`` directory for future runs.
-* Fix a ``RecursionError`` on parsing deeply nested code.
+This patch makes the new features introduced in :ref:`version 6.131.1 <v6.131.1>` much
+faster, and fixes an internal ``RecursionError`` when working with deeply-nested code.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improves the speed of the constants collection introduced in :ref:`version 6.131.1 <v6.131.1>`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,6 +1,7 @@
 RELEASE_TYPE: patch
 
-Improves several issues from code introduced in :ref:`version 6.131.1 <v6.131.1>`:
+Improves several issues surrounding the code introduced in :ref:`version 6.131.1 <v6.131.1>`:
 
-* Improve speed of constants collection, and add a hard internal time limit to avoid running for too long.
-* Fix a ``RecursionError`` on deeply nested code.
+* Improve speed of constants collection.
+* Cache constants to the ``.hypothesis`` directory for future runs.
+* Fix a ``RecursionError`` on parsing deeply nested code.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,6 @@
 RELEASE_TYPE: patch
 
-Improves the speed of the constants collection introduced in :ref:`version 6.131.1 <v6.131.1>`.
+Improves several issues from code introduced in :ref:`version 6.131.1 <v6.131.1>`:
+
+* Improve speed of constants collection, and add a hard internal time limit to aviod running for too long.
+* Fix a ``RecursionError`` on deeply nested code.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -2,5 +2,5 @@ RELEASE_TYPE: patch
 
 Improves several issues from code introduced in :ref:`version 6.131.1 <v6.131.1>`:
 
-* Improve speed of constants collection, and add a hard internal time limit to aviod running for too long.
+* Improve speed of constants collection, and add a hard internal time limit to avoid running for too long.
 * Fix a ``RecursionError`` on deeply nested code.

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -823,7 +823,7 @@ CI = settings(
 settings.register_profile("ci", CI)
 
 
-if is_in_ci():
+if is_in_ci():  # pragma: no cover # covered in ci, but not locally
     settings.load_profile("ci")
 
 assert settings.default is not None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -657,7 +657,7 @@ class ConjectureRunner:
         self.settings.database.delete(self.pareto_key, choices_to_bytes(data.choices))
 
     def generate_novel_prefix(self) -> tuple[ChoiceT, ...]:
-        """Uses the tree to proactively generate a starting sequence of bytes
+        """Uses the tree to proactively generate a starting choice sequence
         that we haven't explored yet for this test.
 
         When this method is called, we assume that there must be at
@@ -1047,10 +1047,8 @@ class ConjectureRunner:
         ran_optimisations = False
 
         while self.should_generate_more():
-            # Unfortunately generate_novel_prefix still operates in terms of
-            # a buffer and uses HypothesisProvider as its backing provider,
-            # not whatever is specified by the backend. We can improve this
-            # once more things are on the ir.
+            # we don't yet integrate DataTree with backends. Instead of generating
+            # a novel prefix, ask the backend for an input.
             if not self.using_hypothesis_backend:
                 data = self.new_conjecture_data([])
                 with suppress(BackendCannotProceed):

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -209,7 +209,7 @@ _local_constants: "ConstantsT" = {
 _local_modules: set[ModuleType] = set()
 
 
-def _get_local_constants(random: Random) -> "ConstantsT":
+def _get_local_constants() -> "ConstantsT":
     new_constants: set[ConstantT] = set()
     new_modules = list(local_modules() - _local_modules)
     for new_module in new_modules:
@@ -396,8 +396,8 @@ class HypothesisProvider(PrimitiveProvider):
 
     @cached_property
     def _local_constants(self):
-        assert self._random is not None
-        return _get_local_constants(self._random)
+        # defer computation of local constants until/if we need it
+        return _get_local_constants()
 
     def _maybe_draw_constant(
         self,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -217,7 +217,7 @@ _local_constants_time_limit: Final[float] = 0.1
 
 def _get_local_constants(random: Random) -> "ConstantsT":
     global _local_constants_time
-    if _local_constants_time > _local_constants_time_limit:
+    if _local_constants_time > _local_constants_time_limit:  # pragma: no cover
         return _local_constants
 
     new_constants: set[ConstantT] = set()
@@ -229,7 +229,7 @@ def _get_local_constants(random: Random) -> "ConstantsT":
     # want to rely on that.
     random.shuffle(new_modules)
     for new_module in new_modules:
-        if _local_constants_time > _local_constants_time_limit:
+        if _local_constants_time > _local_constants_time_limit:  # pragma: no cover
             break
         start = perf_counter()
         new_constants |= constants_from_module(new_module)
@@ -245,7 +245,9 @@ def _get_local_constants(random: Random) -> "ConstantsT":
         # if we add any new constant, invalidate the constant cache for permitted values.
         # A more efficient approach would be invalidating just the keys with this
         # choice_type.
-        if constant not in _local_constants[choice_type]:  # type: ignore # hard to type
+        if (
+            constant not in _local_constants[choice_type]  # type: ignore
+        ):  # pragma: no branch
             CONSTANTS_CACHE.cache.clear()
         _local_constants[choice_type].add(constant)  # type: ignore
 

--- a/hypothesis-python/src/hypothesis/internal/constants_ast.py
+++ b/hypothesis-python/src/hypothesis/internal/constants_ast.py
@@ -102,7 +102,13 @@ def constants_from_module(module: ModuleType) -> AbstractSet[ConstantT]:
         return set()
 
     visitor = ConstantVisitor()
-    visitor.visit(tree)
+    try:
+        visitor.visit(tree)
+    except RecursionError:  # pragma: no cover
+        # NodeVisitor has a recursive structure, and so deeply nested expressions
+        # can hit the recursion limit. See the many related issues on e.g. libcst:
+        # https://github.com/Instagram/LibCST/issues?q=recursion
+        pass
     return visitor.constants
 
 

--- a/hypothesis-python/src/hypothesis/internal/constants_ast.py
+++ b/hypothesis-python/src/hypothesis/internal/constants_ast.py
@@ -143,7 +143,7 @@ def local_modules() -> set[ModuleType]:
         # pyodide may provide some way to distinguish stdlib/third-party/local
         # code. I haven't looked into it. If they do, we should correctly implement
         # ModuleLocation for pyodide instead of this.
-        return ()
+        return set()
 
     return {
         module

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -29,9 +29,7 @@ def test_can_draw_local_constants_integers(monkeypatch, value):
     # _get_local_constants normally invalidates this cache for us, but we're
     # monkeypatching it.
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(
-        providers, "_get_local_constants", lambda random: {"integer": {value}}
-    )
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"integer": {value}})
     find_any(st.integers(), lambda v: choice_equal(v, value))
 
 
@@ -39,27 +37,21 @@ def test_can_draw_local_constants_integers(monkeypatch, value):
 @pytest.mark.parametrize("value", [1.2938, -1823.0239, 1e999, math.nan])
 def test_can_draw_local_constants_floats(monkeypatch, value):
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(
-        providers, "_get_local_constants", lambda random: {"float": {value}}
-    )
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"float": {value}})
     find_any(st.floats(), lambda v: choice_equal(v, value))
 
 
 @pytest.mark.parametrize("value", [b"abdefgh", b"a" * 50])
 def test_can_draw_local_constants_bytes(monkeypatch, value):
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(
-        providers, "_get_local_constants", lambda random: {"bytes": {value}}
-    )
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"bytes": {value}})
     find_any(st.binary(), lambda v: choice_equal(v, value))
 
 
 @pytest.mark.parametrize("value", ["abdefgh", "a" * 50])
 def test_can_draw_local_constants_string(monkeypatch, value):
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(
-        providers, "_get_local_constants", lambda random: {"string": {value}}
-    )
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"string": {value}})
     # we have a bunch of strings in GLOBAL_CONSTANTS, so it might take a while
     # to generate our local constant.
     find_any(

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -15,6 +15,7 @@ import pytest
 from hypothesis import settings, strategies as st
 from hypothesis.internal.conjecture import providers
 from hypothesis.internal.conjecture.choice import choice_equal
+from hypothesis.internal.conjecture.providers import CONSTANTS_CACHE
 
 from tests.common.debug import find_any
 from tests.common.utils import Why, xfail_on_crosshair
@@ -24,26 +25,32 @@ from tests.common.utils import Why, xfail_on_crosshair
 # with CONSTANTS_CACHE when testing it inside of a hypothesis test.
 @pytest.mark.parametrize("value", [2**20 - 50, 2**10 - 10, 129387123, -19827321, 0])
 def test_can_draw_local_constants_integers(monkeypatch, value):
-    monkeypatch.setattr(providers, "local_constants", lambda: {"integer": {value}})
+    # _get_local_constants normally invalidates this cache for us, but we're
+    # monkeypatching it.
+    CONSTANTS_CACHE.cache.clear()
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"integer": {value}})
     find_any(st.integers(), lambda v: choice_equal(v, value))
 
 
 @xfail_on_crosshair(Why.undiscovered)  # I think float_to_int is difficult for crosshair
 @pytest.mark.parametrize("value", [1.2938, -1823.0239, 1e999, math.nan])
 def test_can_draw_local_constants_floats(monkeypatch, value):
-    monkeypatch.setattr(providers, "local_constants", lambda: {"float": {value}})
+    CONSTANTS_CACHE.cache.clear()
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"float": {value}})
     find_any(st.floats(), lambda v: choice_equal(v, value))
 
 
 @pytest.mark.parametrize("value", [b"abdefgh", b"a" * 50])
 def test_can_draw_local_constants_bytes(monkeypatch, value):
-    monkeypatch.setattr(providers, "local_constants", lambda: {"bytes": {value}})
+    CONSTANTS_CACHE.cache.clear()
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"bytes": {value}})
     find_any(st.binary(), lambda v: choice_equal(v, value))
 
 
 @pytest.mark.parametrize("value", ["abdefgh", "a" * 50])
 def test_can_draw_local_constants_string(monkeypatch, value):
-    monkeypatch.setattr(providers, "local_constants", lambda: {"string": {value}})
+    CONSTANTS_CACHE.cache.clear()
+    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"string": {value}})
     # we have a bunch of strings in GLOBAL_CONSTANTS, so it might take a while
     # to generate our local constant.
     find_any(

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -12,7 +12,8 @@ import math
 
 import pytest
 
-from hypothesis import settings, strategies as st
+from hypothesis import given, settings, strategies as st
+from hypothesis.internal import constants_ast
 from hypothesis.internal.conjecture import providers
 from hypothesis.internal.conjecture.choice import choice_equal
 from hypothesis.internal.conjecture.providers import CONSTANTS_CACHE
@@ -66,3 +67,18 @@ def test_can_draw_local_constants_string(monkeypatch, value):
         lambda v: choice_equal(v, value),
         settings=settings(max_examples=5_000),
     )
+
+
+def test_actual_collection(monkeypatch):
+    # covering test for doing some real work collecting constants. We'll fake
+    # hypothesis as being the "local" module, just to get some real constant
+    # collection going.
+    monkeypatch.setattr(
+        constants_ast, "_is_local_module_file", lambda f: "hypothesis" in f
+    )
+
+    @given(st.integers())
+    def f(n):
+        pass
+
+    f()

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -28,7 +28,9 @@ def test_can_draw_local_constants_integers(monkeypatch, value):
     # _get_local_constants normally invalidates this cache for us, but we're
     # monkeypatching it.
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"integer": {value}})
+    monkeypatch.setattr(
+        providers, "_get_local_constants", lambda random: {"integer": {value}}
+    )
     find_any(st.integers(), lambda v: choice_equal(v, value))
 
 
@@ -36,21 +38,27 @@ def test_can_draw_local_constants_integers(monkeypatch, value):
 @pytest.mark.parametrize("value", [1.2938, -1823.0239, 1e999, math.nan])
 def test_can_draw_local_constants_floats(monkeypatch, value):
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"float": {value}})
+    monkeypatch.setattr(
+        providers, "_get_local_constants", lambda random: {"float": {value}}
+    )
     find_any(st.floats(), lambda v: choice_equal(v, value))
 
 
 @pytest.mark.parametrize("value", [b"abdefgh", b"a" * 50])
 def test_can_draw_local_constants_bytes(monkeypatch, value):
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"bytes": {value}})
+    monkeypatch.setattr(
+        providers, "_get_local_constants", lambda random: {"bytes": {value}}
+    )
     find_any(st.binary(), lambda v: choice_equal(v, value))
 
 
 @pytest.mark.parametrize("value", ["abdefgh", "a" * 50])
 def test_can_draw_local_constants_string(monkeypatch, value):
     CONSTANTS_CACHE.cache.clear()
-    monkeypatch.setattr(providers, "_get_local_constants", lambda: {"string": {value}})
+    monkeypatch.setattr(
+        providers, "_get_local_constants", lambda random: {"string": {value}}
+    )
     # we have a bunch of strings in GLOBAL_CONSTANTS, so it might take a while
     # to generate our local constant.
     find_any(

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -73,7 +73,8 @@ def test_pareto_front_omits_invalid_examples():
 
 
 def test_database_contains_only_pareto_front():
-    with deterministic_PRNG():
+    # TODO seed-hacking to avoid a bug, remove soon
+    with deterministic_PRNG(seed=0):
 
         def test(data):
             data.target_observations["1"] = data.draw(st.integers(0, 5))

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -73,8 +73,7 @@ def test_pareto_front_omits_invalid_examples():
 
 
 def test_database_contains_only_pareto_front():
-    # TODO seed-hacking to avoid a bug, remove soon
-    with deterministic_PRNG(seed=0):
+    with deterministic_PRNG():
 
         def test(data):
             data.target_observations["1"] = data.draw(st.integers(0, 5))

--- a/hypothesis-python/tests/cover/test_constants_ast.py
+++ b/hypothesis-python/tests/cover/test_constants_ast.py
@@ -18,6 +18,7 @@ from types import ModuleType
 import pytest
 
 from hypothesis import given, strategies as st
+from hypothesis.internal.compat import PYPY
 from hypothesis.internal.constants_ast import (
     ConstantVisitor,
     _is_local_module_file,
@@ -193,6 +194,7 @@ def test_local_modules_ignores_test_modules(path):
     assert not _is_local_module_file(path)
 
 
+@pytest.mark.skipif(PYPY, reason="no memory error on pypy")
 def test_ignores_ast_parse_error(tmp_path):
     p = tmp_path / "errors_on_parse.py"
     p.write_text("[1, " * 200 + "]" * 200, encoding="utf-8")

--- a/hypothesis-python/tests/cover/test_constants_ast.py
+++ b/hypothesis-python/tests/cover/test_constants_ast.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import ast
+import inspect
 import subprocess
 import sys
 import textwrap
@@ -190,3 +191,15 @@ def test_constants_from_bad_module():
 )
 def test_local_modules_ignores_test_modules(path):
     assert not _is_local_module_file(path)
+
+
+def test_ignores_ast_parse_error(tmp_path):
+    p = tmp_path / "errors_on_parse.py"
+    p.write_text("[1, " * 200 + "]" * 200)
+    module = ModuleType("<test_constants_from_module_large_string>")
+    module.__file__ = str(p)
+
+    with pytest.raises(MemoryError):
+        ast.parse(inspect.getsource(module))
+
+    assert constants_from_module(module) == set()

--- a/hypothesis-python/tests/cover/test_constants_ast.py
+++ b/hypothesis-python/tests/cover/test_constants_ast.py
@@ -196,10 +196,19 @@ def test_local_modules_ignores_test_modules(path):
 def test_ignores_ast_parse_error(tmp_path):
     p = tmp_path / "errors_on_parse.py"
     p.write_text("[1, " * 200 + "]" * 200, encoding="utf-8")
-    module = ModuleType("<test_constants_from_module_large_string>")
+    module = ModuleType("<test_ignores_ast_parse_error>")
     module.__file__ = str(p)
 
+    source = inspect.getsource(module)
     with pytest.raises(MemoryError):
-        ast.parse(inspect.getsource(module))
+        ast.parse(source)
 
     assert constants_from_module(module) == set()
+
+
+@given(st.sets(constants))
+def test_constant_visitor_roundtrips_string(constants):
+    # our files in storage_directory("constants") rely on this roundtrip
+    visitor = ConstantVisitor()
+    visitor.visit(ast.parse(str(constants)))
+    assert visitor.constants == constants

--- a/hypothesis-python/tests/cover/test_constants_ast.py
+++ b/hypothesis-python/tests/cover/test_constants_ast.py
@@ -195,7 +195,7 @@ def test_local_modules_ignores_test_modules(path):
 
 def test_ignores_ast_parse_error(tmp_path):
     p = tmp_path / "errors_on_parse.py"
-    p.write_text("[1, " * 200 + "]" * 200)
+    p.write_text("[1, " * 200 + "]" * 200, encoding="utf-8")
     module = ModuleType("<test_constants_from_module_large_string>")
     module.__file__ = str(p)
 


### PR DESCRIPTION
Closes #4365 and closes #4364

Main improvement here is tracking which modules we've seen before and directly caching `ModuleType -> set[ConstantT]`. This avoids paying the overhead of `SortedSet` and computing the choice type for all local constants, which turned out to take 100ms per provider instance in sympy's case.