### PR TITLE
Adjust pytest CI jobs for dropping python 3.9

### DIFF
--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -202,14 +202,6 @@ deps =
 commands=
     nosetests tests/cover/test_testdecorators.py
 
-[testenv:py{39}-pytest46]
-deps =
-    -r../requirements/test.txt
-commands_pre =
-    pip install pytest==4.6.11 pytest-xdist==1.34
-commands =
-    python -bb -X dev -W'ignore:the imp module:DeprecationWarning' -m pytest tests/pytest tests/cover/test_testdecorators.py
-
 [testenv:py{39}-pytest54]
 deps =
     -r../requirements/test.txt
@@ -232,11 +224,19 @@ commands =
     # https://github.com/HypothesisWorks/hypothesis/pull/4326#issuecomment-2764314834
     python -bb -X dev -m pytest -c ../pytest.ini tests/pytest tests/cover/test_testdecorators.py
 
-[testenv:pytest7]
+[testenv:pytest74]
 deps =
     -r../requirements/test.txt
 commands_pre =
-    pip install pytest==7.* pytest-xdist
+    pip install pytest==7.4.4 pytest-xdist
+commands =
+    python -bb -X dev -m pytest tests/pytest tests/cover/test_testdecorators.py
+
+[testenv:pytest8]
+deps =
+    -r../requirements/test.txt
+commands_pre =
+    pip install pytest==8.* pytest-xdist
 commands =
     python -bb -X dev -m pytest tests/pytest tests/cover/test_testdecorators.py
 


### PR DESCRIPTION
Ticking off the last todo on https://github.com/HypothesisWorks/hypothesis/issues/4557