### PR TITLE
Optimize `sampled_from` and stateful performance

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Optimize performance of |st.sampled_from| and internal selection of :ref:`stateful testing <stateful>` rules.

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -617,9 +617,9 @@ class Bundle(SearchStrategy[Ex]):
         return super().flatmap(expand)
 
     def __hash__(self):
-        # We sample from lists of bundles often in stateful testing, and making
-        # this hashable improves the performance of label calculation in
-        # st.sampled_from.
+        # Making this hashable means we hit the fast path of "everything is
+        # hashable" in st.sampled_from label calculation when sampling which rule
+        # to invoke next
         return hash((self.name,))
 
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -1062,6 +1062,7 @@ class RuleStrategy(SearchStrategy):
                 rule.function.__name__,
             )
         )
+        self.rules_strategy = st.sampled_from(self.rules)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(machine={self.machine.__class__.__name__}({{...}}))"
@@ -1086,7 +1087,7 @@ class RuleStrategy(SearchStrategy):
             # be artificially large.
             return self.is_valid(r) and feature_flags.is_enabled(r.function.__name__)
 
-        rule = data.draw(st.sampled_from(self.rules).filter(rule_is_enabled))
+        rule = data.draw(self.rules_strategy.filter(rule_is_enabled))
 
         arguments = {}
         for k, strat in rule.arguments_strategies.items():

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -619,8 +619,10 @@ class Bundle(SearchStrategy[Ex]):
     def __hash__(self):
         # Making this hashable means we hit the fast path of "everything is
         # hashable" in st.sampled_from label calculation when sampling which rule
-        # to invoke next
-        return hash((self.name,))
+        # to invoke next.
+
+        # Mix in "Bundle" for collision resistance
+        return hash(("Bundle", self.name))
 
 
 class BundleConsumer(Bundle[Ex]):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -525,12 +525,17 @@ class SearchStrategy(Generic[Ex]):
         raise NotImplementedError(f"{type(self).__name__}.do_draw")
 
 
-def is_hashable(value: object) -> bool:
+def _is_hashable(value: object) -> tuple[bool, Optional[int]]:
+    # hashing can be expensive; return the hash value if we compute it, so that
+    # callers don't have to recompute.
     try:
-        hash(value)
-        return True
+        return (True, hash(value))
     except TypeError:
-        return False
+        return (False, None)
+
+
+def is_hashable(value: object) -> bool:
+    return _is_hashable(value)[0]
 
 
 class SampledFromStrategy(SearchStrategy[Ex]):
@@ -628,12 +633,14 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         # The worst case performance of this scheme is
         # itertools.chain(range(2**100), [st.none()]), where it degrades to
         # hashing every int in the range.
-
+        (elements_is_hashable, hash_value) = _is_hashable(self.elements)
         if isinstance(self.elements, range) or (
-            is_hashable(self.elements)
+            elements_is_hashable
             and not any(isinstance(e, SearchStrategy) for e in self.elements)
         ):
-            return combine_labels(self.class_label, calc_label_from_hash(self.elements))
+            return combine_labels(
+                self.class_label, calc_label_from_name(str(hash_value))
+            )
 
         labels = [self.class_label]
         for element in self.elements:


### PR DESCRIPTION
I noticed some performance pickups while investigating https://github.com/HypothesisWorks/hypothesis/issues/4465. This does not fix that issue, but it does help a bit.

---

Benchmark results from https://github.com/HypothesisWorks/hypothesis/issues/4465. That benchmark has substantial between-runs variance on my machine, so I wouldn't treat this as anything more than a sanity check.

| Master | PR |
|--------|--------|
| <img width="3568" height="2368" alt="master  hypothesis_performance_scaling" src="https://github.com/user-attachments/assets/524d0766-94bc-482c-af8e-6fcaacdf5200" /> |  <img width="3568" height="2368" alt="branch  hypothesis_performance_scaling" src="https://github.com/user-attachments/assets/173e6036-8fb9-495a-b270-8191381258a9" />  |