### PR TITLE
Fix pareto listener not firing in one case

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a rare case where database entries were kept after they were no longer needed when using |Phase.target|.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -248,7 +248,7 @@ class ParetoFront:
                 i -= 1
 
             for v in to_remove:
-                self.__remove(v)
+                self._remove(v)
             return data in self.front
         finally:
             self.__pending = None
@@ -272,7 +272,7 @@ class ParetoFront:
     def __len__(self) -> int:
         return len(self.front)
 
-    def __remove(self, data: ConjectureResult) -> None:
+    def _remove(self, data: ConjectureResult) -> None:
         try:
             self.front.remove(data)
         except ValueError:
@@ -338,7 +338,7 @@ class ParetoOptimiser:
                     # the front, or it was not added to it because it was
                     # dominated by something in it.
                     try:
-                        self.front.front.remove(source)
+                        self.front._remove(source)
                     except ValueError:
                         pass
                     return True

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -337,10 +337,7 @@ class ParetoOptimiser:
                     # must be dominated in the front - either ``destination`` is in
                     # the front, or it was not added to it because it was
                     # dominated by something in it.
-                    try:
-                        self.front._remove(source)
-                    except ValueError:
-                        pass
+                    self.front._remove(source)
                     return True
                 return False
 


### PR DESCRIPTION
`self.front.front.remove` bypasses the engine listener, which removes the corresponding entry from the database. This is the cause of the historically-flaky `test_database_contains_only_pareto_front`.