### PR TITLE
Support for numpy.ndarray and pandas.Series with any python object as entry

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -172,6 +172,7 @@ their individual contributions.
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (s.shanabrook@gmail.com)
 * `Sebastiaan Zeeff <https://github.com/SebastiaanZ>`_ (sebastiaan.zeeff@ordina.nl)
 * `Sharyar Memon <https://github.com/sharyar>`_ (smemon.cal@gmail.com)
+* `Shaun Read <https://github.com/philastrophist>`_
 * `Shlok Gandhi <https://github.com/shlok57>`_ (shlok.gandhi@gmail.com)
 * `Sogata Ray <https://github.com/rayardinanda>`_ (rayardinanda@gmail.com)
 * `Stuart Cook <https://www.github.com/Zalathar>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This version adds support for generating numpy.ndarray and pandas.Series with any python object as an element.
+Effectively, hypothesis can now generate `np.array([MyObject()], dtype=object)`.
+The first use-case for this is with Pandas and Pandera where it is possible and sometimes required to have columns which themselves contain structured datatypes.
+Pandera seems to be waiting for this change to support PythonDict, PythonTypedDict, PythonNamedTuple etc.
+
+---
+
+- Accept dtype.kind = 'O' in `from_dtype`
+- Use `.iat` instead of `.iloc` to set values in pandas strategies

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -213,6 +213,8 @@ def from_dtype(
         else:  # NEP-7 defines the NaT value as integer -(2**63)
             elems = st.integers(-(2**63) + 1, 2**63 - 1)
         result = st.builds(dtype.type, elems, res)
+    elif dtype.kind == "O":
+        result = st.from_type(type).flatmap(st.from_type)
     else:
         raise InvalidArgument(f"No strategy inference for {dtype}")
     return result.map(dtype.type)

--- a/hypothesis-python/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis-python/src/hypothesis/extra/pandas/impl.py
@@ -126,6 +126,8 @@ def elements_and_dtype(elements, dtype, source=None):
             if is_na_dtype and value is None:
                 return None
             name = f"draw({prefix}elements)"
+            if dtype.kind == "O":
+                return value  # for objects, just use the object
             try:
                 return np.array([value], dtype=dtype)[0]
             except (TypeError, ValueError, OverflowError):
@@ -638,7 +640,7 @@ def data_frames(
                         else:
                             value = draw(c.elements)
                         try:
-                            data[c.name].iloc[i] = value
+                            data[c.name].iat[i] = value
                         except ValueError as err:  # pragma: no cover
                             # This just works in Pandas 1.4 and later, but gives
                             # a confusing error on previous versions.

--- a/hypothesis-python/tests/numpy/test_argument_validation.py
+++ b/hypothesis-python/tests/numpy/test_argument_validation.py
@@ -40,7 +40,6 @@ def e(a, **kwargs):
         e(nps.array_shapes, min_dims=33),
         e(nps.array_shapes, max_dims=33),
         e(nps.arrays, dtype=float, shape=(0.5,)),
-        e(nps.arrays, dtype=object, shape=1),
         e(nps.arrays, dtype=float, shape=1, fill=3),
         e(nps.arrays, dtype="U", shape=1, elements=st.just("abc\0\0")),
         e(nps.arrays, dtype=int, shape=1, elements="not a strategy"),

--- a/hypothesis-python/tests/pandas/test_series.py
+++ b/hypothesis-python/tests/pandas/test_series.py
@@ -15,7 +15,7 @@ import pytest
 from hypothesis import assume, given, strategies as st
 from hypothesis.extra import numpy as npst, pandas as pdst
 from hypothesis.extra.pandas.impl import IntegerDtype
-
+from hypothesis.strategies._internal.random import HypothesisRandom
 from tests.common.debug import assert_all_examples, assert_no_examples, find_any
 from tests.pandas.helpers import supported_by_pandas
 
@@ -28,6 +28,18 @@ def test_can_create_a_series_of_any_dtype(data):
     # https://github.com/pandas-dev/pandas/issues/27484
     series = data.conjecture_data.draw(pdst.series(dtype=dtype))
     assert series.dtype == pd.Series([], dtype=dtype).dtype
+
+
+@given(series=pdst.series(dtype=object))
+def test_can_create_a_series_of_mixed_python_type(series):
+    assert series.dtype == pd.Series([], dtype=object).dtype
+
+
+@given(data=st.data(), anything=st.from_type(type).flatmap(st.from_type).filter(lambda x: not isinstance(x, HypothesisRandom)))
+def test_can_create_a_series_of_single_python_type(data, anything):
+    """Ensure that elements from a strategy are present in the series without modification."""
+    series = data.draw(pdst.series(elements=st.just(anything), dtype=object).filter(lambda x: not x.empty))
+    assert all(val is anything for val in series.values)
 
 
 @given(pdst.series(dtype=float, index=pdst.range_indexes(min_size=2, max_size=5)))


### PR DESCRIPTION
This change would add support for generating numpy.ndarray and pandas.Series with any python object as an element.
Effectively, hypothesis can now generate `np.array([MyObject()], dtype=object)`.
The first use-case for this is with Pandas and Pandera where it is possible and sometimes required to have columns which themselves contain structured datatypes.
Pandera seems to be waiting for this change to support PythonDict, PythonTypedDict, PythonNamedTuple etc.

- Accept dtype.kind = 'O' in `from_dtype` 
- Add the base case of any type
- Use `.iat` instead of `.iloc` to set values in pandas strategies (this allows setting of dictionaries as elements etc)