### PR TITLE
Safer cache eviction

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a rare race condition in internal cache eviction logic.

--- a/hypothesis-python/src/hypothesis/internal/cache.py
+++ b/hypothesis-python/src/hypothesis/internal/cache.py
@@ -117,7 +117,15 @@ class GenericCache(Generic[K, V]):
                     raise ValueError(
                         "Cannot increase size of cache where all keys have been pinned."
                     ) from None
-                del self.keys_to_indices[evicted.key]
+
+                # it's not clear to me how this can occur with a thread-local
+                # cache, but we've seen failures here before (specifically under
+                # the windows ci tests).
+                try:
+                    del self.keys_to_indices[evicted.key]
+                except KeyError:  # pragma: no cover
+                    pass
+
                 i = 0
                 self.data[0] = entry
             else:


### PR DESCRIPTION
I've seen a rare failure here in CI several times over the past ~month. As far as I can remember, they are always on windows. Most recent failure: https://github.com/HypothesisWorks/hypothesis/actions/runs/15687024864/job/44192686508?pr=4388. 

The cache is threadlocal, so I'm not sure how a race condition could occur here. This makes me a bit nervous that there is an actual logic bug in `GenericCache`, and adding this condition will mask it. On the other hand, only reproducing on windows is evidence of a race condition rather than a logic error.