### PR TITLE
add explicit .iloc to silence Pandas 2.X FutureWarning

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch resolves a Pandas FutureWarning (:issue:`4400`) caused by indexing with an integer key.

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -638,7 +638,7 @@ def data_frames(
                         else:
                             value = draw(c.elements)
                         try:
-                            data[c.name][i] = value
+                            data[c.name].iloc[i] = value
                         except ValueError as err:  # pragma: no cover
                             # This just works in Pandas 1.4 and later, but gives
                             # a confusing error on previous versions.


### PR DESCRIPTION
`hypothesis.extra.pandas.indexes()` -- add missing `.iloc` to silence Pandas 2.X FutureWarning.

Fixes #4400 
