### PR TITLE
Improve detection of sys.monitoring

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve detection of sys.monitoring to avoid errors on GraalPy.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1434,7 +1434,7 @@ class StateForActualGivenExecution:
         # If we have not traced executions, warn about that now (but only when
         # we'd expect to do so reliably, i.e. on CPython>=3.12)
         if (
-            sys.version_info[:2] >= (3, 12)
+            hasattr(sys, "monitoring")
             and not PYPY
             and self._should_trace()
             and not Tracer.can_trace()


### PR DESCRIPTION
GraalPy's next release will update to 3.12, but we didn't yet implement `sys.monitoring`. This PR will avoid failing on the next GraalPy by checking for `sys.monitoring`'s presence instead of the python version. It shouldn't change anything for CPython.

CC @timfel