### PR TITLE
Use alternative backends for all phases, and add `PrimitiveProvider.start_phase`

### DIFF
--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1181,13 +1181,14 @@ class StateForActualGivenExecution:
                     phase = runner._current_phase
                 else:  # pragma: no cover  # in case of messing with internals
                     if self.failed_normally or self.failed_due_to_deadline:
-                        phase = "shrink"
+                        phase = Phase.shrink
                     else:
-                        phase = "unknown"
+                        phase = None
                 backend_desc = f", using backend={self.settings.backend!r}" * (
                     self.settings.backend != "hypothesis"
                     and not getattr(runner, "_switch_to_hypothesis_provider", False)
                 )
+                phase_str = phase.name if phase is not None else "unknown"
                 try:
                     data._observability_args = data.provider.realize(
                         data._observability_args
@@ -1201,7 +1202,7 @@ class StateForActualGivenExecution:
                     start_timestamp=self._start_timestamp,
                     test_name_or_nodeid=self.test_identifier,
                     data=data,
-                    how_generated=f"during {phase} phase{backend_desc}",
+                    how_generated=f"during {phase_str} phase{backend_desc}",
                     string_repr=self._string_repr,
                     arguments=data._observability_args,
                     timing=self._timing_features,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -977,17 +977,13 @@ class ConjectureData:
             if node.type == "simplest":
                 if forced is not None:
                     choice = forced
-                elif isinstance(self.provider, HypothesisProvider):
+                else:
                     try:
-                        choice = choice_from_index(0, choice_type, constraints)
+                        choice = self.provider.draw_choice_template(
+                            node, choice_type, constraints
+                        )
                     except ChoiceTooLarge:
                         self.mark_overrun()
-                else:
-                    # give alternative backends control over ChoiceTemplate draws
-                    # as well
-                    choice = getattr(self.provider, f"draw_{choice_type}")(
-                        **constraints
-                    )
             else:
                 raise NotImplementedError
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
 
     from hypothesis.internal.conjecture.data import ConjectureData
     from hypothesis.internal.constants_ast import ConstantT
+    from hypothesis._settings import Phase
 
 T = TypeVar("T")
 _Lifetime: "TypeAlias" = Literal["test_case", "test_function"]
@@ -416,6 +417,21 @@ class PrimitiveProvider(abc.ABC):
         Note however that side effects can make this determination unsound.
 
         This method is called from ConjectureData.stop_span().
+        """
+
+    def start_phase(self, phase: "Phase", /) -> None:
+        """
+        Called when Hypothesis enters a new phase.
+
+        There is no corresponding `end_phase`; the start of a new phase always
+        implies the end of the previous phase.
+
+        If a phase has been leeft out of a test function's `phase=` setting,
+        start_phase may still be called for that phase, though no test cases will
+        be generated during that phase.
+
+        Do not rely on the phases passed to this function to determine which phases
+        are enabled. For that, use `settings().phases`.
         """
 
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -35,9 +35,12 @@ from hypothesis.internal.cache import LRUCache
 from hypothesis.internal.compat import WINDOWS, int_from_bytes
 from hypothesis.internal.conjecture.choice import (
     ChoiceConstraintsT,
+    ChoiceT,
+    ChoiceTemplate,
     ChoiceTypeT,
     FloatConstraints,
     choice_constraints_key,
+    choice_from_index,
     choice_permitted,
 )
 from hypothesis.internal.conjecture.floats import lex_to_float
@@ -65,9 +68,9 @@ from hypothesis.internal.intervalsets import IntervalSet
 if TYPE_CHECKING:
     from typing import TypeAlias
 
+    from hypothesis._settings import Phase
     from hypothesis.internal.conjecture.data import ConjectureData
     from hypothesis.internal.constants_ast import ConstantT
-    from hypothesis._settings import Phase
 
 T = TypeVar("T")
 _Lifetime: "TypeAlias" = Literal["test_case", "test_function"]
@@ -349,6 +352,17 @@ class PrimitiveProvider(abc.ABC):
         """
         assert lifetime in ("test_case", "test_function")
         yield from []
+
+    def draw_choice_template(
+        self,
+        choice_template: ChoiceTemplate,
+        choice_type: ChoiceTypeT,
+        constraints: ChoiceConstraintsT,
+        /,
+    ) -> ChoiceT:
+        if choice_template.type == "simplest":
+            return choice_from_index(0, choice_type, constraints)
+        raise NotImplementedError
 
     @abc.abstractmethod
     def draw_boolean(

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -19,6 +19,7 @@ from datetime import date, timedelta
 from functools import lru_cache
 from typing import Any, Callable, Optional
 
+from hypothesis._settings import Phase
 from hypothesis.configuration import storage_directory
 from hypothesis.errors import HypothesisWarning
 from hypothesis.internal.conjecture.data import ConjectureData, Status
@@ -41,12 +42,12 @@ def make_testcase(
     arguments: Optional[dict] = None,
     timing: dict[str, float],
     coverage: Optional[dict[str, list[int]]] = None,
-    phase: Optional[str] = None,
+    phase: Optional[Phase] = None,
     backend_metadata: Optional[dict[str, Any]] = None,
 ) -> dict:
     if data.interesting_origin:
         status_reason = str(data.interesting_origin)
-    elif phase == "shrink" and data.status == Status.OVERRUN:
+    elif phase is Phase.shrink and data.status == Status.OVERRUN:
         status_reason = "exceeded size of current best example"
     else:
         status_reason = str(data.events.pop("invalid because", ""))


### PR DESCRIPTION
Inspired by this mailing list question: https://groups.google.com/g/hypothesis-users/c/K6hLJ40eEC8/m/hcZsrWIMEgAJ.

During `Phase.shrink` and `Phase.reuse`, `ConjectureData` is constructed exclusively with `.for_choices`, so the backend provider is not consulted for generating choice sequence values - but can still receive information like `.span_start`.  

The exception here is if the `.for_choices` contains `ChoiceTemplate(type="simplest")` - as it does for the first generated example and during shrinking - which currently does ask the backend to generate. A few things here:

- `backend="crosshair"` needs to know when a `ChoiceTemplate` draw happens, IIRC because it otherwise thinks no choices are possible on the first iteration and claims `BackendCannotProceed("verified")`. Right now, crosshair treats `type="simplest"` like any other draw.
- We use `type="simplest"` in shrinking, and there we really do mean we want the simplest value. We sidestep any issues right now by not using alternative backends for shrinking. 
- IMO, if we do want to use alternative backends for all phases, then when we ask for a `type="simplest"` value, we should strongly expect/recommend that the backend follow that. 
- I don't think crosshair *needs* to modify the `type="simplest"` value, just know that it happened and avoid verifying in that case. So it could just call `super().draw_choice_template`. Alternatively, it applies its own heuristics during `phase != Phase.shrink`, and defers to `super().draw_choice_template` in the shrinking phase. (imagining this use case is why I added `PrimitiveProvider.start_phase`).