### PR TITLE
Refactor shrink pass definitions for threading

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Refactor some internals related to the shrinker for better compatibility with free-threading (:issue:`4451`).

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -44,7 +44,7 @@ from hypothesis.internal.conjecture.engine import (
 )
 from hypothesis.internal.conjecture.junkdrawer import startswith
 from hypothesis.internal.conjecture.pareto import DominanceRelation, dominance
-from hypothesis.internal.conjecture.shrinker import Shrinker
+from hypothesis.internal.conjecture.shrinker import Shrinker, ShrinkPass
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.entropy import deterministic_PRNG
 
@@ -868,7 +868,7 @@ def test_dependent_block_pairs_can_lower_to_zero():
         if n == 1:
             data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
+    shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
     assert shrinker.choices == (False, 1)
 
 
@@ -881,7 +881,7 @@ def test_handle_size_too_large_during_dependent_lowering():
         else:
             data.draw_integer(0, 2**8 - 1)
 
-    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
+    shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
 
 
 def test_block_may_grow_during_lexical_shrinking():
@@ -895,7 +895,7 @@ def test_block_may_grow_during_lexical_shrinking():
             data.draw_integer(0, 2**16 - 1)
         data.mark_interesting()
 
-    shrinker.fixate_shrink_passes(["minimize_individual_choices"])
+    shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
     assert shrinker.choices == (0, 0)
 
 

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -12,7 +12,7 @@ from hypothesis import given, settings, strategies as st
 from hypothesis.database import InMemoryExampleDatabase, choices_from_bytes
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
-from hypothesis.internal.conjecture.shrinker import Shrinker, node_program
+from hypothesis.internal.conjecture.shrinker import Shrinker
 
 from tests.common.utils import (
     Why,
@@ -121,7 +121,7 @@ def test_node_programs_fail_efficiently(monkeypatch):
         Shrinker, "run_node_program", counts_calls(Shrinker.run_node_program)
     )
     shrinker.max_stall = 500
-    shrinker.fixate_shrink_passes([node_program("XX")])
+    shrinker.fixate_shrink_passes([shrinker.node_program("XX")])
 
     assert shrinker.shrinks == 0
     assert 250 <= shrinker.calls <= 260


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451.

Running under free threading can cause race conditions with shrinking pass definitions. `pytest -k test_minimal_min_magnitude_positive --parallel-threads 2 --iterations 500` leads to:

```
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/engine.py", line 1550, in shrink
    s.shrink()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py", line 440, in shrink
    self.greedy_shrink()
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py", line 634, in greedy_shrink
    node_program("X" * 5),
    ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py", line 1739, in accept
    defines_shrink_pass()(run)
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py", line 123, in accept
    ShrinkPassDefinition(run_with_chooser=run_step)
  File "<string>", line 4, in __init__
  File "/Users/tybug/Desktop/Liam/coding/hypothesis/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py", line 115, in __post_init__
    assert self.name not in SHRINK_PASS_DEFINITIONS, self.name
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: node_program('XXXXX')
```

Rather than adding locks, I've restructured to avoid creating a "shrinking pass definition". I also think the new structure is better for code quality. (more indirection is usually bad; explicit is better than implicit).