### PR TITLE
Declare thread safety

### DIFF
--- a/hypothesis-python/RELEASE-sample.rst
+++ b/hypothesis-python/RELEASE-sample.rst
@@ -27,7 +27,7 @@ which should:
   - :class:`package.class` for link to classes (abbreviated as above).
   - :issue:`issue-number` for referencing issues.
   - Similarly, :pull:`pr-number` can be used for PRs, but it's usually
-    preferred to refer to version numbers such as :ref:`version 6.98.9 <v6.98.9>,
+    preferred to refer to version numbers with :v:`6.98.9`,
     as they are meaningful to end users.
   - :doc:`link text <chapter#anchor>` for documentation references.
   - `link text <https://hypothesis.readthedocs.io/en/latest/chapter.html#anchor>`__

--- a/hypothesis-python/docs/compatibility.rst
+++ b/hypothesis-python/docs/compatibility.rst
@@ -135,7 +135,7 @@ Cross-thread API calls
 
 In theory, Hypothesis supports cross-thread API calls, for instance spawning a thread inside of a test and using that to draw from |st.composite| or |st.data|, or to call |event|, |target|, or |assume|.
 
-However, we have not explicitly audited this behavior, and do not regularly test it in our CI. If you find a bug here, please report it. The answer might be "we investigated and this is not something we can support", in which case we will update this page.
+However, we have not explicitly audited this behavior, and do not regularly test it in our CI. If you find a bug here, please report it. If our investigation determines that we cannot support cross-thread calls for the feature in question, we will update this page accordingly.
 
 Type hints
 ----------

--- a/hypothesis-python/docs/compatibility.rst
+++ b/hypothesis-python/docs/compatibility.rst
@@ -1,4 +1,3 @@
-=============
 Compatibility
 =============
 
@@ -7,7 +6,6 @@ possibly need it to be compatible with. Generally you should just try it and
 expect it to work. If it doesn't, you can be surprised and check this document
 for the details.
 
--------------------
 Hypothesis versions
 -------------------
 
@@ -24,7 +22,6 @@ changes in patch releases.
 
 .. _deprecation-policy:
 
-------------
 Deprecations
 ------------
 
@@ -41,7 +38,6 @@ exactly where an error came from, or turn only our warnings into errors.
 .. autoclass:: hypothesis.errors.HypothesisDeprecationWarning
 
 
----------------
 Python versions
 ---------------
 
@@ -55,7 +51,6 @@ patch release of any version of Python it supports. Earlier releases should work
 and bugs in them will get fixed if reported, but they're not tested in CI and
 no guarantees are made.
 
------------------
 Operating systems
 -----------------
 
@@ -69,7 +64,6 @@ operating system it probably won't stay fixed due to the inevitable march of tim
 
 .. _framework-compatibility:
 
-------------------
 Testing frameworks
 ------------------
 
@@ -106,7 +100,6 @@ In terms of what's actually *known* to work:
 * :pypi:`coverage` works out of the box with Hypothesis; our own test suite has
   100% branch coverage.
 
------------------
 Optional packages
 -----------------
 
@@ -117,23 +110,33 @@ all versions that are supported upstream.
 
 .. _thread-safety-policy:
 
---------------------
 Thread-Safety Policy
 --------------------
 
-As discussed in :issue:`2719`, Hypothesis is not truly thread-safe and that's unlikely to change in the future.  This policy therefore describes what you *can* expect if you use Hypothesis with multiple threads.
+As of :version:`6.136.9`, Hypothesis is thread-safe. Each of the following is fully supported, and tested regularly in CI:
 
-**Running tests in multiple processes**, e.g. with ``pytest -n auto``, is fully supported and we test this regularly in CI - thanks to process isolation, we only need to ensure that :class:`~hypothesis.database.DirectoryBasedExampleDatabase` can't tread on its own toes too badly.  If you find a bug here we will fix it ASAP.
+* Running tests in multiple processes
+* Running separate tests in multiple threads
+* Running the same test in multiple threads
 
-**Running separate tests in multiple threads** is not something we design or test for, and is not formally supported.  That said, anecdotally it does mostly work and we would like it to keep working - we accept reasonable patches and low-priority bug reports.  The main risks here are global state, shared caches, and cached strategies.
+If you find a bug here, please report it. The main risks internally are global state, shared caches, and cached strategies.
 
