### PR TITLE
Allow for keyword arguments to be passed to providers in @settings

### DIFF
--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -58,6 +58,7 @@ all_settings: list[str] = [
     "deadline",
     "print_blob",
     "backend",
+    "backend_kwargs"
 ]
 
 
@@ -515,6 +516,7 @@ class settings(metaclass=settingsMeta):
         deadline: Union[int, float, datetime.timedelta, None] = not_set,  # type: ignore
         print_blob: bool = not_set,  # type: ignore
         backend: str = not_set,  # type: ignore
+        backend_kwargs: dict[str, Any] = not_set, # type: ignore
     ) -> None:
         self._in_definition = True
 
@@ -586,6 +588,11 @@ class settings(metaclass=settingsMeta):
             self._fallback.backend  # type: ignore
             if backend is not_set  # type: ignore
             else _validate_backend(backend)
+        )
+        self.backend_kwargs = (
+            {} 
+            if backend_kwargs is not_set
+            else backend_kwargs
         )
 
         self._in_definition = False

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -623,6 +623,7 @@ class ConjectureData:
         observer: Optional[DataObserver] = None,
         provider: Union[type, PrimitiveProvider] = HypothesisProvider,
         random: Optional[Random] = None,
+        provider_kw: Optional[dict[str, Any]] = None,
     ) -> "ConjectureData":
         from hypothesis.internal.conjecture.engine import choice_count
 
@@ -632,6 +633,7 @@ class ConjectureData:
             prefix=choices,
             observer=observer,
             provider=provider,
+            provider_kw=provider_kw
         )
 
     def __init__(

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1453,7 +1453,7 @@ class ConjectureRunner:
             prefix=prefix,
             observer=observer,
             provider=provider,
-            provider_kw=self.settings.provider_kw,
+            provider_kw=self.settings.backend_kwargs,
             max_choices=max_choices,
             random=self.random,
         )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -1453,6 +1453,7 @@ class ConjectureRunner:
             prefix=prefix,
             observer=observer,
             provider=provider,
+            provider_kw=self.settings.provider_kw,
             max_choices=max_choices,
             random=self.random,
         )


### PR DESCRIPTION
I've lately been working on a project to use ML to manipulate choice sequences, to perform, for example, reduction. 

I needed to modify Hypothesis slightly to get control of the provider's kwargs, and thought I'd submit this as a PR if it turns out useful. 

@tybug mentioned that this has been considered previously, but needs to decide the right interface for this as @settings is very public. So here's an attempt at the interface to see if it might work.