### PR TITLE
Fix `PrimitiveProvider.on_observation` being called incorrectly during failure replay

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix |PrimitiveProvider.on_observation| being called with observations it wasn't responsible for generating if the test failed.

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -385,9 +385,9 @@ else:
                 stats = report.__dict__.get(STATS_KEY)
                 if stats and print_stats:
                     terminalreporter.write_line(stats + "\n\n")
-                fex = report.__dict__.get(FAILING_EXAMPLES_KEY)
-                if fex:
-                    failing_examples.append(json.loads(fex))
+                examples = report.__dict__.get(FAILING_EXAMPLES_KEY)
+                if examples:
+                    failing_examples.append(json.loads(examples))
 
         from hypothesis.internal.observability import _WROTE_TO
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -651,7 +651,7 @@ class PrimitiveProvider(abc.ABC):
         internally.
         """
 
-    def span_end(self, discard: bool, /) -> None:  # noqa: B027, FBT001
+    def span_end(self, discard: bool, /) -> None:  # noqa: B027
         """Marks the end of a semantically meaningful span of choices.
 
         ``discard`` is ``True`` when the draw was filtered out or otherwise marked

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -83,8 +83,6 @@ if TYPE_CHECKING:
 
     from hypothesis.control import BuildContext
 
-# ruff: noqa: FBT001
-
 T = TypeVar("T")
 PrettyPrintFunction: "TypeAlias" = Callable[[Any, "RepresentationPrinter", bool], None]
 

--- a/hypothesis-python/tests/conjecture/test_provider.py
+++ b/hypothesis-python/tests/conjecture/test_provider.py
@@ -767,6 +767,20 @@ def test_on_observation_alternates():
     f()
 
 
+@temp_register_backend("observation", ObservationProvider)
+def test_on_observation_alternates_on_failure():
+    @given(st.integers())
+    @settings(backend="observation")
+    def f(n):
+        # Hypothesis tries n == 0 first, and if that fails then we don't exercise
+        # any provider-specific paths.
+        if n == 1:
+            raise ValueError("unique identifier")
+
+    with pytest.raises(ValueError, match="unique identifier"):
+        f()
+
+
 @temp_register_backend("observation", TrivialProvider)
 def test_on_observation_no_override():
     @given(st.integers())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore = [
   "E731",
   "E741",
   "FBT003",
+  "FBT001",
   "PD011",
   "PD901",
   "PIE790",  # See https://github.com/astral-sh/ruff/issues/10538
@@ -74,15 +75,12 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"hypothesis-python/src/hypothesis/core.py" = ["B030", "B904", "FBT001"]
+"hypothesis-python/src/hypothesis/core.py" = ["B904"]
 "hypothesis-python/src/hypothesis/internal/compat.py" = ["F401"]
-"hypothesis-python/src/hypothesis/internal/conjecture/data.py" = ["FBT001"]
-"hypothesis-python/src/hypothesis/internal/conjecture/datatree.py" = ["FBT001"]
 "hypothesis-python/tests/nocover/test_imports.py" = ["F403", "F405"]
 "hypothesis-python/tests/numpy/test_randomness.py" = ["NPY002"]
 "hypothesis-python/src/hypothesis/internal/conjecture/*" = ["B023"]
 "hypothesis-python/tests/conjecture/test_data_tree.py" = ["B023"]
-"hypothesis-python/tests/conjecture/test_test_data.py" = ["FBT001"]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
Previously `on_observation` would be called for the replayed choice sequence on the hypothesis backend