### PR TITLE
Speculative fix for `strategy.label` thread safety

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Speculative fix for a thread-safety issue in calculating strategy labels.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -530,16 +530,16 @@ class SearchStrategy(Generic[Ex]):
 
     @property
     def label(self) -> int:
-        if isinstance(self.__label, int):
+        if isinstance((label := self.__label), int):
             # avoid locking if we've already completely computed the label.
-            return self.__label
+            return label
 
         with label_lock:
             if self.__label is calculating:
                 return 0
             self.__label = calculating
             self.__label = self.calc_label()
-        return self.__label
+            return self.__label
 
     def calc_label(self) -> int:
         return self.class_label


### PR DESCRIPTION
See https://github.com/Quansight-Labs/pytest-run-parallel/actions/runs/16373126695/job/46266326511?pr=96#step:7:178 (https://github.com/Quansight-Labs/pytest-run-parallel/pull/96). I don't have a consistent reproducer for this locally, but this is the only possible way I can see this happening.