### PR TITLE
Prefer `random=` over `deterministic_PRNG` in tests

### DIFF
--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -21,7 +21,6 @@ from types import SimpleNamespace
 from hypothesis import Phase, settings
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.internal import observability
-from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.floats import next_down
 from hypothesis.internal.observability import (
     Observation,
@@ -127,11 +126,7 @@ def fails_with(e, *, match=None):
     def accepts(f):
         @proxies(f)
         def inverted_test(*arguments, **kwargs):
-            # Most of these expected-failure tests are non-deterministic, so
-            # we rig the PRNG to avoid occasional flakiness. We do this outside
-            # the `raises` context manager so that any problems in rigging the
-            # PRNG don't accidentally count as the expected failure.
-            with deterministic_PRNG(), raises(e, match=match):
+            with raises(e, match=match):
                 f(*arguments, **kwargs)
 
         return inverted_test

--- a/hypothesis-python/tests/conjecture/test_optimiser.py
+++ b/hypothesis-python/tests/conjecture/test_optimiser.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
+from random import Random
 
 import pytest
 
@@ -17,7 +18,6 @@ from hypothesis.internal.conjecture.choice import ChoiceNode
 from hypothesis.internal.conjecture.data import Status
 from hypothesis.internal.conjecture.datatree import compute_max_children
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
-from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.internal.intervalsets import IntervalSet
 
 from tests.conjecture.common import (
@@ -32,198 +32,182 @@ runner_settings = settings(
 
 
 def test_optimises_to_maximum():
-    with deterministic_PRNG():
+    def test(data):
+        data.target_observations["m"] = data.draw_integer(0, 2**8 - 1)
 
-        def test(data):
-            data.target_observations["m"] = data.draw_integer(0, 2**8 - 1)
+    runner = ConjectureRunner(test, settings=runner_settings, random=Random(0))
+    runner.cached_test_function((0,))
 
-        runner = ConjectureRunner(test, settings=runner_settings)
-        runner.cached_test_function((0,))
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-
-        assert runner.best_observed_targets["m"] == 255
+    assert runner.best_observed_targets["m"] == 255
 
 
 def test_optimises_multiple_targets():
-    with deterministic_PRNG():
+    def test(data):
+        n = data.draw_integer(0, 2**8 - 1)
+        m = data.draw_integer(0, 2**8 - 1)
+        if n + m > 256:
+            data.mark_invalid()
+        data.target_observations["m"] = m
+        data.target_observations["n"] = n
+        data.target_observations["m + n"] = m + n
 
-        def test(data):
-            n = data.draw_integer(0, 2**8 - 1)
-            m = data.draw_integer(0, 2**8 - 1)
-            if n + m > 256:
-                data.mark_invalid()
-            data.target_observations["m"] = m
-            data.target_observations["n"] = n
-            data.target_observations["m + n"] = m + n
+    runner = ConjectureRunner(test, settings=runner_settings, random=Random(0))
+    runner.cached_test_function((200, 0))
+    runner.cached_test_function((0, 200))
 
-        runner = ConjectureRunner(test, settings=runner_settings)
-        runner.cached_test_function((200, 0))
-        runner.cached_test_function((0, 200))
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-
-        assert runner.best_observed_targets["m"] == 255
-        assert runner.best_observed_targets["n"] == 255
-        assert runner.best_observed_targets["m + n"] == 256
+    assert runner.best_observed_targets["m"] == 255
+    assert runner.best_observed_targets["n"] == 255
+    assert runner.best_observed_targets["m + n"] == 256
 
 
 def test_optimises_when_last_element_is_empty():
-    with deterministic_PRNG():
+    def test(data):
+        data.target_observations["n"] = data.draw_integer(0, 2**8 - 1)
+        data.start_span(label=1)
+        data.stop_span()
 
-        def test(data):
-            data.target_observations["n"] = data.draw_integer(0, 2**8 - 1)
-            data.start_span(label=1)
-            data.stop_span()
+    runner = ConjectureRunner(test, settings=runner_settings, random=Random(0))
+    runner.cached_test_function((250,))
 
-        runner = ConjectureRunner(test, settings=runner_settings)
-        runner.cached_test_function((250,))
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-
-        assert runner.best_observed_targets["n"] == 255
+    assert runner.best_observed_targets["n"] == 255
 
 
 def test_can_optimise_last_with_following_empty():
-    with deterministic_PRNG():
+    def test(data):
+        for _ in range(100):
+            data.draw_integer(0, 3)
+        data.target_observations[""] = data.draw_integer(0, 2**8 - 1)
+        data.start_span(1)
+        data.stop_span()
 
-        def test(data):
-            for _ in range(100):
-                data.draw_integer(0, 3)
-            data.target_observations[""] = data.draw_integer(0, 2**8 - 1)
-            data.start_span(1)
-            data.stop_span()
+    runner = ConjectureRunner(
+        test, settings=settings(runner_settings, max_examples=100), random=Random(0)
+    )
+    runner.cached_test_function((0,) * 101)
 
-        runner = ConjectureRunner(
-            test, settings=settings(runner_settings, max_examples=100)
-        )
-        runner.cached_test_function((0,) * 101)
-
-        with pytest.raises(RunIsComplete):
-            runner.optimise_targets()
-        assert runner.best_observed_targets[""] == 255
+    with pytest.raises(RunIsComplete):
+        runner.optimise_targets()
+    assert runner.best_observed_targets[""] == 255
 
 
 @pytest.mark.parametrize("lower, upper", [(0, 1000), (13, 100), (1000, 2**16 - 1)])
 @pytest.mark.parametrize("score_up", [False, True])
 def test_can_find_endpoints_of_a_range(lower, upper, score_up):
-    with deterministic_PRNG():
+    def test(data):
+        n = data.draw_integer(0, 2**16 - 1)
+        if n < lower or n > upper:
+            data.mark_invalid()
+        if not score_up:
+            n = -n
+        data.target_observations["n"] = n
 
-        def test(data):
-            n = data.draw_integer(0, 2**16 - 1)
-            if n < lower or n > upper:
-                data.mark_invalid()
-            if not score_up:
-                n = -n
-            data.target_observations["n"] = n
+    runner = ConjectureRunner(
+        test, settings=settings(runner_settings, max_examples=1000), random=Random(0)
+    )
+    runner.cached_test_function(((lower + upper) // 2,))
 
-        runner = ConjectureRunner(
-            test, settings=settings(runner_settings, max_examples=1000)
-        )
-        runner.cached_test_function(((lower + upper) // 2,))
-
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-        if score_up:
-            assert runner.best_observed_targets["n"] == upper
-        else:
-            assert runner.best_observed_targets["n"] == -lower
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
+    if score_up:
+        assert runner.best_observed_targets["n"] == upper
+    else:
+        assert runner.best_observed_targets["n"] == -lower
 
 
 def test_targeting_can_drive_length_very_high():
-    with deterministic_PRNG():
+    def test(data):
+        count = 0
+        while data.draw_boolean(0.25):
+            count += 1
+        data.target_observations[""] = min(count, 100)
 
-        def test(data):
-            count = 0
-            while data.draw_boolean(0.25):
-                count += 1
-            data.target_observations[""] = min(count, 100)
+    runner = ConjectureRunner(test, settings=runner_settings, random=Random(0))
+    # extend here to ensure we get a valid (non-overrun) test case. The
+    # outcome of the test case doesn't really matter as long as we have
+    # something for the runner to optimize.
+    runner.cached_test_function([], extend=50)
 
-        runner = ConjectureRunner(test, settings=runner_settings)
-        # extend here to ensure we get a valid (non-overrun) test case. The
-        # outcome of the test case doesn't really matter as long as we have
-        # something for the runner to optimize.
-        runner.cached_test_function([], extend=50)
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-
-        assert runner.best_observed_targets[""] == 100
+    assert runner.best_observed_targets[""] == 100
 
 
 def test_optimiser_when_test_grows_buffer_to_invalid():
-    with deterministic_PRNG():
+    def test(data):
+        m = data.draw_integer(0, 2**8 - 1)
+        data.target_observations["m"] = m
+        if m > 100:
+            data.draw_integer(0, 2**16 - 1)
+            data.mark_invalid()
 
-        def test(data):
-            m = data.draw_integer(0, 2**8 - 1)
-            data.target_observations["m"] = m
-            if m > 100:
-                data.draw_integer(0, 2**16 - 1)
-                data.mark_invalid()
+    runner = ConjectureRunner(test, settings=runner_settings, random=Random(0))
+    runner.cached_test_function((0,) * 10)
 
-        runner = ConjectureRunner(test, settings=runner_settings)
-        runner.cached_test_function((0,) * 10)
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-
-        assert runner.best_observed_targets["m"] == 100
+    assert runner.best_observed_targets["m"] == 100
 
 
 def test_can_patch_up_examples():
-    with deterministic_PRNG():
+    def test(data):
+        data.start_span(42)
+        m = data.draw_integer(0, 2**6 - 1)
+        data.target_observations["m"] = m
+        for _ in range(m):
+            data.draw_boolean()
+        data.stop_span()
+        for i in range(4):
+            if i != data.draw_integer(0, 2**8 - 1):
+                data.mark_invalid()
 
-        def test(data):
-            data.start_span(42)
-            m = data.draw_integer(0, 2**6 - 1)
-            data.target_observations["m"] = m
-            for _ in range(m):
-                data.draw_boolean()
-            data.stop_span()
-            for i in range(4):
-                if i != data.draw_integer(0, 2**8 - 1):
-                    data.mark_invalid()
+    runner = ConjectureRunner(
+        test, settings=settings(runner_settings, max_examples=1000), random=Random(0)
+    )
+    d = runner.cached_test_function((0, 0, 1, 2, 3, 4))
+    assert d.status == Status.VALID
 
-        runner = ConjectureRunner(
-            test, settings=settings(runner_settings, max_examples=1000)
-        )
-        d = runner.cached_test_function((0, 0, 1, 2, 3, 4))
-        assert d.status == Status.VALID
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
-
-        assert runner.best_observed_targets["m"] == 63
+    assert runner.best_observed_targets["m"] == 63
 
 
 def test_optimiser_when_test_grows_buffer_to_overflow():
-    with deterministic_PRNG(), buffer_size_limit(2):
+    def test(data):
+        m = data.draw_integer(0, 2**8 - 1)
+        data.target_observations["m"] = m
+        if m > 100:
+            data.draw_integer(0, 2**64 - 1)
+            data.mark_invalid()
 
-        def test(data):
-            m = data.draw_integer(0, 2**8 - 1)
-            data.target_observations["m"] = m
-            if m > 100:
-                data.draw_integer(0, 2**64 - 1)
-                data.mark_invalid()
+    runner = ConjectureRunner(test, settings=runner_settings, random=Random(0))
 
-        runner = ConjectureRunner(test, settings=runner_settings)
+    with buffer_size_limit(2):
         runner.cached_test_function((0,) * 10)
 
         try:
@@ -231,7 +215,7 @@ def test_optimiser_when_test_grows_buffer_to_overflow():
         except RunIsComplete:
             pass
 
-        assert runner.best_observed_targets["m"] == 100
+    assert runner.best_observed_targets["m"] == 100
 
 
 @given(nodes())
@@ -269,18 +253,17 @@ def test_optimising_all_nodes(node):
         "bytes": lambda b: len(b),
         "boolean": lambda b: int(b),
     }
-    with deterministic_PRNG():
 
-        def test(data):
-            v = getattr(data, f"draw_{node.type}")(**node.constraints)
-            data.target_observations["v"] = size_function[node.type](v)
+    def test(data):
+        v = getattr(data, f"draw_{node.type}")(**node.constraints)
+        data.target_observations["v"] = size_function[node.type](v)
 
-        runner = ConjectureRunner(
-            test, settings=settings(runner_settings, max_examples=50)
-        )
-        runner.cached_test_function([node.value])
+    runner = ConjectureRunner(
+        test, settings=settings(runner_settings, max_examples=50), random=Random(0)
+    )
+    runner.cached_test_function([node.value])
 
-        try:
-            runner.optimise_targets()
-        except RunIsComplete:
-            pass
+    try:
+        runner.optimise_targets()
+    except RunIsComplete:
+        pass

--- a/hypothesis-python/tests/conjecture/test_pareto.py
+++ b/hypothesis-python/tests/conjecture/test_pareto.py
@@ -24,202 +24,189 @@ from hypothesis.errors import StopTest
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, RunIsComplete
 from hypothesis.internal.conjecture.pareto import ParetoFront
-from hypothesis.internal.entropy import deterministic_PRNG
 
 from tests.conjecture.common import interesting_origin
 
 
 def test_pareto_front_contains_different_interesting_reasons():
-    with deterministic_PRNG():
+    def test(data):
+        data.target_observations[""] = 1
+        n = data.draw_integer(0, 2**4 - 1)
+        data.mark_interesting(interesting_origin(n))
 
-        def test(data):
-            data.target_observations[""] = 1
-            n = data.draw_integer(0, 2**4 - 1)
-            data.mark_interesting(interesting_origin(n))
+    runner = ConjectureRunner(
+        test,
+        settings=settings(
+            max_examples=5000,
+            database=InMemoryExampleDatabase(),
+            suppress_health_check=list(HealthCheck),
+        ),
+        database_key=b"stuff",
+        random=Random(0),
+    )
 
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=5000,
-                database=InMemoryExampleDatabase(),
-                suppress_health_check=list(HealthCheck),
-            ),
-            database_key=b"stuff",
-        )
-
-        runner.run()
-
-        assert len(runner.pareto_front) == 2**4
+    runner.run()
+    assert len(runner.pareto_front) == 2**4
 
 
 def test_pareto_front_omits_invalid_examples():
-    with deterministic_PRNG():
+    def test(data):
+        x = data.draw_integer(0, 2**4 - 1)
+        if x % 2:
+            data.target_observations[""] = 1
+            data.mark_invalid()
 
-        def test(data):
-            x = data.draw_integer(0, 2**4 - 1)
-            if x % 2:
-                data.target_observations[""] = 1
-                data.mark_invalid()
+    runner = ConjectureRunner(
+        test,
+        settings=settings(
+            max_examples=5000,
+            database=InMemoryExampleDatabase(),
+            suppress_health_check=list(HealthCheck),
+        ),
+        database_key=b"stuff",
+        random=Random(0),
+    )
 
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=5000,
-                database=InMemoryExampleDatabase(),
-                suppress_health_check=list(HealthCheck),
-            ),
-            database_key=b"stuff",
-        )
-
-        runner.run()
-
-        assert len(runner.pareto_front) == 0
+    runner.run()
+    assert len(runner.pareto_front) == 0
 
 
 def test_database_contains_only_pareto_front():
-    with deterministic_PRNG():
+    def test(data):
+        data.target_observations["1"] = data.draw(st.integers(0, 2**4))
+        data.draw(st.integers(0, 2**64))
+        data.target_observations["2"] = data.draw(st.integers(0, 2**8))
 
-        def test(data):
-            data.target_observations["1"] = data.draw(st.integers(0, 2**4))
-            data.draw(st.integers(0, 2**64))
-            data.target_observations["2"] = data.draw(st.integers(0, 2**8))
+        assert len(set(db.fetch(b"stuff.pareto"))) == len(runner.pareto_front)
 
-            assert len(set(db.fetch(b"stuff.pareto"))) == len(runner.pareto_front)
+    db = InMemoryExampleDatabase()
+    runner = ConjectureRunner(
+        test,
+        settings=settings(
+            max_examples=500, database=db, suppress_health_check=list(HealthCheck)
+        ),
+        database_key=b"stuff",
+        random=Random(0),
+    )
+    runner.run()
 
-        db = InMemoryExampleDatabase()
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=500, database=db, suppress_health_check=list(HealthCheck)
-            ),
-            database_key=b"stuff",
-        )
-        runner.run()
+    assert len(runner.pareto_front) <= 500
+    for v in runner.pareto_front:
+        assert v.status >= Status.VALID
 
