### PR TITLE
Add 2025.12 to allowed array API versions

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+Add 2025.12 to the list of recognized Array API versions in
+``hypothesis.extra.array_api``.

--- a/hypothesis-python/src/hypothesis/extra/array_api.py
+++ b/hypothesis-python/src/hypothesis/extra/array_api.py
@@ -58,10 +58,10 @@ __all__ = [
 ]
 
 
-RELEASED_VERSIONS = ("2021.12", "2022.12", "2023.12", "2024.12")
+RELEASED_VERSIONS = ("2021.12", "2022.12", "2023.12", "2024.12", "2025.12")
 NOMINAL_VERSIONS = (*RELEASED_VERSIONS, "draft")
 assert sorted(NOMINAL_VERSIONS) == list(NOMINAL_VERSIONS)  # sanity check
-NominalVersion = Literal["2021.12", "2022.12", "2023.12", "2024.12", "draft"]
+NominalVersion = Literal["2021.12", "2022.12", "2023.12", "2024.12", "2025.12", "draft"]
 assert get_args(NominalVersion) == NOMINAL_VERSIONS  # sanity check
 
 


### PR DESCRIPTION
Similar to https://github.com/HypothesisWorks/hypothesis/pull/4262, which added support for the 2024.12 revision of the Array API standard, this slightly pre-emptive PR adds "2025.12" to the list of recognized Array API versions.
This version is going to be released "soon", and since our testing heavily relies on hypothesis, this patch would help us with bootstrapping tests of new features of the 2025.12 spec.

Previous PRs of this sort (neither caused problems or required follow-up changes):

https://github.com/HypothesisWorks/hypothesis/pull/3901 added support for 2023.12
https://github.com/HypothesisWorks/hypothesis/pull/4262 added support for 2024.12