-**Running the same test in multiple threads**, or using multiple threads within the same test, makes it pretty easy to trigger internal errors.  We usually accept patches for such issues unless readability or single-thread performance suffer.
+Thread usage inside tests
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Hypothesis assumes that tests are single-threaded, or do a sufficiently-good job of pretending to be single-threaded.  Tests that use helper threads internally should be OK, but the user must be careful to ensure that test outcomes are still deterministic. In particular it counts as nondeterministic if helper-thread timing changes the sequence of dynamic draws using e.g. the |st.data| strategy.
+.. TODO_DOCS: link to not-yet-merged flaky failure tutorial page
 
-Interacting with any Hypothesis APIs from helper threads might do weird/bad things, so avoid that too - we rely on thread-local variables in a few places, and haven't explicitly tested/audited how they respond to cross-thread API calls.  While |st.data| and equivalents are the most obvious danger, other APIs might also be subtly affected.
+Tests that spawn threads internally are supported by Hypothesis.
 
-----------
+However, these as with any Hypothesis test, these tests must have deterministic test outcomes and data generation. For example, if timing changes in the threads change the sequence of dynamic draws from |st.composite| or |st.data|, Hypothesis may report the test as flaky. The solution here is to refactor data generation so it does not depend on test timings.
+
+Cross-thread API calls
+~~~~~~~~~~~~~~~~~~~~~~
+
+In theory, Hypothesis supports cross-thread API calls, for instance spawning a thread inside of a test and using that to draw from |st.composite| or |st.data|, or to call |event|, |target|, or |assume|.
+
+However, we have not explicitly audited this behavior, and do not regularly test it in our CI. If you find a bug here, please report it. The answer might be "we investigated and this is not something we can support", in which case we will update this page.
+
 Type hints
 ----------
 

--- a/hypothesis-python/docs/conf.py
+++ b/hypothesis-python/docs/conf.py
@@ -14,6 +14,9 @@ import sys
 import types
 from pathlib import Path
 
+from docutils import nodes
+from sphinx.util.docutils import SphinxRole
+
 root = Path(__file__).parent.parent
 sys.path.append(str(root / "src"))
 sys.path.append(str(Path(__file__).parent / "_ext"))
@@ -87,6 +90,22 @@ version = _d["__version__"]
 release = _d["__version__"]
 
 
+# custom role for version syntaxes.
+# :v:`6.131.0`       = [v6.131.0](changelog.html#v6.13.0)
+# :version:`6.131.0` = [version 6.131.0](changelog.html#v6.13.0)
+class VersionRole(SphinxRole):
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def run(self):
+        node = nodes.reference(
+            "",
+            f"{self.prefix}{self.text}",
+            refuri=f"changelog.html#v{self.text.replace('.', '-')}",
+        )
+        return [node], []
+
+
 def setup(app):
     if root.joinpath("RELEASE.rst").is_file():
         app.tags.add("has_release_file")
@@ -131,6 +150,8 @@ def setup(app):
         return signature, return_annotation
 
     app.connect("autodoc-process-signature", process_signature)
+    app.add_role("v", VersionRole(prefix="v"))
+    app.add_role("version", VersionRole(prefix="version "))
 
 
 language = "en"

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -344,21 +344,30 @@ def test_machine_with_no_terminals_is_invalid():
 
 
 def test_minimizes_errors_in_teardown():
+    # temporary debugging to try to narrow down a potential thread-safety issue
+    import threading
+
+    from hypothesis import Verbosity
+
     counter = 0
 
+    @Settings(database=None, verbosity=Verbosity.debug)
     class Foo(RuleBasedStateMachine):
         @initialize()
         def init(self):
             nonlocal counter
             counter = 0
+            print(f"[{threading.get_ident()}] init", counter)
 
         @rule()
         def increment(self):
             nonlocal counter
             counter += 1
+            print(f"[{threading.get_ident()}] increment", counter)
 
         def teardown(self):
             nonlocal counter
+            print(f"[{threading.get_ident()}] teardown", counter)
             assert not counter
 
     with raises(AssertionError):


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4451 🎉 

I also saw a `check-threading` failure on master, which I cannot reproduce locally: https://github.com/HypothesisWorks/hypothesis/actions/runs/16794763925/job/47563329138#step:6:671. One of the threads doesn't shrink. I don't see how this can happen unless we have a race inside shrinking (but then why only for `.teardown()`?). I'm adding logging for the next time it triggers.