### PR TITLE
Improvements to bytecode-comparison of lambdas

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+TYPE: patch
+
+This patch further improves stringification of lambdas, by
+never returning a lambda source unless it is confirmed to
+compile to the same code object. This stricter check makes
+it possible to widen the search for a matching source block,
+so that it can often be found even if the file has been
+edited.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
-TYPE: patch
+RELEASE_TYPE: patch
 
 This patch further improves stringification of lambdas, by
 never returning a lambda source unless it is confirmed to

--- a/hypothesis-python/src/hypothesis/internal/filtering.py
+++ b/hypothesis-python/src/hypothesis/internal/filtering.py
@@ -34,10 +34,8 @@ from typing import Any, Callable, NamedTuple, Optional, TypeVar
 
 from hypothesis.internal.compat import ceil, floor
 from hypothesis.internal.floats import next_down, next_up
-from hypothesis.internal.reflection import (
-    get_pretty_function_description,
-    lambda_description,
-)
+from hypothesis.internal.lambda_sources import lambda_description
+from hypothesis.internal.reflection import get_pretty_function_description
 
 Ex = TypeVar("Ex")
 Predicate = Callable[[Ex], bool]

--- a/hypothesis-python/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis-python/src/hypothesis/internal/lambda_sources.py
@@ -1,0 +1,389 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import ast
+import inspect
+import linecache
+import sys
+import textwrap
+from collections.abc import MutableMapping
+from inspect import Parameter
+from typing import Any, Callable, Optional
+from weakref import WeakKeyDictionary
+
+from hypothesis.internal import reflection
+from hypothesis.internal.cache import LRUCache
+
+# we have several levels of caching for lambda descriptions.
+# * LAMBDA_DESCRIPTION_CACHE maps a lambda f to its description _lambda_description(f).
+#   Note that _lambda_description(f) may not be identical to f as it appears in the
+#   source code file.
+# * LAMBDA_DIGEST_DESCRIPTION_CACHE maps _function_key(f) to _lambda_description(f).
+#   _function_key implements something close to "ast equality":
+#   two syntactically identical (minus whitespace etc) lambdas appearing in
+#   different files have the same key. Cache hits here provide a fast path which
+#   avoids ast-parsing syntactic lambdas we've seen before. Two lambdas with the
+#   same _function_key will not have different _lambda_descriptions - if
+#   they do, that's a bug here.
+# * AST_LAMBDAS_CACHE maps source code lines to a list of the lambdas found in
+#   that source code. A cache hit here avoids reparsing the ast.
+LAMBDA_DESCRIPTION_CACHE: MutableMapping[Callable, str] = WeakKeyDictionary()
+LAMBDA_DIGEST_DESCRIPTION_CACHE: LRUCache[tuple[Any], str] = LRUCache(max_size=1000)
+AST_LAMBDAS_CACHE: LRUCache[tuple[str], list[ast.Lambda]] = LRUCache(max_size=100)
+
+
+def extract_all_lambdas(tree, *, extract_nested=True):
+    lambdas = []
+
+    class Visitor(ast.NodeVisitor):
+
+        def visit_Lambda(self, node):
+            lambdas.append(node)
+            if extract_nested:  # pragma: no branch
+                self.visit(node.body)
+
+    Visitor().visit(tree)
+    return lambdas
+
+
+def extract_all_attributes(tree, *, extract_nested=True):
+    attributes = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Attribute(self, node):
+            attributes.append(node)
+            if extract_nested:  # pragma: no branch
+                self.visit(node.value)
+
+    Visitor().visit(tree)
+    return attributes
+
+
+def _normalize_code(f, l):
+    # Opcodes, from dis.opmap (as of 3.13)
+    NOP = 9
+    LOAD_FAST = 85
+    LOAD_FAST_LOAD_FAST = 88
+    LOAD_FAST_BORROW = 86
+    LOAD_FAST_BORROW_LOAD_FAST_BORROW = 87
+
+    # A small selection of possible peephole code transformations, based on what
+    # is actually seen to differ between compilations in our test suite. Each
+    # entry contains two equivalent opcode sequences, plus an optional check
+    # function called with their respective oparg sequences.
+    Checker = Callable[[list[int], list[int]], bool]
+    transforms: tuple[list[int], list[int], Optional[Checker]] = [
+        ([NOP], [], None),
+        (
+            [LOAD_FAST, LOAD_FAST],
+            [LOAD_FAST_LOAD_FAST],
+            lambda a, b: a == [b[0] >> 4, b[0] & 15],
+        ),
+        (
+            [LOAD_FAST_BORROW, LOAD_FAST_BORROW],
+            [LOAD_FAST_BORROW_LOAD_FAST_BORROW],
+            lambda a, b: a == [b[0] >> 4, b[0] & 15],
+        ),
+    ]
+    # augment with inverse
+    transforms += [
+        (ops_b, ops_a, checker and (lambda a, b, checker=checker: checker(b, a)))
+        for ops_a, ops_b, checker in transforms
+    ]
+
+    # Normalize equivalent code. We assume that each bytecode op is 2 bytes,
+    # which is the case since Python 3.6. Since the opcodes values may change
+    # between version, there is a risk that a transform may not be equivalent
+    # -- even so, the risk of a bad transform producing a false positive is
+    # minuscule.
+    co_code = list(l.__code__.co_code)
+    f_code = list(f.__code__.co_code)
+
+    def alternating(code, i, n):
+        return code[i : i + 2 * n : 2]
+
+    i = 2
+    while i < max(len(co_code), len(f_code)):
+        # note that co_code is mutated in loop
+        if i < min(len(co_code), len(f_code)) and f_code[i] == co_code[i]:
+            i += 2
+        else:
+            for op1, op2, checker in transforms:
+                if (
+                    op1 == alternating(f_code, i, len(op1))
+                    and op2 == alternating(co_code, i, len(op2))
+                    and (
+                        checker is None
+                        or checker(
+                            alternating(f_code, i + 1, len(op1)),
+                            alternating(co_code, i + 1, len(op2)),
+                        )
+                    )
+                ):
+                    break
+            else:
+                # no point in continuing since the bytecodes are different anyway
+                break
+            # Splice in the transform and continue
+            co_code = (
+                co_code[:i] + f_code[i : i + 2 * len(op1)] + co_code[i + 2 * len(op2) :]
+            )
+            i += 2 * len(op1)
+
+    # Normalize consts, in particular replace any lambda consts with the
+    # corresponding const from the template function, IFF they have the same
+    # source key.
+
+    f_consts = f.__code__.co_consts
+    l_consts = l.__code__.co_consts
+    if len(f_consts) == len(l_consts) and any(
+        inspect.iscode(l_const) for l_const in l_consts
+    ):
+        normalized_consts = []
+        for f_const, l_const in zip(f_consts, l_consts):
+            if (
+                inspect.iscode(l_const)
+                and inspect.iscode(f_const)
+                and reflection._function_key(f_const)
+                == reflection._function_key(l_const)
+            ):
+                # If the lambdas are compiled from the same source, make them be the
+                # same object so that the toplevel lambdas end up equal. Note that
+                # default arguments are not available on the code objects. But if the
+                # default arguments differ then the lambdas must also differ in other
+                # ways, since default arguments are set up from bytecode and constants.
+                # I.e., this appears to be safe wrt false positives.
+                normalized_consts.append(f_const)
+            else:
+                normalized_consts.append(l_const)
+    else:
+        normalized_consts = l_consts
+
+    return l.__code__.replace(
+        co_code=bytes(co_code),
+        co_consts=tuple(normalized_consts),
+    )
+
+
+_module_map: dict[int, str] = {}
+
+
+def _mimic_lambda_from_node(f, node):
+    # Compile the source (represented by an ast.Lambda node) in a context that
+    # as far as possible mimics the context that f was compiled in. If - and
+    # only if - this was the source of f then the result is indistinguishable
+    # from f itself (to a casual observer such as _function_key).
+    f_globals = f.__globals__.copy()
+    f_code = f.__code__
+    source = ast.unparse(node)
+
+    # Install values for non-literal argument defaults. Thankfully, these are
+    # always captured by value - so there is no interaction with the closure.
+    if f.__defaults__:
+        for f_default, l_default in zip(f.__defaults__, node.args.defaults):
+            if isinstance(l_default, ast.Name):
+                f_globals[l_default.id] = f_default
+    if f.__kwdefaults__:
+        for l_default, l_varname in zip(node.args.kw_defaults, node.args.kwonlyargs):
+            if isinstance(l_default, ast.Name):  # pragma: no cover # shouldn't be?
+                f_globals[l_default.id] = f.__kwdefaults__[l_varname.arg]
+
+    # CPython's compiler treats known imports differently than normal globals,
+    # so check if we use attributes from globals that are modules (if so, we
+    # import them explicitly and redundantly in the exec below)
+    referenced_modules = [
+        (local_name, module)
+        for attr in extract_all_attributes(node)
+        if (
+            isinstance(attr.value, ast.Name)
+            and (local_name := attr.value.id)
+            and inspect.ismodule(module := f_globals.get(local_name))
+        )
+    ]
+
+    if not f_code.co_freevars and not referenced_modules:
+        compiled = eval(source, f_globals)
+    else:
+        if f_code.co_freevars:
+            # We have to reconstruct a local closure. The closure will have
+            # the same values as the original function, although this is not
+            # required for source/bytecode equality.
+            f_globals |= {
+                f"__lc{i}": c.cell_contents for i, c in enumerate(f.__closure__)
+            }
+            captures = [f"{name}=__lc{i}" for i, name in enumerate(f_code.co_freevars)]
+            capture_str = ";".join(captures) + ";"
+        else:
+            capture_str = ""
+        if referenced_modules:
+            # We add import statements for all referenced modules, since that
+            # influences the compiled code. The assumption is that these modules
+            # were explicitly imported, not assigned, in the source - if not,
+            # this may/will give a different compilation result.
+            global _module_map
+            if len(_module_map) != len(sys.modules):  # pragma: no branch
+                _module_map = {id(module): name for name, module in sys.modules.items()}
+            imports = [
+                (module_name, local_name)
+                for local_name, module in referenced_modules
+                if (module_name := _module_map.get(id(module))) is not None
+            ]
+            import_fragments = [f"{name} as {asname}" for name, asname in set(imports)]
+            import_str = f"import {','.join(import_fragments)}\n"
+        else:
+            import_str = ""
+        exec_str = (
+            f"{import_str}def __construct_lambda(): {capture_str} return ({source})"
+        )
+        exec(exec_str, f_globals)
+        compiled = f_globals["__construct_lambda"]()
+
+    return compiled
+
+
+def _lambda_code_matches_node(f, node):
+    try:
+        compiled = _mimic_lambda_from_node(f, node)
+    except (NameError, SyntaxError):  # pragma: no cover
+        return False
+    if reflection._function_key(f) == reflection._function_key(compiled):
+        return True
+    # Try harder
+    compiled.__code__ = _normalize_code(f, compiled)
+    return reflection._function_key(f) == reflection._function_key(compiled)
+
+
+def _lambda_description(f, leeway=10, *, fail_if_confused_with_perfect_candidate=False):
+    if hasattr(f, "__wrapped_target"):
+        f = f.__wrapped_target
+
+    # You might be wondering how a lambda can have a return-type annotation?
+    # The answer is that we add this at runtime, in new_given_signature(),
+    # and we do support strange choices as applying @given() to a lambda.
+    sig = inspect.signature(f)
+    assert sig.return_annotation in (Parameter.empty, None), sig
+
+    # Using pytest-xdist on Python 3.13, there's an entry in the linecache for
+    # file "<string>", which then returns nonsense to getsource.  Discard it.
+    linecache.cache.pop("<string>", None)
+
+    def format_lambda(body):
+        # The signature is more informative than the corresponding ast.unparse
+        # output in the case of default argument values, so add the signature
+        # to the unparsed body
+        return (
+            f"lambda {str(sig)[1:-1]}: {body}" if sig.parameters else f"lambda: {body}"
+        )
+
+    if_confused = format_lambda("<unknown>")
+
+    try:
+        source_lines, lineno0 = inspect.findsource(f)
+        source_lines = tuple(source_lines)  # make it hashable
+    except OSError:
+        return if_confused
+
+    try:
+        all_lambdas = AST_LAMBDAS_CACHE[source_lines]
+    except KeyError:
+        # The source isn't already parsed, so we try to shortcut by parsing just
+        # the local block. If that fails to produce a code-identical lambda,
+        # fall through to the full parse.
+        local_lines = inspect.getblock(source_lines[lineno0:])
+        local_block = textwrap.dedent("".join(local_lines))
+        if local_block.startswith("."):
+            # The fairly common ".map(lambda x: ...)" case. This partial block
+            # isn't valid syntax, but it might be if we remove the leading ".".
+            local_block = local_block[1:]
+
+        try:
+            local_tree = ast.parse(local_block)
+        except SyntaxError:
+            pass
+        else:
+            local_lambdas = extract_all_lambdas(local_tree)
+            for candidate in local_lambdas:
+                if reflection.ast_arguments_matches_signature(
+                    candidate.args, sig
+                ) and _lambda_code_matches_node(f, candidate):
+                    return format_lambda(ast.unparse(candidate.body))
+
+        # Local parse failed or didn't produce a match, go ahead with the full parse
+        try:
+            tree = ast.parse("".join(source_lines))
+        except SyntaxError:  # pragma: no cover
+            all_lambdas = []
+        else:
+            all_lambdas = extract_all_lambdas(tree)
+        AST_LAMBDAS_CACHE[source_lines] = all_lambdas
+
+    aligned_lambdas = []
+    for candidate in all_lambdas:
+        if (
+            candidate.lineno - leeway <= lineno0 + 1 <= candidate.lineno + leeway
+            and reflection.ast_arguments_matches_signature(candidate.args, sig)
+        ):
+            aligned_lambdas.append(candidate)
+
+    aligned_lambdas.sort(key=lambda c: abs(lineno0 + 1 - c.lineno))
+    for candidate in aligned_lambdas:
+        if _lambda_code_matches_node(f, candidate):
+            return format_lambda(ast.unparse(candidate.body))
+
+    # None of the aligned lambdas match perfectly in generated code.
+    if (
+        fail_if_confused_with_perfect_candidate
+        and aligned_lambdas
+        and aligned_lambdas[0].lineno == lineno0 + 1
+    ):  # pragma: no cover
+        # This arg is forced on in conftest.py, to ensure we resolve all known
+        # cases.
+        raise ValueError("None of the source-file lambda candidates were matched")
+    return if_confused
+
+
+def lambda_description(f):
+    """
+    Returns a syntactically-valid expression describing `f`. This is often, but
+    not always, the exact lambda definition string which appears in the source code.
+    The difference comes from parsing the lambda ast into `tree` and then returning
+    the result of `ast.unparse(tree)`, which may differ in whitespace, double vs
+    single quotes, etc.
+
+    Returns a string indicating an unknown body if the parsing gets confused in any way.
+    """
+    try:
+        return LAMBDA_DESCRIPTION_CACHE[f]
+    except KeyError:
+        pass
+
+    key = reflection._function_key(f, bounded_size=True)
+    failed_fnames = []
+    try:
+        description, failed_fnames = LAMBDA_DIGEST_DESCRIPTION_CACHE[key]
+        if (
+            "<unknown>" not in description and f.__code__.co_filename in failed_fnames
+        ):  # pragma: no cover
+            # Only accept the <unknown> description if it comes from parsing this
+            # file - otherwise, try again below, maybe we have more luck in another
+            # file. Once lucky, we keep keep using the successful description for *new*
+            # lambdas but not for this one - so it doesn't change name during its
+            # lifetime.
+            LAMBDA_DESCRIPTION_CACHE[f] = description
+            return description
+    except KeyError:
+        failed_fnames = []
+
+    description = _lambda_description(f)
+    LAMBDA_DESCRIPTION_CACHE[f] = description
+    if "<unknown>" in description:
+        failed_fnames.append(f.__code__.co_filename)
+    LAMBDA_DIGEST_DESCRIPTION_CACHE[key] = description, failed_fnames
+    return description

