### PR TITLE
Fix a filter-rewriting race condition

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes a race condition under threading for strategies which trigger our filter-rewriting rules, like ``st.integers().filter(lambda x: abs(x) > 100)``.


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4521. 

The (speculative; I don't have a consistent reproducer) issue is from manual calls to `FilteredStrategy.__init__` which operate on a strategy shared across threads. One thread sets `self.__condition = None` while the other thread is still computing `self.__condition`.