-        assert len(runner.pareto_front) <= 500
-        for v in runner.pareto_front:
-            assert v.status >= Status.VALID
+    values = set(db.fetch(b"stuff.pareto"))
+    assert len(values) == len(runner.pareto_front), {
+        choices_to_bytes(data.choices) for data in runner.pareto_front
+    }.symmetric_difference(values)
 
-        values = set(db.fetch(b"stuff.pareto"))
-        assert len(values) == len(runner.pareto_front), {
-            choices_to_bytes(data.choices) for data in runner.pareto_front
-        }.symmetric_difference(values)
+    for data in runner.pareto_front:
+        assert choices_to_bytes(data.choices) in values
+        assert data in runner.pareto_front
 
-        for data in runner.pareto_front:
-            assert choices_to_bytes(data.choices) in values
-            assert data in runner.pareto_front
-
-        for b in values:
-            choices = choices_from_bytes(b)
-            assert runner.cached_test_function(choices) in runner.pareto_front
+    for b in values:
+        choices = choices_from_bytes(b)
+        assert runner.cached_test_function(choices) in runner.pareto_front
 
 
 def test_clears_defunct_pareto_front():
-    with deterministic_PRNG():
+    def test(data):
+        data.target_observations[""] = 1
+        data.draw_integer(0, 2**8 - 1)
+        data.draw_integer(0, 2**8 - 1)
 
