### PR TITLE
Improve FlakyStrategyDefinition error messages with specific details

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,6 +83,7 @@ their individual contributions.
 * `Hal Blackburn <https://github.com/h4l>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Humberto Rocha <https://github.com/humrochagf>`_
+* `Ian Hunt-Isaak <https://github.com/ianhi>`_
 * `Ilya Lebedev <https://github.com/melevir>`_ (melevir@gmail.com)
 * `Israel Fruchter <https://github.com/fruch>`_
 * `Ivan Tham <https://github.com/pickfire>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This patch improves :class:`~hypothesis.errors.FlakyStrategyDefinition` error
+messages to describe *what* changed between runs (e.g. different constraints,
+different types, or a different number of draws), making it much easier to
+diagnose flaky data generation. Duplicate errors are no longer raised when a
+single mismatch triggers multiple checks, and when a real test failure is found
+alongside a flaky strategy error, the real failure is now reported cleanly with
+a warning about the flaky issue. Stateful tests also gain context about which
+steps led to the error when observability is enabled.
+
+Thanks to Ian Hunt-Isaak for this contribution!

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -60,6 +60,7 @@ from hypothesis.errors import (
     FailedHealthCheck,
     FlakyFailure,
     FlakyReplay,
+    FlakyStrategyDefinition,
     Found,
     Frozen,
     HypothesisException,
@@ -954,6 +955,12 @@ class StateForActualGivenExecution:
         self._runner: ConjectureRunner | None = None
 
     @property
+    def has_suppressed_flaky_error(self) -> bool:
+        return (
+            self._runner is not None and self._runner.suppressed_flaky_error is not None
+        )
+
+    @property
     def test_identifier(self) -> str:
         return getattr(
             current_pytest_item.value, "nodeid", None
@@ -1239,6 +1246,7 @@ class StateForActualGivenExecution:
             raise
         except (
             FailedHealthCheck,
+            FlakyStrategyDefinition,
             *skip_exceptions_to_reraise(),
         ):
             # These are fatal errors or control exceptions that should stop the
@@ -1569,6 +1577,13 @@ class StateForActualGivenExecution:
                         f"{reproduction_decorator(falsifying_example.choices)} "
                         "as a decorator on your test case"
                     )
+
+        if flaky := runner.suppressed_flaky_error:
+            report(
+                "WARNING: a flaky strategy definition error was detected "
+                "during shrinking and suppressed in favor of the real "
+                f"failure above.\n  {flaky}"
+            )
 
         _raise_to_user(
             errors_to_report,
@@ -2218,7 +2233,14 @@ def given(
                         wrapped_test._hypothesis_internal_use_generated_seed
                     )
                     with local_settings(settings):
-                        if not (state.failed_normally or generated_seed is None):
+                        # Print the seed when the failure is unexpected (not a
+                        # normal test failure), or when a flaky strategy error
+                        # was suppressed — the seed is the only way to
+                        # reproduce the flaky error during shrinking.
+                        if generated_seed is not None and (
+                            not state.failed_normally
+                            or state.has_suppressed_flaky_error
+                        ):
                             if running_under_pytest:
                                 report(
                                     f"You can add @seed({generated_seed}) to this test or "

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -2233,10 +2233,6 @@ def given(
                         wrapped_test._hypothesis_internal_use_generated_seed
                     )
                     with local_settings(settings):
-                        # Print the seed when the failure is unexpected (not a
-                        # normal test failure), or when a flaky strategy error
-                        # was suppressed — the seed is the only way to
-                        # reproduce the flaky error during shrinking.
                         if generated_seed is not None and (
                             not state.failed_normally
                             or state.has_suppressed_flaky_error

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -959,7 +959,7 @@ class DataTree:
         key: ChoiceT,
         random: Random,
     ) -> ChoiceT:
-        (generator, children, rejected) = self._get_children_cache(
+        generator, children, rejected = self._get_children_cache(
             choice_type, constraints, key=key
         )
         # Keep a stock of 100 potentially-valid children at all times.
@@ -989,7 +989,7 @@ class DataTree:
         child: ChoiceT,
         key: ChoiceT,
     ) -> None:
-        (_generator, children, rejected) = self._get_children_cache(
+        _generator, children, rejected = self._get_children_cache(
             choice_type, constraints, key=key
         )
         rejected.add(child)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -464,7 +464,7 @@ class TreeNode:
             self.__forced = set()
         self.__forced.add(i)
 
-    def split_at(self, i: int) -> None:
+    def split_at(self, i: int, *, new_value: object = None) -> None:
         """
         Splits the tree so that it can incorporate a decision at the draw call
         corresponding to the node at position i.
@@ -475,9 +475,9 @@ class TreeNode:
         if i in self.forced:
             raise FlakyStrategyDefinition(
                 _flaky_strat_msg_with_detail(
-                    f"The {self.choice_types[i]} value that was forced to a "
-                    f"specific value in the first run was given a different "
-                    f"value in the second run.\n"
+                    f"The {self.choice_types[i]} value was forced to "
+                    f"{self.values[i]!r} in the first run, but the second "
+                    f"run drew {new_value!r}.\n"
                 )
             )
 
@@ -1108,7 +1108,7 @@ class TreeRecordingObserver(DataObserver):
                 )
             elif value != node.values[i]:
                 try:
-                    node.split_at(i)
+                    node.split_at(i, new_value=value)
                 except FlakyStrategyDefinition:
                     self.flaky = True
                     raise
@@ -1146,7 +1146,7 @@ class TreeRecordingObserver(DataObserver):
                     compute_max_children(choice_type, constraints) == 1
                     and not was_forced
                 ):
-                    node.split_at(i)
+                    node.split_at(i, new_value=value)
                     assert isinstance(node.transition, Branch)
                     self._current_node = node.transition.children[value]
                     self._index_in_current_node = 0

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -1027,10 +1027,6 @@ class TreeRecordingObserver(DataObserver):
         self._index_in_current_node: int = 0
         self._trail: list[TreeNode] = [self._current_node]
         self.killed: bool = False
-        # Set to True when draw_value or split_at raises
-        # FlakyStrategyDefinition, so that conclude_test knows not to
-        # raise a duplicate for "fewer draws" — the test didn't stop
-        # early by choice, it was interrupted by the first error.
         self.flaky: bool = False
 
     def draw_integer(

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -1028,9 +1028,9 @@ class TreeRecordingObserver(DataObserver):
         self._trail: list[TreeNode] = [self._current_node]
         self.killed: bool = False
         # Set to True when draw_value or split_at raises
-        # FlakyStrategyDefinition, so that conclude_test and kill_branch
-        # know not to raise a duplicate for "fewer draws" — the test
-        # didn't stop early by choice, it was interrupted by the first error.
+        # FlakyStrategyDefinition, so that conclude_test knows not to
+        # raise a duplicate for "fewer draws" — the test didn't stop
+        # early by choice, it was interrupted by the first error.
         self.flaky: bool = False
 
     def draw_integer(
@@ -1186,9 +1186,6 @@ class TreeRecordingObserver(DataObserver):
             return
 
         self.killed = True
-
-        if self.flaky:
-            return
 
         if self._index_in_current_node < len(self._current_node.values) or (
             self._current_node.transition is not None

--- a/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/datatree.py
@@ -60,6 +60,28 @@ _FLAKY_STRAT_MSG = (
 )
 
 
+def _flaky_strat_msg_with_detail(detail: str) -> str:
+    return f"{_FLAKY_STRAT_MSG}\n\n{detail}"
+
+
+def _mismatch_detail(expected: tuple[str, object], actual: tuple[str, object]) -> str:
+    expected_type, expected_constraints = expected
+    actual_type, actual_constraints = actual
+    if actual_type != expected_type:
+        return (
+            f"The second run drew a different type of value "
+            f"than the first run.\n"
+            f"  first run:  {expected_type}\n"
+            f"  second run: {actual_type}\n"
+        )
+    return (
+        f"The second run drew {actual_type} with different "
+        f"constraints than the first run.\n"
+        f"  first run:  {expected_constraints}\n"
+        f"  second run: {actual_constraints}\n"
+    )
+
+
 EMPTY: frozenset[int] = frozenset()
 
 
@@ -451,7 +473,13 @@ class TreeNode:
         """
 
         if i in self.forced:
-            raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+            raise FlakyStrategyDefinition(
+                _flaky_strat_msg_with_detail(
+                    f"The {self.choice_types[i]} value that was forced to a "
+                    f"specific value in the first run was given a different "
+                    f"value in the second run.\n"
+                )
+            )
 
         assert not self.is_exhausted
 
@@ -999,6 +1027,11 @@ class TreeRecordingObserver(DataObserver):
         self._index_in_current_node: int = 0
         self._trail: list[TreeNode] = [self._current_node]
         self.killed: bool = False
+        # Set to True when draw_value or split_at raises
+        # FlakyStrategyDefinition, so that conclude_test and kill_branch
+        # know not to raise a duplicate for "fewer draws" — the test
+        # didn't stop early by choice, it was interrupted by the first error.
+        self.flaky: bool = False
 
     def draw_integer(
         self, value: int, *, was_forced: bool, constraints: IntegerConstraints
@@ -1050,17 +1083,35 @@ class TreeRecordingObserver(DataObserver):
                 choice_type != node.choice_types[i]
                 or constraints != node.constraints[i]
             ):
-                raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                self.flaky = True
+                raise FlakyStrategyDefinition(
+                    _flaky_strat_msg_with_detail(
+                        _mismatch_detail(
+                            (node.choice_types[i], node.constraints[i]),
+                            (choice_type, constraints),
+                        )
+                    )
+                )
             # Note that we don't check whether a previously
             # forced value is now free. That will be caught
             # if we ever split the node there, but otherwise
             # may pass silently. This is acceptable because it
             # means we skip a hash set lookup on every
             # draw and that's a pretty niche failure mode.
-            if was_forced and i not in node.forced:
-                raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
-            if value != node.values[i]:
-                node.split_at(i)
+            elif was_forced and i not in node.forced:
+                self.flaky = True
+                raise FlakyStrategyDefinition(
+                    _flaky_strat_msg_with_detail(
+                        f"The {choice_type} value was forced to a specific "
+                        f"value but was not forced on the first run.\n"
+                    )
+                )
+            elif value != node.values[i]:
+                try:
+                    node.split_at(i)
+                except FlakyStrategyDefinition:
+                    self.flaky = True
+                    raise
                 assert i == len(node.values)
                 new_node = TreeNode()
                 assert isinstance(node.transition, Branch)
@@ -1103,11 +1154,24 @@ class TreeRecordingObserver(DataObserver):
                 assert trans.status != Status.OVERRUN
                 # We tried to draw where history says we should have
                 # stopped
-                raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                self.flaky = True
+                raise FlakyStrategyDefinition(
+                    _flaky_strat_msg_with_detail(
+                        "The second run drew more data than the first run.\n"
+                    )
+                )
             else:
                 assert isinstance(trans, Branch), trans
                 if choice_type != trans.choice_type or constraints != trans.constraints:
-                    raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                    self.flaky = True
+                    raise FlakyStrategyDefinition(
+                        _flaky_strat_msg_with_detail(
+                            _mismatch_detail(
+                                (trans.choice_type, trans.constraints),
+                                (choice_type, constraints),
+                            )
+                        )
+                    )
                 try:
                     self._current_node = trans.children[value]
                 except KeyError:
@@ -1123,11 +1187,19 @@ class TreeRecordingObserver(DataObserver):
 
         self.killed = True
 
+        if self.flaky:
+            return
+
         if self._index_in_current_node < len(self._current_node.values) or (
             self._current_node.transition is not None
             and not isinstance(self._current_node.transition, Killed)
         ):
-            raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+            raise FlakyStrategyDefinition(
+                _flaky_strat_msg_with_detail(
+                    "The second run stopped drawing earlier than the "
+                    "first run, which continued to draw more data.\n"
+                )
+            )
 
         if self._current_node.transition is None:
             self._current_node.transition = Killed(TreeNode())
@@ -1144,11 +1216,18 @@ class TreeRecordingObserver(DataObserver):
         node if necessary and checks for consistency."""
         if status == Status.OVERRUN:
             return
+        if self.flaky:
+            return
         i = self._index_in_current_node
         node = self._current_node
 
         if i < len(node.values) or isinstance(node.transition, Branch):
-            raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+            raise FlakyStrategyDefinition(
+                _flaky_strat_msg_with_detail(
+                    "The second run stopped drawing earlier than the "
+                    "first run, which continued to draw more data.\n"
+                )
+            )
 
         new_transition = Conclusion(status, interesting_origin)
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -73,11 +73,7 @@ from hypothesis.internal.conjecture.providers import (
 from hypothesis.internal.conjecture.shrinker import Shrinker, ShrinkPredicateT, sort_key
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.healthcheck import fail_health_check
-from hypothesis.internal.observability import (
-    Observation,
-    observability_enabled,
-    with_observability_callback,
-)
+from hypothesis.internal.observability import Observation, with_observability_callback
 from hypothesis.reporting import base_report, report, verbose_report
 
 # In most cases, the following constants are all Final. However, we do allow users
@@ -586,13 +582,12 @@ class ConjectureRunner:
                     + "\n".join(f"  {s}" for s in data._stateful_repr_parts)
                 )
             elif data._stateful_repr_parts is not None:
-                # Stateful test, but steps weren't recorded because
-                # observability is off — suggest enabling it.
-                if not observability_enabled():
-                    report(
-                        "Tip: to see which steps led to this error, re-run with "
-                        "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1"
-                    )
+                # Stateful test, but no steps were recorded (observability
+                # is off) — suggest enabling it.
+                report(
+                    "Tip: to see which steps led to this error, re-run with "
+                    "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1"
+                )
             # Save the (partial) choices to the database so the reuse phase
             # replays them on the next run. If the flaky external state is
             # still present, the user gets the same error; if they've fixed

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -570,28 +570,20 @@ class ConjectureRunner:
             data.freeze()
             return
         except FlakyStrategyDefinition:
-            # The observer's flaky flag is already set, so freeze() won't
-            # raise a duplicate from conclude_test().
             data.freeze()
-            # _stateful_repr_parts is None for non-stateful tests (skip both
-            # branches), a non-empty list when steps were recorded, or an
-            # empty list for stateful tests where observability was off.
+            # _stateful_repr_parts is:
+            # None for non-stateful tests
+            # a list when steps were recorded
             if data._stateful_repr_parts:
                 report(
                     "Steps leading up to this error:\n"
                     + "\n".join(f"  {s}" for s in data._stateful_repr_parts)
                 )
             elif data._stateful_repr_parts is not None:
-                # Stateful test, but no steps were recorded (observability
-                # is off) — suggest enabling it.
                 report(
                     "Tip: to see which steps led to this error, re-run with "
                     "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1"
                 )
-            # Save the (partial) choices to the database so the reuse phase
-            # replays them on the next run. If the flaky external state is
-            # still present, the user gets the same error; if they've fixed
-            # it, the replay succeeds and the entry is automatically deleted.
             self.save_choices(data.choices)
             raise
         except BaseException:
@@ -1002,9 +994,6 @@ class ConjectureRunner:
             except FlakyStrategyDefinition as e:
                 if not self.interesting_examples:
                     raise
-                # Real bugs were found before the flaky error hit during
-                # shrinking. Stop the engine and let the replay loop
-                # report the real failures.
                 self.statistics["stopped-because"] = (
                     "a flaky strategy was detected during shrinking"
                 )

--- a/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/engine.py
@@ -27,12 +27,18 @@ from hypothesis.database import ExampleDatabase, choices_from_bytes, choices_to_
 from hypothesis.errors import (
     BackendCannotProceed,
     FlakyBackendFailure,
+    FlakyStrategyDefinition,
     HypothesisException,
     InvalidArgument,
     StopTest,
 )
 from hypothesis.internal.cache import LRUReusedCache
-from hypothesis.internal.compat import NotRequired, TypedDict, ceil, override
+from hypothesis.internal.compat import (
+    NotRequired,
+    TypedDict,
+    ceil,
+    override,
+)
 from hypothesis.internal.conjecture.choice import (
     ChoiceConstraintsT,
     ChoiceKeyT,
@@ -67,7 +73,11 @@ from hypothesis.internal.conjecture.providers import (
 from hypothesis.internal.conjecture.shrinker import Shrinker, ShrinkPredicateT, sort_key
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.healthcheck import fail_health_check
-from hypothesis.internal.observability import Observation, with_observability_callback
+from hypothesis.internal.observability import (
+    Observation,
+    observability_enabled,
+    with_observability_callback,
+)
 from hypothesis.reporting import base_report, report, verbose_report
 
 # In most cases, the following constants are all Final. However, we do allow users
@@ -315,6 +325,7 @@ class ConjectureRunner:
         self.first_bug_found_time: float = math.inf
 
         self.shrunk_examples: set[InterestingOrigin] = set()
+        self.suppressed_flaky_error: FlakyStrategyDefinition | None = None
         self.health_check_state: HealthCheckState | None = None
         self.tree: DataTree = DataTree()
         self.provider: PrimitiveProvider | type[PrimitiveProvider] = _get_provider(
@@ -562,6 +573,32 @@ class ConjectureRunner:
             interrupted = True
             data.freeze()
             return
+        except FlakyStrategyDefinition:
+            # The observer's flaky flag is already set, so freeze() won't
+            # raise a duplicate from conclude_test().
+            data.freeze()
+            # _stateful_repr_parts is None for non-stateful tests (skip both
+            # branches), a non-empty list when steps were recorded, or an
+            # empty list for stateful tests where observability was off.
+            if data._stateful_repr_parts:
+                report(
+                    "Steps leading up to this error:\n"
+                    + "\n".join(f"  {s}" for s in data._stateful_repr_parts)
+                )
+            elif data._stateful_repr_parts is not None:
+                # Stateful test, but steps weren't recorded because
+                # observability is off — suggest enabling it.
+                if not observability_enabled():
+                    report(
+                        "Tip: to see which steps led to this error, re-run with "
+                        "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1"
+                    )
+            # Save the (partial) choices to the database so the reuse phase
+            # replays them on the next run. If the flaky external state is
+            # still present, the user gets the same error; if they've fixed
+            # it, the replay succeeds and the entry is automatically deleted.
+            self.save_choices(data.choices)
+            raise
         except BaseException:
             data.freeze()
             if self.settings.backend != "hypothesis":
@@ -967,6 +1004,16 @@ class ConjectureRunner:
                 self._run()
             except RunIsComplete:
                 pass
+            except FlakyStrategyDefinition as e:
+                if not self.interesting_examples:
+                    raise
+                # Real bugs were found before the flaky error hit during
+                # shrinking. Stop the engine and let the replay loop
+                # report the real failures.
+                self.statistics["stopped-because"] = (
+                    "a flaky strategy was detected during shrinking"
+                )
+                self.suppressed_flaky_error = e
             for v in self.interesting_examples.values():
                 self.debug_data(v)
             self.debug(

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -271,8 +271,10 @@ def run_state_machine_as_test(state_machine_factory, *, settings=None, _min_step
         if flaky_state["selecting_rule"]:
             add_note(
                 err,
-                "while selecting a rule to run. This is usually caused by "
-                "a flaky precondition, or a bundle that was unexpectedly empty.",
+                "This error occurred while selecting a rule to run. This is "
+                "usually caused by a flaky precondition, a bundle that "
+                "was unexpectedly empty, or a rule that depends on external "
+                "state such as time or a global variable.",
             )
         raise
 

--- a/hypothesis-python/tests/conjecture/test_data_tree.py
+++ b/hypothesis-python/tests/conjecture/test_data_tree.py
@@ -545,10 +545,7 @@ def test_datatree_repr(bool_constraints, int_constraints):
     observer.draw_boolean(False, was_forced=False, constraints=bool_constraints)
     observer.draw_integer(5, was_forced=False, constraints=int_constraints)
 
-    assert (
-        pretty.pretty(tree)
-        == textwrap.dedent(
-            f"""
+    assert pretty.pretty(tree) == textwrap.dedent(f"""
         boolean True {bool_constraints}
           Conclusion (Status.INVALID)
         boolean False {bool_constraints}
@@ -559,9 +556,7 @@ def test_datatree_repr(bool_constraints, int_constraints):
               Conclusion (Status.INTERESTING, {origin})
           integer 5 {int_constraints}
             unknown
-        """
-        ).strip()
-    )
+        """).strip()
 
 
 def _draw(data, node, *, forced=None):
@@ -581,3 +576,15 @@ def test_simulate_forced_floats(node):
     tree.simulate_test_function(data)
     data.freeze()
     assert data.nodes == (node,)
+
+
+def test_type_mismatch_gives_detail():
+    tree = DataTree()
+    data = ConjectureData.for_choices((1,), observer=tree.new_observer())
+    data.draw_integer(0, 1)
+    with pytest.raises(StopTest):
+        data.conclude_test(Status.INTERESTING)
+
+    data = ConjectureData.for_choices((True,), observer=tree.new_observer())
+    with pytest.raises(Flaky, match="different type"):
+        data.draw_boolean()

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1819,3 +1819,56 @@ def test_discards_invalid_db_entries_pareto():
     assert not set(db.fetch(runner.database_key))
     assert not set(db.fetch(runner.pareto_key))
     assert runner.call_count == 0
+
+
+def test_flaky_stateful_reports_steps():
+    seen_choices = []
+
+    def flaky_stateful(data):
+        data._stateful_repr_parts = ["state = MyMachine()", "state.step_one()"]
+        val = data.draw_integer(0, 10)
+        if (val,) not in seen_choices:
+            seen_choices.append((val,))
+            data.draw_integer(0, 10)
+        else:
+            data.draw_integer(0, 20)
+
+    runner = ConjectureRunner(flaky_stateful, settings=settings(database=None))
+    with pytest.raises(FlakyStrategyDefinition, match="different constraints"):
+        runner.run()
+
+
+def test_flaky_stateful_reports_observability_tip():
+    seen_choices = []
+
+    def flaky_stateful_no_obs(data):
+        data._stateful_repr_parts = []
+        val = data.draw_integer(0, 10)
+        if (val,) not in seen_choices:
+            seen_choices.append((val,))
+            data.draw_integer(0, 10)
+        else:
+            data.draw_integer(0, 20)
+
+    runner = ConjectureRunner(flaky_stateful_no_obs, settings=settings(database=None))
+    with pytest.raises(FlakyStrategyDefinition, match="different constraints"):
+        runner.run()
+
+
+def test_flaky_during_shrinking_suppressed():
+    call_count = 0
+
+    def flaky_on_shrink(data):
+        nonlocal call_count
+        data.draw_integer(0, 10)
+        call_count += 1
+        if call_count > 2:
+            data.draw_integer(0, 20)
+        else:
+            data.draw_integer(0, 10)
+        data.mark_interesting(interesting_origin())
+
+    runner = ConjectureRunner(flaky_on_shrink, settings=settings(database=None))
+    runner.run()
+    assert runner.interesting_examples
+    assert runner.suppressed_flaky_error is not None

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -247,6 +247,7 @@ def test_failure_sequence_inducing(building, testing, rnd):
         raise SatisfyMe from None
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_flaky_strategy_definition_includes_detail_for_different_constraints():
     seen_choices: list[tuple[int, ...]] = []
 
@@ -281,6 +282,7 @@ def test_flaky_strategy_definition_includes_detail_for_fewer_draws():
     assert "stopped drawing earlier" in str(runner.suppressed_flaky_error)
 
 
+@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_flaky_strategy_definition_includes_detail_for_type_mismatch():
     seen_choices: list[tuple[int, ...]] = []
 

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -9,18 +9,54 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import sys
+import time
 
 import pytest
 
-from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
+from hypothesis import (
+    HealthCheck,
+    Verbosity,
+    assume,
+    core,
+    example,
+    given,
+    reject,
+    settings,
+)
 from hypothesis.core import StateForActualGivenExecution
-from hypothesis.errors import Flaky, FlakyFailure, Unsatisfiable, UnsatisfiedAssumption
+from hypothesis.errors import (
+    Flaky,
+    FlakyFailure,
+    FlakyStrategyDefinition,
+    Unsatisfiable,
+    UnsatisfiedAssumption,
+)
 from hypothesis.internal.compat import ExceptionGroup
-from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
+from hypothesis.internal.conjecture.data import Status
+from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS, ConjectureRunner
+from hypothesis.internal.escalation import InterestingOrigin
+from hypothesis.internal.observability import (
+    add_observability_callback,
+    remove_observability_callback,
+)
 from hypothesis.internal.scrutineer import Tracer
-from hypothesis.strategies import booleans, composite, integers, lists, random_module
+from hypothesis.stateful import RuleBasedStateMachine, rule
+from hypothesis.strategies import (
+    booleans,
+    composite,
+    data as st_data,
+    integers,
+    lists,
+    random_module,
+)
 
-from tests.common.utils import Why, no_shrink, skipif_threading, xfail_on_crosshair
+from tests.common.utils import (
+    Why,
+    capture_out,
+    no_shrink,
+    skipif_threading,
+    xfail_on_crosshair,
+)
 
 
 class Nope(Exception):
@@ -71,7 +107,6 @@ def test_fails_differently_is_flaky():
 @skipif_threading  # executing into global scope
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="except* syntax")
 def test_exceptiongroup_wrapped_naked_exception_is_flaky():
-
     # Defer parsing until runtime, as "except*" is syntax error pre 3.11
     rude_def = """
 first_call = True
@@ -210,3 +245,165 @@ def test_failure_sequence_inducing(building, testing, rnd):
         pass
     except UnsatisfiedAssumption:
         raise SatisfyMe from None
+
+
+def test_flaky_strategy_definition_includes_detail_for_different_constraints():
+    seen_choices: list[tuple[int, ...]] = []
+
+    def flaky_int(data):
+        val = data.draw_integer(0, 10)
+        if (val,) not in seen_choices:
+            seen_choices.append((val,))
+            data.draw_integer(0, 10)
+        else:
+            data.draw_integer(0, 20)
+
+    runner = ConjectureRunner(flaky_int, settings=settings(database=None))
+    with pytest.raises(FlakyStrategyDefinition, match="different constraints"):
+        runner.run()
+
+
+def test_flaky_strategy_definition_includes_detail_for_fewer_draws():
+    seen_choices: list[tuple[int, ...]] = []
+
+    def flaky_draw_count(data):
+        val = data.draw_integer(0, 10)
+        if (val,) not in seen_choices:
+            seen_choices.append((val,))
+            data.draw_integer(0, 10)
+        data.mark_interesting(InterestingOrigin(Nope, "", 0, (), ()))
+
+    runner = ConjectureRunner(flaky_draw_count, settings=settings(database=None))
+    # Engine suppresses flaky error because it already found a bug.
+    runner.run()
+    assert runner.interesting_examples
+    assert runner.suppressed_flaky_error is not None
+    assert "stopped drawing earlier" in str(runner.suppressed_flaky_error)
+
+
+def test_flaky_strategy_definition_includes_detail_for_type_mismatch():
+    seen_choices: list[tuple[int, ...]] = []
+
+    def flaky_type(data):
+        val = data.draw_integer(0, 10)
+        if (val,) not in seen_choices:
+            seen_choices.append((val,))
+            data.draw_integer(0, 10)
+        else:
+            data.draw_boolean(forced=None)
+
+    runner = ConjectureRunner(flaky_type, settings=settings(database=None))
+    with pytest.raises(FlakyStrategyDefinition, match="different type"):
+        runner.run()
+
+
+def test_flaky_strategy_definition_includes_detail_for_more_draws():
+    seen_choices: list[tuple[int, ...]] = []
+
+    def flaky_more(data):
+        val = data.draw_integer(0, 10)
+        if (val,) not in seen_choices:
+            seen_choices.append((val,))
+        else:
+            data.draw_integer(0, 10)
+        data.mark_interesting(InterestingOrigin(Nope, "", 0, (), ()))
+
+    runner = ConjectureRunner(flaky_more, settings=settings(database=None))
+    # Engine suppresses flaky error because it already found a bug.
+    runner.run()
+    assert runner.interesting_examples
+    assert runner.suppressed_flaky_error is not None
+    assert "more data" in str(runner.suppressed_flaky_error)
+
+
+def test_failed_split_sets_flaky_flag():
+    from hypothesis.internal.conjecture.datatree import DataTree
+
+    tree = DataTree()
+    int_constraints = {
+        "min_value": 0,
+        "max_value": 10,
+        "weights": None,
+        "shrink_towards": 0,
+    }
+
+    # First run: record a forced draw
+    obs1 = tree.new_observer()
+    obs1.draw_integer(5, was_forced=True, constraints=int_constraints)
+    obs1.conclude_test(Status.VALID, None)
+
+    # Second run: different value at forced position → split_at raises
+    obs2 = tree.new_observer()
+    with pytest.raises(FlakyStrategyDefinition, match="forced"):
+        obs2.draw_integer(3, was_forced=False, constraints=int_constraints)
+    assert obs2.flaky
+
+
+def test_flaky_strategy_definition_fatal_prints_seed(monkeypatch):
+    monkeypatch.setattr(core, "running_under_pytest", False)
+    upper = [10]
+
+    @settings(max_examples=200, database=None)
+    @given(data=st_data())
+    def test(data):
+        data.draw(integers(0, upper[0]))
+        upper[0] += 10
+
+    with capture_out() as o, pytest.raises(FlakyStrategyDefinition):
+        test()
+
+    output = o.getvalue()
+    assert "@seed(" in output
+
+
+def test_flaky_strategy_definition_suppressed_prints_seed(monkeypatch):
+    monkeypatch.setattr(core, "running_under_pytest", False)
+    more_count = [0]
+
+    @settings(max_examples=200, database=None)
+    @given(data=st_data())
+    def test(data):
+        data.draw(integers(0, 10))
+        more_count[0] += 1
+        if more_count[0] > 1:
+            data.draw(integers(0, 10))
+        raise AssertionError
+
+    # FlakyFailure wraps the AssertionError when flaky replay fails
+    with capture_out() as o, pytest.raises((AssertionError, FlakyFailure)):
+        test()
+
+    output = o.getvalue()
+    assert "@seed(" in output
+    assert "WARNING: a flaky strategy definition error was detected" in output
+
+
+class FlakyTimeStateMachine(RuleBasedStateMachine):
+    @rule(data=st_data())
+    def step(self, data):
+        data.draw(integers(time.time_ns(), time.time_ns() + 2))
+
+
+@pytest.mark.parametrize("observability", [False, True])
+def test_flaky_stateful_reports_steps_or_tip(monkeypatch, observability):
+    monkeypatch.setattr(core, "running_under_pytest", False)
+    callback = lambda event: None
+
+    if observability:
+        add_observability_callback(callback)
+
+    try:
+        with capture_out() as o, pytest.raises(FlakyStrategyDefinition):
+            FlakyTimeStateMachine.TestCase.settings = settings(
+                max_examples=200, database=None, stateful_step_count=5
+            )
+            FlakyTimeStateMachine.TestCase().runTest()
+
+        output = o.getvalue()
+        if observability:
+            assert "Steps leading up to this error" in output
+        else:
+            assert "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1" in output
+    finally:
+        if observability:
+            remove_observability_callback(callback)

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -334,7 +334,7 @@ def test_failed_split_sets_flaky_flag():
 
     # Second run: different value at forced position → split_at raises
     obs2 = tree.new_observer()
-    with pytest.raises(FlakyStrategyDefinition, match="forced to 5.*drew 3"):
+    with pytest.raises(FlakyStrategyDefinition, match=r"forced to 5.*drew 3"):
         obs2.draw_integer(3, was_forced=False, constraints=int_constraints)
     assert obs2.flaky
 

--- a/hypothesis-python/tests/cover/test_flakiness.py
+++ b/hypothesis-python/tests/cover/test_flakiness.py
@@ -334,7 +334,7 @@ def test_failed_split_sets_flaky_flag():
 
     # Second run: different value at forced position → split_at raises
     obs2 = tree.new_observer()
-    with pytest.raises(FlakyStrategyDefinition, match="forced"):
+    with pytest.raises(FlakyStrategyDefinition, match="forced to 5.*drew 3"):
         obs2.draw_integer(3, was_forced=False, constraints=int_constraints)
     assert obs2.flaky
 

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -168,7 +168,9 @@ class FlakyPreconditionMachine(RuleBasedStateMachine):
 def test_flaky_precondition_error_message():
     with raises(FlakyStrategyDefinition) as exc_info:
         FlakyPreconditionMachine.TestCase().runTest()
-    assert any("flaky precondition" in note for note in exc_info.value.__notes__)
+    notes = exc_info.value.__notes__
+    assert any("flaky precondition" in note for note in notes)
+    assert any("external state" in note for note in notes)
 
 
 class FlakyDrawInRuleMachine(RuleBasedStateMachine):

--- a/hypothesis-python/tests/cover/test_stateful.py
+++ b/hypothesis-python/tests/cover/test_stateful.py
@@ -733,16 +733,13 @@ def test_invariant_failling_present_in_falsifying_example():
         run_state_machine_as_test(BadInvariant)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == """
+    assert result == """
 Falsifying example:
 state = BadInvariant()
 state.initialize_1()
 state.invariant_1()
 state.teardown()
 """.strip()
-    )
 
 
 def test_invariant_present_in_falsifying_example():
@@ -947,16 +944,13 @@ def test_initialize_rule_populate_bundle():
         run_state_machine_as_test(WithInitializeBundleRules)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == """
+    assert result == """
 Falsifying example:
 state = WithInitializeBundleRules()
 a_0 = state.initialize_a(dep='dep')
 state.fail_fast(param=a_0)
 state.teardown()
 """.strip()
-    )
 
 
 def test_initialize_rule_dont_mix_with_precondition():
@@ -1078,9 +1072,7 @@ def test_can_manually_call_initialize_rule():
         run_state_machine_as_test(StateMachine)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == """
+    assert result == """
 Falsifying example:
 state = StateMachine()
 state.initialize()
@@ -1088,7 +1080,6 @@ state.fail_eventually()
 state.fail_eventually()
 state.teardown()
 """.strip()
-    )
 
 
 def test_steps_printed_despite_pytest_fail():
@@ -1101,14 +1092,11 @@ def test_steps_printed_despite_pytest_fail():
 
     with pytest.raises(Failed) as err:
         run_state_machine_as_test(RaisesProblem)
-    assert (
-        "\n".join(err.value.__notes__).strip()
-        == """
+    assert "\n".join(err.value.__notes__).strip() == """
 Falsifying example:
 state = RaisesProblem()
 state.oops()
 state.teardown()""".strip()
-    )
 
 
 def test_steps_not_printed_with_pytest_skip(capsys):
@@ -1318,16 +1306,13 @@ def test_single_target_multiple():
         run_state_machine_as_test(Machine)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == """
+    assert result == """
 Falsifying example:
 state = Machine()
 a_0, a_1, a_2 = state.initialize()
 state.fail_fast(param=a_2)
 state.teardown()
 """.strip()
-    )
 
 
 @pytest.mark.parametrize(
@@ -1370,16 +1355,13 @@ def test_targets_repr(bundle_names, initial, repr_):
         run_state_machine_as_test(Machine)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == f"""
+    assert result == f"""
 Falsifying example:
 state = Machine()
 {repr_}
 state.fail_fast()
 state.teardown()
 """.strip()
-    )
 
 
 def test_multiple_targets():
@@ -1407,9 +1389,7 @@ def test_multiple_targets():
         run_state_machine_as_test(Machine)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == """
+    assert result == """
 Falsifying example:
 state = Machine()
 a_0, a_1, a_2 = state.initialize()
@@ -1417,7 +1397,6 @@ b_0, b_1, b_2 = a_0, a_1, a_2
 state.fail_fast(a1=a_2, a2=a_1, a3=a_0, b1=b_2, b2=b_1, b3=b_0)
 state.teardown()
 """.strip()
-    )
 
 
 def test_multiple_common_targets():
@@ -1448,9 +1427,7 @@ def test_multiple_common_targets():
         run_state_machine_as_test(Machine)
 
     result = "\n".join(err.value.__notes__)
-    assert (
-        result
-        == """
+    assert result == """
 Falsifying example:
 state = Machine()
 a_0, a_1, a_2 = state.initialize()
@@ -1459,7 +1436,6 @@ a_3, a_4, a_5 = a_0, a_1, a_2
 state.fail_fast(a1=a_5, a2=a_4, a3=a_3, a4=a_2, a5=a_1, a6=a_0, b1=b_2, b2=b_1, b3=b_0)
 state.teardown()
 """.strip()
-    )
 
 
 class LotsOfEntropyPerStepMachine(RuleBasedStateMachine):


### PR DESCRIPTION
Moved into a draft. see: https://github.com/HypothesisWorks/hypothesis/pull/4676#issuecomment-4044060726

---

🤖 - I used claude extensively for this PR, but have personally reviewed every line to the best of my ability. 

Fix for https://github.com/HypothesisWorks/hypothesis/issues/4673

This PR implements four tightly related changes in the output of hypothesis when there is a flaky failure

1. Ensure seed is printed

2. Print the actual different choices in the strategy

the error now says what was different (different constraints, different type, fewer/more draws) instead of just "data generation was inconsistent"

3. For stateful tests give the replay/give info on how to trigger observability

4. Fix duplicate FlakyStrategyDefinition errors

when a mismatch was detected during a draw, a second `FlakyStrategyDefinition` could be raised from `conclude_test` if the mismatch also resulted in fewer draws. Now the observer has a `flaky` flag to prevent this redundant second raise.

One of the tricky things is that a `FlakyStrategyDefinition` error can be thrown with or without a real test failure. In the latter case then you would get a messy output with nested errors (during. the handling another exception...) which made it hard to notice the first error with so much text on the screen. Now the FlakyError is temporarily suppressed and reported in the Hypothesis output, keeping the test failure more visible.  (see final example below)


I cooked up this demo script with claude to test out the various combinations of failure modes and otuput (e.g.  observability) which I found quite helpful. Here is the script:
<details>
<summary>demo_flaky.py (click to expand)</summary>

```python
import hypothesis.strategies as st
from hypothesis import given, settings
from hypothesis.stateful import Bundle, RuleBasedStateMachine, initialize, rule

