### PR TITLE
Fix compatible_shared_strategies_do_not_raise() test without -Werror

### DIFF
--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -13,6 +13,7 @@ import decimal
 import enum
 import fractions
 import math
+import warnings
 from datetime import date, datetime, time, timedelta
 from ipaddress import IPv4Network, IPv6Network
 
@@ -671,4 +672,6 @@ def test_compatible_shared_strategies_do_not_raise(strat_a, strat_b):
     def test_it(a, b):
         assert a == b
 
-    test_it()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", HypothesisWarning)
+        test_it()


### PR DESCRIPTION
Fix xfail-strict failures in `compatible_shared_strategies_do_not_raise()` test when the test suite is run without global `-Werror`.

Fixes #4428