### PR TITLE
Add a lock to `OneOfStrategy.branches`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a threading race condition in |st.one_of| initialization.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -864,6 +864,10 @@ class OneOfStrategy(SearchStrategy[Ex]):
 
     @property
     def branches(self) -> Sequence[SearchStrategy[Ex]]:
+        if self.__element_strategies is not None:
+            # common fast path which avoids the lock
+            return self.element_strategies
+
         with self._branches_lock:
             if not self.__in_branches:
                 try:

--- a/hypothesis-python/tests/nocover/test_threading.py
+++ b/hypothesis-python/tests/nocover/test_threading.py
@@ -210,3 +210,17 @@ def test_deadline_exceeded_can_be_raised_after_threads():
     should_sleep = True
     with pytest.raises(DeadlineExceeded):
         slow_test()
+
+
+def test_one_of_branches_lock():
+    # I can't actually get this test to reproduce the race locally.
+    # This should in theory reproduce, but the timings here are very tight.
+    branch_counts = set()
+    s = st.one_of(st.integers(), st.integers(), st.integers())
+
+    def test():
+        branches = len(s.branches)
+        branch_counts.add(branches)
+
+    run_concurrently(test, n=10)
+    assert len(branch_counts) == 1


### PR DESCRIPTION
Part of #4451. This previously caused `test_inference_on_generic_collections_abc_aliases` to fail under threading.