### PR TITLE
Fix shared strategy warnings

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch re-enables the warning for incompatible :func:`~hypothesis.strategies.shared`
+strategies that was first enabled in :v:`6.133.0` but disabled in :v:`6.135.15`.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -77,7 +77,7 @@ from hypothesis.utils.threading import ThreadLocal
 if TYPE_CHECKING:
     from typing import TypeAlias
 
-    from hypothesis.strategies import SearchStrategy, SharedStrategy
+    from hypothesis.strategies import SearchStrategy
     from hypothesis.strategies._internal.core import DataObject
     from hypothesis.strategies._internal.random import RandomState
     from hypothesis.strategies._internal.strategies import Ex
@@ -706,7 +706,7 @@ class ConjectureData:
         self._sampled_from_all_strategies_elements_message: Optional[
             tuple[str, object]
         ] = None
-        self._shared_strategy_draws: dict[Hashable, tuple[Any, "SharedStrategy"]] = {}
+        self._shared_strategy_draws: dict[Hashable, tuple[Any, "SearchStrategy"]] = {}
         self._shared_data_strategy: Optional[DataObject] = None
         self._stateful_repr_parts: Optional[list[Any]] = None
         self.states_for_ids: Optional[dict[int, RandomState]] = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -77,7 +77,7 @@ from hypothesis.utils.threading import ThreadLocal
 if TYPE_CHECKING:
     from typing import TypeAlias
 
-    from hypothesis.strategies import SearchStrategy
+    from hypothesis.strategies import SearchStrategy, SharedStrategy
     from hypothesis.strategies._internal.core import DataObject
     from hypothesis.strategies._internal.random import RandomState
     from hypothesis.strategies._internal.strategies import Ex

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -706,7 +706,7 @@ class ConjectureData:
         self._sampled_from_all_strategies_elements_message: Optional[
             tuple[str, object]
         ] = None
-        self._shared_strategy_draws: dict[Hashable, tuple[int, Any]] = {}
+        self._shared_strategy_draws: dict[Hashable, tuple[Any, "SharedStrategy"]] = {}
         self._shared_data_strategy: Optional[DataObject] = None
         self._stateful_repr_parts: Optional[list[Any]] = None
         self.states_for_ids: Optional[dict[int, RandomState]] = None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -45,7 +45,7 @@ def calc_label_from_callable(f: Callable) -> int:
         # probably an instance defining __call__
         try:
             return calc_label_from_hash(f)
-        except Exception:  # pragma: no cover
+        except Exception:
             # not hashable
             return calc_label_from_cls(type(f))
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -45,7 +45,7 @@ def calc_label_from_callable(f: Callable) -> int:
         # probably an instance defining __call__
         try:
             return calc_label_from_hash(f)
-        except Exception:
+        except Exception:  # pragma: no cover
             # not hashable
             return calc_label_from_cls(type(f))
 

--- a/hypothesis-python/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis-python/src/hypothesis/internal/lambda_sources.py
@@ -65,7 +65,7 @@ def extract_all_attributes(tree):
     return attributes
 
 
