### PR TITLE
Improve threading compatibility of core strategy definitions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improves the thread safety of caching strategy definitions, as well as usage of strategy transformations like |.map| and |.filter|.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -154,7 +154,7 @@ global_force_seed = None
 # ConjectureRunner instance (roughly speaking). Since only one conjecture runner
 # instance can be active per thread, making engine constants thread-local prevents
 # the ConjectureRunner instances of concurrent threads from treading on each other.
-threadlocal = ThreadLocal(_hypothesis_global_random=None)
+threadlocal = ThreadLocal(_hypothesis_global_random=lambda: None)
 
 
 @dataclass

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -110,7 +110,7 @@ MisalignedAt: "TypeAlias" = tuple[
 TOP_LABEL = calc_label_from_name("top")
 MAX_DEPTH = 100
 
-threadlocal = ThreadLocal(global_test_counter=0)
+threadlocal = ThreadLocal(global_test_counter=int)
 
 
 class ExtraInformation:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -72,6 +72,7 @@ from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.internal.observability import PredicateCounts
 from hypothesis.reporting import debug_report
 from hypothesis.utils.conventions import not_set
+from hypothesis.utils.threading import ThreadLocal
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -107,6 +108,9 @@ MisalignedAt: "TypeAlias" = tuple[
 ]
 
 TOP_LABEL = calc_label_from_name("top")
+MAX_DEPTH = 100
+
+threadlocal = ThreadLocal(global_test_counter=0)
 
 
 class ExtraInformation:
@@ -532,11 +536,6 @@ class _Overrun:
 
 Overrun = _Overrun()
 
-global_test_counter = 0
-
-
-MAX_DEPTH = 100
-
 
 class DataObserver:
     """Observer class for recording the behaviour of a
@@ -669,9 +668,8 @@ class ConjectureData:
         self.output = ""
         self.status = Status.VALID
         self.frozen = False
-        global global_test_counter
-        self.testcounter = global_test_counter
-        global_test_counter += 1
+        self.testcounter = threadlocal.global_test_counter
+        threadlocal.global_test_counter += 1
         self.start_time = time.perf_counter()
         self.gc_start_time = gc_cumulative_time()
         self.events: dict[str, Union[str, int, float]] = {}

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -121,13 +121,12 @@ class LazyStrategy(SearchStrategy[Ex]):
 
             base = self.function(*self.__args, **self.__kwargs)
             if unwrapped_args == self.__args and unwrapped_kwargs == self.__kwargs:
-                self.__wrapped_strategy = base
+                _wrapped_strategy = base
             else:
-                self.__wrapped_strategy = self.function(
-                    *unwrapped_args, **unwrapped_kwargs
-                )
+                _wrapped_strategy = self.function(*unwrapped_args, **unwrapped_kwargs)
             for method, fn in self._transformations:
-                self.__wrapped_strategy = getattr(self.__wrapped_strategy, method)(fn)
+                _wrapped_strategy = getattr(_wrapped_strategy, method)(fn)
+            self.__wrapped_strategy = _wrapped_strategy
         assert self.__wrapped_strategy is not None
         return self.__wrapped_strategy
 

--- a/hypothesis-python/src/hypothesis/utils/threading.py
+++ b/hypothesis-python/src/hypothesis/utils/threading.py
@@ -9,7 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import threading
-from typing import Any
+from typing import Any, Callable
 
 
 class ThreadLocal:
@@ -21,7 +21,11 @@ class ThreadLocal:
     The only supported names to geattr and setattr are the keys of the passed kwargs.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: dict[str, Callable]) -> None:
+        for name, value in kwargs.items():
+            if not callable(value):
+                raise TypeError(f"Attribute {name} must be a callable. Got {value}")
+
         self.__initialized = False
         self.__kwargs = kwargs
         self.__threadlocal = threading.local()
@@ -30,8 +34,11 @@ class ThreadLocal:
     def __getattr__(self, name: str) -> Any:
         if name not in self.__kwargs:
             raise AttributeError(f"No attribute {name}")
+
         if not hasattr(self.__threadlocal, name):
-            setattr(self.__threadlocal, name, self.__kwargs[name])
+            default = self.__kwargs[name]()
+            setattr(self.__threadlocal, name, default)
+
         return getattr(self.__threadlocal, name)
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/hypothesis-python/src/hypothesis/utils/threading.py
+++ b/hypothesis-python/src/hypothesis/utils/threading.py
@@ -21,7 +21,7 @@ class ThreadLocal:
     The only supported names to geattr and setattr are the keys of the passed kwargs.
     """
 
-    def __init__(self, **kwargs: dict[str, Callable]) -> None:
+    def __init__(self, **kwargs: Callable) -> None:
         for name, value in kwargs.items():
             if not callable(value):
                 raise TypeError(f"Attribute {name} must be a callable. Got {value}")

--- a/hypothesis-python/tests/cover/test_threading.py
+++ b/hypothesis-python/tests/cover/test_threading.py
@@ -14,7 +14,7 @@ from hypothesis.utils.threading import ThreadLocal
 
 
 def test_threadlocal_setattr_and_getattr():
-    threadlocal = ThreadLocal(a=1, b=2)
+    threadlocal = ThreadLocal(a=lambda: 1, b=lambda: 2)
     assert threadlocal.a == 1
     assert threadlocal.b == 2
     # check that we didn't add attributes to the ThreadLocal instance itself
@@ -36,12 +36,17 @@ def test_threadlocal_setattr_and_getattr():
 
 
 def test_nonexistent_getattr_raises():
-    threadlocal = ThreadLocal(a=1)
+    threadlocal = ThreadLocal(a=lambda: 1)
     with pytest.raises(AttributeError):
-        _c = threadlocal.c
+        threadlocal.c
 
 
 def test_nonexistent_setattr_raises():
-    threadlocal = ThreadLocal(a=1)
+    threadlocal = ThreadLocal(a=lambda: 1)
     with pytest.raises(AttributeError):
         threadlocal.c = 2
+
+
+def test_raises_if_not_passed_callable():
+    with pytest.raises(TypeError):
+        ThreadLocal(a=1)


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451.

There are three separate fixes here, split by commit:

* https://github.com/HypothesisWorks/hypothesis/commit/dc0e5e7ed98bd612c0591388a674e9ac0096bd26
* https://github.com/HypothesisWorks/hypothesis/commit/56908301f70a29aab4ea5fbc2a335f2c17674d99 - as long as the assignment to `__wrapped_strategy` is atomic (and deterministic), I don't think we need a lock. Worst case is two threads perform the same computation and assign the same value after.
* https://github.com/HypothesisWorks/hypothesis/commit/2548924dbe3a525c6eba13c8e0331ff8458e071a - performance overhead of a lock in single-threaded seems negligible on a microbenchmark