### PR TITLE
Fix Fuzzing CI job

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   fuzz:
+    if: github.repository == 'HypothesisWorks/hypothesis' || github.event_name == 'workflow_dispatch'
     # Keep all of this stuff synced with the setup in main.yml for CI
     runs-on: ubuntu-latest
     steps:
@@ -73,17 +74,17 @@ jobs:
             --ignore=hypothesis-python/tests/ghostwriter/
 
     - name: Upload patch files with covering and failing `@example()`s
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: explicit-example-patches
         path: .hypothesis/patches/latest_hypofuzz_*.patch
-
+    
     # Upload the database so it'll be persisted between runs.
     # Note that we can also pull it down to use locally via
     # https://hypothesis.readthedocs.io/en/latest/database.html#hypothesis.database.GitHubArtifactDatabase
     - name: Upload example database
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: hypothesis-example-db


### PR DESCRIPTION
This job was failing because actions/upload-artifact@v3 was deprecated and disabled.

 - Changed the upload steps to v4 which should be ok according to the docs[^v3]
 - Added a condition so the fuzzing cron job only runs on the canonical repo, not on all forks, but a manual dispatch is still possible.

NB: Someone needs to inspect the run results. This looks like it shouldn't be happening:

> Found a failing input for every test!

[^v3]: https://github.com/actions/upload-artifact/blob/v4.6.2/docs/MIGRATION.md