### PR TITLE
fix: typo in error message

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixed typo in error message around function-scoped fixtures.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Fixed typo in error message around function-scoped fixtures.
+Fixed another typo in error message around function-scoped fixtures.

--- a/hypothesis-python/src/_hypothesis_pytestplugin.py
+++ b/hypothesis-python/src/_hypothesis_pytestplugin.py
@@ -276,7 +276,7 @@ else:
                             "for each generated input, then unfortunately you "
                             "will need to find a different way to achieve your "
                             "goal (for example, replacing the fixture with a similar "
-                            "cotext manager inside of the test)."
+                            "context manager inside of the test)."
                             "\n\n"
                             "If you are confident that your test will work correctly "
                             "even though the fixture is not reset between generated "


### PR DESCRIPTION
Noticed a typo in an error message: "cotext manager" -> "context manager"

My bad for not catching this when submitting my earlier pull request.