### PR TITLE
Add snapshot testing with syrupy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,7 +278,7 @@ jobs:
       run: |
         pip install --upgrade setuptools pip wheel build
         python -m build --wheel hypothesis-python --outdir dist/
-        pip download --dest=dist/ hypothesis-python/ pytest tzdata  # fetch all the wheels
+        pip download --dest=dist/ hypothesis-python/ pytest tzdata syrupy  # fetch all the wheels
          rm dist/packaging-*.whl  # fails with `invalid metadata entry 'name'`
          pyodide venv .venv-pyodide
         source .venv-pyodide/bin/activate

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,3 @@
 RELEASE_TYPE: patch
 
-This release fixes a bug in explain mode where having [syrupy](https://github.com/syrupy-project/syrupy) installed
-as a pytest plugin would cause it to erroneously show up as an explanation for errors.
+This release improves |Phase.explain| output by excluding pytest-related :pypi:`syrupy` files as a possible source of variation.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug in explain mode where having [syrupy](https://github.com/syrupy-project/syrupy) installed
+as a pytest plugin would cause it to erroneously show up as an explanation for errors.

--- a/hypothesis-python/src/hypothesis/internal/scrutineer.py
+++ b/hypothesis-python/src/hypothesis/internal/scrutineer.py
@@ -167,6 +167,9 @@ UNHELPFUL_LOCATIONS = (
     "/typing.py",
     "/conftest.py",
     "/pprint.py",
+    # syrupy registers a pytest_assertrepr_compare hook, which only runs when
+    # assertions fail — making it appear as always-failing-never-passing.
+    "/syrupy/__init__.py",
 )
 
 

--- a/hypothesis-python/tests/common/utils.py
+++ b/hypothesis-python/tests/common/utils.py
@@ -333,3 +333,9 @@ def wait_for(condition, *, timeout=1, interval=0.01):
         f"timing out after waiting {timeout}s for condition "
         f"{get_pretty_function_description(condition)}"
     )
+
+
+def run_test_for_falsifying_example(test_fn):
+    with pytest.raises(AssertionError) as err:
+        test_fn()
+    return "\n".join(err.value.__notes__).strip()

--- a/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
+++ b/hypothesis-python/tests/cover/__snapshots__/test_custom_reprs.ambr
@@ -1,0 +1,44 @@
+# serializer version: 1
+# name: test_map_to_bytes_prints_as_repr
+  '''
+  Falsifying example: inner(
+      b=b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
+  )
+  '''
+# ---
+# name: test_map_to_str_prints_as_repr
+  '''
+  Falsifying example: inner(
+      s='0',
+  )
+  '''
+# ---
+# name: test_reprs_as_created
+  '''
+  Falsifying example: inner(
+      foo=Foo(x=1),
+      bar=Bar(x=-1),
+      baz=Foo(None),
+  )
+  '''
+# ---
+# name: test_reprs_as_created_consistent_calls_despite_indentation
+  '''
+  Falsifying example: inner(
+      a=some_foo('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+      b=Bar(
+          some_foo(
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          ),
+      ),
+  )
+  '''
+# ---
+# name: test_reprs_as_created_interactive
+  '''
+  Falsifying example: inner(
+      data=data(...),
+  )
+  Draw 1: Bar(10)
+  '''
+# ---

--- a/hypothesis-python/tests/cover/test_custom_reprs.py
+++ b/hypothesis-python/tests/cover/test_custom_reprs.py
@@ -17,6 +17,12 @@ from hypothesis import Phase, given, settings, strategies as st
 from hypothesis.strategies._internal.lazy import unwrap_strategies
 
 
+def _get_output(test_fn):
+    with pytest.raises(AssertionError) as err:
+        test_fn()
+    return "\n".join(err.value.__notes__).strip()
+
+
 def test_includes_non_default_args_in_repr():
     assert repr(st.integers()) == "integers()"
     assert repr(st.integers(min_value=1)) == "integers(min_value=1)"
@@ -79,41 +85,24 @@ class Bar(Foo):
     pass
 
 
-def test_reprs_as_created():
+def test_reprs_as_created(snapshot):
     @given(foo=st.builds(Foo), bar=st.from_type(Bar), baz=st.none().map(Foo))
     @settings(print_blob=False, max_examples=10_000, derandomize=True)
     def inner(foo, bar, baz):
         assert baz.x is None
         assert foo.x <= 0 or bar.x >= 0
 
-    with pytest.raises(AssertionError) as err:
-        inner()
-    expected = """
-Falsifying example: inner(
-    foo=Foo(x=1),
-    bar=Bar(x=-1),
-    baz=Foo(None),
-)
-"""
-    assert "\n".join(err.value.__notes__).strip() == expected.strip()
+    assert _get_output(inner) == snapshot
 
 
-def test_reprs_as_created_interactive():
+def test_reprs_as_created_interactive(snapshot):
     @given(st.data())
     @settings(print_blob=False, max_examples=10_000)
     def inner(data):
         bar = data.draw(st.builds(Bar, st.just(10)))
         assert not bar.x
 
-    with pytest.raises(AssertionError) as err:
-        inner()
-    expected = """
-Falsifying example: inner(
-    data=data(...),
-)
-Draw 1: Bar(10)
-"""
-    assert "\n".join(err.value.__notes__).strip() == expected.strip()
+    assert _get_output(inner) == snapshot
 
 
 CONSTANT_FOO = Foo(None)
@@ -143,7 +132,7 @@ Falsifying example: inner\(
     assert re.fullmatch(expected_re, got), got
 
 
-def test_reprs_as_created_consistent_calls_despite_indentation():
+def test_reprs_as_created_consistent_calls_despite_indentation(snapshot):
     aas = "a" * 60
     strat = st.builds(some_foo, st.just(aas))
 
@@ -154,19 +143,7 @@ def test_reprs_as_created_consistent_calls_despite_indentation():
     def inner(a, b):
         assert a == b
 
-    with pytest.raises(AssertionError) as err:
-        inner()
-    expected = f"""
-Falsifying example: inner(
-    a=some_foo({aas!r}),
-    b=Bar(
-        some_foo(
-            {aas!r},
-        ),
-    ),
-)
-"""
-    assert "\n".join(err.value.__notes__).strip() == expected.strip()
+    assert _get_output(inner) == snapshot
 
 
 @pytest.mark.parametrize(
@@ -199,33 +176,19 @@ def test_characters_repr(strategy, expected_repr):
     assert repr(unwrap_strategies(strategy)) == expected_repr
 
 
-def test_map_to_str_prints_as_repr():
+def test_map_to_str_prints_as_repr(snapshot):
     @given(s=st.integers().map(str))
     @settings(phases=[Phase.generate, Phase.shrink], print_blob=False)
     def inner(s):
         raise AssertionError
 
-    with pytest.raises(AssertionError) as err:
-        inner()
-    expected = """
-Falsifying example: inner(
-    s='0',
-)
-"""
-    assert "\n".join(err.value.__notes__).strip() == expected.strip()
+    assert _get_output(inner) == snapshot
 
 
-def test_map_to_bytes_prints_as_repr():
+def test_map_to_bytes_prints_as_repr(snapshot):
     @given(b=st.binary().map(lambda b: hashlib.sha256(b).digest()))
     @settings(phases=[Phase.generate, Phase.shrink], print_blob=False)
     def inner(b):
         raise AssertionError
 
-    with pytest.raises(AssertionError) as err:
-        inner()
-    expected = f"""
-Falsifying example: inner(
-    b={hashlib.sha256(b"").digest()!r},
-)
-"""
-    assert "\n".join(err.value.__notes__).strip() == expected.strip()
+    assert _get_output(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/__init__.py
+++ b/hypothesis-python/tests/snapshots/__init__.py
@@ -1,0 +1,9 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
@@ -2,406 +2,406 @@
 # name: test_always_failing[binary]
   '''
   Falsifying example: inner(
-      b=b'',
+      v0=b'',
   )
   '''
 # ---
 # name: test_always_failing[booleans]
   '''
   Falsifying example: inner(
-      b=False,
+      v0=False,
   )
   '''
 # ---
 # name: test_always_failing[builds]
   '''
   Falsifying example: inner(
-      p=Pair(x=0, y=''),
+      v0=Pair(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_from_type]
   '''
   Falsifying example: inner(
-      xs=[],
+      v0=[],
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_mixed_args]
   '''
   Falsifying example: inner(
-      x=(lambda x, y, z: Opaque())(0, y='', z=False),
+      v0=(lambda x, y, z: Opaque())(0, y='', z=False),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_positional_args]
   '''
   Falsifying example: inner(
-      x=(lambda x, y: Opaque())(0, ''),
+      v0=(lambda x, y: Opaque())(0, ''),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_returning_object]
   '''
   Falsifying example: inner(
-      x=(lambda x, y: Pair(x, y))(x=0, y=''),
+      v0=(lambda x, y: Pair(x, y))(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_lambda_with_defaults]
   '''
   Falsifying example: inner(
-      x=(lambda a, b='hello': Opaque())(a=0),
+      v0=(lambda a, b='hello': Opaque())(a=0),
   )
   '''
 # ---
 # name: test_always_failing[builds_multi_arg_lambda]
   '''
   Falsifying example: inner(
-      x=(lambda x, y: Opaque())(x=0, y=''),
+      v0=(lambda x, y: Opaque())(x=0, y=''),
   )
   '''
 # ---
 # name: test_always_failing[builds_no_arg_lambda]
   '''
   Falsifying example: inner(
-      x=(lambda: Opaque())(),
+      v0=(lambda: Opaque())(),
   )
   '''
 # ---
 # name: test_always_failing[builds_single_arg_lambda]
   '''
   Falsifying example: inner(
-      x=(lambda n: Opaque())(n=0),
+      v0=(lambda n: Opaque())(n=0),
   )
   '''
 # ---
 # name: test_always_failing[characters]
   '''
   Falsifying example: inner(
-      c='0',
+      v0='0',
   )
   '''
 # ---
 # name: test_always_failing[complex_numbers]
   '''
   Falsifying example: inner(
-      z=complex(0.0, 0.0),
+      v0=complex(0.0, 0.0),
   )
   '''
 # ---
 # name: test_always_failing[dates]
   '''
   Falsifying example: inner(
-      d=datetime.date(2000, 1, 1),
+      v0=datetime.date(2000, 1, 1),
   )
   '''
 # ---
 # name: test_always_failing[datetimes]
   '''
   Falsifying example: inner(
-      dt=datetime.datetime(2000, 1, 1, 0, 0),
+      v0=datetime.datetime(2000, 1, 1, 0, 0),
   )
   '''
 # ---
 # name: test_always_failing[decimals]
   '''
   Falsifying example: inner(
-      d=Decimal('Infinity'),
+      v0=Decimal('Infinity'),
   )
   '''
 # ---
 # name: test_always_failing[deferred]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[dictionaries]
   '''
   Falsifying example: inner(
-      d=dict([]),
+      v0=dict([]),
   )
   '''
 # ---
 # name: test_always_failing[emails]
   '''
   Falsifying example: inner(
-      e='0@A.AC',
+      v0='0@A.AC',
   )
   '''
 # ---
 # name: test_always_failing[filter]
   '''
   Falsifying example: inner(
-      n=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[fixed_dictionaries]
   '''
   Falsifying example: inner(
-      d={'name': '', 'age': 0},
+      v0={'name': '', 'age': 0},
   )
   '''
 # ---
 # name: test_always_failing[flatmap_lambda]
   '''
   Falsifying example: inner(
-      x='',
+      v0='',
   )
   '''
 # ---
 # name: test_always_failing[floats]
   '''
   Falsifying example: inner(
-      x=0.0,
+      v0=0.0,
   )
   '''
 # ---
 # name: test_always_failing[fractions]
   '''
   Falsifying example: inner(
-      f=Fraction(0, 1),
+      v0=Fraction(0, 1),
   )
   '''
 # ---
 # name: test_always_failing[from_regex]
   '''
   Falsifying example: inner(
-      s='aaa',
+      v0='aaa',
   )
   '''
 # ---
 # name: test_always_failing[from_type]
   '''
   Falsifying example: inner(
-      x=IPv4Address(b'\x00\x00\x00\x00'),
+      v0=IPv4Address(b'\x00\x00\x00\x00'),
   )
   '''
 # ---
 # name: test_always_failing[frozensets]
   '''
   Falsifying example: inner(
-      xs=frozenset([]),
+      v0=frozenset([]),
   )
   '''
 # ---
 # name: test_always_failing[functions]
   '''
   Falsifying example: inner(
-      f=lambda x: x,
+      v0=lambda x: x,
   )
   '''
 # ---
 # name: test_always_failing[integers]
   '''
   Falsifying example: inner(
-      n=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[ip_addresses]
   '''
   Falsifying example: inner(
-      ip=IPv4Address(b'\x00\x00\x00\x00'),
+      v0=IPv4Address(b'\x00\x00\x00\x00'),
   )
   '''
 # ---
 # name: test_always_failing[iterables]
   '''
   Falsifying example: inner(
-      it=PrettyIter([]),
+      v0=PrettyIter([]),
   )
   '''
 # ---
 # name: test_always_failing[just]
   '''
   Falsifying example: inner(
-      x=42,
+      v0=42,
   )
   '''
 # ---
 # name: test_always_failing[lists]
   '''
   Falsifying example: inner(
-      xs=[],
+      v0=[],
   )
   '''
 # ---
 # name: test_always_failing[many_args]
   '''
   Falsifying example: inner(
-      a=0,
-      b=0.0,
-      c='',
-      d=False,
-      e=None,
+      v0=0,
+      v1=0.0,
+      v2='',
+      v3=False,
+      v4=None,
   )
   '''
 # ---
 # name: test_always_failing[map_chained_lambdas_opaque]
   '''
   Falsifying example: inner(
-      x=(lambda n: Opaque())(0),
+      v0=(lambda n: Opaque())(0),
   )
   '''
 # ---
 # name: test_always_failing[map_lambda_opaque_result]
   '''
   Falsifying example: inner(
-      x=(lambda n: Opaque())(0),
+      v0=(lambda n: Opaque())(0),
   )
   '''
 # ---
 # name: test_always_failing[map_to_bytes]
   '''
   Falsifying example: inner(
-      b=b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
+      v0=b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
   )
   '''
 # ---
 # name: test_always_failing[map_to_str]
   '''
   Falsifying example: inner(
-      s='0',
+      v0='0',
   )
   '''
 # ---
 # name: test_always_failing[mixed_strategies]
   '''
   Falsifying example: inner(
-      xs=[],
-      mapping=dict([]),
-      choice=10,
+      v0=[],
+      v1=dict([]),
+      v2=10,
   )
   '''
 # ---
 # name: test_always_failing[none]
   '''
   Falsifying example: inner(
-      n=None,
+      v0=None,
   )
   '''
 # ---
 # name: test_always_failing[one_of]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[permutations]
   '''
   Falsifying example: inner(
-      p=[0, 1, 2, 3, 4],
+      v0=[0, 1, 2, 3, 4],
   )
   '''
 # ---
 # name: test_always_failing[randoms]
   '''
   Falsifying example: inner(
-      r=HypothesisRandom(generated data),
+      v0=HypothesisRandom(generated data),
   )
   '''
 # ---
 # name: test_always_failing[recursive]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[sampled_from]
   '''
   Falsifying example: inner(
-      x='alice',
+      v0='alice',
   )
   '''
 # ---
 # name: test_always_failing[sets]
   '''
   Falsifying example: inner(
-      xs=set([]),
+      v0=set([]),
   )
   '''
 # ---
 # name: test_always_failing[shared]
   '''
   Falsifying example: inner(
-      x=0,
+      v0=0,
   )
   '''
 # ---
 # name: test_always_failing[slices]
   '''
   Falsifying example: inner(
-      s=slice(None, None, None),
+      v0=slice(None, None, None),
   )
   '''
 # ---
 # name: test_always_failing[text]
   '''
   Falsifying example: inner(
-      s='',
+      v0='',
   )
   '''
 # ---
 # name: test_always_failing[timedeltas]
   '''
   Falsifying example: inner(
-      td=datetime.timedelta(0),
+      v0=datetime.timedelta(0),
   )
   '''
 # ---
 # name: test_always_failing[times]
   '''
   Falsifying example: inner(
-      t=datetime.time(0, 0),
+      v0=datetime.time(0, 0),
   )
   '''
 # ---
 # name: test_always_failing[tuples]
   '''
   Falsifying example: inner(
-      t=(0, '', False),
+      v0=(0, '', False),
   )
   '''
 # ---
 # name: test_always_failing[two_args]
   '''
   Falsifying example: inner(
-      n=0,
-      s='',
+      v0=0,
+      v1='',
   )
   '''
 # ---
 # name: test_always_failing[uuids]
   '''
   Falsifying example: inner(
-      u=(lambda r: UUID(version=version, int=r.getrandbits(128)))(Random(0)),
+      v0=(lambda r: UUID(version=version, int=r.getrandbits(128)))(Random(0)),
   )
   '''
 # ---
 # name: test_always_failing_explain[explain_from_regex]
   '''
   Falsifying example: inner(
-      s='00',  # or any other generated value
+      v0='00',  # or any other generated value
   )
   '''
 # ---
 # name: test_always_failing_explain[explain_map_to_str]
   '''
   Falsifying example: inner(
-      s='0',  # or any other generated value
+      v0='0',  # or any other generated value
   )
   '''
 # ---
 # name: test_always_failing_explain[map_lambda_explain_forces_call_style]
   '''
   Falsifying example: inner(
-      x=1,  # or any other generated value
+      v0=1,  # or any other generated value
   )
   '''
 # ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_always_failing.ambr
@@ -1,0 +1,407 @@
+# serializer version: 1
+# name: test_always_failing[binary]
+  '''
+  Falsifying example: inner(
+      b=b'',
+  )
+  '''
+# ---
+# name: test_always_failing[booleans]
+  '''
+  Falsifying example: inner(
+      b=False,
+  )
+  '''
+# ---
+# name: test_always_failing[builds]
+  '''
+  Falsifying example: inner(
+      p=Pair(x=0, y=''),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_from_type]
+  '''
+  Falsifying example: inner(
+      xs=[],
+  )
+  '''
+# ---
+# name: test_always_failing[builds_lambda_mixed_args]
+  '''
+  Falsifying example: inner(
+      x=(lambda x, y, z: Opaque())(0, y='', z=False),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_lambda_positional_args]
+  '''
+  Falsifying example: inner(
+      x=(lambda x, y: Opaque())(0, ''),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_lambda_returning_object]
+  '''
+  Falsifying example: inner(
+      x=(lambda x, y: Pair(x, y))(x=0, y=''),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_lambda_with_defaults]
+  '''
+  Falsifying example: inner(
+      x=(lambda a, b='hello': Opaque())(a=0),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_multi_arg_lambda]
+  '''
+  Falsifying example: inner(
+      x=(lambda x, y: Opaque())(x=0, y=''),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_no_arg_lambda]
+  '''
+  Falsifying example: inner(
+      x=(lambda: Opaque())(),
+  )
+  '''
+# ---
+# name: test_always_failing[builds_single_arg_lambda]
+  '''
+  Falsifying example: inner(
+      x=(lambda n: Opaque())(n=0),
+  )
+  '''
+# ---
+# name: test_always_failing[characters]
+  '''
+  Falsifying example: inner(
+      c='0',
+  )
+  '''
+# ---
+# name: test_always_failing[complex_numbers]
+  '''
+  Falsifying example: inner(
+      z=complex(0.0, 0.0),
+  )
+  '''
+# ---
+# name: test_always_failing[dates]
+  '''
+  Falsifying example: inner(
+      d=datetime.date(2000, 1, 1),
+  )
+  '''
+# ---
+# name: test_always_failing[datetimes]
+  '''
+  Falsifying example: inner(
+      dt=datetime.datetime(2000, 1, 1, 0, 0),
+  )
+  '''
+# ---
+# name: test_always_failing[decimals]
+  '''
+  Falsifying example: inner(
+      d=Decimal('Infinity'),
+  )
+  '''
+# ---
+# name: test_always_failing[deferred]
+  '''
+  Falsifying example: inner(
+      x=0,
+  )
+  '''
+# ---
+# name: test_always_failing[dictionaries]
+  '''
+  Falsifying example: inner(
+      d=dict([]),
+  )
+  '''
+# ---
+# name: test_always_failing[emails]
+  '''
+  Falsifying example: inner(
+      e='0@A.AC',
+  )
+  '''
+# ---
+# name: test_always_failing[filter]
+  '''
+  Falsifying example: inner(
+      n=0,
+  )
+  '''
+# ---
+# name: test_always_failing[fixed_dictionaries]
+  '''
+  Falsifying example: inner(
+      d={'name': '', 'age': 0},
+  )
+  '''
+# ---
+# name: test_always_failing[flatmap_lambda]
+  '''
+  Falsifying example: inner(
+      x='',
+  )
+  '''
+# ---
+# name: test_always_failing[floats]
+  '''
+  Falsifying example: inner(
+      x=0.0,
+  )
+  '''
+# ---
+# name: test_always_failing[fractions]
+  '''
+  Falsifying example: inner(
+      f=Fraction(0, 1),
+  )
+  '''
+# ---
+# name: test_always_failing[from_regex]
+  '''
+  Falsifying example: inner(
+      s='aaa',
+  )
+  '''
+# ---
+# name: test_always_failing[from_type]
+  '''
+  Falsifying example: inner(
+      x=IPv4Address(b'\x00\x00\x00\x00'),
+  )
+  '''
+# ---
+# name: test_always_failing[frozensets]
+  '''
+  Falsifying example: inner(
+      xs=frozenset([]),
+  )
+  '''
+# ---
+# name: test_always_failing[functions]
+  '''
+  Falsifying example: inner(
+      f=lambda x: x,
+  )
+  '''
+# ---
+# name: test_always_failing[integers]
+  '''
+  Falsifying example: inner(
+      n=0,
+  )
+  '''
+# ---
+# name: test_always_failing[ip_addresses]
+  '''
+  Falsifying example: inner(
+      ip=IPv4Address(b'\x00\x00\x00\x00'),
+  )
+  '''
+# ---
+# name: test_always_failing[iterables]
+  '''
+  Falsifying example: inner(
+      it=PrettyIter([]),
+  )
+  '''
+# ---
+# name: test_always_failing[just]
+  '''
+  Falsifying example: inner(
+      x=42,
+  )
+  '''
+# ---
+# name: test_always_failing[lists]
+  '''
+  Falsifying example: inner(
+      xs=[],
+  )
+  '''
+# ---
+# name: test_always_failing[many_args]
+  '''
+  Falsifying example: inner(
+      a=0,
+      b=0.0,
+      c='',
+      d=False,
+      e=None,
+  )
+  '''
+# ---
+# name: test_always_failing[map_chained_lambdas_opaque]
+  '''
+  Falsifying example: inner(
+      x=(lambda n: Opaque())(0),
+  )
+  '''
+# ---
+# name: test_always_failing[map_lambda_opaque_result]
+  '''
+  Falsifying example: inner(
+      x=(lambda n: Opaque())(0),
+  )
+  '''
+# ---
+# name: test_always_failing[map_to_bytes]
+  '''
+  Falsifying example: inner(
+      b=b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
+  )
+  '''
+# ---
+# name: test_always_failing[map_to_str]
+  '''
+  Falsifying example: inner(
+      s='0',
+  )
+  '''
+# ---
+# name: test_always_failing[mixed_strategies]
+  '''
+  Falsifying example: inner(
+      xs=[],
+      mapping=dict([]),
+      choice=10,
+  )
+  '''
+# ---
+# name: test_always_failing[none]
+  '''
+  Falsifying example: inner(
+      n=None,
+  )
+  '''
+# ---
+# name: test_always_failing[one_of]
+  '''
+  Falsifying example: inner(
+      x=0,
+  )
+  '''
+# ---
+# name: test_always_failing[permutations]
+  '''
+  Falsifying example: inner(
+      p=[0, 1, 2, 3, 4],
+  )
+  '''
+# ---
+# name: test_always_failing[randoms]
+  '''
+  Falsifying example: inner(
+      r=HypothesisRandom(generated data),
+  )
+  '''
+# ---
+# name: test_always_failing[recursive]
+  '''
+  Falsifying example: inner(
+      x=0,
+  )
+  '''
+# ---
+# name: test_always_failing[sampled_from]
+  '''
+  Falsifying example: inner(
+      x='alice',
+  )
+  '''
+# ---
+# name: test_always_failing[sets]
+  '''
+  Falsifying example: inner(
+      xs=set([]),
+  )
+  '''
+# ---
+# name: test_always_failing[shared]
+  '''
+  Falsifying example: inner(
+      x=0,
+  )
+  '''
+# ---
+# name: test_always_failing[slices]
+  '''
+  Falsifying example: inner(
+      s=slice(None, None, None),
+  )
+  '''
+# ---
+# name: test_always_failing[text]
+  '''
+  Falsifying example: inner(
+      s='',
+  )
+  '''
+# ---
+# name: test_always_failing[timedeltas]
+  '''
+  Falsifying example: inner(
+      td=datetime.timedelta(0),
+  )
+  '''
+# ---
+# name: test_always_failing[times]
+  '''
+  Falsifying example: inner(
+      t=datetime.time(0, 0),
+  )
+  '''
+# ---
+# name: test_always_failing[tuples]
+  '''
+  Falsifying example: inner(
+      t=(0, '', False),
+  )
+  '''
+# ---
+# name: test_always_failing[two_args]
+  '''
+  Falsifying example: inner(
+      n=0,
+      s='',
+  )
+  '''
+# ---
+# name: test_always_failing[uuids]
+  '''
+  Falsifying example: inner(
+      u=(lambda r: UUID(version=version, int=r.getrandbits(128)))(Random(0)),
+  )
+  '''
+# ---
+# name: test_always_failing_explain[explain_from_regex]
+  '''
+  Falsifying example: inner(
+      s='00',  # or any other generated value
+  )
+  '''
+# ---
+# name: test_always_failing_explain[explain_map_to_str]
+  '''
+  Falsifying example: inner(
+      s='0',  # or any other generated value
+  )
+  '''
+# ---
+# name: test_always_failing_explain[map_lambda_explain_forces_call_style]
+  '''
+  Falsifying example: inner(
+      x=1,  # or any other generated value
+  )
+  '''
+# ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_combinators.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_combinators.ambr
@@ -1,0 +1,24 @@
+# serializer version: 1
+# name: test_data_draw
+  '''
+  Falsifying example: inner(
+      data=data(...),
+  )
+  Draw 1: 0
+  Draw 2: ''
+  '''
+# ---
+# name: test_sampled_from_enum_flag
+  '''
+  Falsifying example: inner(
+      c=test_sampled_from_enum_flag.<locals>.Color.RED,
+  )
+  '''
+# ---
+# name: test_sampled_from_module_level_enum_flag
+  '''
+  Falsifying example: inner(
+      d=Direction.NORTH,
+  )
+  '''
+# ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_explain.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_explain.ambr
@@ -1,0 +1,114 @@
+# serializer version: 1
+# name: test_explain_builds_kwargs_subargs
+  '''
+  Falsifying example: inner(
+      obj=MyClass(
+          x=0,  # or any other generated value
+          y=True,
+      ),
+  )
+  '''
+# ---
+# name: test_explain_builds_subargs
+  '''
+  Falsifying example: inner(
+      obj=MyClass(
+          0,  # or any other generated value
+          True,
+      ),
+  )
+  '''
+# ---
+# name: test_explain_comments_basic_fail_if_either
+  '''
+  Falsifying example: inner(
+      # The test always failed when commented parts were varied together.
+      a=False,  # or any other generated value
+      b=True,
+      c=[],  # or any other generated value
+      d=True,
+      e=False,  # or any other generated value
+  )
+  '''
+# ---
+# name: test_explain_comments_basic_fail_if_not_all
+  '''
+  Falsifying example: inner(
+      # The test sometimes passed when commented parts were varied together.
+      a='',  # or any other generated value
+      b='',  # or any other generated value
+      c='',  # or any other generated value
+  )
+  '''
+# ---
+# name: test_explain_duplicate_param_names
+  '''
+  Falsifying example: inner(
+      kw=0,  # or any other generated value
+      b={
+          'kw': '',  # or any other generated value
+          'c': True,
+      },
+  )
+  '''
+# ---
+# name: test_explain_fixeddict_subargs
+  '''
+  Falsifying example: inner(
+      d={
+          'x': 0,  # or any other generated value
+          'y': True,
+      },
+  )
+  '''
+# ---
+# name: test_explain_multi_level_nesting
+  '''
+  Falsifying example: inner(
+      bare=0,  # or any other generated value
+      outer=Outer(
+          inner=Inner(x=0),  # or any other generated value
+          value=True,
+      ),
+  )
+  '''
+# ---
+# name: test_explain_no_together_comment_if_single_argument
+  '''
+  Falsifying example: inner(
+      a='',
+      b='',  # or any other generated value
+  )
+  '''
+# ---
+# name: test_explain_skip_subset_slices
+  '''
+  Falsifying example: inner(
+      obj=MyClass(
+          (0, False),  # or any other generated value
+          y=False,
+      ),
+  )
+  '''
+# ---
+# name: test_explain_tuple_multiple_varying
+  '''
+  Falsifying example: inner(
+      t=(
+          0,  # or any other generated value
+          '',  # or any other generated value
+          True,
+      ),
+  )
+  '''
+# ---
+# name: test_explain_tuple_subargs
+  '''
+  Falsifying example: inner(
+      t=(
+          0,  # or any other generated value
+          True,
+      ),
+  )
+  '''
+# ---

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_shrinking.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_shrinking.ambr
@@ -1,0 +1,22 @@
+# serializer version: 1
+# name: test_shrunk_float
+  '''
+  Falsifying example: inner(
+      x=1.0,
+  )
+  '''
+# ---
+# name: test_shrunk_list
+  '''
+  Falsifying example: inner(
+      xs=[1001],
+  )
+  '''
+# ---
+# name: test_shrunk_string
+  '''
+  Falsifying example: inner(
+      s='A',
+  )
+  '''
+# ---

--- a/hypothesis-python/tests/snapshots/conftest.py
+++ b/hypothesis-python/tests/snapshots/conftest.py
@@ -25,13 +25,3 @@ EXPLAIN_SETTINGS = settings(
     derandomize=True,
     database=None,
 )
-
-
-@pytest.fixture()
-def get_output():
-    def _get_output(test_fn):
-        with pytest.raises(AssertionError) as err:
-            test_fn()
-        return "\n".join(err.value.__notes__).strip()
-
-    return _get_output

--- a/hypothesis-python/tests/snapshots/conftest.py
+++ b/hypothesis-python/tests/snapshots/conftest.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
 
 from hypothesis import Phase, settings
 

--- a/hypothesis-python/tests/snapshots/conftest.py
+++ b/hypothesis-python/tests/snapshots/conftest.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-
 from hypothesis import Phase, settings
 
 SNAPSHOT_SETTINGS = settings(

--- a/hypothesis-python/tests/snapshots/conftest.py
+++ b/hypothesis-python/tests/snapshots/conftest.py
@@ -1,0 +1,37 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from hypothesis import Phase, settings
+
+SNAPSHOT_SETTINGS = settings(
+    phases=[Phase.generate, Phase.shrink],
+    print_blob=False,
+    derandomize=True,
+    database=None,
+)
+
+EXPLAIN_SETTINGS = settings(
+    phases=[Phase.generate, Phase.shrink, Phase.explain],
+    print_blob=False,
+    derandomize=True,
+    database=None,
+)
+
+
+@pytest.fixture()
+def get_output():
+    def _get_output(test_fn):
+        with pytest.raises(AssertionError) as err:
+            test_fn()
+        return "\n".join(err.value.__notes__).strip()
+
+    return _get_output

--- a/hypothesis-python/tests/snapshots/test_always_failing.py
+++ b/hypothesis-python/tests/snapshots/test_always_failing.py
@@ -1,0 +1,205 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Snapshot tests for strategies that always fail (body is just ``raise AssertionError``).
+
+Each parametrized case defines the ``@given`` kwargs for a test function whose
+body unconditionally raises.  This exercises the pretty-printing / repr path
+for every strategy without needing a unique test function per strategy.
+"""
+
+import hashlib
+from ipaddress import IPv4Address
+
+import pytest
+
+from hypothesis import given, strategies as st
+
+from tests.snapshots.conftest import EXPLAIN_SETTINGS, SNAPSHOT_SETTINGS
+
+
+class Opaque:
+    """Object with no useful repr, forcing call-style output."""
+
+
+class Pair:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+ALWAYS_FAILING_CASES = [
+    # Primitives
+    pytest.param({"n": st.integers()}, id="integers"),
+    pytest.param({"x": st.floats()}, id="floats"),
+    pytest.param({"b": st.booleans()}, id="booleans"),
+    pytest.param({"s": st.text()}, id="text"),
+    pytest.param({"b": st.binary()}, id="binary"),
+    pytest.param({"c": st.characters()}, id="characters"),
+    pytest.param({"n": st.none()}, id="none"),
+    pytest.param({"z": st.complex_numbers()}, id="complex_numbers"),
+    pytest.param({"d": st.decimals()}, id="decimals"),
+    pytest.param({"f": st.fractions()}, id="fractions"),
+    # Date/time
+    pytest.param({"d": st.dates()}, id="dates"),
+    pytest.param({"dt": st.datetimes()}, id="datetimes"),
+    pytest.param({"t": st.times()}, id="times"),
+    pytest.param({"td": st.timedeltas()}, id="timedeltas"),
+    # Collections
+    pytest.param({"xs": st.lists(st.integers())}, id="lists"),
+    pytest.param({"xs": st.sets(st.integers())}, id="sets"),
+    pytest.param({"xs": st.frozensets(st.integers())}, id="frozensets"),
+    pytest.param(
+        {"t": st.tuples(st.integers(), st.text(), st.booleans())}, id="tuples"
+    ),
+    pytest.param(
+        {"d": st.dictionaries(st.text(max_size=3), st.integers())}, id="dictionaries"
+    ),
+    pytest.param(
+        {
+            "d": st.fixed_dictionaries(
+                {"name": st.text(max_size=5), "age": st.integers()}
+            )
+        },
+        id="fixed_dictionaries",
+    ),
+    pytest.param({"it": st.iterables(st.integers())}, id="iterables"),
+    pytest.param({"p": st.permutations(list(range(5)))}, id="permutations"),
+    # Combinators
+    pytest.param({"x": st.just(42)}, id="just"),
+    pytest.param(
+        {"x": st.sampled_from(["alice", "bob", "charlie"])}, id="sampled_from"
+    ),
+    pytest.param({"x": st.one_of(st.integers(), st.text())}, id="one_of"),
+    pytest.param({"s": st.from_regex(r"[a-z]{3,5}", fullmatch=True)}, id="from_regex"),
+    pytest.param({"x": st.from_type(IPv4Address)}, id="from_type"),
+    pytest.param(
+        {"x": st.recursive(st.integers(), lambda s: st.lists(s, max_size=3))},
+        id="recursive",
+    ),
+    pytest.param({"x": st.deferred(st.integers)}, id="deferred"),
+    pytest.param({"x": st.shared(st.integers(), key="test")}, id="shared"),
+    pytest.param({"s": st.integers().map(str)}, id="map_to_str"),
+    pytest.param(
+        {"b": st.binary().map(lambda b: hashlib.sha256(b).digest())}, id="map_to_bytes"
+    ),
+    pytest.param({"n": st.integers().filter(lambda n: n % 2 == 0)}, id="filter"),
+    pytest.param(
+        {"p": st.builds(Pair, x=st.integers(), y=st.text(max_size=3))}, id="builds"
+    ),
+    pytest.param({"xs": st.from_type(list[int])}, id="builds_from_type"),
+    pytest.param(
+        {"f": st.functions(like=lambda x: x, returns=st.booleans())}, id="functions"
+    ),
+    # Special types
+    pytest.param({"u": st.uuids()}, id="uuids"),
+    pytest.param({"e": st.emails()}, id="emails"),
+    pytest.param({"ip": st.ip_addresses()}, id="ip_addresses"),
+    pytest.param({"s": st.slices(10)}, id="slices"),
+    pytest.param({"r": st.randoms()}, id="randoms"),
+    # Multi-arg
+    pytest.param({"n": st.integers(), "s": st.text()}, id="two_args"),
+    pytest.param(
+        {
+            "a": st.integers(),
+            "b": st.floats(),
+            "c": st.text(),
+            "d": st.booleans(),
+            "e": st.none(),
+        },
+        id="many_args",
+    ),
+    pytest.param(
+        {
+            "xs": st.lists(st.integers()),
+            "mapping": st.dictionaries(st.text(max_size=3), st.booleans()),
+            "choice": st.sampled_from([10, 20, 30]),
+        },
+        id="mixed_strategies",
+    ),
+    # Lambda formatting
+    pytest.param({"x": st.builds(lambda: Opaque())}, id="builds_no_arg_lambda"),
+    pytest.param(
+        {"x": st.builds(lambda n: Opaque(), n=st.integers())},
+        id="builds_single_arg_lambda",
+    ),
+    pytest.param(
+        {"x": st.builds(lambda x, y: Opaque(), x=st.integers(), y=st.text())},
+        id="builds_multi_arg_lambda",
+    ),
+    pytest.param(
+        {"x": st.builds(lambda x, y: Opaque(), st.integers(), st.text())},
+        id="builds_lambda_positional_args",
+    ),
+    pytest.param(
+        {
+            "x": st.builds(
+                lambda x, y, z: Opaque(),
+                st.integers(),
+                y=st.text(),
+                z=st.booleans(),
+            )
+        },
+        id="builds_lambda_mixed_args",
+    ),
+    pytest.param(
+        {"x": st.builds(lambda x, y: Pair(x, y), x=st.integers(), y=st.text())},
+        id="builds_lambda_returning_object",
+    ),
+    pytest.param(
+        {"x": st.integers().map(lambda n: Opaque())}, id="map_lambda_opaque_result"
+    ),
+    pytest.param(
+        {"x": st.integers().map(lambda n: n * 2).map(lambda n: Opaque())},
+        id="map_chained_lambdas_opaque",
+    ),
+    pytest.param(
+        {"x": st.builds(lambda a, b="hello": Opaque(), a=st.integers())},
+        id="builds_lambda_with_defaults",
+    ),
+    pytest.param(
+        {
+            "x": st.integers(min_value=0, max_value=3).flatmap(
+                lambda n: st.text(min_size=n, max_size=n)
+            )
+        },
+        id="flatmap_lambda",
+    ),
+]
+
+
+@pytest.mark.parametrize("given_kwargs", ALWAYS_FAILING_CASES)
+def test_always_failing(given_kwargs, snapshot, get_output):
+    @SNAPSHOT_SETTINGS
+    @given(**given_kwargs)
+    def inner(**kwargs):
+        raise AssertionError
+
+    assert get_output(inner) == snapshot
+
+
+ALWAYS_FAILING_EXPLAIN_CASES = [
+    pytest.param(
+        {"x": st.integers().map(lambda n: n + 1)},
+        id="map_lambda_explain_forces_call_style",
+    ),
+    pytest.param({"s": st.from_regex(r"..", fullmatch=True)}, id="explain_from_regex"),
+    pytest.param({"s": st.integers().map(str)}, id="explain_map_to_str"),
+]
+
+
+@pytest.mark.parametrize("given_kwargs", ALWAYS_FAILING_EXPLAIN_CASES)
+def test_always_failing_explain(given_kwargs, snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(**given_kwargs)
+    def inner(**kwargs):
+        raise AssertionError
+
+    assert get_output(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_always_failing.py
+++ b/hypothesis-python/tests/snapshots/test_always_failing.py
@@ -23,7 +23,7 @@ import pytest
 from hypothesis import given, strategies as st
 
 from tests.snapshots.conftest import EXPLAIN_SETTINGS, SNAPSHOT_SETTINGS
-
+from tests.common.utils import run_test_for_falsifying_example
 
 class Opaque:
     """Object with no useful repr, forcing call-style output."""
@@ -176,13 +176,13 @@ ALWAYS_FAILING_CASES = [
 
 
 @pytest.mark.parametrize("given_kwargs", ALWAYS_FAILING_CASES)
-def test_always_failing(given_kwargs, snapshot, get_output):
+def test_always_failing(given_kwargs, snapshot):
     @SNAPSHOT_SETTINGS
     @given(**given_kwargs)
     def inner(**kwargs):
         raise AssertionError
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
 ALWAYS_FAILING_EXPLAIN_CASES = [
@@ -196,10 +196,10 @@ ALWAYS_FAILING_EXPLAIN_CASES = [
 
 
 @pytest.mark.parametrize("given_kwargs", ALWAYS_FAILING_EXPLAIN_CASES)
-def test_always_failing_explain(given_kwargs, snapshot, get_output):
+def test_always_failing_explain(given_kwargs, snapshot):
     @EXPLAIN_SETTINGS
     @given(**given_kwargs)
     def inner(**kwargs):
         raise AssertionError
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_always_failing.py
+++ b/hypothesis-python/tests/snapshots/test_always_failing.py
@@ -11,6 +11,7 @@ import hashlib
 from ipaddress import IPv4Address
 
 import pytest
+from pytest import param
 
 from hypothesis import given, strategies as st
 
@@ -27,34 +28,35 @@ class Pair:
         self.y = y
 
 
-ALWAYS_FAILING_CASES = [
+@pytest.mark.parametrize("given_kwargs",
+[
     # Primitives
-    pytest.param({"n": st.integers()}, id="integers"),
-    pytest.param({"x": st.floats()}, id="floats"),
-    pytest.param({"b": st.booleans()}, id="booleans"),
-    pytest.param({"s": st.text()}, id="text"),
-    pytest.param({"b": st.binary()}, id="binary"),
-    pytest.param({"c": st.characters()}, id="characters"),
-    pytest.param({"n": st.none()}, id="none"),
-    pytest.param({"z": st.complex_numbers()}, id="complex_numbers"),
-    pytest.param({"d": st.decimals()}, id="decimals"),
-    pytest.param({"f": st.fractions()}, id="fractions"),
+    param({"n": st.integers()}, id="integers"),
+    param({"x": st.floats()}, id="floats"),
+    param({"b": st.booleans()}, id="booleans"),
+    param({"s": st.text()}, id="text"),
+    param({"b": st.binary()}, id="binary"),
+    param({"c": st.characters()}, id="characters"),
+    param({"n": st.none()}, id="none"),
+    param({"z": st.complex_numbers()}, id="complex_numbers"),
+    param({"d": st.decimals()}, id="decimals"),
+    param({"f": st.fractions()}, id="fractions"),
     # Date/time
-    pytest.param({"d": st.dates()}, id="dates"),
-    pytest.param({"dt": st.datetimes()}, id="datetimes"),
-    pytest.param({"t": st.times()}, id="times"),
-    pytest.param({"td": st.timedeltas()}, id="timedeltas"),
+    param({"d": st.dates()}, id="dates"),
+    param({"dt": st.datetimes()}, id="datetimes"),
+    param({"t": st.times()}, id="times"),
+    param({"td": st.timedeltas()}, id="timedeltas"),
     # Collections
-    pytest.param({"xs": st.lists(st.integers())}, id="lists"),
-    pytest.param({"xs": st.sets(st.integers())}, id="sets"),
-    pytest.param({"xs": st.frozensets(st.integers())}, id="frozensets"),
-    pytest.param(
+    param({"xs": st.lists(st.integers())}, id="lists"),
+    param({"xs": st.sets(st.integers())}, id="sets"),
+    param({"xs": st.frozensets(st.integers())}, id="frozensets"),
+    param(
         {"t": st.tuples(st.integers(), st.text(), st.booleans())}, id="tuples"
     ),
-    pytest.param(
+    param(
         {"d": st.dictionaries(st.text(max_size=3), st.integers())}, id="dictionaries"
     ),
-    pytest.param(
+    param(
         {
             "d": st.fixed_dictionaries(
                 {"name": st.text(max_size=5), "age": st.integers()}
@@ -62,43 +64,43 @@ ALWAYS_FAILING_CASES = [
         },
         id="fixed_dictionaries",
     ),
-    pytest.param({"it": st.iterables(st.integers())}, id="iterables"),
-    pytest.param({"p": st.permutations(list(range(5)))}, id="permutations"),
+    param({"it": st.iterables(st.integers())}, id="iterables"),
+    param({"p": st.permutations(list(range(5)))}, id="permutations"),
     # Combinators
-    pytest.param({"x": st.just(42)}, id="just"),
-    pytest.param(
+    param({"x": st.just(42)}, id="just"),
+    param(
         {"x": st.sampled_from(["alice", "bob", "charlie"])}, id="sampled_from"
     ),
-    pytest.param({"x": st.one_of(st.integers(), st.text())}, id="one_of"),
-    pytest.param({"s": st.from_regex(r"[a-z]{3,5}", fullmatch=True)}, id="from_regex"),
-    pytest.param({"x": st.from_type(IPv4Address)}, id="from_type"),
-    pytest.param(
+    param({"x": st.one_of(st.integers(), st.text())}, id="one_of"),
+    param({"s": st.from_regex(r"[a-z]{3,5}", fullmatch=True)}, id="from_regex"),
+    param({"x": st.from_type(IPv4Address)}, id="from_type"),
+    param(
         {"x": st.recursive(st.integers(), lambda s: st.lists(s, max_size=3))},
         id="recursive",
     ),
-    pytest.param({"x": st.deferred(st.integers)}, id="deferred"),
-    pytest.param({"x": st.shared(st.integers(), key="test")}, id="shared"),
-    pytest.param({"s": st.integers().map(str)}, id="map_to_str"),
-    pytest.param(
+    param({"x": st.deferred(st.integers)}, id="deferred"),
+    param({"x": st.shared(st.integers(), key="test")}, id="shared"),
+    param({"s": st.integers().map(str)}, id="map_to_str"),
+    param(
         {"b": st.binary().map(lambda b: hashlib.sha256(b).digest())}, id="map_to_bytes"
     ),
-    pytest.param({"n": st.integers().filter(lambda n: n % 2 == 0)}, id="filter"),
-    pytest.param(
+    param({"n": st.integers().filter(lambda n: n % 2 == 0)}, id="filter"),
+    param(
         {"p": st.builds(Pair, x=st.integers(), y=st.text(max_size=3))}, id="builds"
     ),
-    pytest.param({"xs": st.from_type(list[int])}, id="builds_from_type"),
-    pytest.param(
+    param({"xs": st.from_type(list[int])}, id="builds_from_type"),
+    param(
         {"f": st.functions(like=lambda x: x, returns=st.booleans())}, id="functions"
     ),
     # Special types
-    pytest.param({"u": st.uuids()}, id="uuids"),
-    pytest.param({"e": st.emails()}, id="emails"),
-    pytest.param({"ip": st.ip_addresses()}, id="ip_addresses"),
-    pytest.param({"s": st.slices(10)}, id="slices"),
-    pytest.param({"r": st.randoms()}, id="randoms"),
+    param({"u": st.uuids()}, id="uuids"),
+    param({"e": st.emails()}, id="emails"),
+    param({"ip": st.ip_addresses()}, id="ip_addresses"),
+    param({"s": st.slices(10)}, id="slices"),
+    param({"r": st.randoms()}, id="randoms"),
     # Multi-arg
-    pytest.param({"n": st.integers(), "s": st.text()}, id="two_args"),
-    pytest.param(
+    param({"n": st.integers(), "s": st.text()}, id="two_args"),
+    param(
         {
             "a": st.integers(),
             "b": st.floats(),
@@ -108,7 +110,7 @@ ALWAYS_FAILING_CASES = [
         },
         id="many_args",
     ),
-    pytest.param(
+    param(
         {
             "xs": st.lists(st.integers()),
             "mapping": st.dictionaries(st.text(max_size=3), st.booleans()),
@@ -117,20 +119,20 @@ ALWAYS_FAILING_CASES = [
         id="mixed_strategies",
     ),
     # Lambda formatting
-    pytest.param({"x": st.builds(lambda: Opaque())}, id="builds_no_arg_lambda"),
-    pytest.param(
+    param({"x": st.builds(lambda: Opaque())}, id="builds_no_arg_lambda"),
+    param(
         {"x": st.builds(lambda n: Opaque(), n=st.integers())},
         id="builds_single_arg_lambda",
     ),
-    pytest.param(
+    param(
         {"x": st.builds(lambda x, y: Opaque(), x=st.integers(), y=st.text())},
         id="builds_multi_arg_lambda",
     ),
-    pytest.param(
+    param(
         {"x": st.builds(lambda x, y: Opaque(), st.integers(), st.text())},
         id="builds_lambda_positional_args",
     ),
-    pytest.param(
+    param(
         {
             "x": st.builds(
                 lambda x, y, z: Opaque(),
@@ -141,22 +143,22 @@ ALWAYS_FAILING_CASES = [
         },
         id="builds_lambda_mixed_args",
     ),
-    pytest.param(
+    param(
         {"x": st.builds(lambda x, y: Pair(x, y), x=st.integers(), y=st.text())},
         id="builds_lambda_returning_object",
     ),
-    pytest.param(
+    param(
         {"x": st.integers().map(lambda n: Opaque())}, id="map_lambda_opaque_result"
     ),
-    pytest.param(
+    param(
         {"x": st.integers().map(lambda n: n * 2).map(lambda n: Opaque())},
         id="map_chained_lambdas_opaque",
     ),
-    pytest.param(
+    param(
         {"x": st.builds(lambda a, b="hello": Opaque(), a=st.integers())},
         id="builds_lambda_with_defaults",
     ),
-    pytest.param(
+    param(
         {
             "x": st.integers(min_value=0, max_value=3).flatmap(
                 lambda n: st.text(min_size=n, max_size=n)
@@ -165,9 +167,7 @@ ALWAYS_FAILING_CASES = [
         id="flatmap_lambda",
     ),
 ]
-
-
-@pytest.mark.parametrize("given_kwargs", ALWAYS_FAILING_CASES)
+)
 def test_always_failing(given_kwargs, snapshot):
     @SNAPSHOT_SETTINGS
     @given(**given_kwargs)
@@ -177,17 +177,18 @@ def test_always_failing(given_kwargs, snapshot):
     assert run_test_for_falsifying_example(inner) == snapshot
 
 
-ALWAYS_FAILING_EXPLAIN_CASES = [
-    pytest.param(
+@pytest.mark.parametrize("given_kwargs",
+[
+    param(
         {"x": st.integers().map(lambda n: n + 1)},
         id="map_lambda_explain_forces_call_style",
     ),
-    pytest.param({"s": st.from_regex(r"..", fullmatch=True)}, id="explain_from_regex"),
-    pytest.param({"s": st.integers().map(str)}, id="explain_map_to_str"),
+    param({"s": st.from_regex(r"..", fullmatch=True)}, id="explain_from_regex"),
+    param({"s": st.integers().map(str)}, id="explain_map_to_str"),
 ]
 
 
-@pytest.mark.parametrize("given_kwargs", ALWAYS_FAILING_EXPLAIN_CASES)
+)
 def test_always_failing_explain(given_kwargs, snapshot):
     @EXPLAIN_SETTINGS
     @given(**given_kwargs)

--- a/hypothesis-python/tests/snapshots/test_always_failing.py
+++ b/hypothesis-python/tests/snapshots/test_always_failing.py
@@ -7,6 +7,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
+
 import hashlib
 from ipaddress import IPv4Address
 
@@ -15,8 +16,9 @@ from pytest import param
 
 from hypothesis import given, strategies as st
 
-from tests.snapshots.conftest import EXPLAIN_SETTINGS, SNAPSHOT_SETTINGS
 from tests.common.utils import run_test_for_falsifying_example
+from tests.snapshots.conftest import EXPLAIN_SETTINGS, SNAPSHOT_SETTINGS
+
 
 class Opaque:
     """Object with no useful repr, forcing call-style output."""
@@ -28,147 +30,132 @@ class Pair:
         self.y = y
 
 
-@pytest.mark.parametrize("given_kwargs",
-[
-    # Primitives
-    param({"n": st.integers()}, id="integers"),
-    param({"x": st.floats()}, id="floats"),
-    param({"b": st.booleans()}, id="booleans"),
-    param({"s": st.text()}, id="text"),
-    param({"b": st.binary()}, id="binary"),
-    param({"c": st.characters()}, id="characters"),
-    param({"n": st.none()}, id="none"),
-    param({"z": st.complex_numbers()}, id="complex_numbers"),
-    param({"d": st.decimals()}, id="decimals"),
-    param({"f": st.fractions()}, id="fractions"),
-    # Date/time
-    param({"d": st.dates()}, id="dates"),
-    param({"dt": st.datetimes()}, id="datetimes"),
-    param({"t": st.times()}, id="times"),
-    param({"td": st.timedeltas()}, id="timedeltas"),
-    # Collections
-    param({"xs": st.lists(st.integers())}, id="lists"),
-    param({"xs": st.sets(st.integers())}, id="sets"),
-    param({"xs": st.frozensets(st.integers())}, id="frozensets"),
-    param(
-        {"t": st.tuples(st.integers(), st.text(), st.booleans())}, id="tuples"
-    ),
-    param(
-        {"d": st.dictionaries(st.text(max_size=3), st.integers())}, id="dictionaries"
-    ),
-    param(
-        {
-            "d": st.fixed_dictionaries(
-                {"name": st.text(max_size=5), "age": st.integers()}
-            )
-        },
-        id="fixed_dictionaries",
-    ),
-    param({"it": st.iterables(st.integers())}, id="iterables"),
-    param({"p": st.permutations(list(range(5)))}, id="permutations"),
-    # Combinators
-    param({"x": st.just(42)}, id="just"),
-    param(
-        {"x": st.sampled_from(["alice", "bob", "charlie"])}, id="sampled_from"
-    ),
-    param({"x": st.one_of(st.integers(), st.text())}, id="one_of"),
-    param({"s": st.from_regex(r"[a-z]{3,5}", fullmatch=True)}, id="from_regex"),
-    param({"x": st.from_type(IPv4Address)}, id="from_type"),
-    param(
-        {"x": st.recursive(st.integers(), lambda s: st.lists(s, max_size=3))},
-        id="recursive",
-    ),
-    param({"x": st.deferred(st.integers)}, id="deferred"),
-    param({"x": st.shared(st.integers(), key="test")}, id="shared"),
-    param({"s": st.integers().map(str)}, id="map_to_str"),
-    param(
-        {"b": st.binary().map(lambda b: hashlib.sha256(b).digest())}, id="map_to_bytes"
-    ),
-    param({"n": st.integers().filter(lambda n: n % 2 == 0)}, id="filter"),
-    param(
-        {"p": st.builds(Pair, x=st.integers(), y=st.text(max_size=3))}, id="builds"
-    ),
-    param({"xs": st.from_type(list[int])}, id="builds_from_type"),
-    param(
-        {"f": st.functions(like=lambda x: x, returns=st.booleans())}, id="functions"
-    ),
-    # Special types
-    param({"u": st.uuids()}, id="uuids"),
-    param({"e": st.emails()}, id="emails"),
-    param({"ip": st.ip_addresses()}, id="ip_addresses"),
-    param({"s": st.slices(10)}, id="slices"),
-    param({"r": st.randoms()}, id="randoms"),
-    # Multi-arg
-    param({"n": st.integers(), "s": st.text()}, id="two_args"),
-    param(
-        {
-            "a": st.integers(),
-            "b": st.floats(),
-            "c": st.text(),
-            "d": st.booleans(),
-            "e": st.none(),
-        },
-        id="many_args",
-    ),
-    param(
-        {
-            "xs": st.lists(st.integers()),
-            "mapping": st.dictionaries(st.text(max_size=3), st.booleans()),
-            "choice": st.sampled_from([10, 20, 30]),
-        },
-        id="mixed_strategies",
-    ),
-    # Lambda formatting
-    param({"x": st.builds(lambda: Opaque())}, id="builds_no_arg_lambda"),
-    param(
-        {"x": st.builds(lambda n: Opaque(), n=st.integers())},
-        id="builds_single_arg_lambda",
-    ),
-    param(
-        {"x": st.builds(lambda x, y: Opaque(), x=st.integers(), y=st.text())},
-        id="builds_multi_arg_lambda",
-    ),
-    param(
-        {"x": st.builds(lambda x, y: Opaque(), st.integers(), st.text())},
-        id="builds_lambda_positional_args",
-    ),
-    param(
-        {
-            "x": st.builds(
-                lambda x, y, z: Opaque(),
-                st.integers(),
-                y=st.text(),
-                z=st.booleans(),
-            )
-        },
-        id="builds_lambda_mixed_args",
-    ),
-    param(
-        {"x": st.builds(lambda x, y: Pair(x, y), x=st.integers(), y=st.text())},
-        id="builds_lambda_returning_object",
-    ),
-    param(
-        {"x": st.integers().map(lambda n: Opaque())}, id="map_lambda_opaque_result"
-    ),
-    param(
-        {"x": st.integers().map(lambda n: n * 2).map(lambda n: Opaque())},
-        id="map_chained_lambdas_opaque",
-    ),
-    param(
-        {"x": st.builds(lambda a, b="hello": Opaque(), a=st.integers())},
-        id="builds_lambda_with_defaults",
-    ),
-    param(
-        {
-            "x": st.integers(min_value=0, max_value=3).flatmap(
-                lambda n: st.text(min_size=n, max_size=n)
-            )
-        },
-        id="flatmap_lambda",
-    ),
-]
+@pytest.mark.parametrize(
+    "given_args",
+    [
+        # Primitives
+        param([st.integers()], id="integers"),
+        param([st.floats()], id="floats"),
+        param([st.booleans()], id="booleans"),
+        param([st.text()], id="text"),
+        param([st.binary()], id="binary"),
+        param([st.characters()], id="characters"),
+        param([st.none()], id="none"),
+        param([st.complex_numbers()], id="complex_numbers"),
+        param([st.decimals()], id="decimals"),
+        param([st.fractions()], id="fractions"),
+        # Date/time
+        param([st.dates()], id="dates"),
+        param([st.datetimes()], id="datetimes"),
+        param([st.times()], id="times"),
+        param([st.timedeltas()], id="timedeltas"),
+        # Collections
+        param([st.lists(st.integers())], id="lists"),
+        param([st.sets(st.integers())], id="sets"),
+        param([st.frozensets(st.integers())], id="frozensets"),
+        param([st.tuples(st.integers(), st.text(), st.booleans())], id="tuples"),
+        param([st.dictionaries(st.text(max_size=3), st.integers())], id="dictionaries"),
+        param(
+            [
+                st.fixed_dictionaries(
+                    {"name": st.text(max_size=5), "age": st.integers()}
+                )
+            ],
+            id="fixed_dictionaries",
+        ),
+        param([st.iterables(st.integers())], id="iterables"),
+        param([st.permutations(list(range(5)))], id="permutations"),
+        # Combinators
+        param([st.just(42)], id="just"),
+        param([st.sampled_from(["alice", "bob", "charlie"])], id="sampled_from"),
+        param([st.one_of(st.integers(), st.text())], id="one_of"),
+        param([st.from_regex(r"[a-z]{3,5}", fullmatch=True)], id="from_regex"),
+        param([st.from_type(IPv4Address)], id="from_type"),
+        param(
+            [st.recursive(st.integers(), lambda s: st.lists(s, max_size=3))],
+            id="recursive",
+        ),
+        param([st.deferred(st.integers)], id="deferred"),
+        param([st.shared(st.integers(), key="test")], id="shared"),
+        param([st.integers().map(str)], id="map_to_str"),
+        param(
+            [st.binary().map(lambda b: hashlib.sha256(b).digest())], id="map_to_bytes"
+        ),
+        param([st.integers().filter(lambda n: n % 2 == 0)], id="filter"),
+        param([st.builds(Pair, x=st.integers(), y=st.text(max_size=3))], id="builds"),
+        param([st.from_type(list[int])], id="builds_from_type"),
+        param([st.functions(like=lambda x: x, returns=st.booleans())], id="functions"),
+        # Special types
+        param([st.uuids()], id="uuids"),
+        param([st.emails()], id="emails"),
+        param([st.ip_addresses()], id="ip_addresses"),
+        param([st.slices(10)], id="slices"),
+        param([st.randoms()], id="randoms"),
+        # Multi-arg
+        param([st.integers(), st.text()], id="two_args"),
+        param(
+            [st.integers(), st.floats(), st.text(), st.booleans(), st.none()],
+            id="many_args",
+        ),
+        param(
+            [
+                st.lists(st.integers()),
+                st.dictionaries(st.text(max_size=3), st.booleans()),
+                st.sampled_from([10, 20, 30]),
+            ],
+            id="mixed_strategies",
+        ),
+        # Lambda formatting
+        param([st.builds(lambda: Opaque())], id="builds_no_arg_lambda"),
+        param(
+            [st.builds(lambda n: Opaque(), n=st.integers())],
+            id="builds_single_arg_lambda",
+        ),
+        param(
+            [st.builds(lambda x, y: Opaque(), x=st.integers(), y=st.text())],
+            id="builds_multi_arg_lambda",
+        ),
+        param(
+            [st.builds(lambda x, y: Opaque(), st.integers(), st.text())],
+            id="builds_lambda_positional_args",
+        ),
+        param(
+            [
+                st.builds(
+                    lambda x, y, z: Opaque(),
+                    st.integers(),
+                    y=st.text(),
+                    z=st.booleans(),
+                )
+            ],
+            id="builds_lambda_mixed_args",
+        ),
+        param(
+            [st.builds(lambda x, y: Pair(x, y), x=st.integers(), y=st.text())],
+            id="builds_lambda_returning_object",
+        ),
+        param([st.integers().map(lambda n: Opaque())], id="map_lambda_opaque_result"),
+        param(
+            [st.integers().map(lambda n: n * 2).map(lambda n: Opaque())],
+            id="map_chained_lambdas_opaque",
+        ),
+        param(
+            [st.builds(lambda a, b="hello": Opaque(), a=st.integers())],
+            id="builds_lambda_with_defaults",
+        ),
+        param(
+            [
+                st.integers(min_value=0, max_value=3).flatmap(
+                    lambda n: st.text(min_size=n, max_size=n)
+                )
+            ],
+            id="flatmap_lambda",
+        ),
+    ],
 )
-def test_always_failing(given_kwargs, snapshot):
+def test_always_failing(given_args, snapshot):
+    given_kwargs = {f"v{i}": v for i, v in enumerate(given_args)}
+
     @SNAPSHOT_SETTINGS
     @given(**given_kwargs)
     def inner(**kwargs):
@@ -177,19 +164,20 @@ def test_always_failing(given_kwargs, snapshot):
     assert run_test_for_falsifying_example(inner) == snapshot
 
 
-@pytest.mark.parametrize("given_kwargs",
-[
-    param(
-        {"x": st.integers().map(lambda n: n + 1)},
-        id="map_lambda_explain_forces_call_style",
-    ),
-    param({"s": st.from_regex(r"..", fullmatch=True)}, id="explain_from_regex"),
-    param({"s": st.integers().map(str)}, id="explain_map_to_str"),
-]
-
-
+@pytest.mark.parametrize(
+    "given_args",
+    [
+        param(
+            [st.integers().map(lambda n: n + 1)],
+            id="map_lambda_explain_forces_call_style",
+        ),
+        param([st.from_regex(r"..", fullmatch=True)], id="explain_from_regex"),
+        param([st.integers().map(str)], id="explain_map_to_str"),
+    ],
 )
-def test_always_failing_explain(given_kwargs, snapshot):
+def test_always_failing_explain(given_args, snapshot):
+    given_kwargs = {f"v{i}": v for i, v in enumerate(given_args)}
+
     @EXPLAIN_SETTINGS
     @given(**given_kwargs)
     def inner(**kwargs):

--- a/hypothesis-python/tests/snapshots/test_always_failing.py
+++ b/hypothesis-python/tests/snapshots/test_always_failing.py
@@ -7,14 +7,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
-
-"""Snapshot tests for strategies that always fail (body is just ``raise AssertionError``).
-
-Each parametrized case defines the ``@given`` kwargs for a test function whose
-body unconditionally raises.  This exercises the pretty-printing / repr path
-for every strategy without needing a unique test function per strategy.
-"""
-
 import hashlib
 from ipaddress import IPv4Address
 

--- a/hypothesis-python/tests/snapshots/test_combinators.py
+++ b/hypothesis-python/tests/snapshots/test_combinators.py
@@ -12,8 +12,9 @@ from enum import Flag, auto
 
 from hypothesis import given, strategies as st
 
-from tests.snapshots.conftest import SNAPSHOT_SETTINGS
 from tests.common.utils import run_test_for_falsifying_example
+from tests.snapshots.conftest import SNAPSHOT_SETTINGS
+
 
 class Direction(Flag):
     NORTH = auto()

--- a/hypothesis-python/tests/snapshots/test_combinators.py
+++ b/hypothesis-python/tests/snapshots/test_combinators.py
@@ -13,7 +13,7 @@ from enum import Flag, auto
 from hypothesis import given, strategies as st
 
 from tests.snapshots.conftest import SNAPSHOT_SETTINGS
-
+from tests.common.utils import run_test_for_falsifying_example
 
 class Direction(Flag):
     NORTH = auto()
@@ -22,7 +22,7 @@ class Direction(Flag):
     WEST = auto()
 
 
-def test_data_draw(snapshot, get_output):
+def test_data_draw(snapshot):
     @SNAPSHOT_SETTINGS
     @given(data=st.data())
     def inner(data):
@@ -30,10 +30,10 @@ def test_data_draw(snapshot, get_output):
         data.draw(st.text(max_size=3))
         raise AssertionError
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_sampled_from_enum_flag(snapshot, get_output):
+def test_sampled_from_enum_flag(snapshot):
     class Color(Flag):
         RED = auto()
         GREEN = auto()
@@ -44,13 +44,13 @@ def test_sampled_from_enum_flag(snapshot, get_output):
     def inner(c):
         assert not (c & Color.RED)
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_sampled_from_module_level_enum_flag(snapshot, get_output):
+def test_sampled_from_module_level_enum_flag(snapshot):
     @SNAPSHOT_SETTINGS
     @given(d=st.sampled_from(Direction))
     def inner(d):
         assert not (d & Direction.NORTH)
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_combinators.py
+++ b/hypothesis-python/tests/snapshots/test_combinators.py
@@ -1,0 +1,56 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from enum import Flag, auto
+
+from hypothesis import given, strategies as st
+
+from tests.snapshots.conftest import SNAPSHOT_SETTINGS
+
+
+class Direction(Flag):
+    NORTH = auto()
+    SOUTH = auto()
+    EAST = auto()
+    WEST = auto()
+
+
+def test_data_draw(snapshot, get_output):
+    @SNAPSHOT_SETTINGS
+    @given(data=st.data())
+    def inner(data):
+        data.draw(st.integers())
+        data.draw(st.text(max_size=3))
+        raise AssertionError
+
+    assert get_output(inner) == snapshot
+
+
+def test_sampled_from_enum_flag(snapshot, get_output):
+    class Color(Flag):
+        RED = auto()
+        GREEN = auto()
+        BLUE = auto()
+
+    @SNAPSHOT_SETTINGS
+    @given(c=st.sampled_from(Color))
+    def inner(c):
+        assert not (c & Color.RED)
+
+    assert get_output(inner) == snapshot
+
+
+def test_sampled_from_module_level_enum_flag(snapshot, get_output):
+    @SNAPSHOT_SETTINGS
+    @given(d=st.sampled_from(Direction))
+    def inner(d):
+        assert not (d & Direction.NORTH)
+
+    assert get_output(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_explain.py
+++ b/hypothesis-python/tests/snapshots/test_explain.py
@@ -10,8 +10,9 @@
 
 from hypothesis import given, strategies as st
 
-from tests.snapshots.conftest import EXPLAIN_SETTINGS
 from tests.common.utils import run_test_for_falsifying_example
+from tests.snapshots.conftest import EXPLAIN_SETTINGS
+
 
 def test_explain_comments_basic_fail_if_either(snapshot):
     @EXPLAIN_SETTINGS

--- a/hypothesis-python/tests/snapshots/test_explain.py
+++ b/hypothesis-python/tests/snapshots/test_explain.py
@@ -1,0 +1,144 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from hypothesis import given, strategies as st
+
+from tests.snapshots.conftest import EXPLAIN_SETTINGS
+
+
+def test_explain_comments_basic_fail_if_either(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(
+        st.booleans(),
+        st.booleans(),
+        st.lists(st.none()),
+        st.booleans(),
+        st.booleans(),
+    )
+    def inner(a, b, c, d, e):
+        assert not (b and d)
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_comments_basic_fail_if_not_all(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.text(), st.text(), st.text())
+    def inner(a, b, c):
+        condition = a and b and c
+        assert condition
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_no_together_comment_if_single_argument(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.text(), st.text())
+    def inner(a, b):
+        assert a
+
+    assert get_output(inner) == snapshot
+
+
+class MyClass:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+def test_explain_builds_subargs(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.builds(MyClass, st.integers(), st.booleans()))
+    def inner(obj):
+        assert not obj.y
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_builds_kwargs_subargs(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.builds(MyClass, x=st.integers(), y=st.booleans()))
+    def inner(obj):
+        assert not obj.y
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_tuple_subargs(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.tuples(st.integers(), st.booleans()))
+    def inner(t):
+        assert not t[1]
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_fixeddict_subargs(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.fixed_dictionaries({"x": st.integers(), "y": st.booleans()}))
+    def inner(d):
+        assert not d["y"]
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_tuple_multiple_varying(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.tuples(st.integers(), st.text(), st.booleans()))
+    def inner(t):
+        assert not t[2]
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_skip_subset_slices(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(st.builds(MyClass, st.tuples(st.integers(), st.booleans()), y=st.booleans()))
+    def inner(obj):
+        assert obj.y
+
+    assert get_output(inner) == snapshot
+
+
+def test_explain_duplicate_param_names(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(
+        kw=st.integers(),
+        b=st.fixed_dictionaries({"kw": st.text(), "c": st.booleans()}),
+    )
+    def inner(kw, b):
+        assert not b["c"]
+
+    assert get_output(inner) == snapshot
+
+
+class Outer:
+    def __init__(self, inner, value):
+        self.inner = inner
+        self.value = value
+
+
+class Inner:
+    def __init__(self, x):
+        self.x = x
+
+
+def test_explain_multi_level_nesting(snapshot, get_output):
+    @EXPLAIN_SETTINGS
+    @given(
+        bare=st.integers(),
+        outer=st.builds(
+            Outer, inner=st.builds(Inner, x=st.integers()), value=st.booleans()
+        ),
+    )
+    def inner(bare, outer):
+        assert not outer.value
+
+    assert get_output(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_explain.py
+++ b/hypothesis-python/tests/snapshots/test_explain.py
@@ -11,9 +11,9 @@
 from hypothesis import given, strategies as st
 
 from tests.snapshots.conftest import EXPLAIN_SETTINGS
+from tests.common.utils import run_test_for_falsifying_example
 
-
-def test_explain_comments_basic_fail_if_either(snapshot, get_output):
+def test_explain_comments_basic_fail_if_either(snapshot):
     @EXPLAIN_SETTINGS
     @given(
         st.booleans(),
@@ -25,26 +25,26 @@ def test_explain_comments_basic_fail_if_either(snapshot, get_output):
     def inner(a, b, c, d, e):
         assert not (b and d)
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_comments_basic_fail_if_not_all(snapshot, get_output):
+def test_explain_comments_basic_fail_if_not_all(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.text(), st.text(), st.text())
     def inner(a, b, c):
         condition = a and b and c
         assert condition
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_no_together_comment_if_single_argument(snapshot, get_output):
+def test_explain_no_together_comment_if_single_argument(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.text(), st.text())
     def inner(a, b):
         assert a
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
 class MyClass:
@@ -53,61 +53,61 @@ class MyClass:
         self.y = y
 
 
-def test_explain_builds_subargs(snapshot, get_output):
+def test_explain_builds_subargs(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.builds(MyClass, st.integers(), st.booleans()))
     def inner(obj):
         assert not obj.y
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_builds_kwargs_subargs(snapshot, get_output):
+def test_explain_builds_kwargs_subargs(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.builds(MyClass, x=st.integers(), y=st.booleans()))
     def inner(obj):
         assert not obj.y
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_tuple_subargs(snapshot, get_output):
+def test_explain_tuple_subargs(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.tuples(st.integers(), st.booleans()))
     def inner(t):
         assert not t[1]
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_fixeddict_subargs(snapshot, get_output):
+def test_explain_fixeddict_subargs(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.fixed_dictionaries({"x": st.integers(), "y": st.booleans()}))
     def inner(d):
         assert not d["y"]
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_tuple_multiple_varying(snapshot, get_output):
+def test_explain_tuple_multiple_varying(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.tuples(st.integers(), st.text(), st.booleans()))
     def inner(t):
         assert not t[2]
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_skip_subset_slices(snapshot, get_output):
+def test_explain_skip_subset_slices(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.builds(MyClass, st.tuples(st.integers(), st.booleans()), y=st.booleans()))
     def inner(obj):
         assert obj.y
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_explain_duplicate_param_names(snapshot, get_output):
+def test_explain_duplicate_param_names(snapshot):
     @EXPLAIN_SETTINGS
     @given(
         kw=st.integers(),
@@ -116,7 +116,7 @@ def test_explain_duplicate_param_names(snapshot, get_output):
     def inner(kw, b):
         assert not b["c"]
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
 class Outer:
@@ -130,7 +130,7 @@ class Inner:
         self.x = x
 
 
-def test_explain_multi_level_nesting(snapshot, get_output):
+def test_explain_multi_level_nesting(snapshot):
     @EXPLAIN_SETTINGS
     @given(
         bare=st.integers(),
@@ -141,4 +141,4 @@ def test_explain_multi_level_nesting(snapshot, get_output):
     def inner(bare, outer):
         assert not outer.value
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_shrinking.py
+++ b/hypothesis-python/tests/snapshots/test_shrinking.py
@@ -11,30 +11,30 @@
 from hypothesis import given, strategies as st
 
 from tests.snapshots.conftest import SNAPSHOT_SETTINGS
+from tests.common.utils import run_test_for_falsifying_example
 
-
-def test_shrunk_list(snapshot, get_output):
+def test_shrunk_list(snapshot):
     @SNAPSHOT_SETTINGS
     @given(xs=st.lists(st.integers(), min_size=1))
     def inner(xs):
         assert sum(xs) <= 1000
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_shrunk_string(snapshot, get_output):
+def test_shrunk_string(snapshot):
     @SNAPSHOT_SETTINGS
     @given(s=st.text(min_size=1))
     def inner(s):
         assert s == s.lower()
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot
 
 
-def test_shrunk_float(snapshot, get_output):
+def test_shrunk_float(snapshot):
     @SNAPSHOT_SETTINGS
     @given(x=st.floats(min_value=0, max_value=1))
     def inner(x):
         assert x <= 0.5
 
-    assert get_output(inner) == snapshot
+    assert run_test_for_falsifying_example(inner) == snapshot

--- a/hypothesis-python/tests/snapshots/test_shrinking.py
+++ b/hypothesis-python/tests/snapshots/test_shrinking.py
@@ -10,8 +10,9 @@
 
 from hypothesis import given, strategies as st
 
-from tests.snapshots.conftest import SNAPSHOT_SETTINGS
 from tests.common.utils import run_test_for_falsifying_example
+from tests.snapshots.conftest import SNAPSHOT_SETTINGS
+
 
 def test_shrunk_list(snapshot):
     @SNAPSHOT_SETTINGS

--- a/hypothesis-python/tests/snapshots/test_shrinking.py
+++ b/hypothesis-python/tests/snapshots/test_shrinking.py
@@ -1,0 +1,40 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from hypothesis import given, strategies as st
+
+from tests.snapshots.conftest import SNAPSHOT_SETTINGS
+
+
+def test_shrunk_list(snapshot, get_output):
+    @SNAPSHOT_SETTINGS
+    @given(xs=st.lists(st.integers(), min_size=1))
+    def inner(xs):
+        assert sum(xs) <= 1000
+
+    assert get_output(inner) == snapshot
+
+
+def test_shrunk_string(snapshot, get_output):
+    @SNAPSHOT_SETTINGS
+    @given(s=st.text(min_size=1))
+    def inner(s):
+        assert s == s.lower()
+
+    assert get_output(inner) == snapshot
+
+
+def test_shrunk_float(snapshot, get_output):
+    @SNAPSHOT_SETTINGS
+    @given(x=st.floats(min_value=0, max_value=1))
+    def inner(x):
+        assert x <= 0.5
+
+    assert get_output(inner) == snapshot

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -6,7 +6,6 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 basepython={env:TOX_PYTHON_VERSION:python3}
 deps =
     -r../requirements/test.txt
-    syrupy==5.1.0
 extras =
     zoneinfo
 allowlist_externals =

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -26,11 +26,17 @@ commands =
     full: bash scripts/basic-test.sh
     brief: python -bb -X dev -m pytest -n auto tests/cover/test_testdecorators.py {posargs}
     cover: python -bb -X dev -m pytest -n auto tests/cover/ tests/pytest/ tests/conjecture/ {posargs}
-    rest: python -bb -X dev -m pytest -n auto tests/ --ignore=tests/cover/ --ignore=tests/pytest/ --ignore=tests/conjecture/ --ignore=tests/nocover/ --ignore=tests/quality/ --ignore=tests/ghostwriter/ --ignore=tests/patching/ --ignore=tests/crosshair/test_crosshair.py {posargs}
+    rest: python -bb -X dev -m pytest -n auto tests/ --ignore=tests/cover/ --ignore=tests/pytest/ --ignore=tests/conjecture/ --ignore=tests/nocover/ --ignore=tests/quality/ --ignore=tests/ghostwriter/ --ignore=tests/patching/ --ignore=tests/crosshair/test_crosshair.py --ignore=tests/snapshots/ {posargs}
     conjecture: python -bb -X dev -m pytest -n auto tests/conjecture/ {posargs}
     nocover: python -bb -X dev -m pytest -n auto tests/nocover/ {posargs}
     niche: bash scripts/other-tests.sh
     custom: python -bb -X dev -m pytest {posargs}
+
+[testenv:snapshots]
+deps =
+    -r../requirements/test.txt
+commands =
+    python -bb -X dev -m pytest tests/snapshots/ {posargs}
 
 [testenv:py310-pyjion]
 deps =

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -6,6 +6,7 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 basepython={env:TOX_PYTHON_VERSION:python3}
 deps =
     -r../requirements/test.txt
+    syrupy==5.1.0
 extras =
     zoneinfo
 allowlist_externals =

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -81,6 +81,8 @@ sortedcontainers==2.4.0
     # via
     #   fakeredis
     #   hypothesis (hypothesis-python/pyproject.toml)
+syrupy==5.1.0
+    # via -r requirements/test.in
 typing-extensions==4.15.0
     # via -r requirements/coverage.in
 watchdog==6.0.0

--- a/requirements/crosshair.txt
+++ b/requirements/crosshair.txt
@@ -57,6 +57,8 @@ sortedcontainers==2.4.0
     # via
     #   hypothesis
     #   hypothesis (hypothesis-python/pyproject.toml)
+syrupy==5.1.0
+    # via -r requirements/test.in
 typeshed-client==2.9.0
     # via crosshair-tool
 typing-extensions==4.15.0

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,3 +1,4 @@
 pexpect
 pytest
 pytest-xdist
+syrupy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,3 +26,5 @@ pytest-xdist==3.8.0
     # via -r requirements/test.in
 sortedcontainers==2.4.0
     # via hypothesis (hypothesis-python/pyproject.toml)
+syrupy==5.1.0
+    # via -r requirements/test.in

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -288,6 +288,8 @@ sortedcontainers-stubs==2.4.3
     # via -r requirements/tools.in
 soupsieve==2.8.3
     # via beautifulsoup4
+syrupy==5.1.0
+    # via -r requirements/test.in
 sphinx==9.1.0
     # via
     #   -r requirements/tools.in

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -739,6 +739,7 @@ standard_tox_task("numpy-nightly", py="3.12")
 
 standard_tox_task("coverage")
 standard_tox_task("conjecture-coverage")
+standard_tox_task("snapshots")
 
 
 @task()


### PR DESCRIPTION
This pulls out the commits that are just adding Snapshot testing from #4694.

It does still end up with a release because this necessitates fixing a minor bug (the way the syrupy plugin works means that it shows up as a false positive in scrutineer) but it otherwise just adds tests asserting the current behaviour.