### PR TITLE
Add support for generic memoryview

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+On Python 3.14, |memoryview| is newly generic. This release adds the ability for |st.from_type| to resolve generic |memoryview| types on 3.14, like ``st.from_type(memoryview[CustomBufferClass])`` . ``CustomBufferClass`` must implement ``__buffer__``, as expected by |memoryview|.

--- a/hypothesis-python/docs/prolog.rst
+++ b/hypothesis-python/docs/prolog.rst
@@ -181,6 +181,7 @@
 .. |bytes| replace:: :obj:`python:bytes`
 .. |float| replace:: :obj:`python:float`
 .. |assert| replace:: :keyword:`python:assert`
+.. |memoryview| replace:: :class:`python:memoryview`
 .. |dataclasses| replace:: :mod:`python:dataclasses`
 .. |random.random| replace:: :class:`python:random.Random`
 .. |random.Random| replace:: :class:`python:random.Random`

--- a/hypothesis-python/tests/cover/test_lookup_py314.py
+++ b/hypothesis-python/tests/cover/test_lookup_py314.py
@@ -1,0 +1,62 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from collections.abc import Buffer
+from dataclasses import dataclass
+
+import pytest
+
+from hypothesis import given, strategies as st
+
+from tests.common.debug import find_any
+
+
+@dataclass
+class A:
+    constant = 42
+    x: int
+
+    # see https://docs.python.org/3/reference/datamodel.html#python-buffer-protocol
+    # and https://peps.python.org/pep-0688/
+    def __buffer__(self, flags):
+        return memoryview(
+            self.constant.to_bytes() + self.x.to_bytes(length=32, signed=True)
+        )
+
+
+@given(st.from_type(memoryview[A]))
+def test_resolve_bufferlike_memoryview(v):
+    assert isinstance(v, memoryview)
+    assert v[0] == A.constant
+    assert len(v) == 1 + 32
+
+
+def test_errors_when___buffer___not_implemented():
+    class NoBuffer:
+        pass
+
+    @given(st.from_type(memoryview[NoBuffer]))
+    def f(v):
+        pass
+
+    with pytest.raises(
+        TypeError, match="a bytes-like object is required, not 'NoBuffer'"
+    ):
+        f()
+
+
+def test_resolve_Buffer():
+    s = st.from_type(Buffer)
+    # on 3.12, we can generate neither. On 3.13, we can generate bytearray, because
+    # the removal of ByteString stops blocking bytearray from being the maximal
+    # registered type. On 3.14, we can generate both, because memoryview becomes
+    # generic.
+    find_any(s, lambda v: isinstance(v, memoryview))
+    find_any(s, lambda v: isinstance(v, bytearray))

--- a/hypothesis-python/tests/cover/test_lookup_py37.py
+++ b/hypothesis-python/tests/cover/test_lookup_py37.py
@@ -12,7 +12,6 @@ import collections
 import collections.abc
 import contextlib
 import re
-import sys
 
 import pytest
 
@@ -221,8 +220,10 @@ def test_resolving_standard_valuesview_as_generic(x: collections.abc.ValuesView[
 
 # Weird interaction with fixes in PR #2952
 #
-# 2025-07-31: though that is now fixed by cpython typing refactors in 3.14.
-@pytest.mark.xfail(sys.version_info[:2] < (3, 14), reason="fixed again in 3.14+")
+# 2025-08-11: this gets even weirder with 3.14, where memoryview is in fact a
+# context manager, and so gets resolved for AbstractContextManager[Elem] here.
+# (But then errors during generation, because Elem does not implement __buffer__).
+@pytest.mark.xfail
 @given(...)
 def test_resolving_standard_contextmanager_as_generic(
     x: contextlib.AbstractContextManager[Elem],


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4505.

I forgot that `Buffer` was not generic, so we don't need to add a `@register` for it to get nice type resolution. But it was good for me to go and verify that `st.from_type(Buffer)` works as expected, because it has an interesting interaction with the `collections.abc.ByteString` removal. See test comments.