### PR TITLE
Make the `ensure_free_stackframes` warning thread-safe

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+In order to de-flake ``RecursionError`` failures, Hypothesis sets a deterministic limit on ``sys.setrecursionlimit``. This patch makes the setting of this limit aware of uses by Hypothesis from multiple threads, so it does not produce spurious warnings in multithreaded environments.

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -133,7 +133,7 @@ def charmap() -> dict[CategoryName, IntervalsT]:
             k: tuple(tuple(pair) for pair in pairs) for k, pairs in tmp_charmap.items()
         }
         # each value is a tuple of 2-tuples (that is, tuples of length 2)
-        # and that both elements of that tuple are integers.
+        # and both elements of that tuple are integers.
         for vs in _charmap.values():
             ints = list(sum(vs, ()))
             assert all(isinstance(x, int) for x in ints)

--- a/hypothesis-python/tests/nocover/test_threading.py
+++ b/hypothesis-python/tests/nocover/test_threading.py
@@ -10,8 +10,6 @@
 
 from threading import Barrier, Thread
 
-import pytest
-
 from hypothesis import given, strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
@@ -45,7 +43,6 @@ def test_can_run_given_in_thread():
     assert has_run_successfully
 
 
-@pytest.mark.xfail(reason="hypothesis not yet thread-safe", strict=False)
 def test_run_stateful_test_concurrently():
     class MyStateMachine(RuleBasedStateMachine):
         def __init__(self):

--- a/hypothesis-python/tests/nocover/test_threading.py
+++ b/hypothesis-python/tests/nocover/test_threading.py
@@ -10,11 +10,16 @@
 
 from threading import Barrier, Thread
 
-from hypothesis import given, strategies as st
+import pytest
+
+from hypothesis import given, settings, strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
 
 def run_concurrently(function, n: int) -> None:
+    if settings._current_profile == "crosshair":
+        pytest.skip(reason="crosshair is not thread safe")
+
     def run():
         barrier.wait()
         function()


### PR DESCRIPTION
This was the last blocker to actually running a multithreaded test in CI; yay! (...well, probably; I wouldn't be surprised to hit https://github.com/HypothesisWorks/hypothesis/pull/4453 here)

Previous code related to thread safety and `ensure_free_stackframes`: 

* https://github.com/HypothesisWorks/hypothesis/pull/3683
* https://github.com/jobh/hypothesis/blob/34f5ccec96019cfc30ad8593498cd30291f9e4ec/hypothesis-python/src/hypothesis/internal/conjecture/junkdrawer.py (from the commit history of the above PR)

That made concurrent `__enter__` of the same `ensure_free_stackframes` object thread-safe due to the per-instance lock though, which we don't do anywhere - we use a fresh instance per call.