_catalog_size = [5]

class FlakyConstraints(RuleBasedStateMachine):
    items = Bundle("items")

    @initialize()
    def create_cart(self):
        self.cart = []

    @rule(target=items, name=st.text(min_size=1, max_size=10))
    def add_item(self, name):
        self.cart.append(name)
        return name

    @rule(
        item=items,
        price=st.integers(1, 100).flatmap(
            lambda p: st.integers(p, p + _catalog_size[0])
        ),
    )
    def set_price(self, item, price):
        _catalog_size[0] += 3

TestConstraint = FlakyConstraints.TestCase
TestConstraint.settings = settings(max_examples=200, database=None, stateful_step_count=10)

_call_count = [0]

@settings(max_examples=200, database=None)
@given(data=st.data())
def test_type_mismatch(data):
    _call_count[0] += 1
    if _call_count[0] % 2 == 0:
        data.draw(st.booleans())
    else:
        data.draw(st.integers(0, 10))

_upper = [10]

@settings(max_examples=200, database=None)
@given(data=st.data())
def test_plain_mismatch(data):
    data.draw(st.integers(0, _upper[0]))
    _upper[0] += 10

_more_count = [0]

@settings(max_examples=200, database=None)
@given(data=st.data())
def test_more_draws(data):
    data.draw(st.integers(0, 10))
    _more_count[0] += 1
    if _more_count[0] > 1:
        data.draw(st.integers(0, 10))
    assert False
