### PR TITLE
Optimize local constants further

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Further improve the performance of the new features introduced in :ref:`version 6.131.1 <v6.131.1>`.

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -66,7 +66,7 @@ def test_actual_collection(monkeypatch):
     # hypothesis as being the "local" module, just to get some real constant
     # collection going.
     monkeypatch.setattr(
-        constants_ast, "_is_local_module_file", lambda f: "hypothesis" in f
+        constants_ast, "is_local_module_file", lambda f: "hypothesis" in f
     )
 
     @given(st.integers())


### PR DESCRIPTION
Closes #4370. 

Pandas tests are still ~10% more expensive than pre-6.131.1, but after this PR I think that's due to `_maybe_draw_constant` and the ast constant collection itself.

pandas hash: `e5898b8d33ac943a60250e1466006c073a506e8c`

this PR:
```
pytest pandas/tests/tslibs/test_parsing.py::test_hypothesis_delimited_date
Results (3.07s):
      54 passed
       2 xfailed
```

`gc hypothesis-python-6.131.0`:

```
pytest pandas/tests/tslibs/test_parsing.py::test_hypothesis_delimited_date
Results (2.67s):
      54 passed
       2 xfailed
```