### PR TITLE
Restore compatibility with Python 3.9's legacy LL(1) parser yet again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           - check-coverage
           - check-conjecture-coverage
           - check-py39-cover
+          - check-py39-oldparser
           - check-pypy39-cover
           - check-py310-cover
           - check-py310-nocover

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch restores compatibility when using `the legacy Python 3.9 LL(1)
+parser <https://docs.python.org/3/whatsnew/3.9.html#new-parser>`__ yet
+again, because the fix in :ref:`version 6.131.33 <v6.131.33>` was too
+brittle.
+
+Thanks to Marco Ricci for this fix!

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -305,6 +305,9 @@ else:
                 item.hypothesis_statistics = describe_statistics(stats)
 
             with collector.with_value(note_statistics):
+                # NOTE: For compatibility with Python 3.9's LL(1)
+                # parser, this is written as a nested with-statement,
+                # instead of a compound one.
                 with with_reporter(store):
                     with current_pytest_item.with_value(item):
                         yield

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -976,8 +976,12 @@ class StateForActualGivenExecution:
 
             @proxies(self.test)
             def test(*args, **kwargs):
-                with unwrap_markers_from_group(), ensure_free_stackframes():
-                    return self.test(*args, **kwargs)
+                with unwrap_markers_from_group():
+                    # NOTE: For compatibility with Python 3.9's LL(1)
+                    # parser, this is written as a nested with-statement,
+                    # instead of a compound one.
+                    with ensure_free_stackframes():
+                        return self.test(*args, **kwargs)
 
         else:
 
@@ -988,8 +992,12 @@ class StateForActualGivenExecution:
                 arg_gctime = gc_cumulative_time()
                 start = time.perf_counter()
                 try:
-                    with unwrap_markers_from_group(), ensure_free_stackframes():
-                        result = self.test(*args, **kwargs)
+                    with unwrap_markers_from_group():
+                        # NOTE: For compatibility with Python 3.9's LL(1)
+                        # parser, this is written as a nested with-statement,
+                        # instead of a compound one.
+                        with ensure_free_stackframes():
+                            result = self.test(*args, **kwargs)
                 finally:
                     finish = time.perf_counter()
                     in_drawtime = math.fsum(data.draw_times.values()) - arg_drawtime

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -852,20 +852,21 @@ class ConjectureRunner:
         return nullcontext()
 
     def run(self) -> None:
-        with (
-            local_settings(self.settings),
-            self.observe_for_provider(),
-        ):
-            try:
-                self._run()
-            except RunIsComplete:
-                pass
-            for v in self.interesting_examples.values():
-                self.debug_data(v)
-            self.debug(
-                "Run complete after %d examples (%d valid) and %d shrinks"
-                % (self.call_count, self.valid_examples, self.shrinks)
-            )
+        with local_settings(self.settings):
+            # NOTE: For compatibility with Python 3.9's LL(1)
+            # parser, this is written as a nested with-statement,
+            # instead of a compound one.
+            with self.observe_for_provider():
+                try:
+                    self._run()
+                except RunIsComplete:
+                    pass
+                for v in self.interesting_examples.values():
+                    self.debug_data(v)
+                self.debug(
+                    "Run complete after %d examples (%d valid) and %d shrinks"
+                    % (self.call_count, self.valid_examples, self.shrinks)
+                )
 
     @property
     def database(self) -> Optional[ExampleDatabase]:

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -692,6 +692,9 @@ def _dict_pprinter_factory(
 
         if cycle:
             return p.text("{...}")
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with p.group(1, start, end):
             # If the dict contains both "" and b"" (empty string and empty bytes), we
             # ignore the BytesWarning raised by `python -bb` mode.  We can't use

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -115,6 +115,9 @@ def fails_with(e, *, match=None):
             # the `raises` context manager so that any problems in rigging the
             # PRNG don't accidentally count as the expected failure.
             with deterministic_PRNG():
+                # NOTE: For compatibility with Python 3.9's LL(1)
+                # parser, this is written as a nested with-statement,
+                # instead of a compound one.
                 with raises(e, match=match):
                     f(*arguments, **kwargs)
 
@@ -229,6 +232,9 @@ def temp_registered(type_, strat_or_factory):
 def raises_warning(expected_warning, match=None):
     """Use instead of pytest.warns to check that the raised warning is handled properly"""
     with raises(expected_warning, match=match) as r:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with warnings.catch_warnings():
             warnings.simplefilter("error", category=expected_warning)
             yield r

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1065,16 +1065,20 @@ def test_number_of_examples_in_integer_range_is_bounded(n):
 def test_prefix_cannot_exceed_buffer_size(monkeypatch):
     buffer_size = 10
 
-    with deterministic_PRNG(), buffer_size_limit(buffer_size):
+    with deterministic_PRNG():
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with buffer_size_limit(buffer_size):
 
-        def test(data):
-            while data.draw_boolean():
+            def test(data):
+                while data.draw_boolean():
+                    assert data.length <= buffer_size
                 assert data.length <= buffer_size
-            assert data.length <= buffer_size
 
-        runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS)
-        runner.run()
-        assert runner.valid_examples == buffer_size
+            runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS)
+            runner.run()
+            assert runner.valid_examples == buffer_size
 
 
 def test_does_not_shrink_multiple_bugs_when_told_not_to():

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -210,6 +210,9 @@ def test_can_patch_up_examples():
 
 def test_optimiser_when_test_grows_buffer_to_overflow():
     with deterministic_PRNG():
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with buffer_size_limit(2):
 
             def test(data):

