### PR TITLE
Include GitLab CI variable when checking if in CI

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -69,7 +69,7 @@ their individual contributions.
 * `Francesc Elies <https://www.github.com/FrancescElies>`_
 * `Gabe Joseph <https://github.com/gjoseph92>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
-* `Genevieve Mendoza <https://www.github.com/genevieve-me>`
+* `Genevieve Mendoza <https://www.github.com/genevieve-me>`_
 * `George Macon <https://www.github.com/gmacon>`_
 * `Glenn Lehman <https://www.github.com/glnnlhmn>`_
 * `Graham Williamson <https://github.com/00willo>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -69,6 +69,7 @@ their individual contributions.
 * `Francesc Elies <https://www.github.com/FrancescElies>`_
 * `Gabe Joseph <https://github.com/gjoseph92>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
+* `Genevieve Mendoza <https://www.github.com/genevieve-me>`
 * `George Macon <https://www.github.com/gmacon>`_
 * `Glenn Lehman <https://www.github.com/glnnlhmn>`_
 * `Graham Williamson <https://github.com/00willo>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch adds detection of GitLab CI environments in :func:`_settings.is_in_ci`.
+If `GITLAB_CI` is set in the environment, the default Hypothesis settings
+will be changed to the CI profile. This affects the `derandomize`, `deadline`,
+`database`, `print_blob` settings as well as the `too_slow` healthcheck.
+
+Thanks to Genevieve Mendoza for this contribution!

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,8 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch adds detection of GitLab CI environments in :func:`_settings.is_in_ci`.
-If `GITLAB_CI` is set in the environment, the default Hypothesis settings
-will be changed to the CI profile. This affects the `derandomize`, `deadline`,
-`database`, `print_blob` settings as well as the `too_slow` healthcheck.
+This patch adds ``GITLAB_CI`` to the environment variables checked when enabling the default CI :ref:`settings profile <settings_profiles>`.
 
 Thanks to Genevieve Mendoza for this contribution!

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -249,7 +249,8 @@ class duration(datetime.timedelta):
 def is_in_ci() -> bool:
     # GitHub Actions, Travis CI and AppVeyor have "CI"
     # Azure Pipelines has "TF_BUILD"
-    return "CI" in os.environ or "TF_BUILD" in os.environ
+    # GitLab CI has "GITLAB_CI"
+    return "CI" in os.environ or "TF_BUILD" in os.environ or "GITLAB_CI" in os.environ
 
 
 default_variable = DynamicVariable[Optional["settings"]](None)


### PR DESCRIPTION
Check for GitLab CI in addition to GitHub and other platforms.

> "`GITLAB_CI`: Available for all jobs executed in CI/CD. `true` when available."

<https://docs.gitlab.com/ci/variables/predefined_variables/>

This function doesn't seem to have/need any test coverage, but please let me know if I missed something. (I also wasn't completely sure if creating `RELEASE.rst` was appropriate for such a tiny change - please let me know if I should remove that.)