### PR TITLE
Preserve coroutines in `define_function_signature`

### DIFF
--- a/hypothesis-python/src/hypothesis/internal/reflection.py
+++ b/hypothesis-python/src/hypothesis/internal/reflection.py
@@ -371,6 +371,16 @@ def accept({funcname}):
 """.lstrip()
 
 
+COPY_ASYNC_SIGNATURE_SCRIPT = """
+from hypothesis.utils.conventions import not_set
+
+def accept({funcname}):
+    async def {name}{signature}:
+        return await {funcname}({invocation})
+    return {name}
+""".lstrip()
+
+
 def get_varargs(
     sig: Signature, kind: int = Parameter.VAR_POSITIONAL
 ) -> Optional[Parameter]:
@@ -434,7 +444,11 @@ def define_function_signature(name, docstring, signature):
             if funcname not in used_names:
                 break
 
-        source = COPY_SIGNATURE_SCRIPT.format(
+        if inspect.iscoroutinefunction(f):
+            script = COPY_ASYNC_SIGNATURE_SCRIPT
+        else:
+            script = COPY_SIGNATURE_SCRIPT
+        source = script.format(
             name=name,
             funcname=funcname,
             signature=str(newsig),

--- a/hypothesis-python/tests/cover/test_reflection.py
+++ b/hypothesis-python/tests/cover/test_reflection.py
@@ -12,7 +12,7 @@ import sys
 from copy import deepcopy
 from datetime import time
 from functools import partial, wraps
-from inspect import Parameter, Signature, signature
+from inspect import Parameter, Signature, iscoroutinefunction, signature
 from textwrap import dedent
 from unittest.mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
@@ -279,6 +279,10 @@ def universal_acceptor(*args, **kwargs):
     return args, kwargs
 
 
+async def async_acceptor(*args, **kwargs):
+    return args, kwargs
+
+
 def has_one_arg(hello):
     pass
 
@@ -344,6 +348,13 @@ def test_uses_varargs():
         universal_acceptor
     )
     assert f(1, 2) == ((1, 2), {})
+
+
+def test_copying_preserves_coroutines():
+    f = define_function_signature("foo", "A docstring for foo", signature(has_varargs))(
+        async_acceptor
+    )
+    assert iscoroutinefunction(f)
 
 
 DEFINE_FOO_FUNCTION = """


### PR DESCRIPTION
This patch fixes broken async tests with `define_function_signature` decorators for me, but I haven't looked deep into it in this repository, so maybe there's something else I am missing