### PR TITLE
Preserve patch examples order

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Patch files written by hypothesis now use a deterministic ordering when multiple |@example| decorators are present.

--- a/hypothesis-python/src/hypothesis/extra/_patching.py
+++ b/hypothesis-python/src/hypothesis/extra/_patching.py
@@ -209,7 +209,14 @@ def _get_patch_for(
     # The printed examples might include object reprs which are invalid syntax,
     # so we parse here and skip over those.  If _none_ are valid, there's no patch.
     call_nodes: list[tuple[cst.Call, str]] = []
-    for ex, via in set(examples):
+
+    # we want to preserve order, but remove duplicates.
+    seen_examples = set()
+    for ex, via in examples:
+        if (ex, via) in seen_examples:
+            continue
+        seen_examples.add((ex, via))
+
         with suppress(Exception):
             node: Any = cst.parse_module(ex)
             the_call = node.body[0].body[0].value


### PR DESCRIPTION
would be very nice for https://github.com/Zac-HD/hypofuzz/pull/236 where we want to sort patch examples by shortest-first.