### PR TITLE
Various improvements in printing test cases

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -9,4 +9,3 @@ Principle changes:
   producing a value, we now print the repr (or a pretty-printed version of it).
 * Additionally, in some cases where we would print a complex expression that involved
   a lambda, we are now able to simplify that expression into a more readable one.
-* We strip ``<locals>`` and other invalid syntax from some names.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This release further improves printing of generated values, building on the changes
+in  :version:`6.151.11`.
+
+Principle changes:
+
+* In many cases where we would have printed a complex expression
+  producing a value, we now print the repr (or a pretty-printed version of it).
+* Additionally, in some cases where we would print a complex expression that involved
+  a lambda, we are now able to simplify that expression into a more readable one.
+* We strip ``<locals>`` and other invalid syntax from some names.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -455,6 +455,14 @@ class PrettyIter:
     def __repr__(self) -> str:
         return f"iter({self._values!r})"
 
+    def _repr_pretty_(self, printer, cycle):
+        if cycle:
+            printer.text("iter(...)")
+        else:
+            printer.text("iter(")
+            printer.pretty(self._values)
+            printer.text(")")
+
 
 @defines_strategy()
 def iterables(

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -642,7 +642,7 @@ def _seq_pprinter_factory(start: str, end: str, basetype: type) -> PrettyPrintFu
 def get_class_name(cls: type[object]) -> str:
     class_name = _safe_getattr(cls, "__qualname__", cls.__name__)
     assert isinstance(class_name, str)
-    return class_name
+    return class_name.replace(".<locals>.", ".")
 
 
 def _set_pprinter_factory(

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -130,28 +130,28 @@ def _try_inline_lambda(
     args: Sequence[object],
     kwargs: dict[str, object],
     printer: "RepresentationPrinter",
-) -> None | object:
+) -> bool:
     """Try to inline single-use lambda arguments into the body expression.
 
     Given e.g. func_name="lambda b: hashlib.sha256(b).hexdigest()" with
     args=(b'',), returns the printer output for "hashlib.sha256(b'').hexdigest()"
     by substituting the argument repr into the AST.
 
-    Returns None if inlining is not possible (parse failure, multi-use params, etc).
-    Returns a sentinel otherwise (the printer has already been written to).
+    Returns True if inlining succeeded (the printer has been written to),
+    False if inlining is not possible (parse failure, multi-use params, etc).
     """
     try:
         tree = ast.parse(func_name, mode="eval")
-    except SyntaxError:
-        return None
+    except Exception:
+        return False
     lam = tree.body
     if not isinstance(lam, ast.Lambda):
-        return None
+        return False
 
     # Build param name -> argument repr mapping, matching Python call semantics
     params = lam.args
     if params.vararg or params.kwonlyargs or params.kw_defaults or params.kwarg:
-        return None
+        return False
 
     param_names = [p.arg for p in params.args]
     # params.defaults are right-aligned: if there are 3 params and 1 default,
@@ -164,9 +164,9 @@ def _try_inline_lambda(
     # Bail if there are more positional args than parameters, or if any
     # kwarg doesn't match a parameter name — these can't be inlined.
     if len(args) > len(param_names):
-        return None
+        return False
     if any(k not in param_names for k in kwargs):
-        return None
+        return False
 
     arg_reprs: dict[str, str] = {}
     for i, name in enumerate(param_names):
@@ -177,14 +177,14 @@ def _try_inline_lambda(
         elif name in has_default:
             pass  # not passed, will use its default — just skip
         else:
-            return None
+            return False
 
     # Bail if any repr is not valid Python (e.g. "HypothesisRandom(generated data)")
     for repr_str in arg_reprs.values():
         try:
             ast.parse(repr_str, mode="eval")
-        except SyntaxError:
-            return None
+        except Exception:
+            return False
 
     use_counts = dict.fromkeys(param_names, 0)
     for node in ast.walk(lam.body):
@@ -193,7 +193,7 @@ def _try_inline_lambda(
 
     # Bail if any parameter is used more than once (avoid duplicating expressions)
     if any(count > 1 for count in use_counts.values()):
-        return None
+        return False
 
     # Substitute argument reprs into the body AST
     class _Inliner(ast.NodeTransformer):
@@ -211,7 +211,7 @@ def _try_inline_lambda(
     try:
         result = ast.unparse(new_body)
     except Exception:
-        return None
+        return False
 
     printer.text(result)
     return True
@@ -576,7 +576,7 @@ class RepresentationPrinter:
             )
             if not has_comments:
                 inlined = _try_inline_lambda(func_name, args, kwargs, self)
-                if inlined is not None:
+                if inlined:
                     return
             func_name = f"({func_name})"
         self.text(func_name)
@@ -747,7 +747,7 @@ def _seq_pprinter_factory(start: str, end: str, basetype: type) -> PrettyPrintFu
 def get_class_name(cls: type[object]) -> str:
     class_name = _safe_getattr(cls, "__qualname__", cls.__name__)
     assert isinstance(class_name, str)
-    return class_name.replace(".<locals>.", ".")
+    return class_name
 
 
 def _set_pprinter_factory(

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -125,6 +125,99 @@ class IDKey:
         return isinstance(__o, type(self)) and id(self.value) == id(__o.value)
 
 
+def _try_inline_lambda(
+    func_name: str,
+    args: Sequence[object],
+    kwargs: dict[str, object],
+    printer: "RepresentationPrinter",
+) -> None | object:
+    """Try to inline single-use lambda arguments into the body expression.
+
+    Given e.g. func_name="lambda b: hashlib.sha256(b).hexdigest()" with
+    args=(b'',), returns the printer output for "hashlib.sha256(b'').hexdigest()"
+    by substituting the argument repr into the AST.
+
+    Returns None if inlining is not possible (parse failure, multi-use params, etc).
+    Returns a sentinel otherwise (the printer has already been written to).
+    """
+    try:
+        tree = ast.parse(func_name, mode="eval")
+    except SyntaxError:
+        return None
+    lam = tree.body
+    if not isinstance(lam, ast.Lambda):
+        return None
+
+    # Build param name -> argument repr mapping, matching Python call semantics
+    params = lam.args
+    if params.vararg or params.kwonlyargs or params.kw_defaults or params.kwarg:
+        return None
+
+    param_names = [p.arg for p in params.args]
+    # params.defaults are right-aligned: if there are 3 params and 1 default,
+    # params.defaults applies to the last param only.
+    n_defaults = len(params.defaults)
+    has_default = (
+        set(param_names[len(param_names) - n_defaults :]) if n_defaults else set()
+    )
+
+    # Bail if there are more positional args than parameters, or if any
+    # kwarg doesn't match a parameter name — these can't be inlined.
+    if len(args) > len(param_names):
+        return None
+    if any(k not in param_names for k in kwargs):
+        return None
+
+    arg_reprs: dict[str, str] = {}
+    for i, name in enumerate(param_names):
+        if i < len(args):
+            arg_reprs[name] = pretty(args[i])
+        elif name in kwargs:
+            arg_reprs[name] = pretty(kwargs[name])
+        elif name in has_default:
+            pass  # not passed, will use its default — just skip
+        else:
+            return None
+
+    # Bail if any repr is not valid Python (e.g. "HypothesisRandom(generated data)")
+    for repr_str in arg_reprs.values():
+        try:
+            ast.parse(repr_str, mode="eval")
+        except SyntaxError:
+            return None
+
+    # Count uses of each parameter in the body
+    use_counts: dict[str, int] = dict.fromkeys(param_names, 0)
+    for node in ast.walk(lam.body):
+        if isinstance(node, ast.Name) and node.id in use_counts:
+            use_counts[node.id] += 1
+
+    # Bail if any parameter is used more than once (avoid duplicating expressions)
+    if any(count > 1 for count in use_counts.values()):
+        return None
+
+    # Substitute argument reprs into the body AST
+    class _Inliner(ast.NodeTransformer):
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if node.id in arg_reprs:
+                # Parse the repr as an expression and splice it in.
+                # Wrap in parens to preserve precedence in all contexts.
+                replacement = ast.parse(arg_reprs[node.id], mode="eval").body
+                return ast.copy_location(replacement, node)
+            return node
+
+    new_body = _Inliner().visit(lam.body)
+    ast.fix_missing_locations(new_body)
+
+    try:
+        result = ast.unparse(new_body)
+    except Exception:
+        return None
+
+    printer.text(result)
+    return True
+
+
 class RepresentationPrinter:
     """Special pretty printer that has a `pretty` method that calls the pretty
     printer for a python object.
@@ -473,6 +566,19 @@ class RepresentationPrinter:
         """
         assert isinstance(func_name, str)
         if func_name.startswith(("lambda:", "lambda ")):
+            # Before wrapping the lambda in parens for a call, try to inline
+            # arguments that are used exactly once in the body. If all args
+            # get inlined, we can emit just the body expression with no call.
+            # Skip inlining only when there are actual comments on arguments,
+            # since comments need the call-style repr to attach to.
+            has_comments = arg_slices and any(
+                sr in self.slice_comments and sr not in self._commented_slices
+                for sr in arg_slices.values()
+            )
+            if not has_comments:
+                inlined = _try_inline_lambda(func_name, args, kwargs, self)
+                if inlined is not None:
+                    return
             func_name = f"({func_name})"
         self.text(func_name)
         # Build list of (label, value) pairs. Labels are "arg[i]" for positional

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -93,15 +93,6 @@ __all__ = [
     "pretty",
 ]
 
-PRIMITIVE_TYPES_ALWAYS_USE_REPR = (
-    int,
-    float,
-    str,
-    bytes,
-    bool,
-    type(None),
-)
-
 
 def _safe_getattr(obj: object, attr: str, default: Any | None = None) -> Any:
     """Safe version of getattr.
@@ -428,11 +419,12 @@ class RepresentationPrinter:
         kwargs: dict[str, object],
         arg_labels: ArgLabelsT | None = None,
     ) -> None:
-        if isinstance(obj, PRIMITIVE_TYPES_ALWAYS_USE_REPR):
-            return _repr_pprint(obj, self, cycle)
-
-        # pprint this object as a call, _unless_ the call would be invalid syntax
-        # and the repr would be valid and there are not comments on arguments.
+        # pprint this object as a call if it seems like a good idea to do so,
+        # otherwise pprint as repr.
+        # Rules:
+        # 1. If there are comments, we *must* print as a call.
+        # 2. Prefer valid syntax to invalid syntax.
+        # 3. Prefer shorter expressions.
         if cycle:
             return self.text("<...>")
         # Look up comments from slice_comments if we have arg_labels
@@ -452,6 +444,8 @@ class RepresentationPrinter:
                 p.known_object_printers = self.known_object_printers
                 p.repr_call(name, args, kwargs)
                 # If the call is not valid syntax, use the repr
+                if len(repr(obj)) < len(p.getvalue()):
+                    return _repr_pprint(obj, self, cycle)
                 try:
                     ast.parse(p.getvalue())
                 except Exception:

--- a/hypothesis-python/src/hypothesis/vendor/pretty.py
+++ b/hypothesis-python/src/hypothesis/vendor/pretty.py
@@ -186,8 +186,7 @@ def _try_inline_lambda(
         except SyntaxError:
             return None
 
-    # Count uses of each parameter in the body
-    use_counts: dict[str, int] = dict.fromkeys(param_names, 0)
+    use_counts = dict.fromkeys(param_names, 0)
     for node in ast.walk(lam.body):
         if isinstance(node, ast.Name) and node.id in use_counts:
             use_counts[node.id] += 1

--- a/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
+++ b/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
@@ -9,7 +9,7 @@
 # name: test_map_to_bytes_prints_as_repr
   '''
   Falsifying example: inner(
-      b=(lambda b: hashlib.sha256(b).digest())(b''),
+      b=hashlib.sha256(b'').digest(),
   )
   '''
 # ---

--- a/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
+++ b/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
@@ -1,4 +1,11 @@
 # serializer version: 1
+# name: test_invalid_call_syntax_falls_back_to_repr
+  '''
+  Falsifying example: inner(
+      x='hello world',
+  )
+  '''
+# ---
 # name: test_map_to_bytes_prints_as_repr
   '''
   Falsifying example: inner(

--- a/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
+++ b/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
@@ -2,7 +2,7 @@
 # name: test_map_to_bytes_prints_as_repr
   '''
   Falsifying example: inner(
-      b=b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
+      b=(lambda b: hashlib.sha256(b).digest())(b''),
   )
   '''
 # ---

--- a/hypothesis-python/tests/cover/test_custom_reprs.py
+++ b/hypothesis-python/tests/cover/test_custom_reprs.py
@@ -192,3 +192,20 @@ def test_map_to_bytes_prints_as_repr(snapshot):
         raise AssertionError
 
     assert _get_output(inner) == snapshot
+
+
+def test_invalid_call_syntax_falls_back_to_repr(snapshot):
+    # When the call-style repr (e.g. "a b()") is invalid Python syntax but
+    # repr(obj) is valid, we should fall back to using repr(obj).
+    _BadName = type(
+        "a b",
+        (),
+        {"__repr__": lambda self: "'hello world'"},
+    )
+
+    @given(x=st.builds(_BadName))
+    @settings(phases=[Phase.generate, Phase.shrink], print_blob=False)
+    def inner(x):
+        raise AssertionError
+
+    assert _get_output(inner) == snapshot

--- a/hypothesis-python/tests/cover/test_lambda_inlining.py
+++ b/hypothesis-python/tests/cover/test_lambda_inlining.py
@@ -33,134 +33,111 @@ def _repr_call(func_name, args=(), kwargs=None):
     return p.getvalue()
 
 
-# --- Success cases ---
+class BadRepr:
+    def __repr__(self):
+        return "not valid(python syntax"
 
 
-def test_no_arg_lambda():
-    assert _inline("lambda: 42") == "42"
+@pytest.mark.parametrize(
+    "func_name, args, kwargs, expected",
+    [
+        pytest.param("lambda: 42", (), {}, "42", id="no_args"),
+        pytest.param("lambda x: x + 1", (0,), {}, "0 + 1", id="single_positional"),
+        pytest.param("lambda x: x + 1", (), {"x": 0}, "0 + 1", id="single_kwarg"),
+        pytest.param(
+            "lambda a, b: (b, a)",
+            ("hello", "world"),
+            {},
+            "('world', 'hello')",
+            id="multi_positional",
+        ),
+        pytest.param(
+            "lambda a, b: a + b", (), {"a": 1, "b": 2}, "1 + 2", id="multi_kwargs"
+        ),
+        pytest.param(
+            "lambda a, b: a + b",
+            (1,),
+            {"b": 2},
+            "1 + 2",
+            id="mixed_positional_and_kwargs",
+        ),
+        pytest.param("lambda x: 42", (99,), {}, "42", id="unused_param"),
+        pytest.param(
+            "lambda a, b, c: 42", (1, 2, 3), {}, "42", id="unused_params_multi"
+        ),
+        pytest.param(
+            "lambda s: s.upper()", ("hi",), {}, "'hi'.upper()", id="method_call"
+        ),
+        pytest.param("lambda b: f(b).g()", (0,), {}, "f(0).g()", id="nested_call"),
+        pytest.param(
+            "lambda a, b=10: a + 1",
+            (),
+            {"a": 5},
+            "5 + 1",
+            id="default_not_passed",
+        ),
+        pytest.param(
+            "lambda a, b=10: a + b",
+            (),
+            {"a": 5, "b": 20},
+            "5 + 20",
+            id="default_passed",
+        ),
+        pytest.param("lambda a, b=1, c=2: a", (99,), {}, "99", id="multiple_defaults"),
+    ],
+)
+def test_inline_success(func_name, args, kwargs, expected):
+    assert _inline(func_name, args, kwargs) == expected
 
 
-def test_single_positional_arg():
-    assert _inline("lambda x: x + 1", args=(0,)) == "0 + 1"
+@pytest.mark.parametrize(
+    "func_name, args, kwargs",
+    [
+        pytest.param("not a lambda at all!!!", (), {}, id="syntax_error"),
+        pytest.param("foo", (), {}, id="not_a_lambda"),
+        pytest.param("lambda *args: args", ((1, 2),), {}, id="vararg"),
+        pytest.param("lambda **kw: kw", (), {"a": 1}, id="kwarg_star"),
+        pytest.param("lambda *, x: x", (), {"x": 1}, id="kwonly_args"),
+        pytest.param("lambda x: (x, x)", (1,), {}, id="param_used_twice"),
+        pytest.param("lambda x: x + x", (1,), {}, id="param_used_twice_different"),
+        pytest.param("lambda a, b: a + b", (1,), {}, id="too_few_args_no_default"),
+        pytest.param("lambda x: x", (), {"y": 1}, id="wrong_kwarg_name"),
+        pytest.param("lambda: 42", (1, 2), {}, id="more_args_than_params"),
+        pytest.param("lambda x: x", (BadRepr(),), {}, id="invalid_repr"),
+    ],
+)
+def test_inline_bail_out(func_name, args, kwargs):
+    assert _inline(func_name, args, kwargs) is None
 
 
-def test_single_kwarg():
-    assert _inline("lambda x: x + 1", kwargs={"x": 0}) == "0 + 1"
-
-
-def test_multi_positional_args():
-    assert (
-        _inline("lambda a, b: (b, a)", args=("hello", "world")) == "('world', 'hello')"
-    )
-
-
-def test_multi_kwargs():
-    assert _inline("lambda a, b: a + b", kwargs={"a": 1, "b": 2}) == "1 + 2"
-
-
-def test_mixed_positional_and_kwargs():
-    assert _inline("lambda a, b: a + b", args=(1,), kwargs={"b": 2}) == "1 + 2"
-
-
-def test_unused_param():
-    assert _inline("lambda x: 42", args=(99,)) == "42"
-
-
-def test_unused_params_multi():
-    assert _inline("lambda a, b, c: 42", args=(1, 2, 3)) == "42"
-
-
-def test_method_call_on_arg():
-    assert _inline("lambda s: s.upper()", args=("hi",)) == "'hi'.upper()"
-
-
-def test_nested_call():
-    result = _inline("lambda b: f(b).g()", args=(0,))
-    assert result == "f(0).g()"
-
-
-def test_param_with_default_not_passed():
-    assert _inline("lambda a, b=10: a + 1", kwargs={"a": 5}) == "5 + 1"
-
-
-def test_param_with_default_passed():
-    assert _inline("lambda a, b=10: a + b", kwargs={"a": 5, "b": 20}) == "5 + 20"
-
-
-def test_multiple_defaults():
-    assert _inline("lambda a, b=1, c=2: a", args=(99,)) == "99"
-
-
-# --- Bail-out cases ---
-
-
-def test_syntax_error_returns_none():
-    assert _inline("not a lambda at all!!!") is None
-
-
-def test_not_a_lambda_returns_none():
-    assert _inline("foo") is None
-
-
-def test_vararg_returns_none():
-    assert _inline("lambda *args: args", args=((1, 2),)) is None
-
-
-def test_kwarg_star_returns_none():
-    assert _inline("lambda **kw: kw", kwargs={"a": 1}) is None
-
-
-def test_kwonly_args_returns_none():
-    assert _inline("lambda *, x: x", kwargs={"x": 1}) is None
-
-
-def test_param_used_twice_returns_none():
-    assert _inline("lambda x: (x, x)", args=(1,)) is None
-
-
-def test_param_used_twice_in_different_contexts():
-    assert _inline("lambda x: x + x", args=(1,)) is None
-
-
-def test_too_few_args_no_default():
-    assert _inline("lambda a, b: a + b", args=(1,)) is None
-
-
-def test_wrong_kwarg_name():
-    assert _inline("lambda x: x", kwargs={"y": 1}) is None
-
-
-def test_more_args_than_params():
-    assert _inline("lambda: 42", args=(1, 2)) is None
-
-
-def test_invalid_repr_returns_none():
-    class BadRepr:
-        def __repr__(self):
-            return "not valid(python syntax"
-
-    assert _inline("lambda x: x", args=(BadRepr(),)) is None
-
-
-# --- Integration through repr_call ---
-
-
-def test_repr_call_inlines_single_use_lambda():
-    assert _repr_call("lambda x: f(x)", args=(42,)) == "f(42)"
-
-
-def test_repr_call_inlines_no_arg_lambda():
-    assert _repr_call("lambda: 42") == "42"
-
-
-def test_repr_call_wraps_when_multi_use():
-    assert _repr_call("lambda x: (x, x)", args=(1,)) == "(lambda x: (x, x))(1)"
-
-
-def test_repr_call_wraps_when_vararg():
-    assert _repr_call("lambda *args: args", args=((1, 2),)) == (
-        "(lambda *args: args)((1, 2))"
-    )
+@pytest.mark.parametrize(
+    "func_name, args, kwargs, expected",
+    [
+        pytest.param("lambda: 0", (), {}, "0", id="no_arg_lambda"),
+        pytest.param("lambda x: x", (1,), {}, "1", id="identity"),
+        pytest.param("lambda a, b: a - b", (10, 3), {}, "10 - 3", id="subtraction"),
+        pytest.param(
+            "lambda x: (x, x)", (1,), {}, "(lambda x: (x, x))(1)", id="multi_use"
+        ),
+        pytest.param("lambda x: [x]", (1,), {}, "[1]", id="list_wrap"),
+        pytest.param(
+            "lambda s: s.strip()", ("  hi  ",), {}, "'  hi  '.strip()", id="strip"
+        ),
+        pytest.param("lambda: None", (), {}, "None", id="none"),
+        pytest.param("lambda x: f(x)", (42,), {}, "f(42)", id="inlines_single_use"),
+        pytest.param("lambda: 42", (), {}, "42", id="inlines_no_arg"),
+        pytest.param(
+            "lambda *args: args",
+            ((1, 2),),
+            {},
+            "(lambda *args: args)((1, 2))",
+            id="wraps_vararg",
+        ),
+        pytest.param("foo", (1, 2), {}, "foo(1, 2)", id="non_lambda_unchanged"),
+    ],
+)
+def test_repr_call_parametrized(func_name, args, kwargs, expected):
+    assert _repr_call(func_name, args, kwargs) == expected
 
 
 def test_unparse_failure_returns_none(monkeypatch):
@@ -178,10 +155,6 @@ def test_unparse_failure_returns_none(monkeypatch):
 
     monkeypatch.setattr(ast_mod, "unparse", bad_unparse)
     assert _inline("lambda x: x", args=(1,)) is None
-
-
-def test_repr_call_non_lambda_unchanged():
-    assert _repr_call("foo", args=(1, 2)) == "foo(1, 2)"
 
 
 def test_repr_call_skips_inlining_when_comments_present():
@@ -210,19 +183,3 @@ def test_repr_call_inlines_when_arg_slices_but_no_comments():
         arg_slices={"arg[0]": (0, 5)},
     )
     assert p.getvalue() == "f(42)"
-
-
-@pytest.mark.parametrize(
-    "func_name, args, kwargs, expected",
-    [
-        ("lambda: 0", (), {}, "0"),
-        ("lambda x: x", (1,), {}, "1"),
-        ("lambda a, b: a - b", (10, 3), {}, "10 - 3"),
-        ("lambda x: (x, x)", (1,), {}, "(lambda x: (x, x))(1)"),
-        ("lambda x: [x]", (1,), {}, "[1]"),
-        ("lambda s: s.strip()", ("  hi  ",), {}, "'  hi  '.strip()"),
-        ("lambda: None", (), {}, "None"),
-    ],
-)
-def test_repr_call_parametrized(func_name, args, kwargs, expected):
-    assert _repr_call(func_name, args, kwargs) == expected

--- a/hypothesis-python/tests/cover/test_lambda_inlining.py
+++ b/hypothesis-python/tests/cover/test_lambda_inlining.py
@@ -1,0 +1,228 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from hypothesis.vendor import pretty
+
+
+def _inline(func_name, args=(), kwargs=None):
+    """Helper: run _try_inline_lambda and return the printer output, or None."""
+    if kwargs is None:
+        kwargs = {}
+    p = pretty.RepresentationPrinter()
+    result = pretty._try_inline_lambda(func_name, args, kwargs, p)
+    if result is None:
+        return None
+    return p.getvalue()
+
+
+def _repr_call(func_name, args=(), kwargs=None):
+    """Helper: run repr_call and return the full output string."""
+    if kwargs is None:
+        kwargs = {}
+    p = pretty.RepresentationPrinter()
+    p.repr_call(func_name, args, kwargs)
+    return p.getvalue()
+
+
+# --- Success cases ---
+
+
+def test_no_arg_lambda():
+    assert _inline("lambda: 42") == "42"
+
+
+def test_single_positional_arg():
+    assert _inline("lambda x: x + 1", args=(0,)) == "0 + 1"
+
+
+def test_single_kwarg():
+    assert _inline("lambda x: x + 1", kwargs={"x": 0}) == "0 + 1"
+
+
+def test_multi_positional_args():
+    assert (
+        _inline("lambda a, b: (b, a)", args=("hello", "world")) == "('world', 'hello')"
+    )
+
+
+def test_multi_kwargs():
+    assert _inline("lambda a, b: a + b", kwargs={"a": 1, "b": 2}) == "1 + 2"
+
+
+def test_mixed_positional_and_kwargs():
+    assert _inline("lambda a, b: a + b", args=(1,), kwargs={"b": 2}) == "1 + 2"
+
+
+def test_unused_param():
+    assert _inline("lambda x: 42", args=(99,)) == "42"
+
+
+def test_unused_params_multi():
+    assert _inline("lambda a, b, c: 42", args=(1, 2, 3)) == "42"
+
+
+def test_method_call_on_arg():
+    assert _inline("lambda s: s.upper()", args=("hi",)) == "'hi'.upper()"
+
+
+def test_nested_call():
+    result = _inline("lambda b: f(b).g()", args=(0,))
+    assert result == "f(0).g()"
+
+
+def test_param_with_default_not_passed():
+    assert _inline("lambda a, b=10: a + 1", kwargs={"a": 5}) == "5 + 1"
+
+
+def test_param_with_default_passed():
+    assert _inline("lambda a, b=10: a + b", kwargs={"a": 5, "b": 20}) == "5 + 20"
+
+
+def test_multiple_defaults():
+    assert _inline("lambda a, b=1, c=2: a", args=(99,)) == "99"
+
+
+# --- Bail-out cases ---
+
+
+def test_syntax_error_returns_none():
+    assert _inline("not a lambda at all!!!") is None
+
+
+def test_not_a_lambda_returns_none():
+    assert _inline("foo") is None
+
+
+def test_vararg_returns_none():
+    assert _inline("lambda *args: args", args=((1, 2),)) is None
+
+
+def test_kwarg_star_returns_none():
+    assert _inline("lambda **kw: kw", kwargs={"a": 1}) is None
+
+
+def test_kwonly_args_returns_none():
+    assert _inline("lambda *, x: x", kwargs={"x": 1}) is None
+
+
+def test_param_used_twice_returns_none():
+    assert _inline("lambda x: (x, x)", args=(1,)) is None
+
+
+def test_param_used_twice_in_different_contexts():
+    assert _inline("lambda x: x + x", args=(1,)) is None
+
+
+def test_too_few_args_no_default():
+    assert _inline("lambda a, b: a + b", args=(1,)) is None
+
+
+def test_wrong_kwarg_name():
+    assert _inline("lambda x: x", kwargs={"y": 1}) is None
+
+
+def test_more_args_than_params():
+    assert _inline("lambda: 42", args=(1, 2)) is None
+
+
+def test_invalid_repr_returns_none():
+    class BadRepr:
+        def __repr__(self):
+            return "not valid(python syntax"
+
+    assert _inline("lambda x: x", args=(BadRepr(),)) is None
+
+
+# --- Integration through repr_call ---
+
+
+def test_repr_call_inlines_single_use_lambda():
+    assert _repr_call("lambda x: f(x)", args=(42,)) == "f(42)"
+
+
+def test_repr_call_inlines_no_arg_lambda():
+    assert _repr_call("lambda: 42") == "42"
+
+
+def test_repr_call_wraps_when_multi_use():
+    assert _repr_call("lambda x: (x, x)", args=(1,)) == "(lambda x: (x, x))(1)"
+
+
+def test_repr_call_wraps_when_vararg():
+    assert _repr_call("lambda *args: args", args=((1, 2),)) == (
+        "(lambda *args: args)((1, 2))"
+    )
+
+
+def test_unparse_failure_returns_none(monkeypatch):
+    import ast as ast_mod
+
+    real_unparse = ast_mod.unparse
+    called = False
+
+    def bad_unparse(node):
+        nonlocal called
+        if not called:
+            called = True
+            raise ValueError("boom")
+        return real_unparse(node)
+
+    monkeypatch.setattr(ast_mod, "unparse", bad_unparse)
+    assert _inline("lambda x: x", args=(1,)) is None
+
+
+def test_repr_call_non_lambda_unchanged():
+    assert _repr_call("foo", args=(1, 2)) == "foo(1, 2)"
+
+
+def test_repr_call_skips_inlining_when_comments_present():
+    p = pretty.RepresentationPrinter()
+    # Simulate explain-mode comments on slice (0, 5)
+    p.slice_comments[(0, 5)] = "or any other generated value"
+    p.repr_call(
+        "lambda x: f(x)",
+        args=(42,),
+        kwargs={},
+        arg_slices={"arg[0]": (0, 5)},
+    )
+    result = p.getvalue()
+    # Should NOT inline — must keep call style for the comment
+    assert result.startswith("(lambda x: f(x))")
+    assert "# or any other generated value" in result
+
+
+def test_repr_call_inlines_when_arg_slices_but_no_comments():
+    p = pretty.RepresentationPrinter()
+    # arg_slices present but no matching slice_comments
+    p.repr_call(
+        "lambda x: f(x)",
+        args=(42,),
+        kwargs={},
+        arg_slices={"arg[0]": (0, 5)},
+    )
+    assert p.getvalue() == "f(42)"
+
+
+@pytest.mark.parametrize(
+    "func_name, args, kwargs, expected",
+    [
+        ("lambda: 0", (), {}, "0"),
+        ("lambda x: x", (1,), {}, "1"),
+        ("lambda a, b: a - b", (10, 3), {}, "10 - 3"),
+        ("lambda x: (x, x)", (1,), {}, "(lambda x: (x, x))(1)"),
+        ("lambda x: [x]", (1,), {}, "[1]"),
+        ("lambda s: s.strip()", ("  hi  ",), {}, "'  hi  '.strip()"),
+        ("lambda: None", (), {}, "None"),
+    ],
+)
+def test_repr_call_parametrized(func_name, args, kwargs, expected):
+    assert _repr_call(func_name, args, kwargs) == expected

--- a/hypothesis-python/tests/cover/test_lambda_inlining.py
+++ b/hypothesis-python/tests/cover/test_lambda_inlining.py
@@ -8,12 +8,14 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import ast
+
 import pytest
 
 from hypothesis.vendor import pretty
 
 
-def _inline(func_name, args=(), kwargs=None):
+def _try_inline_lambda(func_name, args=(), kwargs=None):
     """Helper: run _try_inline_lambda and return the printer output, or None."""
     if kwargs is None:
         kwargs = {}
@@ -21,15 +23,6 @@ def _inline(func_name, args=(), kwargs=None):
     result = pretty._try_inline_lambda(func_name, args, kwargs, p)
     if result is None:
         return None
-    return p.getvalue()
-
-
-def _repr_call(func_name, args=(), kwargs=None):
-    """Helper: run repr_call and return the full output string."""
-    if kwargs is None:
-        kwargs = {}
-    p = pretty.RepresentationPrinter()
-    p.repr_call(func_name, args, kwargs)
     return p.getvalue()
 
 
@@ -87,7 +80,7 @@ class BadRepr:
     ],
 )
 def test_inline_success(func_name, args, kwargs, expected):
-    assert _inline(func_name, args, kwargs) == expected
+    assert _try_inline_lambda(func_name, args, kwargs) == expected
 
 
 @pytest.mark.parametrize(
@@ -107,7 +100,7 @@ def test_inline_success(func_name, args, kwargs, expected):
     ],
 )
 def test_inline_bail_out(func_name, args, kwargs):
-    assert _inline(func_name, args, kwargs) is None
+    assert _try_inline_lambda(func_name, args, kwargs) is None
 
 
 @pytest.mark.parametrize(
@@ -137,13 +130,13 @@ def test_inline_bail_out(func_name, args, kwargs):
     ],
 )
 def test_repr_call_parametrized(func_name, args, kwargs, expected):
-    assert _repr_call(func_name, args, kwargs) == expected
+    p = pretty.RepresentationPrinter()
+    p.repr_call(func_name, args, kwargs)
+    assert p.getvalue() == expected
 
 
 def test_unparse_failure_returns_none(monkeypatch):
-    import ast as ast_mod
-
-    real_unparse = ast_mod.unparse
+    real_unparse = ast.unparse
     called = False
 
     def bad_unparse(node):
@@ -153,8 +146,8 @@ def test_unparse_failure_returns_none(monkeypatch):
             raise ValueError("boom")
         return real_unparse(node)
 
-    monkeypatch.setattr(ast_mod, "unparse", bad_unparse)
-    assert _inline("lambda x: x", args=(1,)) is None
+    monkeypatch.setattr(ast, "unparse", bad_unparse)
+    assert _try_inline_lambda("lambda x: x", args=(1,)) is None
 
 
 def test_repr_call_skips_inlining_when_comments_present():

--- a/hypothesis-python/tests/cover/test_lambda_inlining.py
+++ b/hypothesis-python/tests/cover/test_lambda_inlining.py
@@ -20,8 +20,7 @@ def _try_inline_lambda(func_name, args=(), kwargs=None):
     if kwargs is None:
         kwargs = {}
     p = pretty.RepresentationPrinter()
-    result = pretty._try_inline_lambda(func_name, args, kwargs, p)
-    if result is None:
+    if not pretty._try_inline_lambda(func_name, args, kwargs, p):
         return None
     return p.getvalue()
 

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
@@ -30,49 +30,49 @@
 # name: test_always_failing[builds_lambda_mixed_args]
   '''
   Falsifying example: inner(
-      x=(lambda x, y, z: Opaque())(0, y='', z=False),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_positional_args]
   '''
   Falsifying example: inner(
-      x=(lambda x, y: Opaque())(0, ''),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_returning_object]
   '''
   Falsifying example: inner(
-      x=(lambda x, y: Pair(x, y))(x=0, y=''),
+      x=Pair(0, ''),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_with_defaults]
   '''
   Falsifying example: inner(
-      x=(lambda a, b='hello': Opaque())(a=0),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_multi_arg_lambda]
   '''
   Falsifying example: inner(
-      x=(lambda x, y: Opaque())(x=0, y=''),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_no_arg_lambda]
   '''
   Falsifying example: inner(
-      x=(lambda: Opaque())(),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_single_arg_lambda]
   '''
   Falsifying example: inner(
-      x=(lambda n: Opaque())(n=0),
+      x=Opaque(),
   )
   '''
 # ---
@@ -244,21 +244,21 @@
 # name: test_always_failing[map_chained_lambdas_opaque]
   '''
   Falsifying example: inner(
-      x=(lambda n: Opaque())(0),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[map_lambda_opaque_result]
   '''
   Falsifying example: inner(
-      x=(lambda n: Opaque())(0),
+      x=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[map_to_bytes]
   '''
   Falsifying example: inner(
-      b=(lambda b: hashlib.sha256(b).digest())(b''),
+      b=hashlib.sha256(b'').digest(),
   )
   '''
 # ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
@@ -2,406 +2,406 @@
 # name: test_always_failing[binary]
   '''
   Falsifying example: inner(
-      b=b'',
+      v0=b'',
   )
   '''
 # ---
 # name: test_always_failing[booleans]
   '''
   Falsifying example: inner(
-      b=False,
+      v0=False,
   )
   '''
 # ---
 # name: test_always_failing[builds]
   '''
   Falsifying example: inner(
-      p=Pair(x=0, y=''),
+      v0=Pair(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_from_type]
   '''
   Falsifying example: inner(
-      xs=[],
+      v0=[],
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_mixed_args]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_positional_args]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_returning_object]
   '''
   Falsifying example: inner(
-      x=Pair(0, ''),
+      v0=Pair(0, ''),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_with_defaults]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_multi_arg_lambda]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_no_arg_lambda]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[builds_single_arg_lambda]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[characters]
   '''
   Falsifying example: inner(
-      c='0',
+      v0='0',
   )
   '''
 # ---
 # name: test_always_failing[complex_numbers]
   '''
   Falsifying example: inner(
-      z=0j,
+      v0=0j,
   )
   '''
 # ---
 # name: test_always_failing[dates]
   '''
   Falsifying example: inner(
-      d=datetime.date(2000, 1, 1),
+      v0=datetime.date(2000, 1, 1),
   )
   '''
 # ---
 # name: test_always_failing[datetimes]
   '''
   Falsifying example: inner(
-      dt=datetime.datetime(2000, 1, 1, 0, 0),
+      v0=datetime.datetime(2000, 1, 1, 0, 0),
   )
   '''
 # ---
 # name: test_always_failing[decimals]
   '''
   Falsifying example: inner(
-      d=Decimal('Infinity'),
+      v0=Decimal('Infinity'),
   )
   '''
 # ---
 # name: test_always_failing[deferred]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[dictionaries]
   '''
   Falsifying example: inner(
-      d={},
+      v0={},
   )
   '''
 # ---
 # name: test_always_failing[emails]
   '''
   Falsifying example: inner(
-      e='0@A.AC',
+      v0='0@A.AC',
   )
   '''
 # ---
 # name: test_always_failing[filter]
   '''
   Falsifying example: inner(
-      n=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[fixed_dictionaries]
   '''
   Falsifying example: inner(
-      d={'name': '', 'age': 0},
+      v0={'name': '', 'age': 0},
   )
   '''
 # ---
 # name: test_always_failing[flatmap_lambda]
   '''
   Falsifying example: inner(
-      x='',
+      v0='',
   )
   '''
 # ---
 # name: test_always_failing[floats]
   '''
   Falsifying example: inner(
-      x=0.0,
+      v0=0.0,
   )
   '''
 # ---
 # name: test_always_failing[fractions]
   '''
   Falsifying example: inner(
-      f=Fraction(0, 1),
+      v0=Fraction(0, 1),
   )
   '''
 # ---
 # name: test_always_failing[from_regex]
   '''
   Falsifying example: inner(
-      s='aaa',
+      v0='aaa',
   )
   '''
 # ---
 # name: test_always_failing[from_type]
   '''
   Falsifying example: inner(
-      x=IPv4Address('0.0.0.0'),
+      v0=IPv4Address('0.0.0.0'),
   )
   '''
 # ---
 # name: test_always_failing[frozensets]
   '''
   Falsifying example: inner(
-      xs=frozenset(),
+      v0=frozenset(),
   )
   '''
 # ---
 # name: test_always_failing[functions]
   '''
   Falsifying example: inner(
-      f=lambda x: x,
+      v0=lambda x: x,
   )
   '''
 # ---
 # name: test_always_failing[integers]
   '''
   Falsifying example: inner(
-      n=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[ip_addresses]
   '''
   Falsifying example: inner(
-      ip=IPv4Address('0.0.0.0'),
+      v0=IPv4Address('0.0.0.0'),
   )
   '''
 # ---
 # name: test_always_failing[iterables]
   '''
   Falsifying example: inner(
-      it=iter([]),
+      v0=iter([]),
   )
   '''
 # ---
 # name: test_always_failing[just]
   '''
   Falsifying example: inner(
-      x=42,
+      v0=42,
   )
   '''
 # ---
 # name: test_always_failing[lists]
   '''
   Falsifying example: inner(
-      xs=[],
+      v0=[],
   )
   '''
 # ---
 # name: test_always_failing[many_args]
   '''
   Falsifying example: inner(
-      a=0,
-      b=0.0,
-      c='',
-      d=False,
-      e=None,
+      v0=0,
+      v1=0.0,
+      v2='',
+      v3=False,
+      v4=None,
   )
   '''
 # ---
 # name: test_always_failing[map_chained_lambdas_opaque]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[map_lambda_opaque_result]
   '''
   Falsifying example: inner(
-      x=Opaque(),
+      v0=Opaque(),
   )
   '''
 # ---
 # name: test_always_failing[map_to_bytes]
   '''
   Falsifying example: inner(
-      b=hashlib.sha256(b'').digest(),
+      v0=hashlib.sha256(b'').digest(),
   )
   '''
 # ---
 # name: test_always_failing[map_to_str]
   '''
   Falsifying example: inner(
-      s='0',
+      v0='0',
   )
   '''
 # ---
 # name: test_always_failing[mixed_strategies]
   '''
   Falsifying example: inner(
-      xs=[],
-      mapping={},
-      choice=10,
+      v0=[],
+      v1={},
+      v2=10,
   )
   '''
 # ---
 # name: test_always_failing[none]
   '''
   Falsifying example: inner(
-      n=None,
+      v0=None,
   )
   '''
 # ---
 # name: test_always_failing[one_of]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[permutations]
   '''
   Falsifying example: inner(
-      p=[0, 1, 2, 3, 4],
+      v0=[0, 1, 2, 3, 4],
   )
   '''
 # ---
 # name: test_always_failing[randoms]
   '''
   Falsifying example: inner(
-      r=HypothesisRandom(generated data),
+      v0=HypothesisRandom(generated data),
   )
   '''
 # ---
 # name: test_always_failing[recursive]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[sampled_from]
   '''
   Falsifying example: inner(
-      x='alice',
+      v0='alice',
   )
   '''
 # ---
 # name: test_always_failing[sets]
   '''
   Falsifying example: inner(
-      xs=set(),
+      v0=set(),
   )
   '''
 # ---
 # name: test_always_failing[shared]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[slices]
   '''
   Falsifying example: inner(
-      s=slice(None, None, None),
+      v0=slice(None, None, None),
   )
   '''
 # ---
 # name: test_always_failing[text]
   '''
   Falsifying example: inner(
-      s='',
+      v0='',
   )
   '''
 # ---
 # name: test_always_failing[timedeltas]
   '''
   Falsifying example: inner(
-      td=datetime.timedelta(0),
+      v0=datetime.timedelta(0),
   )
   '''
 # ---
 # name: test_always_failing[times]
   '''
   Falsifying example: inner(
-      t=datetime.time(0, 0),
+      v0=datetime.time(0, 0),
   )
   '''
 # ---
 # name: test_always_failing[tuples]
   '''
   Falsifying example: inner(
-      t=(0, '', False),
+      v0=(0, '', False),
   )
   '''
 # ---
 # name: test_always_failing[two_args]
   '''
   Falsifying example: inner(
-      n=0,
-      s='',
+      v0=0,
+      v1='',
   )
   '''
 # ---
 # name: test_always_failing[uuids]
   '''
   Falsifying example: inner(
-      u=UUID('e3e70682-c209-4cac-629f-6fbed82c07cd'),
+      v0=UUID('e3e70682-c209-4cac-629f-6fbed82c07cd'),
   )
   '''
 # ---
 # name: test_always_failing_explain[explain_from_regex]
   '''
   Falsifying example: inner(
-      s='00',  # or any other generated value
+      v0='00',  # or any other generated value
   )
   '''
 # ---
 # name: test_always_failing_explain[explain_map_to_str]
   '''
   Falsifying example: inner(
-      s='0',  # or any other generated value
+      v0='0',  # or any other generated value
   )
   '''
 # ---
 # name: test_always_failing_explain[map_lambda_explain_forces_call_style]
   '''
   Falsifying example: inner(
-      x=1,  # or any other generated value
+      v0=1,  # or any other generated value
   )
   '''
 # ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
@@ -2,210 +2,210 @@
 # name: test_always_failing[binary]
   '''
   Falsifying example: inner(
-      v0=b'',
+      b=b'',
   )
   '''
 # ---
 # name: test_always_failing[booleans]
   '''
   Falsifying example: inner(
-      v0=False,
+      b=False,
   )
   '''
 # ---
 # name: test_always_failing[builds]
   '''
   Falsifying example: inner(
-      v0=Pair(x=0, y=''),
+      p=Pair(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_from_type]
   '''
   Falsifying example: inner(
-      v0=[],
+      xs=[],
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_mixed_args]
   '''
   Falsifying example: inner(
-      v0=(lambda x, y, z: Opaque())(0, y='', z=False),
+      x=(lambda x, y, z: Opaque())(0, y='', z=False),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_positional_args]
   '''
   Falsifying example: inner(
-      v0=(lambda x, y: Opaque())(0, ''),
+      x=(lambda x, y: Opaque())(0, ''),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_returning_object]
   '''
   Falsifying example: inner(
-      v0=(lambda x, y: Pair(x, y))(x=0, y=''),
+      x=(lambda x, y: Pair(x, y))(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_with_defaults]
   '''
   Falsifying example: inner(
-      v0=(lambda a, b='hello': Opaque())(a=0),
+      x=(lambda a, b='hello': Opaque())(a=0),
   )
   '''
 # ---
 # name: test_always_failing[builds_multi_arg_lambda]
   '''
   Falsifying example: inner(
-      v0=(lambda x, y: Opaque())(x=0, y=''),
+      x=(lambda x, y: Opaque())(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_no_arg_lambda]
   '''
   Falsifying example: inner(
-      v0=(lambda: Opaque())(),
+      x=(lambda: Opaque())(),
   )
   '''
 # ---
 # name: test_always_failing[builds_single_arg_lambda]
   '''
   Falsifying example: inner(
-      v0=(lambda n: Opaque())(n=0),
+      x=(lambda n: Opaque())(n=0),
   )
   '''
 # ---
 # name: test_always_failing[characters]
   '''
   Falsifying example: inner(
-      v0='0',
+      c='0',
   )
   '''
 # ---
 # name: test_always_failing[complex_numbers]
   '''
   Falsifying example: inner(
-      v0=complex(0.0, 0.0),
+      z=0j,
   )
   '''
 # ---
 # name: test_always_failing[dates]
   '''
   Falsifying example: inner(
-      v0=datetime.date(2000, 1, 1),
+      d=datetime.date(2000, 1, 1),
   )
   '''
 # ---
 # name: test_always_failing[datetimes]
   '''
   Falsifying example: inner(
-      v0=datetime.datetime(2000, 1, 1, 0, 0),
+      dt=datetime.datetime(2000, 1, 1, 0, 0),
   )
   '''
 # ---
 # name: test_always_failing[decimals]
   '''
   Falsifying example: inner(
-      v0=Decimal('Infinity'),
+      d=Decimal('Infinity'),
   )
   '''
 # ---
 # name: test_always_failing[deferred]
   '''
   Falsifying example: inner(
-      v0=0,
+      x=0,
   )
   '''
 # ---
 # name: test_always_failing[dictionaries]
   '''
   Falsifying example: inner(
-      v0=dict([]),
+      d={},
   )
   '''
 # ---
 # name: test_always_failing[emails]
   '''
   Falsifying example: inner(
-      v0='0@A.AC',
+      e='0@A.AC',
   )
   '''
 # ---
 # name: test_always_failing[filter]
   '''
   Falsifying example: inner(
-      v0=0,
+      n=0,
   )
   '''
 # ---
 # name: test_always_failing[fixed_dictionaries]
   '''
   Falsifying example: inner(
-      v0={'name': '', 'age': 0},
+      d={'name': '', 'age': 0},
   )
   '''
 # ---
 # name: test_always_failing[flatmap_lambda]
   '''
   Falsifying example: inner(
-      v0='',
+      x='',
   )
   '''
 # ---
 # name: test_always_failing[floats]
   '''
   Falsifying example: inner(
-      v0=0.0,
+      x=0.0,
   )
   '''
 # ---
 # name: test_always_failing[fractions]
   '''
   Falsifying example: inner(
-      v0=Fraction(0, 1),
+      f=Fraction(0, 1),
   )
   '''
 # ---
 # name: test_always_failing[from_regex]
   '''
   Falsifying example: inner(
-      v0='aaa',
+      s='aaa',
   )
   '''
 # ---
 # name: test_always_failing[from_type]
   '''
   Falsifying example: inner(
-      v0=IPv4Address(b'\x00\x00\x00\x00'),
+      x=IPv4Address('0.0.0.0'),
   )
   '''
 # ---
 # name: test_always_failing[frozensets]
   '''
   Falsifying example: inner(
-      v0=frozenset([]),
+      xs=frozenset(),
   )
   '''
 # ---
 # name: test_always_failing[functions]
   '''
   Falsifying example: inner(
-      v0=lambda x: x,
+      f=lambda x: x,
   )
   '''
 # ---
 # name: test_always_failing[integers]
   '''
   Falsifying example: inner(
-      v0=0,
+      n=0,
   )
   '''
 # ---
 # name: test_always_failing[ip_addresses]
   '''
   Falsifying example: inner(
-      v0=IPv4Address(b'\x00\x00\x00\x00'),
+      ip=IPv4Address('0.0.0.0'),
   )
   '''
 # ---
@@ -219,189 +219,189 @@
 # name: test_always_failing[just]
   '''
   Falsifying example: inner(
-      v0=42,
+      x=42,
   )
   '''
 # ---
 # name: test_always_failing[lists]
   '''
   Falsifying example: inner(
-      v0=[],
+      xs=[],
   )
   '''
 # ---
 # name: test_always_failing[many_args]
   '''
   Falsifying example: inner(
-      v0=0,
-      v1=0.0,
-      v2='',
-      v3=False,
-      v4=None,
+      a=0,
+      b=0.0,
+      c='',
+      d=False,
+      e=None,
   )
   '''
 # ---
 # name: test_always_failing[map_chained_lambdas_opaque]
   '''
   Falsifying example: inner(
-      v0=(lambda n: Opaque())(0),
+      x=(lambda n: Opaque())(0),
   )
   '''
 # ---
 # name: test_always_failing[map_lambda_opaque_result]
   '''
   Falsifying example: inner(
-      v0=(lambda n: Opaque())(0),
+      x=(lambda n: Opaque())(0),
   )
   '''
 # ---
 # name: test_always_failing[map_to_bytes]
   '''
   Falsifying example: inner(
-      v0=b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
+      b=(lambda b: hashlib.sha256(b).digest())(b''),
   )
   '''
 # ---
 # name: test_always_failing[map_to_str]
   '''
   Falsifying example: inner(
-      v0='0',
+      s='0',
   )
   '''
 # ---
 # name: test_always_failing[mixed_strategies]
   '''
   Falsifying example: inner(
-      v0=[],
-      v1=dict([]),
-      v2=10,
+      xs=[],
+      mapping={},
+      choice=10,
   )
   '''
 # ---
 # name: test_always_failing[none]
   '''
   Falsifying example: inner(
-      v0=None,
+      n=None,
   )
   '''
 # ---
 # name: test_always_failing[one_of]
   '''
   Falsifying example: inner(
-      v0=0,
+      x=0,
   )
   '''
 # ---
 # name: test_always_failing[permutations]
   '''
   Falsifying example: inner(
-      v0=[0, 1, 2, 3, 4],
+      p=[0, 1, 2, 3, 4],
   )
   '''
 # ---
 # name: test_always_failing[randoms]
   '''
   Falsifying example: inner(
-      v0=HypothesisRandom(generated data),
+      r=HypothesisRandom(generated data),
   )
   '''
 # ---
 # name: test_always_failing[recursive]
   '''
   Falsifying example: inner(
-      v0=0,
+      x=0,
   )
   '''
 # ---
 # name: test_always_failing[sampled_from]
   '''
   Falsifying example: inner(
-      v0='alice',
+      x='alice',
   )
   '''
 # ---
 # name: test_always_failing[sets]
   '''
   Falsifying example: inner(
-      v0=set([]),
+      xs=set(),
   )
   '''
 # ---
 # name: test_always_failing[shared]
   '''
   Falsifying example: inner(
-      v0=0,
+      x=0,
   )
   '''
 # ---
 # name: test_always_failing[slices]
   '''
   Falsifying example: inner(
-      v0=slice(None, None, None),
+      s=slice(None, None, None),
   )
   '''
 # ---
 # name: test_always_failing[text]
   '''
   Falsifying example: inner(
-      v0='',
+      s='',
   )
   '''
 # ---
 # name: test_always_failing[timedeltas]
   '''
   Falsifying example: inner(
-      v0=datetime.timedelta(0),
+      td=datetime.timedelta(0),
   )
   '''
 # ---
 # name: test_always_failing[times]
   '''
   Falsifying example: inner(
-      v0=datetime.time(0, 0),
+      t=datetime.time(0, 0),
   )
   '''
 # ---
 # name: test_always_failing[tuples]
   '''
   Falsifying example: inner(
-      v0=(0, '', False),
+      t=(0, '', False),
   )
   '''
 # ---
 # name: test_always_failing[two_args]
   '''
   Falsifying example: inner(
-      v0=0,
-      v1='',
+      n=0,
+      s='',
   )
   '''
 # ---
 # name: test_always_failing[uuids]
   '''
   Falsifying example: inner(
-      v0=(lambda r: UUID(version=version, int=r.getrandbits(128)))(Random(0)),
+      u=UUID('e3e70682-c209-4cac-629f-6fbed82c07cd'),
   )
   '''
 # ---
 # name: test_always_failing_explain[explain_from_regex]
   '''
   Falsifying example: inner(
-      v0='00',  # or any other generated value
+      s='00',  # or any other generated value
   )
   '''
 # ---
 # name: test_always_failing_explain[explain_map_to_str]
   '''
   Falsifying example: inner(
-      v0='0',  # or any other generated value
+      s='0',  # or any other generated value
   )
   '''
 # ---
 # name: test_always_failing_explain[map_lambda_explain_forces_call_style]
   '''
   Falsifying example: inner(
-      v0=1,  # or any other generated value
+      x=1,  # or any other generated value
   )
   '''
 # ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
@@ -212,7 +212,7 @@
 # name: test_always_failing[iterables]
   '''
   Falsifying example: inner(
-      v0=PrettyIter([]),
+      it=iter([]),
   )
   '''
 # ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_combinators.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_combinators.ambr
@@ -11,7 +11,7 @@
 # name: test_sampled_from_enum_flag
   '''
   Falsifying example: inner(
-      c=test_sampled_from_enum_flag.Color.RED,
+      c=test_sampled_from_enum_flag.<locals>.Color.RED,
   )
   '''
 # ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_combinators.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_combinators.ambr
@@ -11,7 +11,7 @@
 # name: test_sampled_from_enum_flag
   '''
   Falsifying example: inner(
-      c=test_sampled_from_enum_flag.<locals>.Color.RED,
+      c=test_sampled_from_enum_flag.Color.RED,
   )
   '''
 # ---


### PR DESCRIPTION
https://github.com/HypothesisWorks/hypothesis/pull/4692 made me suspicious so I went digging. [I added snapshot tests using syrupy to validate Hypothesis's output on various tests and so we can catch regressions in it](https://github.com/HypothesisWorks/hypothesis/pull/4695), and then I manually reviewed all the output and decided that a lot of it sucked, so I fixed it.

Principle things I fixed:

1. I removed my previous more limited fix and generalised the logic. Now, whenever we don't need to print as a call because there are comments, and the repr is both valid syntax and shorter, we use that.
2. I added a `_repr_pretty_` for `PrettyIter` so `iterables` has good output instead of bad output.
3. I added logic to strip `<locals>` from names. This isn't a great solution, because it produces syntax that is valid (and unambiguously refers to the right thing) but won't actually successfully eval because that name is not accessible. I'm not sure there's anything much one can do about this though. I'm just noting that everything we can do here is sortof bad, and I think this is slightly less bad than the status quo (especially given that we have "is this valid syntax?" in a bunch of places in our pretty printing).
4. I ahem may have got a bit over-enthusiastic and got Claude to write me a custom lambda inliner so that we can have less bad expressions in places where we'd previously have printed a lambda. e.g. `"hello" + " " + "world"` instead of `(lambda x, y: x + " " + y)("hello", "world")` or, the motivating example, `hashlib.sha1(b'').digest()` instead of `(lambda b: hashlib.sha1(b).digest())(b'')`.

Some of these changes it might be best to review commitwise because you can see the corresponding changes they make to the snapshots. In all cases I started with a snapshot of existing code, then made some changes to see how it updated the snapshot.