### PR TITLE
Re-raise `DeadlineExceeded` from backends

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve the reporting of |DeadlineExceeded| errors when using :ref:`alternative backends <alternative-backends>`.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-Improve the reporting of |DeadlineExceeded| errors when using :ref:`alternative backends <alternative-backends>`.
+When a failure found by an :ref:`alternative backend <alternative-backends>` does not reproduce under the Hypothesis backend, we now raise |FlakyBackendFailure| instead of an internal ``FlakyReplay`` exception.

--- a/hypothesis-python/docs/prolog.rst
+++ b/hypothesis-python/docs/prolog.rst
@@ -62,6 +62,7 @@
 
 .. |InvalidArgument| replace:: :obj:`InvalidArgument <hypothesis.errors.InvalidArgument>`
 .. |DidNotReproduce| replace:: :obj:`DidNotReproduce <hypothesis.errors.DidNotReproduce>`
+.. |DeadlineExceeded| replace:: :obj:`DeadlineExceeded <hypothesis.errors.DeadlineExceeded>`
 
 .. |st.lists| replace:: :func:`~hypothesis.strategies.lists`
 .. |st.integers| replace:: :func:`~hypothesis.strategies.integers`

--- a/hypothesis-python/docs/prolog.rst
+++ b/hypothesis-python/docs/prolog.rst
@@ -63,6 +63,8 @@
 .. |InvalidArgument| replace:: :obj:`InvalidArgument <hypothesis.errors.InvalidArgument>`
 .. |DidNotReproduce| replace:: :obj:`DidNotReproduce <hypothesis.errors.DidNotReproduce>`
 .. |DeadlineExceeded| replace:: :obj:`DeadlineExceeded <hypothesis.errors.DeadlineExceeded>`
+.. |BackendCannotProceed| replace:: :obj:`~hypothesis.errors.BackendCannotProceed`
+.. |FlakyBackendFailure| replace:: :obj:`~hypothesis.errors.FlakyBackendFailure`
 
 .. |st.lists| replace:: :func:`~hypothesis.strategies.lists`
 .. |st.integers| replace:: :func:`~hypothesis.strategies.integers`
@@ -131,7 +133,6 @@
 .. |BUFFER_SIZE| replace:: :data:`~hypothesis.internal.conjecture.engine.BUFFER_SIZE`
 .. |MAX_SHRINKS| replace:: :data:`~hypothesis.internal.conjecture.engine.MAX_SHRINKS`
 .. |MAX_SHRINKING_SECONDS| replace:: :data:`~hypothesis.internal.conjecture.engine.MAX_SHRINKING_SECONDS`
-.. |BackendCannotProceed| replace:: :exc:`~hypothesis.errors.BackendCannotProceed`
 
 .. |@rule| replace:: :func:`@rule <hypothesis.stateful.rule>`
 .. |@precondition| replace:: :func:`@precondition <hypothesis.stateful.precondition>`

--- a/hypothesis-python/docs/reference/api.rst
+++ b/hypothesis-python/docs/reference/api.rst
@@ -231,6 +231,7 @@ Custom exceptions raised by Hypothesis.
 .. autoclass:: hypothesis.errors.ResolutionFailed
 .. autoclass:: hypothesis.errors.Unsatisfiable
 .. autoclass:: hypothesis.errors.DidNotReproduce
+.. autoclass:: hypothesis.errors.DeadlineExceeded
 
 .. _hypothesis-django:
 

--- a/hypothesis-python/docs/reference/api.rst
+++ b/hypothesis-python/docs/reference/api.rst
@@ -232,6 +232,7 @@ Custom exceptions raised by Hypothesis.
 .. autoclass:: hypothesis.errors.Unsatisfiable
 .. autoclass:: hypothesis.errors.DidNotReproduce
 .. autoclass:: hypothesis.errors.DeadlineExceeded
+.. autoclass:: hypothesis.errors.FlakyBackendFailure
 
 .. _hypothesis-django:
 

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -122,6 +122,26 @@ class FlakyFailure(ExceptionGroup, Flaky):
                 group[i] = err
         return ExceptionGroup.__new__(cls, msg, group)
 