--- a/hypothesis-python/tests/conjecture/test_provider.py
+++ b/hypothesis-python/tests/conjecture/test_provider.py
@@ -303,6 +303,9 @@ class InvalidLifetime(TrivialProvider):
 
 def test_invalid_lifetime():
     with temp_register_backend("invalid_lifetime", InvalidLifetime):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(InvalidArgument):
             ConjectureRunner(
                 lambda: True, settings=settings(backend="invalid_lifetime")
@@ -649,17 +652,18 @@ def test_can_generate_from_all_available_providers(backend, strategy):
     def f(x):
         raise ValueError
 
-    with (
-        pytest.raises(ValueError),
-        (
+    with pytest.raises(ValueError):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with (
             pytest.warns(
                 HypothesisWarning, match="/dev/urandom is not available on windows"
             )
             if backend == "hypothesis-urandom" and WINDOWS
             else nullcontext()
-        ),
-    ):
-        f()
+        ):
+            f()
 
 
 def test_saves_on_fatal_error_with_backend():

--- a/hypothesis-python/tests/cover/test_control.py
+++ b/hypothesis-python/tests/cover/test_control.py
@@ -75,6 +75,9 @@ def test_can_nest_build_context():
 
 def test_does_not_suppress_exceptions():
     with pytest.raises(AssertionError):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with bc():
             raise AssertionError
     assert _current_build_context.value is None
@@ -82,6 +85,9 @@ def test_does_not_suppress_exceptions():
 
 def test_suppresses_exceptions_in_teardown():
     with pytest.raises(ValueError) as exc_info:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with bc():
 
             def foo():
@@ -96,6 +102,9 @@ def test_suppresses_exceptions_in_teardown():
 
 def test_runs_multiple_cleanup_with_teardown():
     with pytest.raises(ExceptionGroup) as exc_info:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with bc():
 
             def foo():
@@ -116,6 +125,9 @@ def test_runs_multiple_cleanup_with_teardown():
 
 def test_raises_error_if_cleanup_fails_but_block_does_not():
     with pytest.raises(ValueError):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with bc():
 
             def foo():
@@ -170,6 +182,9 @@ def test_prints_all_notes_in_verbose_mode():
         assert x < 5
 
     with capture_out() as out:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with reporting.with_reporter(reporting.default):
             with pytest.raises(AssertionError):
                 test()

--- a/hypothesis-python/tests/cover/test_database_backend.py
+++ b/hypothesis-python/tests/cover/test_database_backend.py
@@ -280,6 +280,9 @@ def test_ga_no_artifact(tmp_path):
 
 def test_ga_corrupted_artifact():
     """Tests that corrupted artifacts are properly detected and warned about."""
+    # NOTE: For compatibility with Python 3.9's LL(1)
+    # parser, this is written as a nested with-statement,
+    # instead of a compound one.
     with ga_empty_artifact() as (path, zip_path):
         # Corrupt the CRC of the zip file
         with open(zip_path, "rb+") as f:
@@ -296,6 +299,9 @@ def test_ga_deletes_old_artifacts():
     """Tests that old artifacts are automatically deleted."""
     now = datetime.now(timezone.utc)
     with ga_empty_artifact(date=now) as (path, file_now):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with ga_empty_artifact(date=now - timedelta(hours=2), path=path) as (
             _,
             file_old,

--- a/hypothesis-python/tests/cover/test_debug_information.py
+++ b/hypothesis-python/tests/cover/test_debug_information.py
@@ -27,6 +27,9 @@ def test_reports_passes():
         assert i < 10
 
     with capture_out() as out:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(AssertionError):
             test()
 

--- a/hypothesis-python/tests/cover/test_explicit_examples.py
+++ b/hypothesis-python/tests/cover/test_explicit_examples.py
@@ -141,6 +141,9 @@ def test_does_not_print_on_explicit_examples_if_no_failure():
         assert x > 0
 
     with reporting.with_reporter(reporting.default):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(AssertionError):
             with capture_out() as out:
                 test_positive()
@@ -192,6 +195,9 @@ def test_examples_are_tried_in_order():
         print(f"x -> {x}")
 
     with capture_out() as out:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with reporting.with_reporter(reporting.default):
             test()
     ls = out.getvalue().splitlines()

--- a/hypothesis-python/tests/cover/test_lookup.py
+++ b/hypothesis-python/tests/cover/test_lookup.py
@@ -1258,8 +1258,9 @@ def test_issue_4194_regression():
     inner = typing.Union[typing.Sequence["A"], MyProtocol]
     A = typing.Union[typing.Sequence[inner], MyProtocol]
 
-    with (
-        temp_registered(MyProtocol, st.just(b"")),
-        temp_registered(typing.ForwardRef("A"), st.integers()),
-    ):
-        find_any(st.from_type(A))
+    with temp_registered(MyProtocol, st.just(b"")):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with temp_registered(typing.ForwardRef("A"), st.integers()):
+            find_any(st.from_type(A))

--- a/hypothesis-python/tests/cover/test_monitoring.py
+++ b/hypothesis-python/tests/cover/test_monitoring.py
@@ -32,6 +32,9 @@ def test_monitoring_warns_on_registered_tool_id(warns_or_raises):
 
     # scrutineer can't run if something has already registered its tool id.
     with using_tool_id(MONITORING_TOOL_ID, "rogue"):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with warns_or_raises(HypothesisWarning, match=r"already taken by tool rogue"):
 
             @given(st.integers())

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -169,6 +169,9 @@ def test_consistent_decimal_error():
     with pytest.raises(InvalidArgument) as excinfo:
         check_can_generate_examples(decimals(bad))
     with pytest.raises(InvalidArgument) as excinfo2:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with decimal.localcontext(decimal.Context(traps=[])):
             check_can_generate_examples(decimals(bad))
     assert str(excinfo.value) == str(excinfo2.value)

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -55,6 +55,9 @@ def do_it_all(l, a, x, data):
 @xfail_on_crosshair(Why.other, strict=False)  # flakey BackendCannotProceed ??
 def test_observability():
     with capture_observations() as ls:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ZeroDivisionError):
             do_it_all()
         with pytest.raises(ZeroDivisionError):
@@ -106,11 +109,12 @@ def test_failure_includes_explain_phase_comments():
         if x:
             raise AssertionError
 
-    with (
-        capture_observations() as observations,
-        pytest.raises(AssertionError),
-    ):
-        test_fails()
+    with capture_observations() as observations:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with pytest.raises(AssertionError):
+            test_fails()
 
     test_cases = [tc for tc in observations if tc.type == "test_case"]
     # only the last test case observation, once we've finished shrinking it,
@@ -138,11 +142,12 @@ def test_failure_includes_notes():
         note("not included 2")
         raise AssertionError
 
-    with (
-        capture_observations() as observations,
-        pytest.raises(AssertionError),
-    ):
-        test_fails_with_note()
+    with capture_observations() as observations:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with pytest.raises(AssertionError):
+            test_fails_with_note()
 
     expected = textwrap.dedent(
         """
@@ -229,11 +234,12 @@ def test_minimal_failing_observation():
         if x:
             raise AssertionError
 
-    with (
-        capture_observations() as observations,
-        pytest.raises(AssertionError),
-    ):
-        test_fails()
+    with capture_observations() as observations:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with pytest.raises(AssertionError):
+            test_fails()
 
     observation = [tc for tc in observations if tc.type == "test_case"][-1]
     expected_representation = textwrap.dedent(
@@ -324,11 +330,16 @@ def test_fuzz_one_input_status(buffer, expected_status):
         if should_fail_assume:
             assume(False)
 
-    with (
-        capture_observations() as ls,
-        pytest.raises(AssertionError) if expected_status == "failed" else nullcontext(),
-    ):
-        test_fails.hypothesis.fuzz_one_input(buffer)
+    with capture_observations() as ls:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with (
+            pytest.raises(AssertionError)
+            if expected_status == "failed"
+            else nullcontext()
+        ):
+            test_fails.hypothesis.fuzz_one_input(buffer)
     assert len(ls) == 1
     assert ls[0].status == expected_status
     assert ls[0].how_generated == "fuzz_one_input"

--- a/hypothesis-python/tests/cover/test_pretty.py
+++ b/hypothesis-python/tests/cover/test_pretty.py
@@ -563,6 +563,9 @@ class BigList(list):
             return "[...]"
         else:
             with printer.group(open="[", close="]"):
+                # NOTE: For compatibility with Python 3.9's LL(1)
+                # parser, this is written as a nested with-statement,
+                # instead of a compound one.
                 with printer.indent(5):
                     for v in self:
                         printer.pretty(v)

--- a/hypothesis-python/tests/cover/test_reporting.py
+++ b/hypothesis-python/tests/cover/test_reporting.py
@@ -67,6 +67,9 @@ def test_does_print_verbose_in_debug():
 def test_can_report_when_system_locale_is_ascii(monkeypatch):
     read, write = os.pipe()
     with open(read, encoding="ascii") as read:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with open(write, "w", encoding="ascii") as write:
             monkeypatch.setattr(sys, "stdout", write)
             reporting.default("☃")

--- a/hypothesis-python/tests/cover/test_reproduce_failure.py
+++ b/hypothesis-python/tests/cover/test_reproduce_failure.py
@@ -157,6 +157,9 @@ def test_does_not_print_reproduction_for_simple_examples_by_default():
         raise AssertionError
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(AssertionError):
             test()
     assert "@reproduce_failure" not in o.getvalue()
@@ -170,6 +173,9 @@ def test_does_not_print_reproduction_for_simple_data_examples_by_default():
         raise AssertionError
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(AssertionError):
             test()
     assert "@reproduce_failure" not in o.getvalue()
@@ -184,6 +190,9 @@ def test_does_not_print_reproduction_for_large_data_examples_by_default():
             raise ValueError
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ValueError):
             test()
     assert "@reproduce_failure" not in o.getvalue()
@@ -201,6 +210,9 @@ def test_does_not_print_reproduction_if_told_not_to():
         raise ValueError
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ValueError):
             test()
 
@@ -227,6 +239,9 @@ def test_does_not_print_reproduction_if_verbosity_set_to_quiet():
         assert data.draw(st.just(False))
 
     with capture_out() as out:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(AssertionError):
             test_always_fails()
 

--- a/hypothesis-python/tests/cover/test_seed_printing.py
+++ b/hypothesis-python/tests/cover/test_seed_printing.py
@@ -45,6 +45,9 @@ def test_prints_seed_only_on_healthcheck(
         assert fail_healthcheck
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(expected_exc):
             test()
 
@@ -72,6 +75,9 @@ def test_uses_global_force(monkeypatch):
 
     for _ in range(2):
         with capture_out() as o:
+            # NOTE: For compatibility with Python 3.9's LL(1)
+            # parser, this is written as a nested with-statement,
+            # instead of a compound one.
             with pytest.raises(ValueError):
                 test()
         output.append(o.getvalue())
@@ -92,6 +98,9 @@ def test_does_print_on_reuse_from_database():
         raise ValueError
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(FailedHealthCheck):
             test()
 
@@ -100,6 +109,9 @@ def test_does_print_on_reuse_from_database():
     passes_healthcheck = True
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ValueError):
             test()
 
@@ -109,6 +121,9 @@ def test_does_print_on_reuse_from_database():
     passes_healthcheck = False
 
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(FailedHealthCheck):
             test()
 

--- a/hypothesis-python/tests/cover/test_slippage.py
+++ b/hypothesis-python/tests/cover/test_slippage.py
@@ -24,8 +24,12 @@ from tests.common.utils import (
 
 
 def capture_reports(test):
-    with capture_out() as o, pytest.raises(ExceptionGroup) as err:
-        test()
+    with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with pytest.raises(ExceptionGroup) as err:
+            test()
 
     return o.getvalue() + "\n\n".join(
         f"{e!r}\n" + "\n".join(getattr(e, "__notes__", []))

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -444,10 +444,14 @@ def test_saves_failing_example_in_database():
 
 
 def test_can_run_with_no_db():
-    with deterministic_PRNG(), raises(AssertionError):
-        run_state_machine_as_test(
-            DepthMachine, settings=Settings(database=None, max_examples=10_000)
-        )
+    with deterministic_PRNG():
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with raises(AssertionError):
+            run_state_machine_as_test(
+                DepthMachine, settings=Settings(database=None, max_examples=10_000)
+            )
 
 
 def test_stateful_double_rule_is_forbidden(recwarn):

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -471,6 +471,9 @@ def test_does_not_print_notes_if_all_succeed():
         note("Hi there")
 
     with capture_out() as out:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with reporting.with_reporter(reporting.default):
             test()
     assert not out.getvalue()
@@ -535,14 +538,15 @@ def test_notes_high_overrun_rates_in_unsatisfiable_error():
     def f(v):
         pass
 
-    with (
-        raises(
-            Unsatisfiable,
-            match=(
-                r"1000 of 1000 examples were too large to finish generating; "
-                r"try reducing the typical size of your inputs\?"
-            ),
+    with raises(
+        Unsatisfiable,
+        match=(
+            r"1000 of 1000 examples were too large to finish generating; "
+            r"try reducing the typical size of your inputs\?"
         ),
-        buffer_size_limit(10),
     ):
-        f()
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
+        with buffer_size_limit(10):
+            f()

--- a/hypothesis-python/tests/cover/test_type_lookup.py
+++ b/hypothesis-python/tests/cover/test_type_lookup.py
@@ -161,6 +161,9 @@ def test_custom_type_resolution_with_function():
 
 def test_custom_type_resolution_with_function_non_strategy():
     with temp_registered(UnknownType, lambda _: None):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ResolutionFailed):
             check_can_generate_examples(st.from_type(UnknownType))
         with pytest.raises(ResolutionFailed):

--- a/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
+++ b/hypothesis-python/tests/cover/test_type_lookup_forward_ref.py
@@ -138,5 +138,8 @@ def test_bound_type_cheking_only_forward_ref():
 def test_bound_type_checking_only_forward_ref_wrong_type():
     """We should check ``ForwardRef`` parameter name correctly."""
     with utils.temp_registered(ForwardRef("WrongType"), st.just(1)):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ResolutionFailed):
             check_can_generate_examples(st.builds(typechecking_only_fun))

--- a/hypothesis-python/tests/cover/test_unittest.py
+++ b/hypothesis-python/tests/cover/test_unittest.py
@@ -27,6 +27,9 @@ class Thing_with_a_subThing(unittest.TestCase):
     def thing(self, lst):
         for i, b in enumerate(lst):
             with pytest.warns(HypothesisWarning):
+                # NOTE: For compatibility with Python 3.9's LL(1)
+                # parser, this is written as a nested with-statement,
+                # instead of a compound one.
                 with self.subTest((i, b)):
                     self.assertTrue(b)
 

--- a/hypothesis-python/tests/cover/test_verbosity.py
+++ b/hypothesis-python/tests/cover/test_verbosity.py
@@ -22,6 +22,9 @@ from tests.common.utils import Why, capture_out, fails, xfail_on_crosshair
 @contextmanager
 def capture_verbosity():
     with capture_out() as o:
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with with_reporter(default_reporter):
             yield o
 

--- a/hypothesis-python/tests/nocover/test_drypython_returns.py
+++ b/hypothesis-python/tests/nocover/test_drypython_returns.py
@@ -199,5 +199,8 @@ def wrong_generic_func2(obj: _SecondBase[None, bool]):
 @pytest.mark.parametrize("func", [wrong_generic_func1, wrong_generic_func2])
 def test_several_generic_bases_wrong_functions(func):
     with temp_registered(AllConcrete, st.builds(AllConcrete)):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(ResolutionFailed):
             check_can_generate_examples(st.builds(func))

--- a/hypothesis-python/tests/numpy/test_deprecation.py
+++ b/hypothesis-python/tests/numpy/test_deprecation.py
@@ -20,6 +20,9 @@ from tests.common.debug import check_can_generate_examples
 
 def test_basic_indices_bad_min_dims_warns():
     with pytest.warns(HypothesisDeprecationWarning):
+        # NOTE: For compatibility with Python 3.9's LL(1)
+        # parser, this is written as a nested with-statement,
+        # instead of a compound one.
         with pytest.raises(InvalidArgument):
             check_can_generate_examples(nps.basic_indices((3, 3, 3), min_dims=4))
 

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -44,6 +44,15 @@ deps=
 commands=
     python -bb -X dev -m pytest tests/quality/ -n auto
 
+[testenv:py39-oldparser]
+deps=
+    -r../requirements/test.txt
+setenv=
+    PYTHONWARNDEFAULTENCODING=1
+    PYTHONOLDPARSER=1
+commands=
+    python -bb -X dev -m pytest -n auto tests/cover/ {posargs}
+
 # This test job runs on the oldest version of CPython we support, against the minimum
 # version specified in our runtime dependencies.  For now, that's the oldest version
 # with a wheel for non-EOL Python.  In future we might deprecate faster per NEP-29.

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -645,6 +645,7 @@ for kind in ("cover", "nocover", "niche", "custom"):
     standard_tox_task(f"crosshair-{kind}")
 
 standard_tox_task("py39-oldestnumpy", py="3.9")
+standard_tox_task("py39-oldparser", py="3.9")
 standard_tox_task("numpy-nightly", py="3.12")
 
 standard_tox_task("coverage")


### PR DESCRIPTION
Fixes #4421, yet again, this time taking care of compound with-statements with parentheses, which Python 3.9/LL(1) would parse as simple with-statements with a tuple as the single context manager expression.

I don't know why this didn't trigger when I originally tested my fix in #4423, but it does now: on pretty much every `hypothesis.given(...)`, I get an `AttributeError` in `hypothesis.internal.conjecture.engine.ConjectureRunner.run`.

This PR now splits up all compound with-statements into nested simple ones *and* adds a comment on why they shouldn't be combined again. ~As before, I only tackle the `src` directory, not the `tests` or otherwise.~ I double-checked every with-statement ~in `src`~ I could find for false positives/negatives and forgotten constellations.