### PR TITLE
Annotate `register_type_strategy` as accepting `TypeAliasType`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The type annotations for |st.register_type_strategy| now indicate that it accepts registering types created with |TypeAliasType| (aka ``type MyType = int``).

--- a/hypothesis-python/docs/prolog.rst
+++ b/hypothesis-python/docs/prolog.rst
@@ -187,3 +187,7 @@
 .. |random.Random| replace:: :class:`python:random.Random`
 .. |ellipsis| replace:: :obj:`python:Ellipsis`
 .. |Ellipsis| replace:: :obj:`python:Ellipsis`
+
+.. |TypeAlias| replace:: :obj:`python:typing.TypeAlias`
+.. |TypeAliasType| replace:: :class:`python:typing.TypeAliasType`
+.. |NewType| replace:: :class:`python:typing.NewType`

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -27,6 +27,7 @@ from inspect import Parameter, Signature, isabstract, isclass
 from re import Pattern
 from types import FunctionType, GenericAlias
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     AnyStr,
@@ -141,6 +142,9 @@ from hypothesis.strategies._internal.strings import (
 from hypothesis.strategies._internal.utils import cacheable, defines_strategy
 from hypothesis.utils.conventions import not_set
 from hypothesis.vendor.pretty import RepresentationPrinter
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
 
 
 @cacheable
@@ -2357,8 +2361,18 @@ def data() -> SearchStrategy[DataObject]:
     return DataStrategy()
 
 
+if sys.version_info < (3, 12):
+    # TypeAliasType is new in 3.12
+    RegisterTypeT: "TypeAlias" = type[Ex]
+else:
+    from typing import TypeAliasType
+
+    # see https://github.com/HypothesisWorks/hypothesis/issues/4410
+    RegisterTypeT: "TypeAlias" = Union[type[Ex], TypeAliasType]
+
+
 def register_type_strategy(
-    custom_type: type[Ex],
+    custom_type: RegisterTypeT,
     strategy: Union[SearchStrategy[Ex], Callable[[type[Ex]], SearchStrategy[Ex]]],
 ) -> None:
     """Add an entry to the global type-to-strategy lookup.

--- a/whole_repo_tests/test_mypy.py
+++ b/whole_repo_tests/test_mypy.py
@@ -614,7 +614,7 @@ def test_raises_for_mixed_pos_kwargs_in_given(tmp_path, python_version):
 
 
 def test_register_random_interface(tmp_path):
-    f = tmp_path / "check_mypy_on_pos_arg_only_strats.py"
+    f = tmp_path / "test_register_random_interface.py"
     f.write_text(
         textwrap.dedent(
             """
@@ -635,3 +635,26 @@ def test_register_random_interface(tmp_path):
         encoding="utf-8",
     )
     assert_mypy_errors(f, [])
+
+
+def test_register_type_strategy_type_alias_type(tmp_path):
+    # see https://github.com/HypothesisWorks/hypothesis/issues/4410
+    f = tmp_path / "test_register_type_strategy_type_alias_type.py"
+    f.write_text(
+        textwrap.dedent(
+            """
+            from hypothesis import strategies as st
+            from typing import TypeAliasType
+
+            def ints() -> st.SearchStrategy[int]:
+                return st.from_type(int)
+
+            Ints = TypeAliasType("Ints", int)  # or `type Ints = int`
+
+            # this previous failed type-checking
+            st.register_type_strategy(Ints, ints())
+            """
+        ),
+        encoding="utf-8",
+    )
+    assert_mypy_errors(f, [], python_version="3.12")


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4410. That behavior is intentional upstream: https://github.com/python/mypy/issues/19661. The proposed `TypeForm` there looks like what we want, but that's still in draft PEP stage. In the meantime, we can type it as supporting `TypeAliasType` explicitly, although it's an overapproximation relative to `TypeForm[Ex]` because we can't say `TypeAliasType[Ex]`.