### PR TITLE
Respect `__TOX_ENVIRONMENT_VARIABLE_ORIGINAL_CI` under tox

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The automatic switch to the CI :class:`settings profile <hypothesis.settings>` now works under :pypi:`tox` (for ``tox >= 4.30.0``).

--- a/hypothesis-python/src/hypothesis/_settings.py
+++ b/hypothesis-python/src/hypothesis/_settings.py
@@ -294,7 +294,9 @@ class duration(datetime.timedelta):
 # see https://adamj.eu/tech/2020/03/09/detect-if-your-tests-are-running-on-ci
 # initially from https://github.com/tox-dev/tox/blob/e911788a/src/tox/util/ci.py
 _CI_VARS = {
-    "CI": None,  # GitHub Actions, Travis CI, and AppVeyor
+    "CI": None,  # various, including GitHub Actions, Travis CI, and AppVeyor
+    # see https://github.com/tox-dev/tox/issues/3442
+    "__TOX_ENVIRONMENT_VARIABLE_ORIGINAL_CI": None,
     "TF_BUILD": "true",  # Azure Pipelines
     "bamboo.buildKey": None,  # Bamboo
     "BUILDKITE": "true",  # Buildkite


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/4481. Untested - I'm happy to add one if someone sees an easy way to test this.