### PR TITLE
Fix a remaining thread safety issue in the random deprecation warning

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a remaining thread-safety issue with the deprecation warning for use of the global random instance (see :ref:`v6.135.24 <v6.135.24>`).

--- a/hypothesis-python/docs/changelog.rst
+++ b/hypothesis-python/docs/changelog.rst
@@ -24,7 +24,7 @@ Hypothesis 6.x
 6.135.30 - 2025-07-14
 ---------------------
 
-Fix a remaining thread-safety issue with the recursion limit warning Hypothesis issues when an outside caller sets ``sys.setrecursionlimit`` (see :ref:`v6.135.23`).
+Fix a remaining thread-safety issue with the recursion limit warning Hypothesis issues when an outside caller sets ``sys.setrecursionlimit`` (see :ref:`v6.135.23 <v6.135.23>`).
 
 .. _v6.135.29:
 

--- a/hypothesis-python/src/hypothesis/control.py
+++ b/hypothesis-python/src/hypothesis/control.py
@@ -93,29 +93,12 @@ def current_build_context() -> "BuildContext":
     return context
 
 
-class RandomSeeder:
-    def __init__(self, seed):
-        self.seed = seed
-
-    def __repr__(self):
-        return f"RandomSeeder({self.seed!r})"
-
-
-class _Checker:
-    def __init__(self) -> None:
-        self.saw_global_random = False
-
-    def __call__(self, x):
-        self.saw_global_random |= isinstance(x, RandomSeeder)
-        return x
-
-
 @contextmanager
 def deprecate_random_in_strategy(fmt, *args):
     from hypothesis.internal import entropy
 
     state_before = random.getstate()
-    yield (checker := _Checker())
+    yield
     state_after = random.getstate()
     if (
         # there is a threading race condition here with deterministic_PRNG. Say
@@ -134,21 +117,14 @@ def deprecate_random_in_strategy(fmt, *args):
         # where state_before != state_after because a different thread has reset
         # the global random state.
         #
-        # To fix this, we track the latest set global random state in
-        # deterministic_PRNG, and will not note a deprecation (or error, in the
-        # future) if the state afterwards is the same as the state that
-        # deterministic_PRNG set to.
-        state_after
-        not in [
-            state_before,
-            entropy._most_recent_random_state_enter,
-            entropy._most_recent_random_state_exit,
-        ]
-        and not checker.saw_global_random
+        # To fix this, we track the known random states set by deterministic_PRNG,
+        # and will not note a deprecation if it matches one of those.
+        state_after != state_before
+        and hash(state_after) not in entropy._known_random_state_hashes
     ):
         note_deprecation(
             "Do not use the `random` module inside strategies; instead "
-            "consider  `st.randoms()`, `st.sampled_from()`, etc.  " + fmt.format(*args),
+            "consider `st.randoms()`, `st.sampled_from()`, etc.  " + fmt.format(*args),
             since="2024-02-05",
             has_codemod=False,
             stacklevel=1,
@@ -195,8 +171,8 @@ class BuildContext:
         kwargs = {}
         for k, s in kwarg_strategies.items():
             start_idx = len(self.data.nodes)
-            with deprecate_random_in_strategy("from {}={!r}", k, s) as check:
-                obj = check(self.data.draw(s, observe_as=f"generate:{k}"))
+            with deprecate_random_in_strategy("from {}={!r}", k, s):
+                obj = self.data.draw(s, observe_as=f"generate:{k}")
             end_idx = len(self.data.nodes)
             kwargs[k] = obj
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -48,7 +48,6 @@ import attr
 
 from hypothesis._settings import note_deprecation
 from hypothesis.control import (
-    RandomSeeder,
     cleanup,
     current_build_context,
     deprecate_random_in_strategy,
@@ -983,8 +982,16 @@ def randoms(
     )
 
 
+class RandomSeeder:
+    def __init__(self, seed):
+        self.seed = seed
+
+    def __repr__(self):
+        return f"RandomSeeder({self.seed!r})"
+
+
 class RandomModule(SearchStrategy):
-    def do_draw(self, data):
+    def do_draw(self, data: ConjectureData) -> RandomSeeder:
         # It would be unsafe to do run this method more than once per test case,
         # because cleanup() runs tasks in FIFO order (at time of writing!).
         # Fortunately, the random_module() strategy wraps us in shared(), so


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451. We're quite close to a clean `--parallel-threads 2` run at this point.

Tracking this more concretely also lets us get rid of `_Checker` (which frees up a stackframe call on every strategy draw - that might actually be noticeable in perf! though it probably isn't).