### PR TITLE
Fix strategy validation thread-safety

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,5 @@
 RELEASE_TYPE: patch
 
 Improve the thread-safety of strategy validation.
+
+Before this release, Hypothesis did not require that ``super().__init__()`` be called in ``SearchStrategy`` subclasses. Subclassing ``SearchStrategy`` is not supported or part of the public API, but if you are subclassing it anyway, you will need to make sure to call ``super().__init__()`` after this release.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve the thread-safety of strategy validation.

--- a/hypothesis-python/src/hypothesis/extra/_array_helpers.py
+++ b/hypothesis-python/src/hypothesis/extra/_array_helpers.py
@@ -632,6 +632,7 @@ class BasicIndexStrategy(st.SearchStrategy):
         allow_newaxis,
         allow_fewer_indices_than_dims,
     ):
+        super().__init__()
         self.shape = shape
         self.min_dims = min_dims
         self.max_dims = max_dims

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -313,6 +313,7 @@ class ArrayStrategy(st.SearchStrategy):
     def __init__(
         self, *, xp, api_version, elements_strategy, dtype, shape, fill, unique
     ):
+        super().__init__()
         self.xp = xp
         self.elements_strategy = elements_strategy
         self.dtype = dtype

--- a/hypothesis-python/src/hypothesis/extra/lark.py
+++ b/hypothesis-python/src/hypothesis/extra/lark.py
@@ -68,6 +68,7 @@ class LarkStrategy(st.SearchStrategy):
         explicit: dict[str, st.SearchStrategy[str]],
         alphabet: st.SearchStrategy[str],
     ) -> None:
+        super().__init__()
         assert isinstance(grammar, lark.lark.Lark)
         start: list[str] = grammar.options.start if start is None else [start]
 

--- a/hypothesis-python/src/hypothesis/extra/numpy.py
+++ b/hypothesis-python/src/hypothesis/extra/numpy.py
@@ -220,6 +220,7 @@ def from_dtype(
 
 class ArrayStrategy(st.SearchStrategy):
     def __init__(self, element_strategy, shape, dtype, fill, unique):
+        super().__init__()
         self.shape = tuple(shape)
         self.fill = fill
         self.array_size = int(np.prod(shape))

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -539,6 +539,7 @@ self_strategy = st.runner()
 
 class BundleReferenceStrategy(SearchStrategy):
     def __init__(self, name: str, *, consume: bool = False):
+        super().__init__()
         self.name = name
         self.consume = consume
 
@@ -582,6 +583,7 @@ class Bundle(SearchStrategy[Ex]):
     def __init__(
         self, name: str, *, consume: bool = False, draw_references: bool = True
     ) -> None:
+        super().__init__()
         self.name = name
         self.__reference_strategy = BundleReferenceStrategy(name, consume=consume)
         self.draw_references = draw_references

--- a/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/collections.py
@@ -352,6 +352,7 @@ class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
         *,
         optional: Optional[dict[Any, SearchStrategy[Any]]],
     ):
+        super().__init__()
         dict_type = type(mapping)
         self.mapping = mapping
         keys = tuple(mapping.keys())

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1029,6 +1029,7 @@ class BuildsStrategy(SearchStrategy[Ex]):
         args: tuple[SearchStrategy[Any], ...],
         kwargs: dict[str, SearchStrategy[Any]],
     ):
+        super().__init__()
         self.target = target
         self.args = args
         self.kwargs = kwargs