-        def test(data):
-            data.target_observations[""] = 1
-            data.draw_integer(0, 2**8 - 1)
-            data.draw_integer(0, 2**8 - 1)
+    db = InMemoryExampleDatabase()
 
-        db = InMemoryExampleDatabase()
+    runner = ConjectureRunner(
+        test,
+        settings=settings(
+            max_examples=10000,
+            database=db,
+            suppress_health_check=list(HealthCheck),
+            phases=[Phase.reuse],
+        ),
+        database_key=b"stuff",
+        random=Random(0),
+    )
 
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=10000,
-                database=db,
-                suppress_health_check=list(HealthCheck),
-                phases=[Phase.reuse],
-            ),
-            database_key=b"stuff",
-        )
+    for i in range(256):
+        db.save(runner.pareto_key, choices_to_bytes((i, 0)))
 
-        for i in range(256):
-            db.save(runner.pareto_key, choices_to_bytes((i, 0)))
-
-        runner.run()
-
-        assert len(list(db.fetch(runner.pareto_key))) == 1
+    runner.run()
+    assert len(list(db.fetch(runner.pareto_key))) == 1
 
 
 def test_down_samples_the_pareto_front():
-    with deterministic_PRNG():
+    def test(data):
+        data.draw_integer(0, 2**8 - 1)
+        data.draw_integer(0, 2**8 - 1)
 
