### PR TITLE
Remove `supports_find`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactor to simplify |SearchStrategy|.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -924,7 +924,6 @@ class StateForActualGivenExecution:
         self.thread_overlap = {} if thread_overlap is None else thread_overlap
 
         self.test_runner = get_executor(stuff.selfy)
-        self.is_find = getattr(wrapped_test, "_hypothesis_internal_is_find", False)
         self.print_given_args = getattr(
             wrapped_test, "_hypothesis_internal_print_given_args", True
         )
@@ -982,7 +981,6 @@ class StateForActualGivenExecution:
         """
 
         self.ever_executed = True
-        data.is_find = self.is_find
 
         self._string_repr = ""
         text_repr = None
@@ -1493,7 +1491,7 @@ class StateForActualGivenExecution:
                 with with_reporter(fragments.append):
                     self.execute_once(
                         ran_example,
-                        print_example=not self.is_find,
+                        print_example=True,
                         is_final=True,
                         expected_failure=(
                             falsifying_example.expected_exception,
@@ -2294,7 +2292,6 @@ def find(
     # Aliasing as Any avoids mypy errors (attr-defined) when accessing and
     # setting custom attributes on the decorated function or class.
     _test: Any = test
-    _test._hypothesis_internal_is_find = True
     _test._hypothesis_internal_database_key = database_key
 
     try:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/data.py
@@ -663,7 +663,6 @@ class ConjectureData:
         self.observer = observer
         self.max_choices = max_choices
         self.max_length = BUFFER_SIZE
-        self.is_find = False
         self.overdraw = 0
         self._random = random
 
@@ -1201,12 +1200,6 @@ class ConjectureData:
         from hypothesis.internal.observability import observability_enabled
         from hypothesis.strategies._internal.lazy import unwrap_strategies
         from hypothesis.strategies._internal.utils import to_jsonable
-
-        if self.is_find and not strategy.supports_find:
-            raise InvalidArgument(
-                f"Cannot use strategy {strategy!r} within a call to find "
-                "(presumably because it would be invalid after the call had ended)."
-            )
 
         at_top_level = self.depth == 0
         start_time = None

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -2272,8 +2272,6 @@ class DataObject:
 
 
 class DataStrategy(SearchStrategy):
-    supports_find = False
-
     def do_draw(self, data):
         if data._shared_data_strategy is None:
             data._shared_data_strategy = DataObject(data)

--- a/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/deferred.py
@@ -58,10 +58,6 @@ class DeferredStrategy(SearchStrategy[Ex]):
     def branches(self) -> Sequence[SearchStrategy[Ex]]:
         return self.wrapped_strategy.branches
 
-    @property
-    def supports_find(self) -> bool:
-        return self.wrapped_strategy.supports_find
-
     def calc_label(self) -> int:
         """Deferred strategies don't have a calculated label, because we would
         end up having to calculate the fixed point of some hash function in

--- a/hypothesis-python/src/hypothesis/strategies/_internal/functions.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/functions.py
@@ -22,8 +22,6 @@ from hypothesis.strategies._internal.strategies import RecurT, SearchStrategy
 
 
 class FunctionStrategy(SearchStrategy):
-    supports_find = False
-
     def __init__(self, like, returns, pure):
         super().__init__()
         self.like = like

--- a/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/lazy.py
@@ -87,10 +87,6 @@ class LazyStrategy(SearchStrategy[Ex]):
         self.__kwargs = kwargs
         self._transformations = transforms
 
-    @property
-    def supports_find(self) -> bool:
-        return self.wrapped_strategy.supports_find
-
     def calc_is_empty(self, recur: RecurT) -> bool:
         return recur(self.wrapped_strategy)
 

--- a/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/shared.py
@@ -22,10 +22,6 @@ class SharedStrategy(SearchStrategy[Ex]):
         self.key = key
         self.base = base
 
-    @property
-    def supports_find(self) -> bool:
-        return self.base.supports_find
-
     def __repr__(self) -> str:
         if self.key is not None:
             return f"shared({self.base!r}, key={self.key!r})"