@@ -1798,6 +1799,7 @@ def recursive(
 
 class PermutationStrategy(SearchStrategy):
     def __init__(self, values):
+        super().__init__()
         self.values = values
 
     def do_draw(self, data):
@@ -1828,6 +1830,7 @@ def permutations(values: Sequence[T]) -> SearchStrategy[list[T]]:
 
 class CompositeStrategy(SearchStrategy):
     def __init__(self, definition, args, kwargs):
+        super().__init__()
         self.definition = definition
         self.args = args
         self.kwargs = kwargs
@@ -2173,6 +2176,7 @@ def uuids(
 
 class RunnerStrategy(SearchStrategy):
     def __init__(self, default):
+        super().__init__()
         self.default = default
 
     def do_draw(self, data):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1070,7 +1070,7 @@ class BuildsStrategy(SearchStrategy[Ex]):
         current_build_context().record_call(obj, self.target, args, kwargs)
         return obj
 
-    def validate(self) -> None:
+    def do_validate(self) -> None:
         tuples(*self.args).validate()
         fixed_dictionaries(self.kwargs).validate()
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py
@@ -120,6 +120,7 @@ def draw_capped_multipart(
 
 class DatetimeStrategy(SearchStrategy):
     def __init__(self, min_value, max_value, timezones_strat, allow_imaginary):
+        super().__init__()
         assert isinstance(min_value, dt.datetime)
         assert isinstance(max_value, dt.datetime)
         assert min_value.tzinfo is None
@@ -219,6 +220,7 @@ def datetimes(
 
 class TimeStrategy(SearchStrategy):
     def __init__(self, min_value, max_value, timezones_strat):
+        super().__init__()
         self.min_value = min_value
         self.max_value = max_value
         self.tz_strat = timezones_strat
@@ -257,6 +259,7 @@ def times(
 
 class DateStrategy(SearchStrategy):
     def __init__(self, min_value, max_value):
+        super().__init__()
         assert isinstance(min_value, dt.date)
         assert isinstance(max_value, dt.date)
         assert min_value < max_value
@@ -320,6 +323,7 @@ def dates(
 
 class TimedeltaStrategy(SearchStrategy):
     def __init__(self, min_value, max_value):
+        super().__init__()
         assert isinstance(min_value, dt.timedelta)
         assert isinstance(max_value, dt.timedelta)
         assert min_value < max_value

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -50,6 +50,7 @@ Real = Union[int, float, Fraction, Decimal]
 
 class IntegersStrategy(SearchStrategy[int]):
     def __init__(self, start: Optional[int], end: Optional[int]) -> None:
+        super().__init__()
         assert isinstance(start, int) or start is None
         assert isinstance(end, int) or end is None
         assert start is None or end is None or start <= end

--- a/hypothesis-python/src/hypothesis/strategies/_internal/random.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/random.py
@@ -434,6 +434,7 @@ class TrueRandom(HypothesisRandom):
 
 class RandomStrategy(SearchStrategy[HypothesisRandom]):
     def __init__(self, *, note_method_calls: bool, use_true_random: bool) -> None:
+        super().__init__()
         self.__note_method_calls = note_method_calls
         self.__use_true_random = use_true_random
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/recursive.py
@@ -73,6 +73,7 @@ class LimitedStrategy(SearchStrategy):
 
 class RecursiveStrategy(SearchStrategy):
     def __init__(self, base, extend, max_leaves):
+        super().__init__()
         self.max_leaves = max_leaves
         self.base = base
         self.limited_base = LimitedStrategy(base)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
@@ -18,6 +18,7 @@ from hypothesis.strategies._internal.strategies import Ex
 
 class SharedStrategy(SearchStrategy[Ex]):
     def __init__(self, base: SearchStrategy[Ex], key: Optional[Hashable] = None):
+        super().__init__()
         self.key = key
         self.base = base
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strings.py
@@ -50,6 +50,7 @@ class OneCharStringStrategy(SearchStrategy[str]):
     def __init__(
         self, intervals: IntervalSet, force_repr: Optional[str] = None
     ) -> None:
+        super().__init__()
         assert isinstance(intervals, IntervalSet)
         self.intervals = intervals
         self._force_repr = force_repr
@@ -349,6 +350,7 @@ def _identifier_characters():
 
 class BytesStrategy(SearchStrategy):
     def __init__(self, min_size: int, max_size: Optional[int]):
+        super().__init__()
         self.min_size = min_size
         self.max_size = (
             max_size if max_size is not None else COLLECTION_DEFAULT_MAX_SIZE

--- a/hypothesis-python/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/types.py
@@ -997,6 +997,7 @@ def resolve_Match(thing):
 
 class GeneratorStrategy(st.SearchStrategy):
     def __init__(self, yields, returns):
+        super().__init__()
         assert isinstance(yields, st.SearchStrategy)
         assert isinstance(returns, st.SearchStrategy)
         self.yields = yields

--- a/hypothesis-python/tests/common/strategies.py
+++ b/hypothesis-python/tests/common/strategies.py
@@ -24,6 +24,7 @@ SLOW = _Slow()
 
 class HardToShrink(SearchStrategy):
     def __init__(self):
+        super().__init__()
         self.__last = None
         self.accepted = set()
 

--- a/hypothesis-python/tests/nocover/test_duplication.py
+++ b/hypothesis-python/tests/nocover/test_duplication.py
@@ -20,6 +20,7 @@ from tests.common.utils import Why, xfail_on_crosshair
 
 class Blocks(SearchStrategy):
     def __init__(self, n):
+        super().__init__()
         self.n = n
 
     def do_draw(self, data):

--- a/website/content/2016-12-10-how-hypothesis-works.md
+++ b/website/content/2016-12-10-how-hypothesis-works.md
@@ -163,6 +163,7 @@ For example, suppose we tried to implement lists as follows:
 ```python
 class ListStrategy(SearchStrategy):
     def __init__(self, elements):
+        super().__init__()
         self.elements = elements
 
     def do_draw(self, data):
@@ -191,6 +192,7 @@ this as follows:
 ```python
 class ListStrategy(SearchStrategy):
     def __init__(self, elements):
+        super().__init__()
         self.elements = elements
 
     def do_draw(self, data):
@@ -388,6 +390,7 @@ class SearchStrategy:
 
 class FlatmappedStrategy(SearchStrategy):
     def __init__(self, base, bind):
+        super().__init__()
         self.base = base
         self.bind = bind
 


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451. This one is pretty rare, only triggering about once per full test suite run under `--parallel-threads 2`. There might be a way to write `do_validate` that takes recursion into account and only tracks `validate_called = True` at the end, but that's a bigger rewrite.

I'm somewhat worried about the unconditional lock overhead in the singlethreaded case. It's ~pure lock/unlock overhead, I expect ~zero contention. Here's a claude benchmark for `.validate` for `lambda i: st.integers().map(lambda x: x + i))`, where the `lambda i` and `.map` are cache-busters so each strategy really gets `.validate` called.

```
master        : 0.000080612s per call (12405 calls/sec)
pr        : 0.000086325s per call (11584 calls/sec)
```


<details><summary>Details</summary>

```python
from hypothesis import given, settings, HealthCheck, strategies as st
from hypothesis.strategies import integers, text
from hypothesis import settings
import pytest
import timeit
import statistics

def benchmark_integers_validate():
    """Benchmark st.integers().validate() performance with cached strategies"""

    # Test different integer strategy configurations with unique mapped functions
    test_cases = [
        ("default", lambda i: st.integers().map(lambda x: x + i)),
        ("bounded", lambda i: st.integers(min_value=0, max_value=1000).map(lambda x: x * i)),
        ("min_only", lambda i: st.integers(min_value=0).map(lambda x: x - i)),
        ("max_only", lambda i: st.integers(max_value=1000).map(lambda x: x // (i + 1))),
        ("large_range", lambda i: st.integers(min_value=-1000000, max_value=1000000).map(lambda x: x % (i + 1))),
    ]

    results = {}

    for name, strategy_func in test_cases:
        print(f"\nBenchmarking {name} integers strategy with unique mapped functions:")

        # Benchmark creating and validating unique strategies
        def run_validate_with_unique_strategy():
            # Create a unique strategy for each call using a different function
            import random
            i = random.randint(1, 1000)  # Random value to make function unique
            strategy = strategy_func(i)
            return strategy.validate()

        # Run multiple times for accuracy
        times = timeit.repeat(run_validate_with_unique_strategy, repeat=100, number=100)

        # Calculate statistics
        mean_time = statistics.mean(times)
        median_time = statistics.median(times)
        min_time = min(times)
        max_time = max(times)
        std_dev = statistics.stdev(times) if len(times) > 1 else 0

        results[name] = {
            'mean': mean_time,
            'median': median_time,
            'min': min_time,
            'max': max_time,
            'std_dev': std_dev,
            'total_calls': 100 * 100
        }

        print(f"  Mean time: {mean_time:.6f} seconds per 100 calls")
        print(f"  Median time: {median_time:.6f} seconds per 100 calls")
        print(f"  Min time: {min_time:.6f} seconds per 100 calls")
        print(f"  Max time: {max_time:.6f} seconds per 100 calls")
        print(f"  Std dev: {std_dev:.6f} seconds")
        print(f"  Per call: {mean_time/100:.9f} seconds")
        print(f"  Calls per second: {100/mean_time:.0f}")

    # Summary comparison
    print("\n" + "="*50)
    print("SUMMARY COMPARISON")
    print("="*50)

    sorted_results = sorted(results.items(), key=lambda x: x[1]['mean'])

    for name, stats in sorted_results:
        print(f"{name:15s}: {stats['mean']/100:.9f}s per call ({100/stats['mean']:.0f} calls/sec)")

    return results

def benchmark_strategy_caching_comparison():
    """Compare performance of reused vs unique strategies"""

    print("\n" + "="*60)
    print("STRATEGY CACHING COMPARISON")
    print("="*60)

    # Test 1: Reusing the same strategy
    print("\nTest 1: Reusing same strategy")
    same_strategy = st.integers().map(lambda x: x + 1)

    def run_same_strategy():
        return same_strategy.validate()

    times_same = timeit.repeat(run_same_strategy, repeat=50, number=1000)
    mean_same = statistics.mean(times_same)

    print(f"  Mean time (same strategy): {mean_same:.6f} seconds per 1000 calls")
    print(f"  Per call: {mean_same/1000:.9f} seconds")

    # Test 2: Creating unique strategies each time
    print("\nTest 2: Creating unique strategies each time")

    def run_unique_strategies():
        import random
        i = random.randint(1, 1000000)
        strategy = st.integers().map(lambda x: x + i)
        return strategy.validate()

    times_unique = timeit.repeat(run_unique_strategies, repeat=50, number=100)
    mean_unique = statistics.mean(times_unique)

    print(f"  Mean time (unique strategies): {mean_unique:.6f} seconds per 100 calls")
    print(f"  Per call: {mean_unique/100:.9f} seconds")

    # Compare
    print(f"\nComparison:")
    print(f"  Same strategy per call: {mean_same/1000:.9f}s")
    print(f"  Unique strategy per call: {mean_unique/100:.9f}s")
    print(f"  Overhead ratio: {(mean_unique/100) / (mean_same/1000):.2f}x")
    print(f"  Caching saves: {((mean_unique/100) - (mean_same/1000)) / (mean_unique/100) * 100:.1f}% per call")

if __name__ == "__main__":
    print("Benchmarking st.integers().validate() performance with cached strategies...")
    benchmark_integers_validate()
    benchmark_strategy_caching_comparison()

```

</details> 


Around 7% slower. Not great, since I've seen `.validate` be a performance hotspot before. 

The following command reproduces the relevant failure on master: ` counter=1; while pytest hypothesis-python/tests/ --parallel-threads 2 -k test_invalid_args; do ((counter++)); done;`