### PR TITLE
Fix stateful test performance regression

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes a substantial performance regression in stateful tests from computing string representations, present since :ref:`version 6.131.20 <v6.131.20>`.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -453,7 +453,7 @@ def get_pretty_function_description(f: object) -> str:
         return pretty(f)
     if not hasattr(f, "__name__"):
         return repr(f)
-    name = f.__name__  # type: ignore # validated by hasattr above
+    name = f.__name__  # type: ignore
     if name == "<lambda>":
         return extract_lambda_source(f)
     elif isinstance(f, (types.MethodType, types.BuiltinMethodType)):

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -504,8 +504,12 @@ class Rule:
         self.bundles = tuple(bundles)
 
     def __repr__(self) -> str:
-        rep = get_pretty_function_description
-        bits = [f"{k}={rep(v)}" for k, v in dataclasses.asdict(self).items() if v]
+        bits = [
+            f"{field.name}="
+            f"{get_pretty_function_description(getattr(self, field.name))}"
+            for field in dataclasses.fields(self)
+            if getattr(self, field.name)
+        ]
         return f"{self.__class__.__name__}({', '.join(bits)})"
 
 


### PR DESCRIPTION
`dataclasses.asdict` deepcopies and can be very expensive. Regressed in https://github.com/HypothesisWorks/hypothesis/pull/4395, where I copied `attrs.asdict` -> `dataclasses.asdict` (but that's no excuse!)

closes (very likely) https://github.com/HypothesisWorks/hypothesis/issues/4431.