+    # defining `derive` is required for `split` to return an instance of FlakyFailure
+    # instead of ExceptionGroup. See https://github.com/python/cpython/issues/119287
+    # and https://docs.python.org/3/library/exceptions.html#BaseExceptionGroup.derive
+    def derive(self, excs):
+        return FlakyFailure(self.message, excs)
+
+
+class FlakyBackendFailure(FlakyFailure):
+    """
+    A failure was reported by an :ref:`alternative backend <alternative-backends>`,
+    but this failure did not reproduce when replayed under the Hypothesis backend.
+
+    When an alternative backend reports a failure, Hypothesis first replays it
+    under the standard Hypothesis backend to check for flakiness. If the failure
+    does not reproduce, Hypothesis raises this exception.
+    """
+
+    def derive(self, excs):
+        return FlakyBackendFailure(self.message, excs)
+
 
 class InvalidArgument(_Trimmable, TypeError):
     """Used to indicate that the arguments to a Hypothesis function were in

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -126,7 +126,7 @@ class FlakyFailure(ExceptionGroup, Flaky):
     # instead of ExceptionGroup. See https://github.com/python/cpython/issues/119287
     # and https://docs.python.org/3/library/exceptions.html#BaseExceptionGroup.derive
     def derive(self, excs):
-        return FlakyFailure(self.message, excs)
+        return type(self)(self.message, excs)
 
 
 class FlakyBackendFailure(FlakyFailure):
@@ -138,9 +138,6 @@ class FlakyBackendFailure(FlakyFailure):
     under the standard Hypothesis backend to check for flakiness. If the failure
     does not reproduce, Hypothesis raises this exception.
     """
-
-    def derive(self, excs):
-        return FlakyBackendFailure(self.message, excs)
 
 
 class InvalidArgument(_Trimmable, TypeError):
@@ -223,7 +220,8 @@ def __getattr__(name: str) -> Any:
 
 class DeadlineExceeded(_Trimmable):
     """
-    Raised when an input takes longer than the |settings.deadline| setting to run.
+    Raised when an input takes too long to run, relative to the |settings.deadline|
+    setting.
     """
 
     def __init__(self, runtime: timedelta, deadline: timedelta) -> None:

--- a/hypothesis-python/src/hypothesis/errors.py
+++ b/hypothesis-python/src/hypothesis/errors.py
@@ -202,7 +202,9 @@ def __getattr__(name: str) -> Any:
 
 
 class DeadlineExceeded(_Trimmable):