```

</details>

---

With these outputs (formatted by claude to elide portions of the error to focus on whats relevant for this PR)

### 1. Stateful test — constraint mismatch (observability off)

`python -m pytest demo_flaky.py -s -k constraint`

<table>
<tr><th>Before (v6.151.9)</th><th>After</th></tr>
<tr>
<td>

```
FlakyStrategyDefinition: Inconsistent data
generation! Data generation behaved differently
between different runs. Is your data generation
depending on external state?
while generating 'price' from integers(...)
  .flatmap(...) for rule set_price

During handling of the above exception,
another exception occurred:

  ...long chained traceback...

FlakyStrategyDefinition: Inconsistent data
generation! ...
while selecting a rule to run. This is usually
caused by a flaky precondition, or a bundle
that was unexpectedly empty.
```


</td>
<td>

```
FlakyStrategyDefinition: Inconsistent data
generation! Data generation behaved differently
between different runs. Is your data generation
depending on external state?

The second run drew integer with different
constraints than the first run.
  first run:  {'min_value': 99, 'max_value': 278,
               'weights': ...}
  second run: {'min_value': 99, 'max_value': 290,
               'weights': ...}

while generating 'price' from integers(...)
  .flatmap(...) for rule set_price
This error occurred while selecting a rule to
run. This is usually caused by a flaky
precondition, a bundle that was unexpectedly
empty, or a rule that depends on external state
such as time or a global variable.
---------- Hypothesis ----------
Tip: to see which steps led to this error,
  re-run with
  HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1
