### PR TITLE
Cache, defer, and truncate `sampled_from` repr

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Speed up usages of |st.sampled_from| by deferring evaluation of its repr, and truncating its repr for large collections (over 512 elements). This is especially noticeable when using |st.sampeld_from| with large collections. The repr of |st.sampled_from| strategies involving sequence classes with custom reprs may change as a result of this release.

--- a/hypothesis-python/tests/nocover/test_sampled_from.py
+++ b/hypothesis-python/tests/nocover/test_sampled_from.py
@@ -81,6 +81,12 @@ def test_enum_repr_uses_class_not_a_list():
     assert lazy_repr == "sampled_from(tests.nocover.test_sampled_from.AnEnum)"
 
 
+def test_repr_truncates_with_many_elements():
+    s = st.sampled_from([n for n in range(10_000)])
+    repr_limit = 512
+    assert repr(s) == f"sampled_from([{', '.join(map(str, range(repr_limit)))}, ...])"
+
+
 class AFlag(enum.Flag):
     a = enum.auto()
     b = enum.auto()


### PR DESCRIPTION
We're currently eagerly evaluating the repr of arguments passed to `sampled_from`. I don't think this should be eager, and I don't think we should evaluate the entire collection either. The speedup on bdict's tests (which uses `sampled_from` on sequences of 65k integers) is over 40x (!!), from 9.5s to 0.2s.

We give up respecting custom reprs on custom sequences classes. I think this is rare enough that the speedups are worthwhile.