### PR TITLE
Fix `ensure_free_stackframes` thread-safety

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a remaining thread-safety issue with the recursion limit warning Hypothesis issues when an outside caller sets ``sys.setrecursionlimit`` (see :ref:`v6.135.23`).

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -290,3 +290,12 @@ def xfail_on_crosshair(why: Why, /, *, strict=True, as_marks=False):
     if as_marks:  # for use with pytest.param(..., marks=xfail_on_crosshair())
         return (pytest.mark.xf_crosshair, pytest.mark.xfail(**kw))
     return lambda fn: pytest.mark.xf_crosshair(pytest.mark.xfail(**kw)(fn))
+
+
+@contextlib.contextmanager
+def restore_recursion_limit():
+    original_limit = sys.getrecursionlimit()
+    try:
+        yield
+    finally:
+        sys.setrecursionlimit(original_limit)

--- a/hypothesis-python/tests/conjecture/test_junkdrawer.py
+++ b/hypothesis-python/tests/conjecture/test_junkdrawer.py
@@ -10,10 +10,14 @@
 
 import copy
 import inspect
+import sys
+import warnings
 
 import pytest
 
 from hypothesis import example, given, strategies as st
+from hypothesis.errors import HypothesisWarning
+from hypothesis.internal.conjecture import junkdrawer
 from hypothesis.internal.conjecture.junkdrawer import (
     IntList,
     LazySequenceCopy,
@@ -21,11 +25,14 @@ from hypothesis.internal.conjecture.junkdrawer import (
     SelfOrganisingList,
     binary_search,
     endswith,
+    ensure_free_stackframes,
     replace_all,
     stack_depth_of_caller,
     startswith,
 )
 from hypothesis.internal.floats import clamp, float_to_int, sign_aware_lte
+
+from tests.common.utils import restore_recursion_limit
 
 
 def test_out_of_range():
@@ -226,3 +233,43 @@ def test_startswith(b1, b2):
 @given(st.binary(), st.binary())
 def test_endswith(b1, b2):
     assert b1.endswith(b2) == endswith(b1, b2)
+
+
+def test_stackframes_warns_when_recursion_limit_is_changed():
+    with restore_recursion_limit():
+        with pytest.warns(
+            HypothesisWarning,
+            match=(
+                "The recursion limit will not be reset, since it was changed during "
+                "test execution."
+            ),
+        ) as warnings:
+            with ensure_free_stackframes():
+                sys.setrecursionlimit(100)
+
+        # we only got the warning once
+        assert len(warnings) == 1
+
+
+def test_stackframes_cleans_up_on_werror():
+    limiter = junkdrawer._stackframe_limiter
+    with restore_recursion_limit():
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert limiter._active_contexts == 0
+
+            # the code for this cleanup case only triggers when the warning is raised
+            # on __enter__. set that up by entering one context, changing the limit,
+            # then entering another.
+            with pytest.raises(HypothesisWarning):
+                with ensure_free_stackframes():
+                    assert limiter._active_contexts == 1
+                    sys.setrecursionlimit(101)
+
+                    with ensure_free_stackframes():
+                        assert limiter._active_contexts == 2
+                        sys.setrecursionlimit(102)
+
+                    assert limiter._active_contexts == 1
+
+            assert limiter._active_contexts == 0

--- a/hypothesis-python/tests/nocover/test_threading.py
+++ b/hypothesis-python/tests/nocover/test_threading.py
@@ -8,18 +8,21 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import sys
 from threading import Barrier, Thread
 
 import pytest
 
 from hypothesis import given, settings, strategies as st
+from hypothesis.internal.conjecture.junkdrawer import ensure_free_stackframes
 from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+
+pytestmark = pytest.mark.skipif(
+    settings._current_profile == "crosshair", reason="crosshair is not thread safe"
+)
 
 
 def run_concurrently(function, n: int) -> None:
-    if settings._current_profile == "crosshair":
-        pytest.skip(reason="crosshair is not thread safe")
-
     def run():
         barrier.wait()
         function()
@@ -63,3 +66,62 @@ def test_run_stateful_test_concurrently():
 
     TestMyStateful = MyStateMachine.TestCase().runTest
     run_concurrently(TestMyStateful, n=2)
+
+
+def do_work():
+    # arbitrary moderately-expensive work
+    for x in range(500):
+        _y = x**x
+
+
+def test_run_different_tests_in_threads():
+    @given(st.integers())
+    def test1(n):
+        do_work()
+
+    @given(st.integers())
+    def test2(n):
+        do_work()
+
+    thread1 = Thread(target=test1)
+    thread2 = Thread(target=test2)
+
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()
+
+
+def test_run_given_concurrently():
+    @given(st.data(), st.integers(-5, 5).map(lambda x: 10**x))
+    def test(data, magnitude):
+        assert magnitude != 0
+        data.draw(st.complex_numbers(max_magnitude=magnitude))
+
+    run_concurrently(test, n=2)
+
+
+def test_stackframes_restores_original_recursion_limit():
+    original_recursionlimit = sys.getrecursionlimit()
+
+    def test():
+        with ensure_free_stackframes():
+            do_work()
+
+            # also mix in a hypothesis test; why not.
+            @given(st.integers())
+            @settings(max_examples=10)
+            def test(n):
+                pass
+
+            test()
+
+    threads = []
+    for _ in range(4):
+        threads.append(Thread(target=test))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sys.getrecursionlimit() == original_recursionlimit


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451.

The old implementation still had thread-safety problems, as I discovered when testing afterwards. This is a complete and maybe slightly overkill solution which retains (almost; see refcounting comment) as much power of the warning as possible.

This also fixes an actual concurrency bug (not just to do with warnings) where the recursion limit might not be restored to its correct value. We track the original recursion limit of the first `ensure_free_stackframes` call on the stack, and reset it to that unconditionally when the last context exits (regardless of that context's initial value). Intermediate threads can still trample each other's limits, but there's nothing we can do about that.