--- a/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py
@@ -260,10 +260,6 @@ class SearchStrategy(Generic[Ex]):
         # intended to be an optimisation for some cases.
         return recursive_property(self, "is_empty", True)
 
-    @property
-    def supports_find(self) -> bool:
-        return True
-
     # Returns True if values from this strategy can safely be reused without
     # this causing unexpected behaviour.
 

--- a/hypothesis-python/tests/conjecture/test_test_data.py
+++ b/hypothesis-python/tests/conjecture/test_test_data.py
@@ -13,7 +13,7 @@ import itertools
 import pytest
 
 from hypothesis import strategies as st
-from hypothesis.errors import Frozen, InvalidArgument
+from hypothesis.errors import Frozen
 from hypothesis.internal.conjecture.data import (
     MAX_DEPTH,
     ConjectureData,
@@ -284,13 +284,6 @@ def test_empty_strategy_is_invalid():
     with pytest.raises(StopTest):
         d.draw(st.nothing())
     assert d.status == Status.INVALID
-
-
-def test_will_error_on_find():
-    d = ConjectureData.for_choices([])
-    d.is_find = True
-    with pytest.raises(InvalidArgument):
-        d.draw(st.data())
 
 
 def test_can_note_non_str():

--- a/hypothesis-python/tests/cover/test_arbitrary_data.py
+++ b/hypothesis-python/tests/cover/test_arbitrary_data.py
@@ -64,9 +64,9 @@ def test_given_twice_is_same():
     assert "Draw 2: 0" in err.value.__notes__
 
 
-def test_errors_when_used_in_find():
-    with raises(InvalidArgument):
-        find(st.data(), lambda x: x.draw(st.booleans()))
+def test_data_supports_find():
+    data = find(st.data(), lambda data: data.draw(st.integers()) >= 10)
+    assert data.conjecture_data.choices == (10,)
 
 
 @pytest.mark.parametrize("f", ["filter", "map", "flatmap"])

--- a/hypothesis-python/tests/cover/test_deferred_strategies.py
+++ b/hypothesis-python/tests/cover/test_deferred_strategies.py
@@ -141,8 +141,3 @@ def test_recursion_in_middle():
     # to determine the non-emptiness of the tuples.
     x = st.deferred(lambda: st.tuples(st.none(), x, st.integers().map(abs)) | st.none())
     assert not x.is_empty
-
-
-def test_deferred_supports_find():
-    nested = st.deferred(lambda: st.integers() | st.lists(nested))
-    assert nested.supports_find

--- a/hypothesis-python/tests/cover/test_functions.py
+++ b/hypothesis-python/tests/cover/test_functions.py
@@ -12,7 +12,7 @@ from inspect import signature
 
 import pytest
 
-from hypothesis import Verbosity, assume, given, settings
+from hypothesis import Verbosity, assume, find, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument, InvalidState
 from hypothesis.reporting import with_reporter
 from hypothesis.strategies import booleans, functions, integers
@@ -204,3 +204,12 @@ def test_functions_note_only_first_to_pure_functions(f):
         f()
         f()
     assert len(ls) == 1
+
+
+def test_functions_supports_find():
+    f = find(
+        st.functions(like=pure_func, returns=st.integers(), pure=True), lambda x: True
+    )
+    with pytest.raises(InvalidState):
+        f(1, 2)
+    assert f.__name__ == pure_func.__name__


### PR DESCRIPTION
I don't think it makes sense to restrict the strategies `find` accepts. We have this wonderful integrated shrinker which works for all strategies, and that "everything is shrinkable" guarantee should shine in our APIs. 

I imagine the motivation for `supports_find` is "some objects don't make sense to use outside of `@given`, like `st.data` and `st.functions`". My response is that introspection of the minimal test case for those strategies *is* useful, for example to retrieve `data.conjecture_data.choices` (albeit this is not a public api) or inspecting the function signature. We can and do still happily throw errors if the returned values from `find` are used in a way that requires a build context. I don't think we should also enforce this at the entrance to `find`, since doing so is over-eager.

This was originally motivated by trying to simplify and/or document the internal methods on `SearchStrategy`.

(note that we don't publicly document `find` anywhere, but we in theory could.)