### PR TITLE
doc: add user facing section on swarms

### DIFF
--- a/hypothesis-python/docs/stateful.rst
+++ b/hypothesis-python/docs/stateful.rst
@@ -210,6 +210,11 @@ Invariants can also have :func:`~hypothesis.stateful.precondition`\ s applied to
 
 Note that currently invariants can't access bundles; if you need to use invariants, you should store relevant data on the instance instead.
 
+Scaling to many rules
+---------------------
+
+As you add more rules to a state machine, it becomes harder to deeply explore any particular combination of them. Hypothesis handles this by automatically focusing each test example run on a different subset of your rules, a technique known as `swarm testing <https://www.cs.utah.edu/~regehr/papers/swarm12.pdf>`__
+
 More fine grained control
 -------------------------
 


### PR DESCRIPTION
When investigating limiting rules on a state machine I figured out that what I wanted was swarm test. At first I didn't think hypothesis implemented this becuase a search for `swarm` only returns a single changelog entry: https://hypothesis.readthedocs.io/en/latest/search.html?q=swarm&check_keywords=yes&area=default


So this is a minimal version of the docs that I think would have gotten me to my current understanding quicker. Wasn't super confident on the jargon of test case vs run vs example so that last sentence might need some help to be less confusing.