### PR TITLE
respect TypedDict annotation constraints

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+:func:`~hypothesis.strategies.from_type` now correctly handles :pypi:`annotated-types`
+annotations on :class:`typing.TypedDict` fields which are also marked as being
+:obj:`~typing.ReadOnly`, :obj:`~typing.Required`, or :obj:`~typing.NotRequired`
+(:issue:`4474`).

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1424,11 +1424,13 @@ def _from_type(thing: type[Ex]) -> SearchStrategy[Ex]:
         # Taken from `Lib/typing.py` and modified:
         def _get_typeddict_qualifiers(key, annotation_type):
             qualifiers = []
+            annotations = []
             while True:
                 annotation_origin = types.extended_get_origin(annotation_type)
                 if annotation_origin is Annotated:
                     if annotation_args := get_args(annotation_type):
                         annotation_type = annotation_args[0]
+                        annotations.extend(annotation_args[1:])
                     else:
                         break
                 elif annotation_origin in types.RequiredTypes:
@@ -1442,6 +1444,8 @@ def _from_type(thing: type[Ex]) -> SearchStrategy[Ex]:
                     annotation_type = _get_annotation_arg(key, annotation_type)
                 else:
                     break
+            if annotations:
+                annotation_type = Annotated[(annotation_type, *annotations)]
             return set(qualifiers), annotation_type
 
         # The __optional_keys__ attribute may or may not be present, but if there's no

--- a/hypothesis-python/tests/test_annotated_types.py
+++ b/hypothesis-python/tests/test_annotated_types.py
@@ -135,3 +135,22 @@ def test_flattens_grouped_metadata():
     grp = GroupedStuff(GroupedStuff(GroupedStuff(at.Len(min_length=1, max_length=5))))
     constraints = list(_get_constraints(grp))
     assert constraints == [at.MinLen(1), at.MaxLen(5)]
+
+
+try:
+    # we can drop this ugly code when Python 3.10 reaches EOL
+    from typing import NotRequired, TypedDict
+except ImportError:
+    pass
+else:
+
+    class TypedDictWithAnnotations(TypedDict):
+        x: Annotated[int, at.Ge(0)]
+        y: Annotated[NotRequired[int], at.Ge(0)]
+        z: NotRequired[Annotated[int, at.Ge(0)]]
+
+    @given(st.from_type(TypedDictWithAnnotations))
+    def test_typeddict_with_annotated_constraints(value):
+        assert value["x"] >= 0
+        assert value.get("y", 0) >= 0
+        assert value.get("z", 0) >= 0


### PR DESCRIPTION


The test will only run on 3.11+, but that seems fine to me.  Closes https://github.com/HypothesisWorks/hypothesis/issues/4474.