-        def test(data):
-            data.draw_integer(0, 2**8 - 1)
-            data.draw_integer(0, 2**8 - 1)
+    db = InMemoryExampleDatabase()
 
-        db = InMemoryExampleDatabase()
+    runner = ConjectureRunner(
+        test,
+        settings=settings(
+            max_examples=1000,
+            database=db,
+            suppress_health_check=list(HealthCheck),
+            phases=[Phase.reuse],
+        ),
+        database_key=b"stuff",
+        random=Random(0),
+    )
 
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=1000,
-                database=db,
-                suppress_health_check=list(HealthCheck),
-                phases=[Phase.reuse],
-            ),
-            database_key=b"stuff",
-        )
+    for n1, n2 in itertools.product(range(256), range(256)):
+        db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
 
-        for n1, n2 in itertools.product(range(256), range(256)):
-            db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
+    with pytest.raises(RunIsComplete):
+        runner.reuse_existing_examples()
 
-        with pytest.raises(RunIsComplete):
-            runner.reuse_existing_examples()
-
-        assert runner.valid_examples == 1000
+    assert runner.valid_examples == 1000
 
 
 def test_stops_loading_pareto_front_if_interesting():
-    with deterministic_PRNG():
+    def test(data):
+        data.draw_integer()
+        data.draw_integer()
+        data.mark_interesting(interesting_origin())
 
