### PR TITLE
Disable `HealthCheck.too_slow` under threading

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+When a test is executed concurrently from multiple threads, |HealthCheck.too_slow| is now disabled, since the Python runtime may decide to switch away from a thread for arbitrarily long and Hypothesis cannot track execution time per-thread.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1023,8 +1023,11 @@ class StateForActualGivenExecution:
                     }
 
                 if (
-                    current_deadline := self.settings.deadline
-                ) is not None and not self.thread_overlap[threading.get_ident()]:
+                    (current_deadline := self.settings.deadline) is not None
+                    # we disable the deadline check under concurrent threads, since
+                    # cpython may switch away from a thread for arbitrarily long.
+                    and not self.thread_overlap.get(threading.get_ident(), False)
+                ):
                     if not is_final:
                         current_deadline = (current_deadline // 4) * 5
                     if runtime >= current_deadline.total_seconds():
@@ -1373,6 +1376,7 @@ class StateForActualGivenExecution:
             settings=self.settings,
             random=self.random,
             database_key=database_key,
+            thread_overlap=self.thread_overlap,
         )
         # Use the Conjecture engine to run the test function many times
         # on different inputs.
@@ -1861,8 +1865,8 @@ def given(
         thread_local = ThreadLocal(prev_self=lambda: not_set)
         # maps thread_id to whether that thread overlaps in execution with any
         # other thread in this @given. We use this to detect whether an @given is
-        # being run from multiple different threads at once, which informs whether
-        # decisions like whether to raise DeadlineExceeded.
+        # being run from multiple different threads at once, which informs
+        # decisions like whether to raise DeadlineExceeded or HealthCheck.too_slow.
         thread_overlap: dict[int, bool] = {}
         thread_overlap_lock = Lock()
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -11,6 +11,7 @@
 import importlib
 import inspect
 import math
+import threading
 import time
 from collections import defaultdict
 from collections.abc import Generator, Sequence
@@ -278,6 +279,7 @@ class ConjectureRunner:
         random: Optional[Random] = None,
         database_key: Optional[bytes] = None,
         ignore_limits: bool = False,
+        thread_overlap: Optional[dict[int, bool]] = None,
     ) -> None:
         self._test_function: Callable[[ConjectureData], None] = test_function
         self.settings: Settings = settings or Settings()
@@ -291,6 +293,7 @@ class ConjectureRunner:
         self.random: Random = random or Random(getrandbits(128))
         self.database_key: Optional[bytes] = database_key
         self.ignore_limits: bool = ignore_limits
+        self.thread_overlap = {} if thread_overlap is None else thread_overlap
 
         # Global dict of per-phase statistics, and a list of per-call stats
         # which transfer to the global dict at the end of each phase.
@@ -779,7 +782,12 @@ class ConjectureRunner:
         # Allow at least the greater of one second or 5x the deadline.  If deadline
         # is None, allow 30s - the user can disable the healthcheck too if desired.
         draw_time_limit = 5 * (self.settings.deadline or timedelta(seconds=6))
-        if draw_time > max(1.0, draw_time_limit.total_seconds()):
+        if (
+            draw_time > max(1.0, draw_time_limit.total_seconds())
+            # we disable HealthCheck.too_slow under concurrent threads, since
+            # cpython may switch away from a thread for arbitrarily long.
+            and not self.thread_overlap.get(threading.get_ident(), False)
+        ):
             fail_health_check(
                 self.settings,
                 "Data generation is extremely slow: Only produced "


### PR DESCRIPTION
Part of https://github.com/HypothesisWorks/hypothesis/issues/4451. Discussion in https://github.com/HypothesisWorks/hypothesis/pull/4388#issuecomment-3124748043. Untested since I don't have a consistent local reproducer, but follows the same pattern as `DeadlineExceeded`.