### PR TITLE
Add `wrapped_test` to `BuildContext`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal changes to support `hypofuzz <https://hypofuzz.com>`__.

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -131,10 +131,12 @@ class BuildContext:
         data: ConjectureData,
         *,
         is_final: bool = False,
+        wrapped_test: Callable,
     ) -> None:
         self.data = data
         self.tasks: list[Callable[[], Any]] = []
         self.is_final = is_final
+        self.wrapped_test = wrapped_test
 
         # Use defaultdict(list) here to handle the possibility of having multiple
         # functions registered for the same object (due to caching, small ints, etc).

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1109,7 +1109,9 @@ class StateForActualGivenExecution:
         # three nested with-statements, instead of one compound statement.
         with local_settings(self.settings):
             with deterministic_PRNG():
-                with BuildContext(data, is_final=is_final) as context:
+                with BuildContext(
+                    data, is_final=is_final, wrapped_test=self.wrapped_test
+                ) as context:
                     # providers may throw in per_case_context_fn, and we'd like
                     # `result` to still be set in these cases.
                     result = None

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -37,7 +37,7 @@ from tests.common.utils import capture_out
 
 
 def bc():
-    return BuildContext(ConjectureData.for_choices([]))
+    return BuildContext(ConjectureData.for_choices([]), wrapped_test=None)
 
 
 def test_cannot_cleanup_with_no_context():

--- a/hypothesis-python/tests/nocover/test_precise_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_precise_shrinking.py
@@ -68,7 +68,7 @@ pytestmark = pytest.mark.skipif(
 def safe_draw(data, strategy):
     """Set up just enough of the Hypothesis machinery to use draw on
     a strategy."""
-    with BuildContext(data):
+    with BuildContext(data, wrapped_test=None):
         try:
             return data.draw(strategy)
         except UnsatisfiedAssumption:
@@ -222,7 +222,7 @@ def find_random(
     while True:
         data = ConjectureData(random=random)
         try:
-            with BuildContext(data=data):
+            with BuildContext(data=data, wrapped_test=None):
                 value = data.draw(s)
                 if condition(value):
                     data.freeze()
@@ -251,7 +251,7 @@ def shrinks(strategy, nodes, *, allow_sloppy=True, seed=0):
             assert runner.exit_reason in (ExitReason.finished, ExitReason.max_shrinks)
     else:
         trial = ConjectureData(prefix=choices, random=random)
-        with BuildContext(trial):
+        with BuildContext(trial, wrapped_test=None):
             trial.draw(strategy)
             assert trial.choices == choices, "choice sequence is already sloppy"
             padding = safe_draw(trial, st.integers())

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -74,7 +74,7 @@ def define_test(specifier, predicate, condition=None, p=0.5, suppress_health_che
             )
 
         def test_function(data):
-            with BuildContext(data):
+            with BuildContext(data, wrapped_test=None):
                 try:
                     value = data.draw(specifier)
                 except UnsatisfiedAssumption:


### PR DESCRIPTION
Split from #4422, required for https://github.com/Zac-HD/hypofuzz/pull/113

Hypofuzz uses this for the following in `HypofuzzProvider`:

```python
        self.database_key = function_digest(context.wrapped_test.hypothesis.inner_test)

        self.nodeid = getattr(
            current_pytest_item.value, "nodeid", None
        ) or get_pretty_function_description(context.wrapped_test)

        self.worker_identity = worker_identity(
            in_directory=Path(inspect.getfile(context.wrapped_test)).parent
        )
```