-        def test(data):
-            data.draw_integer()
-            data.draw_integer()
-            data.mark_interesting(interesting_origin())
+    db = InMemoryExampleDatabase()
 
-        db = InMemoryExampleDatabase()
+    runner = ConjectureRunner(
+        test,
+        settings=settings(
+            max_examples=1000,
+            database=db,
+            suppress_health_check=list(HealthCheck),
+            phases=[Phase.reuse],
+        ),
+        database_key=b"stuff",
+        random=Random(0),
+    )
 
-        runner = ConjectureRunner(
-            test,
-            settings=settings(
-                max_examples=1000,
-                database=db,
-                suppress_health_check=list(HealthCheck),
-                phases=[Phase.reuse],
-            ),
-            database_key=b"stuff",
-        )
+    for n1, n2 in itertools.product(range(256), range(256)):
+        db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
 
-        for n1, n2 in itertools.product(range(256), range(256)):
-            db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
-
-        runner.reuse_existing_examples()
-
-        assert runner.call_count == 1
+    runner.reuse_existing_examples()
+    assert runner.call_count == 1
 
 
 def test_uses_tags_in_calculating_pareto_front():
-    with deterministic_PRNG():
+    def test(data):
+        data.target_observations[""] = 1
+        if data.draw_boolean():
+            data.start_span(11)
+            data.draw_integer(0, 2**8 - 1)
+            data.stop_span()
 
