### PR TITLE
Restore compatibility with Python 3.9's legacy LL(1) parser

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -120,6 +120,7 @@ their individual contributions.
 * `Louis Taylor <https://github.com/kragniz>`_
 * `Luke Barone-Adesi <https://github.com/baluke>`_
 * `Lundy Bernard <https://github.com/lundybernard>`_
+* `Marco Ricci <https://github.com/the-13th-letter>`_
 * `Marco Sirabella <https://www.github.com/mjsir911>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (marius@gedmin.as)

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch restores compatibility when using `the legacy Python 3.9 LL(1)
+parser <https://docs.python.org/3/whatsnew/3.9.html#new-parser>`__, which
+was accidentally broken since :ref:`version 6.130.13 <v6.130.13>`.
+
+Thanks to Marco Ricci for this fix!

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1102,18 +1102,19 @@ class StateForActualGivenExecution:
 
         # self.test_runner can include the execute_example method, or setup/teardown
         # _example, so it's important to get the PRNG and build context in place first.
-        with (
-            local_settings(self.settings),
-            deterministic_PRNG(),
-            BuildContext(data, is_final=is_final) as context,
-        ):
-            # providers may throw in per_case_context_fn, and we'd like
-            # `result` to still be set in these cases.
-            result = None
-            with data.provider.per_test_case_context_manager():
-                # Run the test function once, via the executor hook.
-                # In most cases this will delegate straight to `run(data)`.
-                result = self.test_runner(data, run)
+        #
+        # NOTE: For compatibility with Python 3.9's LL(1) parser, this is written as
+        # three nested with-statements, instead of one compound statement.
+        with local_settings(self.settings):
+            with deterministic_PRNG():
+                with BuildContext(data, is_final=is_final) as context:
+                    # providers may throw in per_case_context_fn, and we'd like
+                    # `result` to still be set in these cases.
+                    result = None
+                    with data.provider.per_test_case_context_manager():
+                        # Run the test function once, via the executor hook.
+                        # In most cases this will delegate straight to `run(data)`.
+                        result = self.test_runner(data, run)
 
         # If a failure was expected, it should have been raised already, so
         # instead raise an appropriate diagnostic error.


### PR DESCRIPTION
The legacy LL(1) parser cannot handle compound with-statements using grouping parentheses and the `EXPR as TARGET` syntax, because it is not LL(1)-recognizable.

This partially reverts commit f151eec1e28b07f78837c08806401cd292ff6949.

---

Fixes #4421.

With this, to the best of my knowledge[^1], there are no current LL(1) parser failures in the `src` directory of the current (6.131.32) codebase.

There are still some such non-parsable expressions left over in the tests. Should I bother with those? There should be no differences compared to running Python 3.9 with the newer PEG-based parser, save for lack of parsing errors.

[^1]: `grep -E '^ *with\b'`