You can add @seed(...) to this test or run
  pytest with --hypothesis-seed=... to reproduce
  this failure.
```

</td>
</tr>
</table>

---

### 2. Stateful test — constraint mismatch (observability on)

`HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1 python -m pytest demo_flaky.py -s -k constraint`

<table>
<tr><th>Before (v6.151.9)</th><th>After</th></tr>
<tr>
<td>

```
  ...same duplicate chained traceback as above...

FlakyStrategyDefinition: Inconsistent data
generation! ...
while selecting a rule to run. This is usually
caused by a flaky precondition, or a bundle
that was unexpectedly empty.
```


</td>
<td>

```
FlakyStrategyDefinition: ...

The second run drew integer with different
constraints than the first run.
  first run:  {'min_value': 29, 'max_value': 220,
               'weights': ...}
  second run: {'min_value': 29, 'max_value': 238,
               'weights': ...}

while generating 'price' from integers(...)
  .flatmap(...) for rule set_price
This error occurred while selecting a rule ...
---------- Hypothesis ----------
Steps leading up to this error:
  state = FlakyConstraints()
  state.create_cart()
  items_0 = state.add_item(name='...')
  state.teardown()
You can add @seed(...) to this test or run
  pytest with --hypothesis-seed=... to reproduce
  this failure.
