### PR TITLE
Make `deprecate_random_in_strategy` thread safe

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Makes the deprecation warning for using the global random instance thread-safe, as part of our work towards thread safety (:issue:`4451`).

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -112,10 +112,36 @@ class _Checker:
 
 @contextmanager
 def deprecate_random_in_strategy(fmt, *args):
-    _global_rand_state = random.getstate()
+    from hypothesis.internal import entropy
+
+    state_before = random.getstate()
     yield (checker := _Checker())
-    if _global_rand_state != random.getstate() and not checker.saw_global_random:
-        # raise InvalidDefinition
+    state_after = random.getstate()
+    if (
+        state_before != state_after
+        and not checker.saw_global_random
+        # there is a threading race condition here with deterministic_PRNG. Say
+        # we have two threads 1 and 2. We start in global random state A, and
+        # deterministic_PRNG sets to global random state B (which is constant across
+        # threads since we seed to 0 unconditionally). Then we might have state
+        # transitions:
+        #
+        #  [1]        [2]
+        # A -> B                           deterministic_PRNG().__enter__
+        #            B ->B                 deterministic_PRNG().__enter__
+        #            state_before = B      deprecate_random_in_strategy.__enter__
+        # B -> A                           deterministic_PRNG().__exit__
+        #            state_after  = A      deprecate_random_in_strategy.__exit__
+        #
+        # where state_before != state_after because a different thread has reset
+        # the global random state.
+        #
+        # To fix this, we track the latest restored global random state in
+        # deterministic_PRNG, and will not note a deprecation (or error, in the
+        # future) if the state afterwards is the same as the state that
+        # deterministic_PRNG restored to.
+        and state_after != entropy._global_random_restored_state
+    ):
         note_deprecation(
             "Do not use the `random` module inside strategies; instead "
             "consider  `st.randoms()`, `st.sampled_from()`, etc.  " + fmt.format(*args),

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -200,8 +200,9 @@ def get_seeder_and_restorer(
         # RANDOMS_TO_MANAGE being empty when running under crosshair.
         # `pytest -k test_seed_random_twice --hypothesis-profile=crosshair`
         # reproduces an empty RANDOMS_TO_MANAGE at time of writing.
-        if _global_random_rkey in states:  # pragma: no branch
-            _global_random_restored_state = states[_global_random_rkey]
+        _global_random_restored_state = states.get(
+            _global_random_rkey, _global_random_restored_state
+        )
         states.clear()
 
     return seed_all, restore_all

--- a/hypothesis-python/src/hypothesis/internal/entropy.py
+++ b/hypothesis-python/src/hypothesis/internal/entropy.py
@@ -194,7 +194,14 @@ def get_seeder_and_restorer(
             r = RANDOMS_TO_MANAGE.get(k)
             if r is not None:  # i.e., hasn't been garbage-collected
                 r.setstate(state)
-        _global_random_restored_state = states[_global_random_rkey]
+
+        # we don't expect the global random to ever be gc'd (and therefore removed
+        # from the WeakValueDictionary RANDOMS_TO_MANAGE), but I have observed
+        # RANDOMS_TO_MANAGE being empty when running under crosshair.
+        # `pytest -k test_seed_random_twice --hypothesis-profile=crosshair`
+        # reproduces an empty RANDOMS_TO_MANAGE at time of writing.
+        if _global_random_rkey in states:  # pragma: no branch
+            _global_random_restored_state = states[_global_random_rkey]
         states.clear()
 
     return seed_all, restore_all


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451

No tests, because any test I could write immediately runs into other thread-safety issues that I've temporarily hacked around locally. 