--- a/hypothesis-python/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis-python/src/hypothesis/internal/lambda_sources.py
@@ -117,7 +117,7 @@ def _normalize_code(f, l):
     # true for the transformation to be valid.
     Checker = Callable[[list[int], list[int]], bool]
     transforms: tuple[list[int], list[int], Optional[Checker]] = [
-        ([NOP], [], lambda: True),
+        ([NOP], [], lambda a, b: True),
         (
             [LOAD_FAST, LOAD_FAST],
             [LOAD_FAST_LOAD_FAST],

--- a/hypothesis-python/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis-python/src/hypothesis/internal/lambda_sources.py
@@ -303,7 +303,7 @@ def _check_unknown_perfectly_aligned_lambda(candidate):
     pass
 
 
-def _lambda_description(f, leeway=10, *, fail_if_confused_with_perfect_candidate=False):
+def _lambda_description(f, leeway=50, *, fail_if_confused_with_perfect_candidate=False):
     if hasattr(f, "__wrapped_target"):
         f = f.__wrapped_target
 

--- a/hypothesis-python/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis-python/src/hypothesis/internal/lambda_sources.py
@@ -117,7 +117,7 @@ def _normalize_code(f, l):
     # true for the transformation to be valid.
     Checker = Callable[[list[int], list[int]], bool]
     transforms: tuple[list[int], list[int], Optional[Checker]] = [
-        ([NOP], [], lambda a, b: True),
+        ([_op.NOP], [], lambda a, b: True),
         (
             [_op.LOAD_FAST, _op.LOAD_FAST],
             [_op.LOAD_FAST_LOAD_FAST],

--- a/hypothesis-python/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis-python/src/hypothesis/internal/lambda_sources.py
@@ -302,6 +302,7 @@ def _check_unknown_perfectly_aligned_lambda(candidate):
     # lambdas raise.
     pass
 
+
 def _lambda_description(f, leeway=10, *, fail_if_confused_with_perfect_candidate=False):
     if hasattr(f, "__wrapped_target"):
         f = f.__wrapped_target
@@ -342,7 +343,7 @@ def _lambda_description(f, leeway=10, *, fail_if_confused_with_perfect_candidate
         local_block = textwrap.dedent("".join(local_lines))
         # The fairly common ".map(lambda x: ...)" case. This partial block
         # isn't valid syntax, but it might be if we remove the leading ".".
-        local_block.removeprefix(".")
+        local_block = local_block.removeprefix(".")
 
         try:
             local_tree = ast.parse(local_block)

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -117,41 +117,6 @@ def function_digest(function: Any) -> bytes:
     return hasher.digest()
 
 
-def _function_key(f, *, bounded_size=False):
-    """Returns a digest that differentiates functions that have different sources.
-
-    Either a function or a code object may be passed. If code object, default
-    arg/kwarg values are not recoverable - this is the best we can do, and is
-    sufficient for the use case of comparing nested lambdas.
-    """
-    try:
-        code = f.__code__
-        defaults_repr = repr((f.__defaults__, f.__kwdefaults__))
-    except AttributeError:
-        code = f
-        defaults_repr = ()
-    consts_repr = repr(code.co_consts)
-    if bounded_size:
-        # Compress repr to avoid keeping arbitrarily large strings pinned as cache
-        # keys. We don't do this unconditionally because hashing takes time, and is
-        # not necessary if the key is used just for comparison (and is not stored).
-        if len(consts_repr) > 48:
-            consts_repr = hashlib.sha384(consts_repr.encode()).digest()
-        if len(defaults_repr) > 48:
-            defaults_repr = hashlib.sha384(consts_repr.encode()).digest()
-    return (
-        consts_repr,
-        defaults_repr,
-        code.co_argcount,
-        code.co_kwonlyargcount,
-        code.co_code,
-        code.co_names,
-        code.co_varnames,
-        code.co_freevars,
-        code.co_name,
-    )
-
-
 def check_signature(sig: Signature) -> None:
     # Backport from Python 3.11; see https://github.com/python/cpython/pull/92065
     for p in sig.parameters.values():

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -376,7 +376,8 @@ def _normalize_code(f, l):
                     op1 == alternating(f_code, i, len(op1))
                     and op2 == alternating(co_code, i, len(op2))
                     and (
-                        checker is None or checker(
+                        checker is None
+                        or checker(
                             alternating(f_code, i + 1, len(op1)),
                             alternating(co_code, i + 1, len(op2)),
                         )
@@ -630,7 +631,7 @@ def _lambda_description(f, leeway=10, *, fail_if_confused_with_perfect_candidate
         fail_if_confused_with_perfect_candidate
         and aligned_lambdas
         and aligned_lambdas[0].lineno == lineno0 + 1
-    ):
+    ):  # pragma: no cover
         # This arg is forced on in conftest.py, to ensure we resolve all known
         # cases.
         raise ValueError("None of the source-file lambda candidates were matched")
@@ -656,7 +657,7 @@ def lambda_description(f):
     failed_fnames = []
     try:
         description, failed_fnames = LAMBDA_DIGEST_DESCRIPTION_CACHE[key]
-        if "<unknown>" not in description and f.__code__.co_filename in failed_fnames:
+        if "<unknown>" not in description and f.__code__.co_filename in failed_fnames:  # pragma: no cover
             # Only accept the <unknown> description if it comes from parsing this
             # file - otherwise, try again below, maybe we have more luck in another
             # file. Once lucky, we keep keep using the successful description for *new*

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -14,13 +14,12 @@ to really unreasonable lengths to produce pretty output."""
 import ast
 import hashlib
 import inspect
-import linecache
 import re
 import sys
 import textwrap
 import types
 import warnings
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Sequence
 from functools import partial, wraps
 from inspect import Parameter, Signature
 from io import StringIO
@@ -30,10 +29,9 @@ from tokenize import COMMENT, generate_tokens, untokenize
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 from unittest.mock import _patch as PatchType
-from weakref import WeakKeyDictionary
 
 from hypothesis.errors import HypothesisWarning
-from hypothesis.internal.cache import LRUCache
+from hypothesis.internal import lambda_sources
 from hypothesis.internal.compat import EllipsisType, is_typed_named_tuple
 from hypothesis.utils.conventions import not_set
 from hypothesis.vendor.pretty import pretty
@@ -42,23 +40,6 @@ if TYPE_CHECKING:
     from hypothesis.strategies._internal.strategies import SearchStrategy
 
 T = TypeVar("T")
-
-# we have several levels of caching for lambda descriptions.
-# * LAMBDA_DESCRIPTION_CACHE maps a lambda f to its description _lambda_description(f).
-#   Note that _lambda_description(f) may not be identical to f as it appears in the
-#   source code file.
-# * LAMBDA_DIGEST_DESCRIPTION_CACHE maps _function_key(f) to _lambda_description(f).
-#   _function_key implements something close to "ast equality":
-#   two syntactically identical (minus whitespace etc) lambdas appearing in
-#   different files have the same key. Cache hits here provide a fast path which
-#   avoids ast-parsing syntactic lambdas we've seen before. Two lambdas with the
-#   same _function_key will not have different _lambda_descriptions - if
-#   they do, that's a bug here.
-# * AST_LAMBDAS_CACHE maps source code lines to a list of the lambdas found in
-#   that source code. A cache hit here avoids reparsing the ast.
-LAMBDA_DESCRIPTION_CACHE: MutableMapping[Callable, str] = WeakKeyDictionary()
-LAMBDA_DIGEST_DESCRIPTION_CACHE: LRUCache[tuple[Any], str] = LRUCache(max_size=1000)
-AST_LAMBDAS_CACHE: LRUCache[tuple[str], list[ast.Lambda]] = LRUCache(max_size=100)
 
 
 def is_mock(obj: object) -> bool:
@@ -134,6 +115,41 @@ def function_digest(function: Any) -> bytes:
     except AttributeError:
         pass
     return hasher.digest()
+
+
+def _function_key(f, *, bounded_size=False):
+    """Returns a digest that differentiates functions that have different sources.
+
+    Either a function or a code object may be passed. If code object, default
+    arg/kwarg values are not recoverable - this is the best we can do, and is
+    sufficient for the use case of comparing nested lambdas.
+    """
+    try:
+        code = f.__code__
+        defaults_repr = repr((f.__defaults__, f.__kwdefaults__))
+    except AttributeError:
+        code = f
+        defaults_repr = ()
+    consts_repr = repr(code.co_consts)
+    if bounded_size:
+        # Compress repr to avoid keeping arbitrarily large strings pinned as cache
+        # keys. We don't do this unconditionally because hashing takes time, and is
+        # not necessary if the key is used just for comparison (and is not stored).
+        if len(consts_repr) > 48:
+            consts_repr = hashlib.sha384(consts_repr.encode()).digest()
+        if len(defaults_repr) > 48:
+            defaults_repr = hashlib.sha384(consts_repr.encode()).digest()
+    return (
+        consts_repr,
+        defaults_repr,
+        code.co_argcount,
+        code.co_kwonlyargcount,
+        code.co_code,
+        code.co_names,
+        code.co_varnames,
+        code.co_freevars,
+        code.co_name,
+    )
 
 
 def check_signature(sig: Signature) -> None:
@@ -295,389 +311,6 @@ def is_first_param_referenced_in_function(f: Any) -> bool:
     )
 
 
-def extract_all_lambdas(tree, *, extract_nested=True):
-    lambdas = []
-
-    class Visitor(ast.NodeVisitor):
-
-        def visit_Lambda(self, node):
-            lambdas.append(node)
-            if extract_nested:  # pragma: no branch
-                self.visit(node.body)
-
-    Visitor().visit(tree)
-    return lambdas
-
-
-def extract_all_attributes(tree, *, extract_nested=True):
-    attributes = []
-
-    class Visitor(ast.NodeVisitor):
-        def visit_Attribute(self, node):
-            attributes.append(node)
-            if extract_nested:  # pragma: no branch
-                self.visit(node.value)
-
-    Visitor().visit(tree)
-    return attributes
-
-
-def _normalize_code(f, l):
-    # Opcodes, from dis.opmap (as of 3.13)
-    NOP = 9
-    LOAD_FAST = 85
-    LOAD_FAST_LOAD_FAST = 88
-    LOAD_FAST_BORROW = 86
-    LOAD_FAST_BORROW_LOAD_FAST_BORROW = 87
-
-    # A small selection of possible keyhole code transformations, based on what
-    # is actually seen to differ between compilations in our test suite. Each
-    # entry contains two equivalent opcode sequences, plus an optional check
-    # function called with their respective oparg sequences.
-    Checker = Callable[[list[int], list[int]], bool]
-    transforms: tuple[list[int], list[int], Optional[Checker]] = [
-        ([NOP], [], None),
-        (
-            [LOAD_FAST, LOAD_FAST],
-            [LOAD_FAST_LOAD_FAST],
-            lambda a, b: a == [b[0] >> 4, b[0] & 15],
-        ),
-        (
-            [LOAD_FAST_BORROW, LOAD_FAST_BORROW],
-            [LOAD_FAST_BORROW_LOAD_FAST_BORROW],
-            lambda a, b: a == [b[0] >> 4, b[0] & 15],
-        ),
-    ]
-    # augment with inverse
-    transforms += [
-        (ops_b, ops_a, checker and (lambda a, b, checker=checker: checker(b, a)))
-        for ops_a, ops_b, checker in transforms
-    ]
-
-    # Normalize equivalent code. We assume that each bytecode op is 2 bytes,
-    # which is the case since Python 3.6. Since the opcodes values may change
-    # between version, there is a risk that a transform may not be equivalent
-    # -- even so, the risk of a bad transform producing a false positive is
-    # minuscule.
-    co_code = list(l.__code__.co_code)
-    f_code = list(f.__code__.co_code)
-
-    def alternating(code, i, n):
-        return code[i : i + 2 * n : 2]
-
-    i = 2
-    while i < max(len(co_code), len(f_code)):
-        # note that co_code is mutated in loop
-        if i < min(len(co_code), len(f_code)) and f_code[i] == co_code[i]:
-            i += 2
-        else:
-            for op1, op2, checker in transforms:
-                if (
-                    op1 == alternating(f_code, i, len(op1))
-                    and op2 == alternating(co_code, i, len(op2))
-                    and (
-                        checker is None
-                        or checker(
-                            alternating(f_code, i + 1, len(op1)),
-                            alternating(co_code, i + 1, len(op2)),
-                        )
-                    )
-                ):
-                    break
-            else:
-                # no point in continuing since the bytecodes are different anyway
-                break
-            # Splice in the transform and continue
-            co_code = (
-                co_code[:i] + f_code[i : i + 2 * len(op1)] + co_code[i + 2 * len(op2) :]
-            )
-            i += 2 * len(op1)
-
-    # Normalize consts, in particular replace any lambda consts with the
-    # corresponding const from the template function, IFF they have the same
-    # source key.
-
-    f_consts = f.__code__.co_consts
-    l_consts = l.__code__.co_consts
-    if len(f_consts) == len(l_consts) and any(
-        inspect.iscode(l_const) for l_const in l_consts
-    ):
-        normalized_consts = []
-        for f_const, l_const in zip(f_consts, l_consts):
-            if (
-                inspect.iscode(l_const)
-                and inspect.iscode(f_const)
-                and _function_key(f_const) == _function_key(l_const)
-            ):
-                # If the lambdas are compiled from the same source, make them be the
-                # same object so that the toplevel lambdas end up equal. Note that if
-                # the default arguments differ in this case then the bytecode must
-                # also differ, since the default arguments are set up by the bytecode.
-                # I.e., this appears to be safe wrt false positives.
-                normalized_consts.append(f_const)
-            else:
-                normalized_consts.append(l_const)
-    else:
-        normalized_consts = l_consts
-
-    return l.__code__.replace(
-        co_code=bytes(co_code),
-        co_consts=tuple(normalized_consts),
-    )
-
-
-def _function_key(f, *, bounded_size=False):
-    """Returns a digest that differentiates functions that have different sources.
-
-    Either a function or a code object may be passed. If code object, default
-    arg/kwarg values are not recoverable - this is the best we can do, and is
-    sufficient for the use case of comparing nested lambdas.
-    """
-    try:
-        code = f.__code__
-        defaults_repr = repr((f.__defaults__, f.__kwdefaults__))
-    except AttributeError:
-        code = f
-        defaults_repr = ()
-    consts_repr = repr(code.co_consts)
-    if bounded_size:
-        # Compress repr to avoid keeping arbitrarily large strings pinned as cache
-        # keys. We don't do this unconditionally because hashing takes time, and is
-        # not necessary if the key is used just for comparison (and is not stored).
-        if len(consts_repr) > 48:
-            consts_repr = hashlib.sha384(consts_repr.encode()).digest()
-        if len(defaults_repr) > 48:
-            defaults_repr = hashlib.sha384(consts_repr.encode()).digest()
-    return (
-        consts_repr,
-        defaults_repr,
-        code.co_argcount,
-        code.co_kwonlyargcount,
-        code.co_code,
-        code.co_names,
-        code.co_varnames,
-        code.co_freevars,
-        code.co_name,
-    )
-
-
-_module_map: dict[int, str] = {}
-
-
-def _mimic_lambda_from_node(f, node):
-    # Compile the source (represented by an ast.Lambda node) in a context that
-    # as far as possible mimics the context that f was compiled in. If - and
-    # only if - this was the source of f then the result is indistinguishable
-    # from f itself (to a casual observer such as _function_key).
-    f_globals = f.__globals__.copy()
-    f_code = f.__code__
-    source = ast.unparse(node)
-
-    # Install values for non-literal argument defaults. Thankfully, these are
-    # always captured by value - so there is no interaction with the closure.
-    if f.__defaults__:
-        for f_default, l_default in zip(f.__defaults__, node.args.defaults):
-            if isinstance(l_default, ast.Name):
-                f_globals[l_default.id] = f_default
-    if f.__kwdefaults__:
-        for l_default, l_varname in zip(node.args.kw_defaults, node.args.kwonlyargs):
-            if isinstance(l_default, ast.Name):  # pragma: no cover # shouldn't be?
-                f_globals[l_default.id] = f.__kwdefaults__[l_varname.arg]
-
-    # CPython's compiler treats known imports differently than normal globals,
-    # so check if we use attributes from globals that are modules (if so, we
-    # import them explicitly and redundantly in the exec below)
-    referenced_modules = [
-        (local_name, module)
-        for attr in extract_all_attributes(node)
-        if (
-            isinstance(attr.value, ast.Name)
-            and (local_name := attr.value.id)
-            and inspect.ismodule(module := f_globals.get(local_name))
-        )
-    ]
-
-    if not f_code.co_freevars and not referenced_modules:
-        compiled = eval(source, f_globals)
-    else:
-        if f_code.co_freevars:
-            # We have to reconstruct a local closure. The closure will have
-            # the same values as the original function, although this is not
-            # required for source/bytecode equality.
-            f_globals |= {
-                f"__lc{i}": c.cell_contents for i, c in enumerate(f.__closure__)
-            }
-            captures = [f"{name}=__lc{i}" for i, name in enumerate(f_code.co_freevars)]
-            capture_str = ";".join(captures) + ";"
-        else:
-            capture_str = ""
-        if referenced_modules:
-            # We add import statements for all referenced modules, since that
-            # influences the compiled code. The assumption is that these modules
-            # were explicitly imported, not assigned, in the source - if not,
-            # this may/will give a different compilation result.
-            global _module_map
-            if len(_module_map) != len(sys.modules):  # pragma: no branch
-                _module_map = {id(module): name for name, module in sys.modules.items()}
-            imports = [
-                (module_name, local_name)
-                for local_name, module in referenced_modules
-                if (module_name := _module_map.get(id(module))) is not None
-            ]
-            import_fragments = [f"{name} as {asname}" for name, asname in set(imports)]
-            import_str = f"import {','.join(import_fragments)}\n"
-        else:
-            import_str = ""
-        exec_str = (
-            f"{import_str}def __construct_lambda(): {capture_str} return ({source})"
-        )
-        exec(exec_str, f_globals)
-        compiled = f_globals["__construct_lambda"]()
-
-    return compiled
-
-
-def _lambda_code_matches_node(f, node):
-    try:
-        compiled = _mimic_lambda_from_node(f, node)
-    except (NameError, SyntaxError):  # pragma: no cover
-        return False
-    if _function_key(f) == _function_key(compiled):
-        return True
-    # Try harder
-    compiled.__code__ = _normalize_code(f, compiled)
-    return _function_key(f) == _function_key(compiled)
-
-
-def _lambda_description(f, leeway=10, *, fail_if_confused_with_perfect_candidate=False):
-    if hasattr(f, "__wrapped_target"):
-        f = f.__wrapped_target
-
-    # You might be wondering how a lambda can have a return-type annotation?
-    # The answer is that we add this at runtime, in new_given_signature(),
-    # and we do support strange choices as applying @given() to a lambda.
-    sig = inspect.signature(f)
-    assert sig.return_annotation in (Parameter.empty, None), sig
-
-    # Using pytest-xdist on Python 3.13, there's an entry in the linecache for
-    # file "<string>", which then returns nonsense to getsource.  Discard it.
-    linecache.cache.pop("<string>", None)
-
-    def format_lambda(body):
-        # The signature is more informative than the corresponding ast.unparse
-        # output in the case of default argument values, so add the signature
-        # to the unparsed body
-        return (
-            f"lambda {str(sig)[1:-1]}: {body}" if sig.parameters else f"lambda: {body}"
-        )
-
-    if_confused = format_lambda("<unknown>")
-
-    try:
-        source_lines, lineno0 = inspect.findsource(f)
-        source_lines = tuple(source_lines)  # make it hashable
-    except OSError:
-        return if_confused
-
-    try:
-        all_lambdas = AST_LAMBDAS_CACHE[source_lines]
-    except KeyError:
-        # The source isn't already parsed, so we try to shortcut by parsing just
-        # the local block. If that fails to produce a code-identical lambda,
-        # fall through to the full parse.
-        local_lines = inspect.getblock(source_lines[lineno0:])
-        local_block = textwrap.dedent("".join(local_lines))
-        if local_block.startswith("."):
-            # The fairly common ".map(lambda x: ...)" case. This partial block
-            # isn't valid syntax, but it might be if we remove the leading ".".
-            local_block = local_block[1:]
-
-        try:
-            local_tree = ast.parse(local_block)
-        except SyntaxError:
-            pass
-        else:
-            local_lambdas = extract_all_lambdas(local_tree)
-            for candidate in local_lambdas:
-                if ast_arguments_matches_signature(
-                    candidate.args, sig
-                ) and _lambda_code_matches_node(f, candidate):
-                    return format_lambda(ast.unparse(candidate.body))
-
-        # Local parse failed or didn't produce a match, go ahead with the full parse
-        try:
-            tree = ast.parse("".join(source_lines))
-        except SyntaxError:  # pragma: no cover
-            all_lambdas = []
-        else:
-            all_lambdas = extract_all_lambdas(tree)
-        AST_LAMBDAS_CACHE[source_lines] = all_lambdas
-
-    aligned_lambdas = []
-    for candidate in all_lambdas:
-        if (
-            candidate.lineno - leeway <= lineno0 + 1 <= candidate.lineno + leeway
-            and ast_arguments_matches_signature(candidate.args, sig)
-        ):
-            aligned_lambdas.append(candidate)
-
-    aligned_lambdas.sort(key=lambda c: abs(lineno0 + 1 - c.lineno))
-    for candidate in aligned_lambdas:
-        if _lambda_code_matches_node(f, candidate):
-            return format_lambda(ast.unparse(candidate.body))
-
-    # None of the aligned lambdas match perfectly in generated code.
-    if (
-        fail_if_confused_with_perfect_candidate
-        and aligned_lambdas
-        and aligned_lambdas[0].lineno == lineno0 + 1
-    ):  # pragma: no cover
-        # This arg is forced on in conftest.py, to ensure we resolve all known
-        # cases.
-        raise ValueError("None of the source-file lambda candidates were matched")
-    return if_confused
-
-
-def lambda_description(f):
-    """
-    Returns a syntactically-valid expression describing `f`. This is often, but
-    not always, the exact lambda definition string which appears in the source code.
-    The difference comes from parsing the lambda ast into `tree` and then returning
-    the result of `ast.unparse(tree)`, which may differ in whitespace, double vs
-    single quotes, etc.
-
-    Returns a string indicating an unknown body if the parsing gets confused in any way.
-    """
-    try:
-        return LAMBDA_DESCRIPTION_CACHE[f]
-    except KeyError:
-        pass
-
-    key = _function_key(f, bounded_size=True)
-    failed_fnames = []
-    try:
-        description, failed_fnames = LAMBDA_DIGEST_DESCRIPTION_CACHE[key]
-        if (
-            "<unknown>" not in description and f.__code__.co_filename in failed_fnames
-        ):  # pragma: no cover
-            # Only accept the <unknown> description if it comes from parsing this
-            # file - otherwise, try again below, maybe we have more luck in another
-            # file. Once lucky, we keep keep using the successful description for *new*
-            # lambdas but not for this one - so it doesn't change name during its
-            # lifetime.
-            LAMBDA_DESCRIPTION_CACHE[f] = description
-            return description
-    except KeyError:
-        failed_fnames = []
-
-    description = _lambda_description(f)
-    LAMBDA_DESCRIPTION_CACHE[f] = description
-    if "<unknown>" in description:
-        failed_fnames.append(f.__code__.co_filename)
-    LAMBDA_DIGEST_DESCRIPTION_CACHE[key] = description, failed_fnames
-    return description
-
-
 def get_pretty_function_description(f: object) -> str:
     if isinstance(f, partial):
         return pretty(f)
@@ -685,7 +318,7 @@ def get_pretty_function_description(f: object) -> str:
         return repr(f)
     name = f.__name__  # type: ignore
     if name == "<lambda>":
-        return lambda_description(f)
+        return lambda_sources.lambda_description(f)
     elif isinstance(f, (types.MethodType, types.BuiltinMethodType)):
         self = f.__self__
         # Some objects, like `builtins.abs` are of BuiltinMethodType but have

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -461,7 +461,7 @@ def _function_key(f, *, bounded_size=False):
     )
 
 
-_module_map = {}
+_module_map: dict[int, str] = {}
 
 
 def _mimic_lambda_from_node(f, node):
@@ -481,7 +481,7 @@ def _mimic_lambda_from_node(f, node):
                 f_globals[l_default.id] = f_default
     if f.__kwdefaults__:
         for l_default, l_varname in zip(node.args.kw_defaults, node.args.kwonlyargs):
-            if isinstance(l_default, ast.Name):
+            if isinstance(l_default, ast.Name):  # pragma: no cover # shouldn't be?
                 f_globals[l_default.id] = f.__kwdefaults__[l_varname.arg]
 
     # CPython's compiler treats known imports differently than normal globals,
@@ -517,7 +517,7 @@ def _mimic_lambda_from_node(f, node):
             # were explicitly imported, not assigned, in the source - if not,
             # this may/will give a different compilation result.
             global _module_map
-            if len(_module_map) != len(sys.modules):
+            if len(_module_map) != len(sys.modules):  # pragma: no branch
                 _module_map = {id(module): name for name, module in sys.modules.items()}
             imports = [
                 (module_name, local_name)
@@ -657,7 +657,9 @@ def lambda_description(f):
     failed_fnames = []
     try:
         description, failed_fnames = LAMBDA_DIGEST_DESCRIPTION_CACHE[key]
-        if "<unknown>" not in description and f.__code__.co_filename in failed_fnames:  # pragma: no cover
+        if (
+            "<unknown>" not in description and f.__code__.co_filename in failed_fnames
+        ):  # pragma: no cover
             # Only accept the <unknown> description if it comes from parsing this
             # file - otherwise, try again below, maybe we have more luck in another
             # file. Once lucky, we keep keep using the successful description for *new*

--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -627,7 +627,7 @@ def _lambda_description(f, leeway=10, fail_if_confused_with_perfect_candidate=Fa
     ):
         # This arg is forced on in conftest.py, to ensure we resolve all known
         # cases.
-        raise ValueError(f"None of the source-file lambda candidates were matched")
+        raise ValueError("None of the source-file lambda candidates were matched")
     return if_confused
 
 

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -115,7 +115,7 @@ if sys.version_info >= (3, 11):
                 "or just a previously unknown case. To quickly resolve this "
                 "problem, use the `allow_unknown_lambdas` fixture."
             )
-            assert False, msg
+            raise AssertionError(msg)
 
         monkeypatch.setattr(
             lambda_sources, "_check_unknown_perfectly_aligned_lambda", fail

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -121,6 +121,7 @@ if sys.version_info >= (3, 11):
             lambda_sources, "_check_unknown_perfectly_aligned_lambda", fail
         )
 
+
 @pytest.fixture(scope="function")
 def allow_unknown_lambdas(monkeypatch):
     # Will run after make...fail since autouse are run first

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -101,19 +101,25 @@ except ImportError:
     pass
 
 
-@pytest.fixture(scope="function", autouse=True)
-def _make_unknown_lambdas_fail(monkeypatch):
+if sys.version_info >= (3, 11):
+    # To detect if changes in code generation causes lambda test compilation
+    # to fail. Older versions (3.10 and earlier) have a few known false
+    # negatives which we ignore.
+    @pytest.fixture(scope="function", autouse=True)
+    def _make_unknown_lambdas_fail(monkeypatch):
 
-    @wraps(reflection._lambda_description)
-    def wrapper(*args, **kwargs):
-        return original(*args, **kwargs, fail_if_confused_with_perfect_candidate=True)
+        @wraps(reflection._lambda_description)
+        def wrapper(*args, **kwargs):
+            return original(
+                *args, **kwargs, fail_if_confused_with_perfect_candidate=True
+            )
 
-    original=reflection._lambda_description
-    monkeypatch.setattr(
-        reflection,
-        "_lambda_description",
-        wrapper,
-    )
+        original = reflection._lambda_description
+        monkeypatch.setattr(
+            reflection,
+            "_lambda_description",
+            wrapper,
+        )
 
 
 # monkeypatch is not thread-safe, so pytest-run-parallel will skip all our tests

--- a/hypothesis-python/tests/conftest.py
+++ b/hypothesis-python/tests/conftest.py
@@ -24,7 +24,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from hypothesis import is_hypothesis_test, settings
 from hypothesis._settings import is_in_ci
 from hypothesis.errors import NonInteractiveExampleWarning
-from hypothesis.internal import reflection
+from hypothesis.internal import lambda_sources
 from hypothesis.internal.compat import add_note
 from hypothesis.internal.conjecture import junkdrawer
 
@@ -108,15 +108,15 @@ if sys.version_info >= (3, 11):
     @pytest.fixture(scope="function", autouse=True)
     def _make_unknown_lambdas_fail(monkeypatch):
 
-        @wraps(reflection._lambda_description)
+        @wraps(lambda_sources._lambda_description)
         def wrapper(*args, **kwargs):
             return original(
                 *args, **kwargs, fail_if_confused_with_perfect_candidate=True
             )
 
-        original = reflection._lambda_description
+        original = lambda_sources._lambda_description
         monkeypatch.setattr(
-            reflection,
+            lambda_sources,
             "_lambda_description",
             wrapper,
         )

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -290,4 +290,3 @@ def test_adding_other_lambda_does_not_confuse(tmp_path):
     )
     f1 = module_globals["test_lambda"]
     assert get_pretty_function_description(f1) == "lambda x: x * 2"
-

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -13,7 +13,7 @@ import sys
 
 import pytest
 
-from hypothesis.internal import reflection
+from hypothesis.internal import lambda_sources
 from hypothesis.internal.conjecture.utils import identity
 from hypothesis.internal.reflection import get_pretty_function_description
 
@@ -25,9 +25,9 @@ def clear_lambda_caches(request, monkeypatch):
     # Run all tests in this file twice, once using cache and once forcing
     # from-scratch generation
     if request.param:
-        monkeypatch.setattr(reflection, "LAMBDA_DESCRIPTION_CACHE", {})
-        monkeypatch.setattr(reflection, "LAMBDA_DIGEST_DESCRIPTION_CACHE", {})
-        monkeypatch.setattr(reflection, "AST_LAMBDAS_CACHE", {})
+        monkeypatch.setattr(lambda_sources, "LAMBDA_DESCRIPTION_CACHE", {})
+        monkeypatch.setattr(lambda_sources, "LAMBDA_DIGEST_DESCRIPTION_CACHE", {})
+        monkeypatch.setattr(lambda_sources, "AST_LAMBDAS_CACHE", {})
 
 
 def test_bracket_whitespace_is_stripped():

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -311,6 +311,7 @@ def test_changing_lambda_confuses(tmp_path, allow_unknown_lambdas):
 
 
 @skipif_threading  # concurrent writes to the same file
+@pytest.mark.skipif(sys.version_info[:2] < (3, 11), reason="not checked before 3.11")
 def test_that_test_harness_raises_on_unknown_lambda(tmp_path):
     test_module = tmp_path / "test_module.py"
     test_module.write_text("test_lambda = lambda x: x * 2", encoding="utf-8")

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -275,3 +275,19 @@ def test_modifying_lambda_source_code_returns_unknown(tmp_path):
         get_pretty_function_description(module_globals["test_lambda"])
         == "lambda x: <unknown>"
     )
+
+
+@skipif_threading  # concurrent writes to the same file
+def test_adding_other_lambda_does_not_confuse(tmp_path):
+    test_module = tmp_path / "test_module.py"
+    test_module.write_text(
+        "# line one\ntest_lambda = lambda x: x * 2", encoding="utf-8"
+    )
+    module_globals = runpy.run_path(str(test_module))
+
+    test_module.write_text(
+        "# line one\nlambda x: x\n\n\ntest_lambda = lambda x: x * 2", encoding="utf-8"
+    )
+    f1 = module_globals["test_lambda"]
+    assert get_pretty_function_description(f1) == "lambda x: x * 2"
+

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -302,14 +302,10 @@ def test_adding_other_lambda_does_not_confuse(tmp_path):
 @skipif_threading  # concurrent writes to the same file
 def test_changing_lambda_confuses(tmp_path, allow_unknown_lambdas):
     test_module = tmp_path / "test_module.py"
-    test_module.write_text(
-        "test_lambda = lambda x: x * 2", encoding="utf-8"
-    )
+    test_module.write_text("test_lambda = lambda x: x * 2", encoding="utf-8")
     module_globals = runpy.run_path(str(test_module))
 
-    test_module.write_text(
-        "lambda x: x", encoding="utf-8"
-    )
+    test_module.write_text("lambda x: x", encoding="utf-8")
     f1 = module_globals["test_lambda"]
     assert get_pretty_function_description(f1) == "lambda x: <unknown>"
 
@@ -317,14 +313,10 @@ def test_changing_lambda_confuses(tmp_path, allow_unknown_lambdas):
 @skipif_threading  # concurrent writes to the same file
 def test_that_test_harness_raises_on_unknown_lambda(tmp_path):
     test_module = tmp_path / "test_module.py"
-    test_module.write_text(
-        "test_lambda = lambda x: x * 2", encoding="utf-8"
-    )
+    test_module.write_text("test_lambda = lambda x: x * 2", encoding="utf-8")
     module_globals = runpy.run_path(str(test_module))
 
-    test_module.write_text(
-        "lambda x: x", encoding="utf-8"
-    )
+    test_module.write_text("lambda x: x", encoding="utf-8")
     f1 = module_globals["test_lambda"]
     with pytest.raises(AssertionError):
         assert get_pretty_function_description(f1) == "lambda x: <unknown>"

--- a/hypothesis-python/tests/cover/test_lambda_formatting.py
+++ b/hypothesis-python/tests/cover/test_lambda_formatting.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import runpy
+import sys
 
 import pytest
 
@@ -41,6 +42,9 @@ def test_can_have_unicode_in_lambda_sources():
     assert get_pretty_function_description(t) == "lambda x: 'é' not in x"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="nested lambdas fail compile-test"
+)
 def test_can_get_descriptions_of_nested_lambdas_with_different_names():
     # fmt: off
     ordered_pair = (
@@ -64,6 +68,9 @@ def test_does_not_error_on_unparsable_source():
     assert get_pretty_function_description(t) == "lambda x: x"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="nested lambdas fail compile-test"
+)
 def test_separate_line_map_filter():
     # this isn't intentionally testing nested lambdas, but hey, it's a nice bonus.
     # fmt: off

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -764,8 +764,8 @@ def test_cache_key_size_is_bounded():
 def test_function_key_distinguishes_alpha_renames():
     # these terms are equivalent under the lambda calculus, but their
     # representations are not, so they should be cached differently.
-    assert (
-        reflection._function_key(lambda x: x) != reflection._function_key(lambda y: y)
+    assert reflection._function_key(lambda x: x) != reflection._function_key(
+        lambda y: y
     )
 
 

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -757,14 +757,14 @@ def test_cache_key_size_is_bounded():
     f.__code__ = f.__code__.replace(
         co_consts=tuple(c * 1000 if c == "a" else c for c in f.__code__.co_consts)
     )
-    assert len(repr(reflection._function_key(f))) > 1000
-    assert len(repr(reflection._function_key(f, bounded_size=True))) < 1000
+    assert len(repr(lambda_sources._function_key(f))) > 1000
+    assert len(repr(lambda_sources._function_key(f, bounded_size=True))) < 1000
 
 
 def test_function_key_distinguishes_alpha_renames():
     # these terms are equivalent under the lambda calculus, but their
     # representations are not, so they should be cached differently.
-    assert reflection._function_key(lambda x: x) != reflection._function_key(
+    assert lambda_sources._function_key(lambda x: x) != lambda_sources._function_key(
         lambda y: y
     )
 
@@ -781,15 +781,15 @@ def test_code_normalization(nop_on_f):
     f = lambda x: x
     g = lambda x: x
     h = f if nop_on_f else g
-    assert reflection._function_key(f) == reflection._function_key(g)
+    assert lambda_sources._function_key(f) == lambda_sources._function_key(g)
 
     # Append a NOP to one of the bytecodes
     h.__code__ = h.__code__.replace(co_code=h.__code__.co_code + b"\x09\x00")
-    assert reflection._function_key(f) != reflection._function_key(g)
+    assert lambda_sources._function_key(f) != lambda_sources._function_key(g)
 
     # ...and then normalize g to match f (adding or removing a NOP)
     g.__code__ = lambda_sources._normalize_code(f, g)
-    assert reflection._function_key(f) == reflection._function_key(g)
+    assert lambda_sources._function_key(f) == lambda_sources._function_key(g)
 
 
 def test_lambda_mimicry_with_arg_defaults():

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -774,14 +774,3 @@ def test_import():
 
     f = lambda: t.ctime()
     assert get_pretty_function_description(f) == "lambda: t.ctime()"
-
-
-@pytest.mark.xfail
-def test_renamed_import():
-    # This test showcases a known weakness, that modules are assumed to be
-    # imported explicitly (this affects bytecode generation on python >= 3.11).
-    import time
-
-    t = time
-    f = lambda: t.ctime()
-    assert get_pretty_function_description() == "lambda: t.ctime()"

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -793,7 +793,8 @@ def test_code_normalization(nop_on_f):
     assert lambda_sources._function_key(f) == lambda_sources._function_key(g)
 
 
-@pytest.mark.parametrize("f, source",
+@pytest.mark.parametrize(
+    "f, source",
     [
         (lambda x=1, *, y=2: (x, y), "lambda x=1, *, y=2: (x, y)"),
         (lambda x=1, *, y: (x, y), "lambda x=1, *, y: (x, y)"),
@@ -806,7 +807,7 @@ def test_code_normalization(nop_on_f):
         (lambda x, /: (x, y), "lambda x, /: (x, y)"),
         (lambda x=1, /, y=2: (x, y), "lambda x=1, /, y=2: (x, y)"),
         (lambda x=1, /: (x, y), "lambda x=1, /: (x, y)"),
-    ]
+    ],
 )
 def test_lambda_mimicry_with_arg_defaults(f, source):
     assert get_pretty_function_description(f) == source

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -800,13 +800,13 @@ def test_code_normalization(nop_on_f):
         (lambda x=1, *, y: (x, y), "lambda x=1, *, y: (x, y)"),
         (lambda x, *, y=2: (x, y), "lambda x, *, y=2: (x, y)"),
         (lambda x, *, y: (x, y), "lambda x, *, y: (x, y)"),
-        (lambda *, y=2: (x, y), "lambda *, y=2: (x, y)"),
-        (lambda *, y: (x, y), "lambda *, y: (x, y)"),
+        (lambda *, y=2: (x, y), "lambda *, y=2: (x, y)"),  # noqa: F821
+        (lambda *, y: (x, y), "lambda *, y: (x, y)"),  # noqa: F821
         (lambda x, /, y=1: (x, y), "lambda x, /, y=1: (x, y)"),
         (lambda x, /, y: (x, y), "lambda x, /, y: (x, y)"),
-        (lambda x, /: (x, y), "lambda x, /: (x, y)"),
+        (lambda x, /: (x, y), "lambda x, /: (x, y)"),  # noqa: F821
         (lambda x=1, /, y=2: (x, y), "lambda x=1, /, y=2: (x, y)"),
-        (lambda x=1, /: (x, y), "lambda x=1, /: (x, y)"),
+        (lambda x=1, /: (x, y), "lambda x=1, /: (x, y)"),  # noqa: F821
     ],
 )
 def test_lambda_mimicry_with_arg_defaults(f, source):

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -21,7 +21,7 @@ from pytest import raises
 
 from hypothesis import assume, example, given, strategies as st
 from hypothesis.errors import HypothesisWarning
-from hypothesis.internal import reflection
+from hypothesis.internal import lambda_sources, reflection
 from hypothesis.internal.reflection import (
     convert_keyword_arguments,
     convert_positional_arguments,
@@ -788,7 +788,7 @@ def test_code_normalization(nop_on_f):
     assert reflection._function_key(f) != reflection._function_key(g)
 
     # ...and then normalize g to match f (adding or removing a NOP)
-    g.__code__ = reflection._normalize_code(f, g)
+    g.__code__ = lambda_sources._normalize_code(f, g)
     assert reflection._function_key(f) == reflection._function_key(g)
 
 

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -784,9 +784,14 @@ def test_code_normalization(nop_on_f):
     assert reflection._function_key(f) == reflection._function_key(g)
 
     # Append a NOP to one of the bytecodes
-    h.__code__ = h.__code__.replace(co_code=h.__code__.co_code + b'\x09\x00')
+    h.__code__ = h.__code__.replace(co_code=h.__code__.co_code + b"\x09\x00")
     assert reflection._function_key(f) != reflection._function_key(g)
 
     # ...and then normalize g to match f (adding or removing a NOP)
     g.__code__ = reflection._normalize_code(f, g)
     assert reflection._function_key(f) == reflection._function_key(g)
+
+
+def test_lambda_mimicry_with_arg_defaults():
+    f = lambda x=1, *, y=2: (x, y)
+    assert get_pretty_function_description(f) == "lambda x=1, *, y=2: (x, y)"

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -784,7 +784,8 @@ def test_code_normalization(nop_on_f):
     assert lambda_sources._function_key(f) == lambda_sources._function_key(g)
 
     # Append a NOP to one of the bytecodes
-    h.__code__ = h.__code__.replace(co_code=h.__code__.co_code + b"\x09\x00")
+    NOP_instr = bytes([lambda_sources._op.NOP, 0])
+    h.__code__ = h.__code__.replace(co_code=h.__code__.co_code + NOP_instr)
     assert lambda_sources._function_key(f) != lambda_sources._function_key(g)
 
     # ...and then normalize g to match f (adding or removing a NOP)
@@ -792,6 +793,20 @@ def test_code_normalization(nop_on_f):
     assert lambda_sources._function_key(f) == lambda_sources._function_key(g)
 
 
-def test_lambda_mimicry_with_arg_defaults():
-    f = lambda x=1, *, y=2: (x, y)
-    assert get_pretty_function_description(f) == "lambda x=1, *, y=2: (x, y)"
+@pytest.mark.parametrize("f, source",
+    [
+        (lambda x=1, *, y=2: (x, y), "lambda x=1, *, y=2: (x, y)"),
+        (lambda x=1, *, y: (x, y), "lambda x=1, *, y: (x, y)"),
+        (lambda x, *, y=2: (x, y), "lambda x, *, y=2: (x, y)"),
+        (lambda x, *, y: (x, y), "lambda x, *, y: (x, y)"),
+        (lambda *, y=2: (x, y), "lambda *, y=2: (x, y)"),
+        (lambda *, y: (x, y), "lambda *, y: (x, y)"),
+        (lambda x, /, y=1: (x, y), "lambda x, /, y=1: (x, y)"),
+        (lambda x, /, y: (x, y), "lambda x, /, y: (x, y)"),
+        (lambda x, /: (x, y), "lambda x, /: (x, y)"),
+        (lambda x=1, /, y=2: (x, y), "lambda x=1, /, y=2: (x, y)"),
+        (lambda x=1, /: (x, y), "lambda x=1, /: (x, y)"),
+    ]
+)
+def test_lambda_mimicry_with_arg_defaults(f, source):
+    assert get_pretty_function_description(f) == source

--- a/hypothesis-python/tests/cover/test_simple_strings.py
+++ b/hypothesis-python/tests/cover/test_simple_strings.py
@@ -15,7 +15,7 @@ from tests.common.debug import minimal
 
 
 def test_can_minimize_up_to_zero():
-    s = minimal(text(), lambda x: any(lambda t: t <= "0" for t in x))
+    s = minimal(text(), lambda x: any(t <= "0" for t in x))
     assert s == "0"
 
 


### PR DESCRIPTION
Closes #4457

The source compilation test for lambda is tweaked so that it has no false negatives on our test corpus. To be confirmed by CI, as (apparent) false negative is now a self-test failure.

That means the test compilation can be done on all sources, and then it's trivial and safe to expand the search to surrounding lines.

There is probably an impact on performance, but I imagine it will be fairly small in practive - given extensive caching and also that most cases will be satisfied by the same-line source match.