-        def test(data):
-            data.target_observations[""] = 1
-            if data.draw_boolean():
-                data.start_span(11)
-                data.draw_integer(0, 2**8 - 1)
-                data.stop_span()
+    runner = ConjectureRunner(
+        test,
+        settings=settings(max_examples=10, database=InMemoryExampleDatabase()),
+        database_key=b"stuff",
+        random=Random(0),
+    )
 
-        runner = ConjectureRunner(
-            test,
-            settings=settings(max_examples=10, database=InMemoryExampleDatabase()),
-            database_key=b"stuff",
-        )
-
-        runner.run()
-
-        assert len(runner.pareto_front) == 2
+    runner.run()
+    assert len(runner.pareto_front) == 2
 
 
 def test_optimises_the_pareto_front():

--- a/hypothesis-python/tests/cover/test_random_module.py
+++ b/hypothesis-python/tests/cover/test_random_module.py
@@ -191,7 +191,7 @@ def test_evil_prng_registration_nonsense():
     # The first test to call deterministic_PRNG registers a new random instance.
     # If that's this test, it will throw off our n_registered count in the middle.
     # start with a no-op to ensure this registration has occurred.
-    with deterministic_PRNG(0):
+    with deterministic_PRNG():
         pass
 
     n_registered = len(entropy.RANDOMS_TO_MANAGE)
@@ -206,7 +206,7 @@ def test_evil_prng_registration_nonsense():
     register_random(r2)
     assert len(entropy.RANDOMS_TO_MANAGE) == n_registered + 2
 
