### PR TITLE
Improve performance of string max-children count

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve performance of an internal method to count possible choices.

--- a/hypothesis-python/tests/conjecture/test_choice.py
+++ b/hypothesis-python/tests/conjecture/test_choice.py
@@ -110,7 +110,7 @@ def test_compute_max_children_is_positive(choice_type_and_constraints):
                 "max_size": COLLECTION_DEFAULT_MAX_SIZE,
                 "intervals": IntervalSet.from_string("a"),
             },
-            MAX_CHILDREN_EFFECTIVELY_INFINITE,
+            COLLECTION_DEFAULT_MAX_SIZE + 1,
         ),
         (
             "string",
@@ -169,7 +169,11 @@ def test_compute_max_children_is_positive(choice_type_and_constraints):
     ],
 )
 def test_compute_max_children(choice_type, constraints, count_children):
-    assert compute_max_children(choice_type, constraints) == count_children
+    candidates = [count_children]
+    if count_children > MAX_CHILDREN_EFFECTIVELY_INFINITE:
+        # Acceptable to return either the exact value or the estimate
+        candidates.append(MAX_CHILDREN_EFFECTIVELY_INFINITE)
+    assert compute_max_children(choice_type, constraints) in candidates
 
 
 @given(st.text(min_size=1, max_size=1), st.integers(0, 100))


### PR DESCRIPTION
Uses a closed form expression to calculate the number of distinct strings, hence improving performance.

I also bumped `MAX_CHILDREN_EFFECTIVELY_INFINITE` by a factor 100 (to 10 million). This seems like a reasonable maximum number for all practical purposes, considering possible memory limits and so on, but if it's *only* for the counting performance then it can be increased (much) more without very bad effects.