### PR TITLE
Error when `@precondition` is used without `@rule`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+|@precondition| now errors if used without |@rule| or |@invariant|. Doing so has no effect and is indicative of a user error (:issue:`4413`).

--- a/hypothesis-python/docs/prolog.rst
+++ b/hypothesis-python/docs/prolog.rst
@@ -137,6 +137,7 @@
 .. |@rule| replace:: :func:`@rule <hypothesis.stateful.rule>`
 .. |@precondition| replace:: :func:`@precondition <hypothesis.stateful.precondition>`
 .. |@initialize| replace:: :func:`@initialize <hypothesis.stateful.initialize>`
+.. |@invariant| replace:: :func:`@invariant <hypothesis.stateful.invariant>`
 .. |RuleBasedStateMachine| replace:: :class:`~hypothesis.stateful.RuleBasedStateMachine`
 .. |run_state_machine_as_test| replace:: :func:`~hypothesis.stateful.run_state_machine_as_test`
 

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -800,14 +800,15 @@ def rule(
     def accept(f):
         if getattr(f, INVARIANT_MARKER, None):
             raise InvalidDefinition(
-                "A function cannot be used for both a rule and an invariant.",
-                Settings.default,
+                "A function cannot be used for both a rule and an invariant. "
+                f"Function: {get_pretty_function_description(f)}",
             )
         existing_rule = getattr(f, RULE_MARKER, None)
         existing_initialize_rule = getattr(f, INITIALIZE_RULE_MARKER, None)
         if existing_rule is not None or existing_initialize_rule is not None:
             raise InvalidDefinition(
-                "A function cannot be used for two distinct rules. ", Settings.default
+                "A function cannot be used for two distinct rules. "
+                f"Function: {get_pretty_function_description(f)}",
             )
         preconditions = getattr(f, PRECONDITIONS_MARKER, ())
         rule = Rule(
@@ -876,19 +877,21 @@ def initialize(
     def accept(f):
         if getattr(f, INVARIANT_MARKER, None):
             raise InvalidDefinition(
-                "A function cannot be used for both a rule and an invariant.",
-                Settings.default,
+                "A function cannot be used for both a rule and an invariant. "
+                f"Function: {get_pretty_function_description(f)}",
             )
         existing_rule = getattr(f, RULE_MARKER, None)
         existing_initialize_rule = getattr(f, INITIALIZE_RULE_MARKER, None)
         if existing_rule is not None or existing_initialize_rule is not None:
             raise InvalidDefinition(
-                "A function cannot be used for two distinct rules. ", Settings.default
+                "A function cannot be used for two distinct rules. "
+                f"Function: {get_pretty_function_description(f)}",
             )
         preconditions = getattr(f, PRECONDITIONS_MARKER, ())
         if preconditions:
             raise InvalidDefinition(
-                "An initialization rule cannot have a precondition. ", Settings.default
+                "An initialization rule cannot have a precondition. "
+                f"Rule: {get_pretty_function_description(f)}",
             )
         rule = Rule(
             targets=converted_targets,
@@ -1013,14 +1016,14 @@ def invariant(*, check_during_init: bool = False) -> Callable[[TestFunc], TestFu
     def accept(f):
         if getattr(f, RULE_MARKER, None) or getattr(f, INITIALIZE_RULE_MARKER, None):
             raise InvalidDefinition(
-                "A function cannot be used for both a rule and an invariant.",
-                Settings.default,
+                "A function cannot be used for both a rule and an invariant. "
+                f"Function: {get_pretty_function_description(f)}",
             )
         existing_invariant = getattr(f, INVARIANT_MARKER, None)
         if existing_invariant is not None:
             raise InvalidDefinition(
-                "A function cannot be used for two distinct invariants.",
-                Settings.default,
+                "A function cannot be used for two distinct invariants. "
+                f"Function: {get_pretty_function_description(f)}",
             )
         preconditions = getattr(f, PRECONDITIONS_MARKER, ())
         invar = Invariant(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/featureflags.py
@@ -124,7 +124,7 @@ class FeatureFlags:
 
 
 class FeatureStrategy(SearchStrategy[FeatureFlags]):
-    def __init__(self, at_least_one_of: Sequence[Hashable] = ()):
+    def __init__(self, at_least_one_of: Iterable[Hashable] = ()):
         super().__init__()
         self._at_least_one_of = frozenset(at_least_one_of)
 

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -949,6 +949,20 @@ def test_initialize_rule_dont_mix_with_regular_rule():
             def initialize(self):
                 pass
 
+    with pytest.raises(
+        InvalidDefinition,
+        match=(
+            "BadStateMachineReverseOrder.initialize has been decorated with both "
+            "@rule and @initialize"
+        ),
+    ):
+
+        class BadStateMachineReverseOrder(RuleBasedStateMachine):
+            @initialize()
+            @rule()
+            def initialize(self):
+                pass
+
 
 def test_initialize_rule_cannot_be_double_applied():
     with pytest.raises(

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -1437,3 +1437,21 @@ def test_use_bundle_within_other_strategies():
 
     Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
     run_state_machine_as_test(Machine)
+
+
+def test_precondition_cannot_be_used_without_rule():
+    with pytest.raises(
+        InvalidDefinition,
+        match=r"@precondition must be combined with @rule \(or @invariant\), since it has no effect alone.",
+    ):
+
+        class BadStateMachine(RuleBasedStateMachine):
+            @precondition(lambda: True)
+            def has_precondition_but_no_rule(self):
+                pass
+
+            @rule(n=st.integers())
+            def trivial(self, n):
+                pass
+
+        BadStateMachine.TestCase().runTest()

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -906,8 +906,13 @@ state.teardown()
 
 
 def test_initialize_rule_dont_mix_with_precondition():
-    match = "An initialization rule cannot have a precondition."
-    with pytest.raises(InvalidDefinition, match=match):
+    with pytest.raises(
+        InvalidDefinition,
+        match=(
+            "BadStateMachine.initialize has been decorated with both @initialize "
+            "and @precondition"
+        ),
+    ):
 
         class BadStateMachine(RuleBasedStateMachine):
             @precondition(lambda self: True)
@@ -917,7 +922,13 @@ def test_initialize_rule_dont_mix_with_precondition():
 
     # Also test decorator application in reverse order
 
-    with pytest.raises(InvalidDefinition, match=match):
+    with pytest.raises(
+        InvalidDefinition,
+        match=(
+            "BadStateMachineReverseOrder.initialize has been decorated with both "
+            "@initialize and @precondition"
+        ),
+    ):
 
         class BadStateMachineReverseOrder(RuleBasedStateMachine):
             @initialize()
@@ -928,7 +939,8 @@ def test_initialize_rule_dont_mix_with_precondition():
 
 def test_initialize_rule_dont_mix_with_regular_rule():
     with pytest.raises(
-        InvalidDefinition, match="A function cannot be used for two distinct rules."
+        InvalidDefinition,
+        match="BadStateMachine.initialize has been decorated with both @rule and @initialize",
     ):
 
         class BadStateMachine(RuleBasedStateMachine):
@@ -940,7 +952,8 @@ def test_initialize_rule_dont_mix_with_regular_rule():
 
 def test_initialize_rule_cannot_be_double_applied():
     with pytest.raises(
-        InvalidDefinition, match="A function cannot be used for two distinct rules."
+        InvalidDefinition,
+        match="BadStateMachine.initialize has been decorated with @initialize twice",
     ):
 
         class BadStateMachine(RuleBasedStateMachine):
@@ -1440,18 +1453,20 @@ def test_use_bundle_within_other_strategies():
 
 
 def test_precondition_cannot_be_used_without_rule():
+    class BadStateMachine(RuleBasedStateMachine):
+        @precondition(lambda: True)
+        def has_precondition_but_no_rule(self):
+            pass
+
+        @rule(n=st.integers())
+        def trivial(self, n):
+            pass
+
     with pytest.raises(
         InvalidDefinition,
-        match=r"@precondition must be combined with @rule \(or @invariant\), since it has no effect alone.",
+        match=(
+            "BadStateMachine.has_precondition_but_no_rule has been decorated "
+            "with @precondition, but not @rule"
+        ),
     ):
-
-        class BadStateMachine(RuleBasedStateMachine):
-            @precondition(lambda: True)
-            def has_precondition_but_no_rule(self):
-                pass
-
-            @rule(n=st.integers())
-            def trivial(self, n):
-                pass
-
         BadStateMachine.TestCase().runTest()

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -906,7 +906,8 @@ state.teardown()
 
 
 def test_initialize_rule_dont_mix_with_precondition():
-    with pytest.raises(InvalidDefinition) as exc:
+    match = "An initialization rule cannot have a precondition."
+    with pytest.raises(InvalidDefinition, match=match):
 
         class BadStateMachine(RuleBasedStateMachine):
             @precondition(lambda self: True)
@@ -914,11 +915,9 @@ def test_initialize_rule_dont_mix_with_precondition():
             def initialize(self):
                 pass
 
-    assert "An initialization rule cannot have a precondition." in str(exc.value)
-
     # Also test decorator application in reverse order
 
-    with pytest.raises(InvalidDefinition) as exc:
+    with pytest.raises(InvalidDefinition, match=match):
 
         class BadStateMachineReverseOrder(RuleBasedStateMachine):
             @initialize()
@@ -926,11 +925,11 @@ def test_initialize_rule_dont_mix_with_precondition():
             def initialize(self):
                 pass
 
-    assert "An initialization rule cannot have a precondition." in str(exc.value)
-
 
 def test_initialize_rule_dont_mix_with_regular_rule():
-    with pytest.raises(InvalidDefinition) as exc:
+    with pytest.raises(
+        InvalidDefinition, match="A function cannot be used for two distinct rules."
+    ):
 
         class BadStateMachine(RuleBasedStateMachine):
             @rule()
@@ -938,19 +937,17 @@ def test_initialize_rule_dont_mix_with_regular_rule():
             def initialize(self):
                 pass
 
-    assert "A function cannot be used for two distinct rules." in str(exc.value)
-
 
 def test_initialize_rule_cannot_be_double_applied():
-    with pytest.raises(InvalidDefinition) as exc:
+    with pytest.raises(
+        InvalidDefinition, match="A function cannot be used for two distinct rules."
+    ):
 
         class BadStateMachine(RuleBasedStateMachine):
             @initialize()
             @initialize()
             def initialize(self):
                 pass
-
-    assert "A function cannot be used for two distinct rules." in str(exc.value)
 
 
 def test_initialize_rule_in_state_machine_with_inheritance():


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4413.

Since `@precondition` can be applied either before or after `@rule`, it's easiest to raise this error at runtime, rather than definition time.

I refactored stateful initialization to make this possible / cleaner. `inspect.getmembers` makes me nervous performance-wise, so it's good to cut that down to just a single use as well.