### PR TITLE
Don't raise `HealthCheck.differing_executors` under different executors from different threads

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+|HealthCheck.differing_executors| is no longer raised if a test is executed by different executors from different threads. |HealthCheck.differing_executors| will still be raised if a test is executed by different executors in the same thread.

--- a/hypothesis-python/tests/cover/test_threading.py
+++ b/hypothesis-python/tests/cover/test_threading.py
@@ -76,3 +76,12 @@ def test_run_given_concurrently():
 
     for thread in threads:
         thread.join(timeout=10)
+
+
+# rely on our pytest-run-parallel job to test this, since this only happens because
+# pytest instantiates a new class instance for each parametrization.
+class TestNoDifferingExecutorsHealthCheck:
+    @given(st.integers())
+    @pytest.mark.parametrize("x", range(2))
+    def test_a(self, x, i):
+        pass


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451. If you're running your test under threading, I think you're signing up for different threads to have different executors. The same thread having differing executors is still worth raising for, though.