```

</td>
</tr>
</table>

---

### 3. Non-stateful — type mismatch

`python -m pytest demo_flaky.py -s -k type_mismatch`

<table>
<tr><th>Before (v6.151.9)</th><th>After</th></tr>
<tr>
<td>

```
FlakyFailure: Inconsistent results from
replaying a test case!
  last: VALID from None
  this: INTERESTING from
    FlakyStrategyDefinition at datatree.py:1053
  (1 sub-exception)
+-+---------------- 1 ----------------
  |   ...long traceback...
  | FlakyStrategyDefinition: Inconsistent data
  |   generation! ...
  | while generating 'Draw 1' from booleans()
  +------------------------------------
```


</td>
<td>

```
FlakyStrategyDefinition: Inconsistent data
generation! Data generation behaved differently
between different runs. Is your data generation
depending on external state?

The second run drew a different type of value
than the first run.
  first run:  integer
  second run: boolean

while generating 'Draw 1' from booleans()
---------- Hypothesis ----------
You can add @seed(...) to this test or run
  pytest with --hypothesis-seed=... to reproduce
  this failure.
```

</td>
</tr>
</table>

---

### 4. Non-stateful — constraint mismatch

`python -m pytest demo_flaky.py -s -k plain`

<table>
<tr><th>Before (v6.151.9)</th><th>After</th></tr>
<tr>
<td>

```
FlakyFailure: Inconsistent results from
replaying a test case!
  last: VALID from None
  this: INTERESTING from
    FlakyStrategyDefinition at datatree.py:1053
  (1 sub-exception)