-    with deterministic_PRNG(0):
+    with deterministic_PRNG():
         del r1
         gc_collect()
         assert k not in entropy.RANDOMS_TO_MANAGE, "r1 has been garbage-collected"

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -29,7 +29,6 @@ from hypothesis.control import current_build_context
 from hypothesis.core import encode_failure
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import DidNotReproduce, Flaky, InvalidArgument, InvalidDefinition
-from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.stateful import (
     Bundle,
     RuleBasedStateMachine,
@@ -456,7 +455,7 @@ def test_saves_failing_example_in_database():
 
 
 def test_can_run_with_no_db():
-    with deterministic_PRNG(), raises(AssertionError):
+    with raises(AssertionError):
         run_state_machine_as_test(
             DepthMachine, settings=Settings(database=None, max_examples=10_000)
         )

--- a/hypothesis-python/tests/cover/test_testdecorators.py
+++ b/hypothesis-python/tests/cover/test_testdecorators.py
@@ -263,7 +263,7 @@ def test_list_is_sorted(xs):
 @fails
 @given(floats(1.0, 2.0))
 def test_is_an_endpoint(x):
-    assert x == 1.0 or x == 2.0
+    assert x in {1.0, 2.0}
 
 
 def test_breaks_bounds():

--- a/hypothesis-python/tests/nocover/test_database_usage.py
+++ b/hypothesis-python/tests/nocover/test_database_usage.py
@@ -18,7 +18,6 @@ from hypothesis.database import (
     ReadOnlyDatabase,
 )
 from hypothesis.errors import NoSuchExample, Unsatisfiable
-from hypothesis.internal.entropy import deterministic_PRNG
 
 from tests.common.utils import (
     Why,
@@ -80,7 +79,6 @@ def test_clears_out_database_as_things_get_boring():
 
 @xfail_on_crosshair(Why.other, strict=False)
 def test_trashes_invalid_examples():
-    key = b"a database key"
     database = InMemoryExampleDatabase()
 
     invalid = set()
@@ -96,20 +94,18 @@ def test_trashes_invalid_examples():
                 st.binary(min_size=5),
                 condition,
                 settings=settings(database=database),
-                database_key=key,
+                database_key=b"a database key",
             )
         except (Unsatisfiable, NoSuchExample):
             pass
 
-    with deterministic_PRNG():
-        value = stuff()
+    value = stuff()
 
     original = len(all_values(database))
     assert original > 1
 
     invalid.add(value)
-    with deterministic_PRNG():
-        stuff()
+    stuff()
     assert len(all_values(database)) < original
 
 
@@ -118,7 +114,6 @@ def test_trashes_invalid_examples():
     reason="condition is easy for crosshair, stops early",
 )
 def test_respects_max_examples_in_database_usage():
-    key = b"a database key"
     database = InMemoryExampleDatabase()
     do_we_care = True
     counter = 0
@@ -134,18 +129,18 @@ def test_respects_max_examples_in_database_usage():
                 st.binary(min_size=100),
                 check,
                 settings=settings(database=database, max_examples=10),
-                database_key=key,
+                database_key=b"a database key",
             )
         except NoSuchExample:
             pass
 
-    with deterministic_PRNG():
-        stuff()
+    stuff()
     assert len(all_values(database)) > 10
+
     do_we_care = False
     counter = 0
-    with deterministic_PRNG():
-        stuff()
+    stuff()
+
     assert counter == 10
 
 

--- a/hypothesis-python/tests/nocover/test_health_checks.py
+++ b/hypothesis-python/tests/nocover/test_health_checks.py
@@ -17,7 +17,6 @@ from hypothesis import HealthCheck, Phase, given, seed, settings, strategies as 
 from hypothesis.errors import FailedHealthCheck
 from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE
-from hypothesis.internal.entropy import deterministic_PRNG
 from hypothesis.strategies._internal.lazy import LazyStrategy
 
 pytestmark = pytest.mark.skipif(
@@ -95,17 +94,16 @@ def test_does_not_trigger_health_check_on_simple_strategies(monkeypatch):
 
     monkeypatch.setattr(ConjectureData, "draw_integer", draw_integer)
 
-    with deterministic_PRNG():
-        for _ in range(100):
-            # Setting max_examples=11 ensures we have enough examples for the
-            # health checks to finish running, but cuts the generation short
-            # after that point to allow this test to run in reasonable time.
-            @settings(database=None, max_examples=11, phases=[Phase.generate])
-            @given(st.integers())
-            def test(n):
-                pass
+    for _ in range(100):
+        # Setting max_examples=11 ensures we have enough examples for the
+        # health checks to finish running, but cuts the generation short
+        # after that point to allow this test to run in reasonable time.
+        @settings(database=None, max_examples=11, phases=[Phase.generate])
+        @given(st.integers())
+        def test(n):
+            pass
 
-            test()
+        test()
 
 
 def test_does_not_trigger_health_check_when_most_examples_are_small():


### PR DESCRIPTION
`deterministic_PRNG` seeds the entire global state, which might mask issues in tests. I think it's better to seed only what we need in tests, which is often just the `ConjectureRunner`'s random instance. 

This fixes recent flakes of `test_variadic_draw`, because we recently changed the default ConjectureRunner random (when not passed, ie only in tests) to use our own global `Random()` instance rather than the global `random.random` instance, which does not get seeded by `deterministic_PRNG`.