### PR TITLE
Add `for_failure: bool = False` to `provider.realize`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add a ``for_failure: bool = False`` parameter to ``provider.realize`` in :ref:`alternative backends <alternative-backends>`, indicating that symbolic-based backends should spend more effort realizing this symbolic.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Add a ``for_failure: bool = False`` parameter to ``provider.realize`` in :ref:`alternative backends <alternative-backends>`, indicating that symbolic-based backends should spend more effort realizing this symbolic.
+Add a ``for_failure: bool = False`` parameter to ``provider.realize`` in :ref:`alternative backends <alternative-backends>`, so that symbolic-based backends can increase their timeouts when realizing failures, which are more important than regular examples.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -850,10 +850,9 @@ class ConjectureData:
         *,
         allow_nan: bool = True,
         smallest_nonzero_magnitude: float = SMALLEST_SUBNORMAL,
-        # TODO: consider supporting these float widths at the IR level in the
-        # future.
+        # TODO: consider supporting these float widths at the choice sequence
+        # level in the future.
         # width: Literal[16, 32, 64] = 64,
-        # exclude_min and exclude_max handled higher up,
         forced: Optional[float] = None,
         observe: bool = True,
     ) -> float:
@@ -1006,12 +1005,12 @@ class ConjectureData:
             bytes: "bytes",
         }[type(choice)]
         # If we're trying to:
-        # * draw a different ir type at the same location
-        # * draw the same ir type with a different constraints, which does not permit
+        # * draw a different choice type at the same location
+        # * draw the same choice type with a different constraints, which does not permit
         #   the current value
         #
         # then we call this a misalignment, because the choice sequence has
-        # slipped from what we expected at some point. An easy misalignment is
+        # changed from what we expected at some point. An easy misalignment is
         #
         #   one_of(integers(0, 100), integers(101, 200))
         #

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -223,10 +223,10 @@ def realize_choices(data: ConjectureData, *, for_failure: bool) -> None:
             kwargs["for_failure"] = True
         else:
             note_deprecation(
-                "provider.realize does not have the for_failure parameter. This "
-                "will be an error in future versions of Hypothesis. (If you "
-                "installed this backend from a separate package, upgrading that "
-                "package may help).",
+                f"{type(data.provider).__qualname__}.realize does not have the "
+                "for_failure parameter. This will be an error in future versions "
+                "of Hypothesis. (If you installed this backend from a separate "
+                "package, upgrading that package may help).",
                 has_codemod=False,
                 since="RELEASEDAY",
             )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -317,7 +317,7 @@ class PrimitiveProvider(abc.ABC):
     def per_test_case_context_manager(self):
         return contextlib.nullcontext()
 
-    def realize(self, value: T) -> T:
+    def realize(self, value: T, *, for_failure: bool = False) -> T:
         """
         Called whenever hypothesis requires a concrete (non-symbolic) value from
         a potentially symbolic value. Hypothesis will not check that `value` is
@@ -325,7 +325,14 @@ class PrimitiveProvider(abc.ABC):
         `value` is non-symbolic.
 
         The returned value should be non-symbolic.  If you cannot provide a value,
-        raise hypothesis.errors.BackendCannotProceed("discard_test_case")
+        raise hypothesis.errors.BackendCannotProceed("discard_test_case").
+
+        If for_failure is True, the value is associated with a failing example.
+        In this case, the backend should spend substantially more effort when
+        attempting to realize the value, since it is important to avoid discarding
+        failing  examples. Backends may still raise BackendCannotProceed when
+        for_failure is True, if realization is truly impossible or if realization
+        takes significantly longer than expected (say, 5 minutes).
         """
         return value
 

--- a/hypothesis-python/tests/conjecture/test_alt_backend.py
+++ b/hypothesis-python/tests/conjecture/test_alt_backend.py
@@ -377,7 +377,7 @@ def test_flaky_with_backend():
 
 
 class BadRealizeProvider(TrivialProvider):
-    def realize(self, value):
+    def realize(self, value, *, for_failure=False):
         return None
 
 
@@ -399,7 +399,7 @@ def test_bad_realize():
 class RealizeProvider(TrivialProvider):
     avoid_realization = True
 
-    def realize(self, value):
+    def realize(self, value, *, for_failure=False):
         if isinstance(value, int):
             return 42
         return value
@@ -473,7 +473,7 @@ class ObservableProvider(TrivialProvider):
             yield {"type": "alert", "title": "Trivial alert", "content": "message here"}
             yield {"type": "info", "title": "trivial-data", "content": {"k2": "v2"}}
 
-    def realize(self, value):
+    def realize(self, value, *, for_failure=False):
         # Get coverage of the can't-realize path for observability outputs
         raise BackendCannotProceed
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,4 @@ filterwarnings =
     default:`np\.object` is a deprecated alias for the builtin `object`:DeprecationWarning
     # pytest-cov can't see into subprocesses; we'll see <100% covered if this is an issue
     ignore:Module hypothesis.* was previously imported, but not measured
+    ignore:CrosshairPrimitiveProvider.realize does not have the for_failure parameter


### PR DESCRIPTION
Crosshair can raise `BackendCannotProceed` when realizing choices for any example - including failing examples, as seen in https://github.com/HypothesisWorks/hypothesis/actions/runs/14853721823/job/41703445166, where we don't catch `BackendCannotProceed` and it bubbles up to the user.

Failing examples are more important to fully realize than standard examples, though. This PR adds a `for_failure` parameter which backends like crosshair can use to bump up the timeout and hopefully avoid `BackendCannotProceed` for failing examples.

This doesn't yet add exception handling for `BackendCannotProceed` for failing examples; we could do so now, or we could wait to see how big of a problem this is in practice with the increased timeout.

(cc @pschanely, ~~for release coordination as a breaking interface change~~, and if you have other ideas on solving this problem)