### PR TITLE
Fix error message formatting

### DIFF
--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -335,7 +335,7 @@ def _hypothesis_parse_gufunc_signature(signature):
                 names_out = {n.strip("?") for n in result_shape}
                 if name.strip("?") in (names_out - names_in):
                     raise InvalidArgument(
-                        "The {name!r} dimension only appears in the output shape, and is "
+                        f"The {name!r} dimension only appears in the output shape, and is "
                         "not frozen, so the size is not determined ({signature=})."
                     ) from None
     return _GUfuncSig(input_shapes=input_shapes, result_shape=result_shape)


### PR DESCRIPTION
## PR Summary
This small PR fixes the error message formatting in `hypothesis-python/src/hypothesis/extra/_array_helpers.py`.