-    """Raised when an individual test body has taken too long to run."""
+    """
+    Raised when an input takes longer than the |settings.deadline| setting to run.
+    """
 
     def __init__(self, runtime: timedelta, deadline: timedelta) -> None:
         super().__init__(

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -1362,9 +1362,7 @@ class ConjectureData:
         self.freeze()
         raise StopTest(self.testcounter)
 
-    def mark_interesting(
-        self, interesting_origin: Optional[InterestingOrigin] = None
-    ) -> NoReturn:
+    def mark_interesting(self, interesting_origin: InterestingOrigin) -> NoReturn:
         self.conclude_test(Status.INTERESTING, interesting_origin)
 
     def mark_invalid(self, why: Optional[str] = None) -> NoReturn:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -607,7 +607,8 @@ class ConjectureRunner:
                 data = ConjectureData.for_choices(data.choices)
                 self.__stoppable_test_function(data)
                 data.freeze()
-                # TODO: Should same-origin also be checked?
+                # TODO: Should same-origin also be checked? (discussion in
+                # https://github.com/HypothesisWorks/hypothesis/pull/4470#discussion_r2217055487)
                 if data.status != Status.INTERESTING:
                     desc_new_status = {
                         data.status.VALID: "passed",

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -11,7 +11,6 @@
 import importlib
 import inspect
 import math
-import textwrap
 import time
 from collections import defaultdict
 from collections.abc import Generator, Sequence
@@ -27,8 +26,7 @@ from hypothesis._settings import local_settings, note_deprecation
 from hypothesis.database import ExampleDatabase, choices_from_bytes, choices_to_bytes
 from hypothesis.errors import (
     BackendCannotProceed,
-    DeadlineExceeded,
-    FlakyReplay,
+    FlakyBackendFailure,
     HypothesisException,
     InvalidArgument,
     StopTest,
@@ -300,10 +298,7 @@ class ConjectureRunner:
         self.statistics: StatisticsDict = {}
         self.stats_per_test_case: list[CallStats] = []
 
-        # At runtime, the keys are only ever type `InterestingOrigin`, but can be `None` during tests.
-        self.interesting_examples: dict[
-            Optional[InterestingOrigin], ConjectureResult
-        ] = {}
+        self.interesting_examples: dict[InterestingOrigin, ConjectureResult] = {}
         # We use call_count because there may be few possible valid_examples.
         self.first_bug_found_at: Optional[int] = None
         self.last_bug_found_at: Optional[int] = None
@@ -605,47 +600,31 @@ class ConjectureRunner:
             self.overrun_examples += 1
 
         if data.status == Status.INTERESTING:
-            # Don't attempt to replay DeadlineExceeded failures from backends.
-            # Just re-raise it.
-            if (
-                not self.using_hypothesis_backend
-                and data.interesting_origin.exc_type is DeadlineExceeded
-            ):
-                self._backend_exceeded_deadline = True
-
-            if (
-                not self.using_hypothesis_backend
-                and data.interesting_origin.exc_type is not DeadlineExceeded
-            ):
+            if not self.using_hypothesis_backend:
                 # replay this failure on the hypothesis backend to ensure it still
                 # finds a failure. otherwise, it is flaky.
-                initial_origin = data.interesting_origin
-                initial_traceback = data.expected_traceback
+                initial_exception = data.expected_exception
                 data = ConjectureData.for_choices(data.choices)
                 self.__stoppable_test_function(data)
                 data.freeze()
-                # TODO: Convert to FlakyFailure on the way out. Should same-origin
-                #       also be checked?
+                # TODO: Should same-origin also be checked?
                 if data.status != Status.INTERESTING:
                     desc_new_status = {
                         data.status.VALID: "passed",
                         data.status.INVALID: "failed filters",
                         data.status.OVERRUN: "overran",
                     }[data.status]
-                    wrapped_tb = (
-                        ""
-                        if initial_traceback is None
-                        else textwrap.indent(initial_traceback, "  | ")
-                    )
-                    raise FlakyReplay(
-                        f"Inconsistent results from replaying a failing test case!\n"
-                        f"{wrapped_tb}on backend={self.settings.backend!r} but "
-                        f"{desc_new_status} under backend='hypothesis'",
-                        interesting_origins=[initial_origin],
+                    raise FlakyBackendFailure(
+                        f"Inconsistent results from replaying a failing test case! "
+                        f"Raised {type(initial_exception).__name__} on "
+                        f"backend={self.settings.backend!r}, but "
+                        f"{desc_new_status} under backend='hypothesis'.",
+                        [initial_exception],
                     )
 
                 self._cache(data)
 
+            assert data.interesting_origin is not None
             key = data.interesting_origin
             changed = False
             try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/pareto.py
@@ -87,6 +87,7 @@ def dominance(left: ConjectureResult, right: ConjectureResult) -> DominanceRelat
     # the dominance relationship.
     if (
         left.status == Status.INTERESTING
+        and right.interesting_origin is not None
         and left.interesting_origin != right.interesting_origin
     ):
         return DominanceRelation.NO_DOMINANCE

--- a/hypothesis-python/tests/conjecture/common.py
+++ b/hypothesis-python/tests/conjecture/common.py
@@ -34,11 +34,6 @@ from hypothesis.internal.intervalsets import IntervalSet
 SOME_LABEL = calc_label_from_name("some label")
 
 
-TEST_SETTINGS = settings(
-    max_examples=5000, database=None, suppress_health_check=list(HealthCheck)
-)
-
-
 def interesting_origin(n: Optional[int] = None) -> InterestingOrigin:
     """
     Creates and returns an InterestingOrigin, parameterized by n, such that
@@ -57,7 +52,12 @@ def interesting_origin(n: Optional[int] = None) -> InterestingOrigin:
 
 def run_to_data(f):
     with deterministic_PRNG():
-        runner = ConjectureRunner(f, settings=TEST_SETTINGS)
+        runner = ConjectureRunner(
+            f,
+            settings=settings(
+                max_examples=300, database=None, suppress_health_check=list(HealthCheck)
+            ),
+        )
         runner.run()
         assert runner.interesting_examples
         (last_data,) = runner.interesting_examples.values()

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -147,7 +147,7 @@ def test_stores_the_tree_flat_until_needed():
     def runner(data):
         for _ in range(10):
             data.draw_boolean()
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     root = runner.tree.root
     assert len(root.constraints) == 10
@@ -161,7 +161,7 @@ def test_split_in_the_middle():
         data.draw_integer(0, 1)
         data.draw_integer(0, 1)
         data.draw_integer(0, 15)
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     root = runner.tree.root
     assert len(root.constraints) == len(root.values) == 1
@@ -175,7 +175,7 @@ def test_stores_forced_nodes():
         data.draw_integer(0, 1, forced=0)
         data.draw_integer(0, 1)
         data.draw_integer(0, 1, forced=0)
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     root = runner.tree.root
     assert root.forced == {0, 2}
@@ -186,7 +186,7 @@ def test_correctly_relocates_forced_nodes():
     def runner(data):
         data.draw_integer(0, 1)
         data.draw_integer(0, 1, forced=0)
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     root = runner.tree.root
     assert root.transition.children[1].forced == {0}
@@ -496,7 +496,7 @@ def test_can_generate_hard_floats():
         def nodes(data):
             f = next_up_n(min_value, n)
             data.draw_float(min_value, max_value, forced=f, allow_nan=False)
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
         data = ConjectureData.for_choices(
             [n.value for n in nodes], observer=tree.new_observer()

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -39,14 +39,14 @@ from tests.conjecture.common import (
     run_to_nodes,
 )
 
-TEST_SETTINGS = settings(
-    max_examples=5000, database=None, suppress_health_check=list(HealthCheck)
+runner_settings = settings(
+    max_examples=100, database=None, suppress_health_check=list(HealthCheck)
 )
 
 
 def runner_for(*examples):
     def accept(tf):
-        runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
+        runner = ConjectureRunner(tf, settings=runner_settings, random=Random(0))
         runner.exit_with = lambda reason: None
         ran_examples = []
         for choices in examples:
@@ -123,7 +123,9 @@ def test_novel_prefixes_are_novel():
             data.draw_bytes(1, 1, forced=b"\0")
             data.draw_integer(0, 3)
 
-    runner = ConjectureRunner(tf, settings=TEST_SETTINGS, random=Random(0))
+    runner = ConjectureRunner(
+        tf, settings=settings(runner_settings, max_examples=1000), random=Random(0)
+    )
     for _ in range(100):
         prefix = runner.tree.generate_novel_prefix(runner.random)
         extension = prefix + (ChoiceTemplate("simplest", count=100),)
@@ -135,7 +137,7 @@ def test_novel_prefixes_are_novel():
 def test_overruns_if_prefix():
     runner = ConjectureRunner(
         lambda data: [data.draw_boolean() for _ in range(2)],
-        settings=TEST_SETTINGS,
+        settings=runner_settings,
         random=Random(0),
     )
     runner.cached_test_function([False, False])

--- a/hypothesis-python/tests/conjecture/test_float_encoding.py
+++ b/hypothesis-python/tests/conjecture/test_float_encoding.py
@@ -19,6 +19,8 @@ from hypothesis.internal.conjecture import floats as flt
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.floats import SIGNALING_NAN, float_to_int
 
+from tests.conjecture.common import interesting_origin
+
 EXPONENTS = list(range(flt.MAX_EXPONENT + 1))
 assert len(EXPONENTS) == 2**11
 
@@ -127,7 +129,7 @@ def float_runner(start, condition, *, constraints=None):
     def test_function(data):
         f = data.draw_float(**constraints)
         if condition(f):
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(test_function)
     runner.cached_test_function((float(start),))

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -178,7 +178,7 @@ def test_stops_loading_pareto_front_if_interesting():
         def test(data):
             data.draw_integer()
             data.draw_integer()
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
         db = InMemoryExampleDatabase()
 
@@ -248,7 +248,7 @@ def test_does_not_optimise_the_pareto_front_if_interesting():
         n = data.draw_integer(0, 2**8 - 1)
         data.target_observations[""] = n
         if n == 255:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(
         test,
@@ -270,7 +270,7 @@ def test_stops_optimising_once_interesting():
         n = data.draw_integer(0, 2**16 - 1)
         data.target_observations[""] = n
         if n < hi:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(
         test,

--- a/hypothesis-python/tests/conjecture/test_provider.py
+++ b/hypothesis-python/tests/conjecture/test_provider.py
@@ -32,8 +32,8 @@ from hypothesis.control import current_build_context
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import (
     BackendCannotProceed,
-    DeadlineExceeded,
     Flaky,
+    FlakyBackendFailure,
     HypothesisException,
     HypothesisWarning,
     InvalidArgument,
@@ -784,8 +784,9 @@ def test_provider_conformance(provider):
     )
 
 
-# regression test for https://github.com/HypothesisWorks/hypothesis/issues/4462
-def test_backend_deadline_exceeded_is_not_flaky():
+# see https://github.com/HypothesisWorks/hypothesis/issues/4462 and discussion
+# in https://github.com/HypothesisWorks/hypothesis/pull/4470
+def test_backend_deadline_exceeded_raised_as_flaky_backend_failure():
     with temp_register_backend("trivial", TrivialProvider):
 
         @given(st.integers())
@@ -794,5 +795,5 @@ def test_backend_deadline_exceeded_is_not_flaky():
             if isinstance(current_build_context().data.provider, TrivialProvider):
                 time.sleep(1)
 
-        with pytest.raises(DeadlineExceeded):
+        with pytest.raises(FlakyBackendFailure):
             f()

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -39,7 +39,7 @@ def test_can_shrink_variable_draws_with_just_deletion(n):
         n = data.draw_integer(0, 2**4 - 1)
         b = [data.draw_integer(0, 2**8 - 1) for _ in range(n)]
         if any(b):
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
     assert shrinker.choices == (1, 1)
@@ -63,7 +63,7 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
     def nodes(data):
         for _ in range(10):
             data.draw_bytes(1, 1)
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     assert tuple(n.value for n in nodes) == (b"\0",) * 10
 
@@ -77,7 +77,7 @@ def test_duplicate_nodes_that_go_away():
             data.mark_invalid()
         b = [data.draw_bytes(1, 1) for _ in range(x & 255)]
         if len(set(b)) <= 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_duplicated_choices)])
     assert shrinker.shrink_target.choices == (0, 0)
@@ -94,7 +94,7 @@ def test_accidental_duplication():
             data.mark_invalid()
         b = [data.draw_bytes(1, 1) for _ in range(x)]
         if len(set(b)) == 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_duplicated_choices)])
     print(shrinker.choices)
@@ -112,7 +112,7 @@ def test_can_zero_subintervals():
             data.stop_span()
             if data.draw_integer(0, 2**8 - 1) != 1:
                 return
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (0, 1) * 10
@@ -136,7 +136,7 @@ def test_can_pass_to_an_indirect_descendant():
     def shrinker(data: ConjectureData):
         tree(data)
         if data.choices in good:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.pass_to_descendant)])
     assert shrinker.choices == target
@@ -148,7 +148,7 @@ def test_shrinking_blocks_from_common_offset():
         m = data.draw_integer(0, 2**8 - 1)
         n = data.draw_integer(0, 2**8 - 1)
         if abs(m - n) <= 1 and max(m, n) > 0:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.mark_changed(0)
     shrinker.mark_changed(1)
@@ -167,7 +167,7 @@ def test_handle_empty_draws():
             data.stop_span(discard=n > 0)
             if not n:
                 break
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     assert tuple(n.value for n in nodes) == (0,)
 
@@ -183,7 +183,7 @@ def test_can_reorder_spans():
                 total += data.draw_integer(0, 2**9 - 1)
             data.stop_span()
         if total == 2:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.reorder_spans)])
     assert shrinker.choices == (0, 0, 0, 1, 1, 1, 1)
@@ -203,7 +203,7 @@ def test_permits_but_ignores_raising_order(monkeypatch):
     @run_to_nodes
     def nodes(data):
         data.draw_integer(0, 3)
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     assert tuple(n.value for n in nodes) == (1,)
 
@@ -217,7 +217,7 @@ def test_node_deletion_can_delete_short_ranges():
                 if data.draw_integer(0, 2**16 - 1) != n:
                     data.mark_invalid()
             if n == 4:
-                data.mark_interesting()
+                data.mark_interesting(interesting_origin())
 
     passes = [shrinker.node_program("X" * i) for i in range(1, 5)]
     shrinker.fixate_shrink_passes(passes)
@@ -238,7 +238,7 @@ def test_dependent_block_pairs_is_up_to_shrinking_integers():
         cap = data.draw_integer(0, 2**8 - 1)
 
         if result >= 32768 and cap == 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
     assert shrinker.choices == (1, True, 65536, 1)
@@ -266,7 +266,7 @@ def test_finding_a_minimal_balanced_binary_tree():
     def shrinker(data: ConjectureData):
         _, b = tree(data)
         if not b:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (True, False, True, False, True, False, False)
@@ -277,7 +277,7 @@ def test_node_programs_are_adaptive():
     def shrinker(data: ConjectureData):
         while not data.draw_boolean():
             pass
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([shrinker.node_program("X")])
 
@@ -293,7 +293,7 @@ def test_zero_examples_with_variable_min_size():
             any_nonzero |= data.draw_integer(0, 2**i - 1) > 0
         if not any_nonzero:
             data.mark_invalid()
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (0,) * 8 + (1,)
@@ -310,7 +310,7 @@ def test_zero_contained_examples():
             data.draw_integer(0, 2**8 - 1)
             data.stop_span()
             data.stop_span()
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (1, 0) * 4
@@ -361,7 +361,7 @@ def test_zig_zags_quickly_with_shrink_towards(
         if abs(m - shrink_towards) < 10 or abs(n - shrink_towards) < 10:
             data.mark_invalid()
         if abs(m - n) <= 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
     assert shrinker.engine.valid_examples <= 40
@@ -381,7 +381,7 @@ def test_zero_irregular_examples():
         )
         data.stop_span()
         if interesting:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (0,) * 2 + (1, 1)
@@ -398,7 +398,7 @@ def test_retain_end_of_buffer():
             if n == 0:
                 break
         if interesting:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (6, 0)
@@ -414,7 +414,7 @@ def test_can_expand_zeroed_region():
                     data.mark_invalid()
             else:
                 seen_non_zero = True
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (0,) * 5
@@ -442,7 +442,7 @@ def test_can_expand_deleted_region():
             if t() != (3, 4):
                 data.mark_invalid()
         if v1 == (0, 0) or t() == (0, 0):
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.choices == (0, 0)
@@ -463,7 +463,7 @@ def test_will_terminate_stalled_shrinks():
                 count += 1
                 if count >= 10:
                     return
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.shrink()
     assert shrinker.calls <= 1 + 2 * shrinker.max_stall
@@ -475,7 +475,7 @@ def test_will_let_fixate_shrink_passes_do_a_full_run_through():
         for i in range(50):
             if data.draw_integer(0, 2**8 - 1) != i:
                 data.mark_invalid()
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     shrinker.max_stall = 5
     passes = [shrinker.node_program("X" * i) for i in range(1, 11)]
@@ -498,7 +498,7 @@ def test_can_simultaneously_lower_non_duplicated_nearby_integers(n_gap):
         n = data.draw_integer(0, 2**16 - 1)
 
         if n == m + 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.lower_integers_together)])
     assert shrinker.choices == (1, 0) + (0,) * n_gap + (1,)
@@ -510,7 +510,7 @@ def test_redistribute_with_forced_node_integer():
         n1 = data.draw_integer(0, 100)
         n2 = data.draw_integer(0, 100, forced=10)
         if n1 + n2 > 20:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.redistribute_numeric_pairs)])
     # redistribute_numeric_pairs shouldn't try modifying forced nodes while
@@ -525,7 +525,7 @@ def test_can_quickly_shrink_to_trivial_collection(n):
     def shrinker(data: ConjectureData):
         b = data.draw_bytes()
         if len(b) >= n:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
     assert shrinker.choices == (b"\x00" * n,)
@@ -545,7 +545,7 @@ def test_alternative_shrinking_will_lower_to_alternate_value():
         i = data.draw_integer(min_value=0, max_value=1)
         if i == 1:
             if data.draw_bytes():
-                data.mark_interesting()
+                data.mark_interesting(interesting_origin())
         else:
             n = data.draw_integer(0, 100)
             if n == 0:
@@ -553,7 +553,7 @@ def test_alternative_shrinking_will_lower_to_alternate_value():
             if seen_int is None:
                 seen_int = n
             elif n != seen_int:
-                data.mark_interesting()
+                data.mark_interesting(interesting_origin())
 
     shrinker.initial_coarse_reduction()
     assert shrinker.choices[0] == 0
@@ -608,7 +608,7 @@ def test_redistribute_numeric_pairs(node1, node2, stop):
         v1 = getattr(data, f"draw_{node1.type}")(**node1.constraints)
         v2 = getattr(data, f"draw_{node2.type}")(**node2.constraints)
         if v1 + v2 > stop:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.redistribute_numeric_pairs)])
     assert len(shrinker.choices) == 2
@@ -639,7 +639,7 @@ def test_lower_duplicated_characters_across_choices(start, expected, gap):
 
         s2 = data.draw(st.text())
         if s1 == s2:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.lower_duplicated_characters)])
     assert shrinker.choices == (expected[0],) + (0,) * gap + (expected[1],)
@@ -653,7 +653,7 @@ def test_shrinking_one_of_with_same_shape():
         n = data.draw_integer(0, 1)
         data.draw_integer()
         if n == 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     shrinker.initial_coarse_reduction()
     assert shrinker.choices == (1, 0)

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -65,7 +65,7 @@ def test_notes_repr():
 def test_can_mark_interesting():
     d = ConjectureData.for_choices([])
     with pytest.raises(StopTest):
-        d.mark_interesting()
+        d.mark_interesting(interesting_origin())
     assert d.frozen
     assert d.status == Status.INTERESTING
 

--- a/hypothesis-python/tests/cover/test_exceptiongroup.py
+++ b/hypothesis-python/tests/cover/test_exceptiongroup.py
@@ -168,3 +168,12 @@ def test_exceptiongroups_reconstruct_original_type(ExceptionClass):
     with pytest.raises(ExceptionClass):
         with suppress(UnrelatedException):
             raise ExceptionClass("exception message", [Exception()])
+
+
+@pytest.mark.parametrize("ExceptionClass", [FlakyFailure, FlakyBackendFailure])
+def test_derived_exception_group(ExceptionClass):
+    exception = ExceptionClass("exception message", [Exception()])
+    # we don't expect a match, we just want to test .derive.
+    match, rest = exception.split(())
+    assert match is None
+    assert isinstance(rest, ExceptionClass)

--- a/hypothesis-python/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis-python/tests/nocover/test_conjecture_engine.py
@@ -20,7 +20,7 @@ from tests.common.utils import (
     non_covering_examples,
     xfail_on_crosshair,
 )
-from tests.conjecture.common import run_to_nodes, shrinking_from
+from tests.conjecture.common import interesting_origin, run_to_nodes, shrinking_from
 
 
 @xfail_on_crosshair(Why.nested_given)
@@ -30,7 +30,7 @@ def test_lot_of_dead_nodes():
         for i in range(4):
             if data.draw_integer(0, 2**8 - 1) != i:
                 data.mark_invalid()
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     assert tuple(n.value for n in nodes) == (0, 1, 2, 3)
 
@@ -53,7 +53,7 @@ def test_saves_data_while_shrinking(monkeypatch):
         if sum(x) >= 2000 and len(seen) < n:
             seen.add(x)
         if x in seen:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(f, settings=settings(database=db), database_key=key)
     runner.run()
@@ -81,7 +81,7 @@ def test_can_discard(monkeypatch):
         seen = set()
         while len(seen) < n:
             seen.add(data.draw_bytes())
-        data.mark_interesting()
+        data.mark_interesting(interesting_origin())
 
     assert len(nodes) == n
 
@@ -115,7 +115,7 @@ def test_node_programs_fail_efficiently(monkeypatch):
             v = data.draw_integer(0, 2**8 - 1)
             values.add(v)
         if len(values) == 256:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     monkeypatch.setattr(
         Shrinker, "run_node_program", counts_calls(Shrinker.run_node_program)

--- a/hypothesis-python/tests/nocover/test_precise_shrinking.py
+++ b/hypothesis-python/tests/nocover/test_precise_shrinking.py
@@ -57,6 +57,8 @@ from hypothesis.internal.conjecture.engine import (
 )
 from hypothesis.internal.conjecture.shrinker import sort_key
 
+from tests.conjecture.common import interesting_origin
+
 T = TypeVar("T")
 
 pytestmark = pytest.mark.skipif(
@@ -108,7 +110,7 @@ def precisely_shrink(
         value = safe_draw(data, strategy)
         check_value = safe_draw(data, end_marker)
         if is_interesting(value) and check_value == target_check_value:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(test_function, random=random)
     try:

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -42,6 +42,7 @@ from hypothesis.strategies import (
 )
 
 from tests.common.utils import no_shrink
+from tests.conjecture.common import interesting_origin
 
 RUNS = 100
 
@@ -82,7 +83,7 @@ def define_test(specifier, predicate, condition=None, p=0.5, suppress_health_che
                 if not _condition(value):
                     data.mark_invalid()
                 if predicate(value):
-                    data.mark_interesting()
+                    data.mark_interesting(interesting_origin())
 
         successes = 0
         actual_runs = 0

--- a/hypothesis-python/tests/quality/test_poisoned_lists.py
+++ b/hypothesis-python/tests/quality/test_poisoned_lists.py
@@ -17,6 +17,8 @@ from hypothesis.internal.compat import ceil
 from hypothesis.internal.conjecture.engine import ConjectureData, ConjectureRunner
 from hypothesis.strategies._internal import SearchStrategy
 
+from tests.conjecture.common import interesting_origin
+
 POISON = "POISON"
 
 
@@ -75,7 +77,7 @@ def test_minimal_poisoned_containers(seed, size, p, strategy_class):
         v = data.draw(strategy)
         data.output = repr(v)
         if POISON in v:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(
         test_function, random=Random(seed), settings=TRIAL_SETTINGS

--- a/hypothesis-python/tests/quality/test_poisoned_trees.py
+++ b/hypothesis-python/tests/quality/test_poisoned_trees.py
@@ -16,6 +16,8 @@ from hypothesis import HealthCheck, settings
 from hypothesis.internal.conjecture.engine import ConjectureData, ConjectureRunner
 from hypothesis.strategies._internal import SearchStrategy
 
+from tests.conjecture.common import interesting_origin
+
 POISON = "POISON"
 MAX_INT = 2**32 - 1
 
@@ -75,7 +77,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
     def test_function(data):
         v = data.draw(strat)
         if len(v) >= size:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(test_function, random=random, settings=TEST_SETTINGS)
     runner.generate_new_examples()
@@ -103,7 +105,7 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
             v = data.draw(strat)
             m = data.draw_bytes(len(marker), len(marker))
             if POISON in v and m == marker:
-                data.mark_interesting()
+                data.mark_interesting(interesting_origin())
 
         runner = ConjectureRunner(
             test_function_with_poison, random=random, settings=TEST_SETTINGS

--- a/hypothesis-python/tests/quality/test_zig_zagging.py
+++ b/hypothesis-python/tests/quality/test_zig_zagging.py
@@ -25,6 +25,8 @@ from hypothesis.internal.compat import ceil
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
+from tests.conjecture.common import interesting_origin
+
 
 @st.composite
 def problems(draw):
@@ -80,7 +82,7 @@ def test_avoids_zig_zag_trap(p):
         if data.draw_bytes(len(marker), len(marker)) != marker:
             data.mark_invalid()
         if abs(m - n) == 1:
-            data.mark_interesting()
+            data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(
         test_function,


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4462.

Suppressing the "failed on backend A but not backend B" note for `DeadlineExceeded` is simple enough. Once that's done, and `DeadlineExceeded` gets raised, we replay it. We're very likely to get a `FlakyFailure` report of the deadline being exceeded in the failing input but not in the replay, because we switched to the hypothesis backend for the replay. 

This would be similarly confusing to the flaky-backend report, so I've chosen to re-raise the initial failure instead of reporting a flaky failure if a backend-raised `DeadlineExceeded` does not reproduce. We have to replay an `is_final=True` input to get `should_note()` output, even if flakiness is out of the picture, so our options are (1) reraise the initial exception (this PR), or (2) drop the special case and let Hypothesis raise a `FlakyFailure`.