### PR TITLE
Remove lambda source code assertion

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Remove an internal assertion which could trigger if (1) a lambda was present in the source code of a test, (2) and the source code file was edited on disk between the start of the python process and when Hypothesis runs the property.

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -330,9 +330,13 @@ def _extract_lambda_source(f):
     source = LINE_CONTINUATION.sub(" ", source)
     source = WHITESPACE.sub(" ", source)
     source = source.strip()
-    if "lambda" not in source and sys.platform == "emscripten":  # pragma: no cover
-        return if_confused  # work around Pyodide bug in inspect.getsource()
-    assert "lambda" in source, source
+    if "lambda" not in source:  # pragma: no cover
+        # If a user starts a hypothesis process, then edits their code, the lines
+        # in the parsed source code might not match the live __code__ objects.
+        #
+        # (and on sys.platform == "emscripten", this can happen regardless
+        # due to a pyodide bug in inspect.getsource()).
+        return if_confused
 
     tree = None
 

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import runpy
+
 from hypothesis.internal.conjecture.utils import identity
 from hypothesis.internal.reflection import get_pretty_function_description
 
@@ -174,4 +176,17 @@ def decorator_with_wrapper():
 def test_can_handle_nested_lambda_in_decorator_argument():
     assert (
         get_pretty_function_description(decorator_with_wrapper[0]) == "lambda x: x + 1"
+    )
+
+
+def test_modifying_lambda_source_code_returns_unknown(tmp_path):
+    # see https://github.com/HypothesisWorks/hypothesis/pull/4452
+    test_module = tmp_path / "test_module.py"
+    test_module.write_text("# line one\n\ntest_lambda = lambda x: x * 2")
+
+    module_globals = runpy.run_path(str(test_module))
+    test_module.write_text("# line one\n\n# line two")
+    assert (
+        get_pretty_function_description(module_globals["test_lambda"])
+        == "lambda x: <unknown>"
     )

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -182,10 +182,12 @@ def test_can_handle_nested_lambda_in_decorator_argument():
 def test_modifying_lambda_source_code_returns_unknown(tmp_path):
     # see https://github.com/HypothesisWorks/hypothesis/pull/4452
     test_module = tmp_path / "test_module.py"
-    test_module.write_text("# line one\n\ntest_lambda = lambda x: x * 2")
+    test_module.write_text(
+        "# line one\n\ntest_lambda = lambda x: x * 2", encoding="utf-8"
+    )
 
     module_globals = runpy.run_path(str(test_module))
-    test_module.write_text("# line one\n\n# line two")
+    test_module.write_text("# line one\n\n# line two", encoding="utf-8")
     assert (
         get_pretty_function_description(module_globals["test_lambda"])
         == "lambda x: <unknown>"


### PR DESCRIPTION
I have actually hit this many times over the years. I know what the reason for the failure is, so it's not too bad for me, but I can imagine this being confusing and frustrating to developers who are not familiar with hypothesis internals.

To reproduce, you can do something like run a stateful test with a one-line lambda in a precondition, then quickly delete a line at the start of the file to offset all the line numbers.