### PR TITLE
Simplify traceback elision check

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Tweak how Hypothesis hides internal tracebacks to fix an error under rare conditions (:issue:`3822`).

--- a/hypothesis-python/src/hypothesis/internal/escalation.py
+++ b/hypothesis-python/src/hypothesis/internal/escalation.py
@@ -16,7 +16,7 @@ import traceback
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from inspect import getframeinfo
+from inspect import getfile, getsourcefile
 from pathlib import Path
 from types import ModuleType, TracebackType
 
@@ -82,7 +82,7 @@ def get_trimmed_traceback(
         return tb
     while tb.tb_next is not None and (
         # If the frame is from one of our files, it's been added by Hypothesis.
-        is_hypothesis_file(getframeinfo(tb.tb_frame).filename)
+        is_hypothesis_file(getsourcefile(tb.tb_frame) or getfile(tb.tb_frame))
         # But our `@proxies` decorator overrides the source location,
         # so we check for an attribute it injects into the frame too.
         or tb.tb_frame.f_globals.get("__hypothesistracebackhide__") is True


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/3822.

I didn't end up figuring out why exactly the reported test failed. `getframeinfo` is the following, where the error is at `start = lineno - 1 - context//2`. We only use the filename from this so we can just compute it exactly instead. This also saves some io disk calls to read the source file (because `context=1` previously).

```python
def getframeinfo(frame, context=1):
    """Get information about a frame or traceback object.

    A tuple of five things is returned: the filename, the line number of
    the current line, the function name, a list of lines of context from
    the source code, and the index of the current line within that list.
    The optional second argument specifies the number of lines of context
    to return, which are centered around the current line."""
    if istraceback(frame):
        positions = _get_code_position_from_tb(frame)
        lineno = frame.tb_lineno
        frame = frame.tb_frame
    else:
        lineno = frame.f_lineno
        positions = _get_code_position(frame.f_code, frame.f_lasti)

    if positions[0] is None:
        frame, *positions = (frame, lineno, *positions[1:])
    else:
        frame, *positions = (frame, *positions)

    lineno = positions[0]

    if not isframe(frame):
        raise TypeError('{!r} is not a frame or traceback object'.format(frame))

    filename = getsourcefile(frame) or getfile(frame)
    if context > 0:
        start = lineno - 1 - context//2
        try:
            lines, lnum = findsource(frame)
        except OSError:
            lines = index = None
        else:
            start = max(0, min(start, len(lines) - context))
            lines = lines[start:start+context]
            index = lineno - 1 - start
    else:
        lines = index = None

    return Traceback(filename, lineno, frame.f_code.co_name, lines,
                     index, positions=dis.Positions(*positions))
```