+-+---------------- 1 ----------------
  |   ...long traceback...
  | FlakyStrategyDefinition: Inconsistent data
  |   generation! ...
  | while generating 'Draw 1' from
  |   integers(min_value=0, max_value=20)
  +------------------------------------
```


</td>
<td>

```
FlakyStrategyDefinition: Inconsistent data
generation! Data generation behaved differently
between different runs. Is your data generation
depending on external state?

The second run drew integer with different
constraints than the first run.
  first run:  {'min_value': 0, 'max_value': 10,
               'weights': None,
               'shrink_towards': 0}
  second run: {'min_value': 0, 'max_value': 20,
               'weights': None,
               'shrink_towards': 0}

while generating 'Draw 1' from
  integers(min_value=0, max_value=20)
---------- Hypothesis ----------
You can add @seed(...) to this test or run
  pytest with --hypothesis-seed=... to reproduce
  this failure.
```

</td>
</tr>
</table>

---

### 5. Real bug + suppressed flaky error

`python -m pytest demo_flaky.py -s -k more`

<table>
<tr><th>Before (v6.151.9)</th><th>After</th></tr>
<tr>
<td>

```
FlakyFailure: Inconsistent results from
replaying a test case!
  last: INTERESTING from AssertionError ...
  this: INTERESTING from
    FlakyStrategyDefinition at datatree.py:1106
  (2 sub-exceptions)
+-+---------------- 1 ----------------
  |   ...
  |     assert False
  | AssertionError: assert False
  +---------------- 2 ----------------
  |   ...long traceback...
  | FlakyStrategyDefinition: Inconsistent data
  |   generation! ...
  | while generating 'Draw 2' from
  |   integers(min_value=0, max_value=10)
  +------------------------------------
```


</td>
<td>

```
FlakyFailure: ...An example failed on the
  first run but now succeeds ...
Falsifying example: test_more_draws(
    data=data(...),
)
Draw 1: 0
+-+---------------- 1 ----------------
  |   ...
  |     assert False
  | AssertionError: assert False
  +------------------------------------
---------- Hypothesis ----------
WARNING: a flaky strategy definition error was
  detected during shrinking and suppressed in
  favor of the real failure above.
  Inconsistent data generation! ...

The second run drew more data than the first run.

You can add @seed(...) to this test or run
  pytest with --hypothesis-seed=... to reproduce
  this failure.
```


</td>
</tr>
</table>