-def _function_key(f, *, bounded_size=False):
+def _function_key(f, *, bounded_size=False, ignore_name=False):
     """Returns a digest that differentiates functions that have different sources.
 
     Either a function or a code object may be passed. If code object, default
@@ -96,7 +96,7 @@ def _function_key(f, *, bounded_size=False):
         code.co_names,
         code.co_varnames,
         code.co_freevars,
-        code.co_name,
+        ignore_name or code.co_name,
     )
 
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1886,7 +1886,10 @@ class CompositeStrategy(SearchStrategy):
         return self.definition(data.draw, *self.args, **self.kwargs)
 
     def calc_label(self) -> int:
-        return calc_label_from_callable(self.definition)
+        return combine_labels(
+            self.class_label,
+            calc_label_from_callable(self.definition),
+        )
 
 
 class DrawFn(Protocol):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -83,7 +83,7 @@ from hypothesis.internal.compat import (
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.utils import (
     calc_label_from_callable,
-    calc_label_from_hash,
+    calc_label_from_name,
     check_sample,
     combine_labels,
     identity,
@@ -1060,7 +1060,7 @@ class BuildsStrategy(SearchStrategy[Ex]):
             self.class_label,
             calc_label_from_callable(self.target),
             *[strat.label for strat in self.args],
-            *[calc_label_from_hash(k) for k in self.kwargs],
+            *[calc_label_from_name(k) for k in self.kwargs],
             *[strat.label for strat in self.kwargs.values()],
         )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -82,8 +82,11 @@ from hypothesis.internal.compat import (
 )
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.utils import (
+    calc_label_from_callable,
     calc_label_from_cls,
+    calc_label_from_hash,
     check_sample,
+    combine_labels,
     identity,
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
@@ -1053,6 +1056,15 @@ class BuildsStrategy(SearchStrategy[Ex]):
         self.args = args
         self.kwargs = kwargs
 
+    def calc_label(self) -> int:
+        return combine_labels(
+            self.class_label,
+            calc_label_from_callable(self.target),
+            *[strat.label for strat in self.args],
+            *[calc_label_from_hash(k) for k in self.kwargs.keys()],
+            *[strat.label for strat in self.kwargs.values()],
+        )
+
     def do_draw(self, data: ConjectureData) -> Ex:
         args = [data.draw(s) for s in self.args]
         kwargs = {k: data.draw(v) for k, v in self.kwargs.items()}
@@ -1875,7 +1887,7 @@ class CompositeStrategy(SearchStrategy):
         return self.definition(data.draw, *self.args, **self.kwargs)
 
     def calc_label(self) -> int:
-        return calc_label_from_cls(self.definition)
+        return calc_label_from_callable(self.definition)
 
 
 class DrawFn(Protocol):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -83,7 +83,6 @@ from hypothesis.internal.compat import (
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.utils import (
     calc_label_from_callable,
-    calc_label_from_cls,
     calc_label_from_hash,
     check_sample,
     combine_labels,
@@ -1061,7 +1060,7 @@ class BuildsStrategy(SearchStrategy[Ex]):
             self.class_label,
             calc_label_from_callable(self.target),
             *[strat.label for strat in self.args],
-            *[calc_label_from_hash(k) for k in self.kwargs.keys()],
+            *[calc_label_from_hash(k) for k in self.kwargs],
             *[strat.label for strat in self.kwargs.values()],
         )
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
@@ -11,6 +11,7 @@
 from typing import Callable, Generic, TypeVar
 
 from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.utils import calc_label_from_callable, combine_labels
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal.strategies import (
     RecurT,
@@ -34,6 +35,13 @@ class FlatMapStrategy(SearchStrategy[MappedTo], Generic[MappedFrom, MappedTo]):
 
     def calc_is_empty(self, recur: RecurT) -> bool:
         return recur(self.base)
+
+    def calc_label(self) -> int:
+        return combine_labels(
+            self.class_label,
+            self.base.label,
+            calc_label_from_callable(self.expand),
+        )
 
     def __repr__(self) -> str:
         if not hasattr(self, "_cached_repr"):

--- a/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/flatmapped.py
@@ -11,7 +11,10 @@
 from typing import Callable, Generic, TypeVar
 
 from hypothesis.internal.conjecture.data import ConjectureData
-from hypothesis.internal.conjecture.utils import calc_label_from_callable, combine_labels
+from hypothesis.internal.conjecture.utils import (
+    calc_label_from_callable,
+    combine_labels,
+)
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal.strategies import (
     RecurT,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -16,7 +16,6 @@ from typing import Literal, Optional, Union, cast
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture.data import ConjectureData
-from hypothesis.internal.conjecture.utils import calc_label_from_hash, combine_labels
 from hypothesis.internal.filtering import (
     get_float_predicate_bounds,
     get_integer_predicate_bounds,
@@ -66,13 +65,6 @@ class IntegersStrategy(SearchStrategy[int]):
         if self.start is None:
             return f"integers(max_value={self.end})"
         return f"integers({self.start}, {self.end})"
-
-    def calc_label(self) -> int:
-        return combine_labels(
-            self.class_label,
-            calc_label_from_hash(self.start),
-            calc_label_from_hash(self.end),
-        )
 
     def do_draw(self, data: ConjectureData) -> int:
         # For bounded integers, make the bounds and near-bounds more likely.
@@ -188,15 +180,6 @@ class FloatStrategy(SearchStrategy[float]):
             f"{self.__class__.__name__}({self.min_value=}, {self.max_value=}, "
             f"{self.allow_nan=}, {self.smallest_nonzero_magnitude=})"
         ).replace("self.", "")
-
-    def calc_label(self) -> int:
-        return combine_labels(
-            self.class_label,
-            calc_label_from_hash(self.min_value),
-            calc_label_from_hash(self.max_value),
-            calc_label_from_hash(self.allow_nan),
-            calc_label_from_hash(self.smallest_nonzero_magnitude),
-        )
 
     def do_draw(self, data: ConjectureData) -> float:
         return data.draw_float(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -15,8 +15,8 @@ from typing import Literal, Optional, Union, cast
 
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.conjecture.utils import calc_label_from_hash, combine_labels
 from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.utils import calc_label_from_hash, combine_labels
 from hypothesis.internal.filtering import (
     get_float_predicate_bounds,
     get_integer_predicate_bounds,

--- a/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py
@@ -15,6 +15,7 @@ from typing import Literal, Optional, Union, cast
 
 from hypothesis.control import reject
 from hypothesis.errors import InvalidArgument
+from hypothesis.internal.conjecture.utils import calc_label_from_hash, combine_labels
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.filtering import (
     get_float_predicate_bounds,
@@ -65,6 +66,13 @@ class IntegersStrategy(SearchStrategy[int]):
         if self.start is None:
             return f"integers(max_value={self.end})"
         return f"integers({self.start}, {self.end})"
+
+    def calc_label(self) -> int:
+        return combine_labels(
+            self.class_label,
+            calc_label_from_hash(self.start),
+            calc_label_from_hash(self.end),
+        )
 
     def do_draw(self, data: ConjectureData) -> int:
         # For bounded integers, make the bounds and near-bounds more likely.
@@ -180,6 +188,15 @@ class FloatStrategy(SearchStrategy[float]):
             f"{self.__class__.__name__}({self.min_value=}, {self.max_value=}, "
             f"{self.allow_nan=}, {self.smallest_nonzero_magnitude=})"
         ).replace("self.", "")
+
+    def calc_label(self) -> int:
+        return combine_labels(
+            self.class_label,
+            calc_label_from_hash(self.min_value),
+            calc_label_from_hash(self.max_value),
+            calc_label_from_hash(self.allow_nan),
+            calc_label_from_hash(self.smallest_nonzero_magnitude),
+        )
 
     def do_draw(self, data: ConjectureData) -> float:
         return data.draw_float(

--- a/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
@@ -23,15 +23,15 @@ class SharedStrategy(SearchStrategy[Ex]):
         super().__init__()
         self.key = key
         self.base = base
-        while isinstance(self.base, SharedStrategy):
-            # Unwrap nested shares
-            self.base = self.base.base
 
     def __repr__(self) -> str:
         if self.key is not None:
             return f"shared({self.base!r}, key={self.key!r})"
         else:
             return f"shared({self.base!r})"
+
+    def calc_label(self) -> int:
+        return self.base.calc_label()
 
     # Ideally would be -> Ex, but key collisions with different-typed values are
     # possible. See https://github.com/HypothesisWorks/hypothesis/issues/4301.
@@ -44,7 +44,7 @@ class SharedStrategy(SearchStrategy[Ex]):
             drawn, other = data._shared_strategy_draws[key]
 
             # Check that the strategies shared under this key are equivalent
-            if self.base.label != other.base.label:
+            if self.label != other.label:
                 warnings.warn(
                     f"Different strategies are shared under {key=}. This"
                     " risks drawing values that are not valid examples for the strategy,"

--- a/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
@@ -49,7 +49,7 @@ class SharedStrategy(SearchStrategy[Ex]):
                     f"Different strategies are shared under {key=}. This"
                     " risks drawing values that are not valid examples for the strategy,"
                     " or that have a narrower range than expected."
-                    f" Conflicting strategies: ({self.base!r}, {other.base!r}).",
+                    f" Conflicting strategies: ({self!r}, {other!r}).",
                     HypothesisWarning,
                     stacklevel=1,
                 )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
@@ -43,19 +43,14 @@ class SharedStrategy(SearchStrategy[Ex]):
         else:
             drawn, other = data._shared_strategy_draws[key]
 
-            if other.base is not self.base:
-                # Check that the strategies shared under this key are equivalent,
-                # approximated as having equal `repr`s. False positives are ok,
-                # false negatives (erroneous warnings) less so.
-                if not hasattr(self, "_is_compatible"):
-                    self._is_compatible = repr(self.base) == repr(other.base)
-                if not self._is_compatible:
-                    warnings.warn(
-                        f"Different strategies are shared under {key=}. This"
-                        " risks drawing values that are not valid examples for the strategy,"
-                        " or that have a narrower range than expected."
-                        f" Conflicting strategies: ({self.base!r}, {other.base!r}).",
-                        HypothesisWarning,
-                        stacklevel=1,
-                    )
+            # Check that the strategies shared under this key are equivalent
+            if self.base.label != other.base.label:
+                warnings.warn(
+                    f"Different strategies are shared under {key=}. This"
+                    " risks drawing values that are not valid examples for the strategy,"
+                    " or that have a narrower range than expected."
+                    f" Conflicting strategies: ({self.base!r}, {other.base!r}).",
+                    HypothesisWarning,
+                    stacklevel=1,
+                )
         return drawn

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -702,7 +702,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
             isinstance(x, SearchStrategy) for x in self.elements
         ):
             data._sampled_from_all_strategies_elements_message = (
-                "sample_from was given a collection of strategies: "
+                "sampled_from was given a collection of strategies: "
                 "{!r}. Was one_of intended?",
                 self.elements,
             )

--- a/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/utils.py
@@ -69,7 +69,6 @@ def cacheable(fn: T) -> T:
         else:
             result = fn(*args, **kwargs)
             if not isinstance(result, SearchStrategy) or result.is_cacheable:
-                result._is_singleton = True
                 _STRATEGY_CACHE[cache_key] = result
             return result
 

--- a/hypothesis-python/tests/conjecture/test_utils.py
+++ b/hypothesis-python/tests/conjecture/test_utils.py
@@ -208,3 +208,20 @@ def test_samples_from_a_range_directly():
 
 def test_p_continue_to_average_saturates():
     assert cu._p_continue_to_avg(1.1, 100) == 100
+
+
+def test_unhashable_calc_label():
+
+    class Unhashable:
+        def __call__(self):
+            return None
+
+        def __hash__(self):
+            raise TypeError
+
+    c1 = Unhashable()
+    c2 = Unhashable()
+
+    with pytest.raises(TypeError):
+        assert cu.calc_label_from_hash(c1) == cu.calc_label_from_hash(c2)
+    assert cu.calc_label_from_callable(c1) == cu.calc_label_from_callable(c2)

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -589,14 +589,23 @@ def test_builds_error_messages(data):
 @pytest.mark.parametrize(
     "strat_a,strat_b",
     [
-        (st.integers(), st.integers(0)),
+        pytest.param(
+            st.integers(),
+            st.integers(0),
+            marks=pytest.mark.xfail(
+                # this is the exception raised by failed pytest.warns(),
+                # ref https://github.com/pytest-dev/pytest/issues/8928
+                raises=pytest.fail.Exception,
+                strict=True,
+                reason="constraints not checked",
+            ),
+        ),
         (st.builds(int), st.builds(float)),
         (st.none(), st.integers()),
         (
             st.composite(lambda draw: draw(st.none()))(),
             st.composite(lambda draw: draw(st.integers()))(),
         ),
-        (st.builds(int, st.integers()), st.builds(int, st.integers(0))),
     ],
 )
 def test_incompatible_shared_strategies_warns(strat_a, strat_b):

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -592,16 +592,11 @@ def test_builds_error_messages(data):
         (st.integers(), st.integers(0)),
         (st.builds(int), st.builds(float)),
         (st.none(), st.integers()),
-        pytest.param(
+        (
             st.composite(lambda draw: draw(st.none()))(),
             st.composite(lambda draw: draw(st.integers()))(),
-            marks=pytest.mark.xfail(
-                # https://github.com/pytest-dev/pytest/issues/8928
-                raises=pytest.fail.Exception,
-                strict=True,
-                reason="same-name incompatible @composite",
-            ),
         ),
+        (st.builds(int, st.integers()), st.builds(int, st.integers(0))),
     ],
 )
 def test_incompatible_shared_strategies_warns(strat_a, strat_b):
@@ -633,24 +628,11 @@ def _composite2(draw):
         (st.floats(allow_nan=False), st.floats(allow_nan=False)),
         (st.builds(float), st.builds(float)),
         (_composite1(), _composite1()),
-        pytest.param(
+        (
             st.floats(allow_nan=False, allow_infinity=False),
             st.floats(allow_nan=False, allow_infinity=0),
-            marks=pytest.mark.xfail(
-                raises=HypothesisWarning,
-                strict=True,
-                reason="un-normalized constraint value (issue #4417)",
-            ),
         ),
-        pytest.param(
-            _composite1(),
-            _composite2(),
-            marks=pytest.mark.xfail(
-                raises=HypothesisWarning,
-                strict=True,
-                reason="differently named @composites",
-            ),
-        ),
+        (_composite1(), _composite2()),
         pytest.param(
             st.integers().flatmap(st.just),
             st.integers(),

--- a/hypothesis-python/tests/cover/test_direct_strategies.py
+++ b/hypothesis-python/tests/cover/test_direct_strategies.py
@@ -661,11 +661,12 @@ def test_compatible_shared_strategies_do_not_warn(strat_a, strat_b):
 def test_compatible_nested_shared_strategies_do_not_warn():
     shared_a = st.shared(st.integers(), key="share")
     shared_b = st.shared(st.integers(), key="share")
-    shared_c = st.shared(shared_a, key="share")
+    shared_c = st.shared(shared_a, key="nested_share")
+    shared_d = st.shared(shared_b, key="nested_share")
 
-    @given(shared_a, shared_b, shared_c)
+    @given(shared_a, shared_b, shared_c, shared_d)
     @settings(max_examples=10, phases=[Phase.generate])
-    def test_it(a, b, c):
-        assert a == b == c
+    def test_it(a, b, c, d):
+        assert a == b == c == d
 
     test_it()

--- a/hypothesis-python/tests/cover/test_sampled_from.py
+++ b/hypothesis-python/tests/cover/test_sampled_from.py
@@ -313,7 +313,7 @@ class TestErrorNoteBehavior3819:
             matching_messages = [
                 n
                 for n in notes
-                if n.startswith("sample_from was given a collection of strategies")
+                if n.startswith("sampled_from was given a collection of strategies")
                 and n.endswith("Was one_of intended?")
             ]
             assert len(matching_messages) == (1 if should_exp_msg else 0)

--- a/hypothesis-python/tests/nocover/test_labels.py
+++ b/hypothesis-python/tests/nocover/test_labels.py
@@ -34,8 +34,17 @@ def bar(draw):
     return draw(st.none())
 
 
+@st.composite
+def baz(draw):
+    return draw(st.booleans())
+
+
+def test_equivalent_composites_have_same_label():
+    assert foo().label == bar().label
+
+
 def test_different_composites_have_different_labels():
-    assert foo().label != bar().label
+    assert foo().label != baz().label
 
 
 def test_one_of_label_is_distinct():


### PR DESCRIPTION
Closes #4301.

After I realized that a single strategy may be present multiple times by different keys in the strategy cache, dealing with cache revocations became untenable. So this alternative solution does not refer to the cache or singletons at all, and just compares strategy labels. This is strictly less powerful, as it it doesn't distinguish strategies with incompatible constraints; but it is reasonably clean&safe, and if the label concept grow more powerful in the future then the warning will, too.