### PR TITLE
Add `observation.metadata.phase`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add ``phase`` to the :ref:`hypothesis-specific metadata <observability-hypothesis-metadata>` in :ref:`observability <observability>`.

--- a/hypothesis-python/docs/reference/schema_metadata.json
+++ b/hypothesis-python/docs/reference/schema_metadata.json
@@ -47,6 +47,10 @@
             "type": "number",
             "description": "The unix timestamp when Hypothesis was imported."
         },
+        "phase": {
+            "type": "string",
+            "description": "The Hypothesis |Phase| this test case was generated in."
+        },
         "data_status": {
             "type": "number",
             "enum": [0, 1, 2, 3],

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -306,13 +306,9 @@ class ConjectureRunner:
         self.first_bug_found_at: Optional[int] = None
         self.last_bug_found_at: Optional[int] = None
 
-        # At runtime, the keys are only ever type `InterestingOrigin`, but can be `None` during tests.
-        self.shrunk_examples: set[Optional[InterestingOrigin]] = set()
-
+        self.shrunk_examples: set[InterestingOrigin] = set()
         self.health_check_state: Optional[HealthCheckState] = None
-
         self.tree: DataTree = DataTree()
-
         self.provider: Union[type, PrimitiveProvider] = _get_provider(
             self.settings.backend
         )
@@ -383,8 +379,6 @@ class ConjectureRunner:
             self._current_phase = phase
             yield
         finally:
-            # We ignore the mypy type error here. Because `phase` is a string literal and "-phase" is a string literal
-            # as well, the concatenation will always be valid key in the dictionary.
             self.statistics[phase + "-phase"] = {  # type: ignore
                 "duration-seconds": time.perf_counter() - start_time,
                 "test-cases": list(self.stats_per_test_case),

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -171,6 +171,7 @@ class ObservationMetadata:
     os_getpid: int
     imported_at: float
     data_status: "Status"
+    phase: str
     interesting_origin: Optional[InterestingOrigin]
     choice_nodes: Optional[tuple[ChoiceNode, ...]]
     choice_spans: Optional["Spans"]
@@ -185,6 +186,7 @@ class ObservationMetadata:
             "os.getpid()": self.os_getpid,
             "imported_at": self.imported_at,
             "data_status": self.data_status,
+            "phase": self.phase,
             "interesting_origin": self.interesting_origin,
             "choice_nodes": (
                 None if self.choice_nodes is None else nodes_to_json(self.choice_nodes)
@@ -456,6 +458,7 @@ def make_testcase(
                 "predicates": dict(data._observability_predicates),
                 "backend": backend_metadata or {},
                 "data_status": data.status,
+                "phase": phase,
                 "interesting_origin": data.interesting_origin,
                 "choice_nodes": data.nodes if OBSERVABILITY_CHOICES else None,
                 "choice_spans": data.spans if OBSERVABILITY_CHOICES else None,

--- a/hypothesis-python/tests/conjecture/test_provider.py
+++ b/hypothesis-python/tests/conjecture/test_provider.py
@@ -654,8 +654,10 @@ def test_available_providers_deprecation():
     "strategy", [st.integers(), st.text(), st.floats(), st.booleans(), st.binary()]
 )
 def test_can_generate_from_all_available_providers(backend, strategy):
+    # note: database=InMemoryExampleDatabase() is for compatibility with HypoFuzz
+    # here.
     @given(strategy)
-    @settings(backend=backend, database=None)
+    @settings(backend=backend, database=InMemoryExampleDatabase())
     def f(x):
         raise ValueError
 

--- a/hypothesis-python/tests/cover/test_observability.py
+++ b/hypothesis-python/tests/cover/test_observability.py
@@ -578,6 +578,7 @@ def test_metadata_to_json():
             "os.getpid()",
             "imported_at",
             "data_status",
+            "phase",
             "interesting_origin",
             "choice_nodes",
             "choice_spans",


### PR DESCRIPTION
I don't have a concrete use case for this, but it seems as useful as `observation.metadata.data_status`. (I was going to use it for statistics in https://github.com/HypothesisWorks/hypothesis/issues/4508, but that didn't end up working out).