### PR TITLE
Automatically write `.gitignore` to `.hypothesis`

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 Hypothesis generally recommends that the ``.hypothesis`` directory not be checked into version control. As a result, Hypothesis now automatically creates a ``.gitignore`` with ``*`` in the ``.hypothesis`` directory, which excludes it from being tracked by git.
 

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Hypothesis generally recommends that the ``.hypothesis`` directory not be checked into version control. As a result, Hypothesis now automatically creates a ``.gitignore`` with ``*`` in the ``.hypothesis`` directory, which excludes it from being tracked by git.
+
+If you do want to check ``.hypothesis`` into git, you can remove the ``.gitignore`` file. Hypothesis will not re-create it unless the entire ``.hypothesis`` directory is removed.

--- a/hypothesis-python/src/hypothesis/configuration.py
+++ b/hypothesis-python/src/hypothesis/configuration.py
@@ -50,9 +50,8 @@ class StorageDirectory:
         existed_before = self.home_directory.exists()
         self.path.mkdir(parents=True, exist_ok=True)
         if not existed_before:
-            gitignore_p = self.home_directory / ".gitignore"
-            if not gitignore_p.exists():
-                gitignore_p.write_text(_GITIGNORE_STRING, encoding="utf-8")
+            p = self.home_directory / ".gitignore"
+            p.write_text(_GITIGNORE_STRING, encoding="utf-8")
 
 
 def storage_directory(*names: str, intent_to_write: bool = True) -> StorageDirectory:

--- a/hypothesis-python/src/hypothesis/configuration.py
+++ b/hypothesis-python/src/hypothesis/configuration.py
@@ -26,7 +26,36 @@ def set_hypothesis_home_dir(directory: str | Path | None) -> None:
     __hypothesis_home_directory = None if directory is None else Path(directory)
 
 
-def storage_directory(*names: str, intent_to_write: bool = True) -> Path:
+_GITIGNORE_STRING = """\
+# This .gitignore file was automatically created by Hypothesis. Hypothesis gitignores
+# .hypothesis by default, because we generally recommend that .hypothesis not be checked
+# into version control.
+#
+# If you *would* like to check .hypothesis into version control, you should delete this
+# file. Hypothesis will not re-create this .gitignore unless .hypothesis is deleted (and
+# if it does, that's a bug - please report it!)
+
+*
+"""
+
+
+class StorageDirectory:
+    def __init__(self, path: Path, *, home_directory: Path) -> None:
+        self.path = path
+        self.home_directory = home_directory
+
+    def create_if_missing(self) -> None:
+        # create the appropriate directory and files, if necessary.
+
+        existed_before = self.home_directory.exists()
+        self.path.mkdir(parents=True, exist_ok=True)
+        if not existed_before:
+            gitignore_p = self.home_directory / ".gitignore"
+            if not gitignore_p.exists():
+                gitignore_p.write_text(_GITIGNORE_STRING, encoding="utf-8")
+
+
+def storage_directory(*names: str, intent_to_write: bool = True) -> StorageDirectory:
     if intent_to_write:
         check_sideeffect_during_initialization(
             "accessing storage for {}", "/".join(names)
@@ -38,7 +67,10 @@ def storage_directory(*names: str, intent_to_write: bool = True) -> Path:
             __hypothesis_home_directory = Path(where)
     if not __hypothesis_home_directory:
         __hypothesis_home_directory = __hypothesis_home_directory_default
-    return __hypothesis_home_directory.joinpath(*names)
+    return StorageDirectory(
+        __hypothesis_home_directory.joinpath(*names),
+        home_directory=__hypothesis_home_directory,
+    )
 
 
 _first_postinit_what = None

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -37,7 +37,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 from zipfile import BadZipFile, ZipFile
 
-from hypothesis.configuration import storage_directory
+from hypothesis.configuration import StorageDirectory, storage_directory
 from hypothesis.errors import HypothesisException, HypothesisWarning
 from hypothesis.internal.conjecture.choice import ChoiceT
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
@@ -93,16 +93,17 @@ def _db_for_path(
                 "https://hypothesis.readthedocs.io/en/latest/settings.html#settings-profiles"
             )
 
-        path = storage_directory("examples", intent_to_write=False)
-        if not _usable_dir(path):  # pragma: no cover
+        storage_dir = storage_directory("examples", intent_to_write=False)
+        if not _usable_dir(storage_dir.path):  # pragma: no cover
             warnings.warn(
                 "The database setting is not configured, and the default "
                 "location is unusable - falling back to an in-memory "
-                f"database for this session.  {path=}",
+                f"database for this session.  path={storage_dir.path!r}",
                 HypothesisWarning,
                 stacklevel=3,
             )
             return InMemoryExampleDatabase()
+        return _StorageDirectoryDatabase(storage_dir)
     if path in (None, ":memory:"):
         return InMemoryExampleDatabase()
     path = cast(StrPathT, path)
@@ -446,6 +447,15 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         self.path = Path(path)
         self.keypaths: dict[bytes, Path] = {}
         self._observer: BaseObserver | None = None
+        self._ensure_directory_exists_called = False
+
+    def _ensure_directory_exists(self) -> None:
+        # disk hits are expensive: early-return for performance
+        if self._ensure_directory_exists_called:
+            return
+
+        self.path.mkdir(exist_ok=True, parents=True)
+        self._ensure_directory_exists_called = True
 
     def __repr__(self) -> str:
         return f"DirectoryBasedExampleDatabase({self.path!r})"
@@ -492,6 +502,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         # already checked for permissions, but there can still be other issues,
         # e.g. the disk is full, or permissions might have been changed.
         try:
+            self._ensure_directory_exists()
             key_path.mkdir(exist_ok=True, parents=True)
             path = self._value_path(key, value)
             if not path.exists():
@@ -654,7 +665,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         # events, even after the directory gets created.
         #
         # Ensure the directory exists before starting the observer.
-        self.path.mkdir(exist_ok=True, parents=True)
+        self._ensure_directory_exists()
         self._observer = Observer()
         self._observer.schedule(
             Handler(),
@@ -671,6 +682,28 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         self._observer.stop()
         self._observer.join()
         self._observer = None
+
+
+class _StorageDirectoryDatabase(DirectoryBasedExampleDatabase):
+    # A DirectoryBasedExampleDatabase which is located at the same directory as the storage
+    # directory. This lets our database logic interact with our logic for writing .gitignore
+    # files to the storage directory.
+    #
+    # The reason why we need this class is because the first interaction we have
+    # with .hypothesis might be writing a file to .hypothesis/examples, and
+    # DirectoryBasedExampleDatabase.save would otherwise create .hypothesis without
+    # performing our .gitignore logic.
+
+    def __init__(self, storage_dir: StorageDirectory) -> None:
+        super().__init__(storage_dir.path)
+        self._storage_dir = storage_dir
+
+    def _ensure_directory_exists(self) -> None:
+        if self._ensure_directory_exists_called:
+            return
+
+        self._storage_dir.create_if_missing()
+        self._ensure_directory_exists_called = True
 
 
 class ReadOnlyDatabase(ExampleDatabase):
@@ -868,10 +901,12 @@ class GitHubArtifactDatabase(ExampleDatabase):
         # It's unnecessary to use a token if the repo is public
         self.token: str | None = getenv("GITHUB_TOKEN")
 
+        self._storage_dir: StorageDirectory | None = None
         if path is None:
-            self.path: Path = Path(
-                storage_directory(f"github-artifacts/{self.artifact_name}/")
+            self._storage_dir = storage_directory(
+                f"github-artifacts/{self.artifact_name}/"
             )
+            self.path = self._storage_dir.path
         else:
             self.path = Path(path)
 
@@ -953,7 +988,10 @@ class GitHubArtifactDatabase(ExampleDatabase):
         # Trigger warning that we suppressed earlier by intent_to_write=False
         storage_directory(self.path.name)
         # Create the cache directory if it doesn't exist
-        self.path.mkdir(exist_ok=True, parents=True)
+        if self._storage_dir is not None:
+            self._storage_dir.create_if_missing()
+        else:
+            self.path.mkdir(exist_ok=True, parents=True)
 
         # Get all artifacts
         cached_artifacts = sorted(

--- a/hypothesis-python/src/hypothesis/database.py
+++ b/hypothesis-python/src/hypothesis/database.py
@@ -988,7 +988,7 @@ class GitHubArtifactDatabase(ExampleDatabase):
         # Trigger warning that we suppressed earlier by intent_to_write=False
         storage_directory(self.path.name)
         # Create the cache directory if it doesn't exist
-        if self._storage_dir is not None:
+        if self._storage_dir is not None:  # pragma: no cover
             self._storage_dir.create_if_missing()
         else:
             self.path.mkdir(exist_ok=True, parents=True)

--- a/hypothesis-python/src/hypothesis/extra/_patching.py
+++ b/hypothesis-python/src/hypothesis/extra/_patching.py
@@ -183,7 +183,7 @@ def get_patch_for(
     if patch is None:
         return None
 
-    (before, after) = patch
+    before, after = patch
     return (str(fname), before, after)
 
 
@@ -326,16 +326,17 @@ def save_patch(patch: str, *, slug: str = "") -> Path:  # pragma: no cover
     now = date.today().isoformat()
     cleaned = re.sub(r"^Date: .+?$", "", patch, count=1, flags=re.MULTILINE)
     hash8 = hashlib.sha1(cleaned.encode()).hexdigest()[:8]
-    fname = Path(storage_directory("patches", f"{now}--{slug}{hash8}.patch"))
-    fname.parent.mkdir(parents=True, exist_ok=True)
-    fname.write_text(patch, encoding="utf-8")
-    return fname.relative_to(Path.cwd())
+    patches_dir = storage_directory("patches")
+    patches_dir.create_if_missing()
+    p = patches_dir.path / f"{now}--{slug}{hash8}.patch"
+    p.write_text(patch, encoding="utf-8")
+    return p.relative_to(Path.cwd())
 
 
 def gc_patches(slug: str = "") -> None:  # pragma: no cover
     cutoff = date.today() - timedelta(days=7)
-    for fname in Path(storage_directory("patches")).glob(
+    for p in storage_directory("patches").path.glob(
         f"????-??-??--{slug}????????.patch"
     ):
-        if date.fromisoformat(fname.stem.split("--")[0]) < cutoff:
-            fname.unlink()
+        if date.fromisoformat(p.stem.split("--")[0]) < cutoff:
+            p.unlink()

--- a/hypothesis-python/src/hypothesis/internal/charmap.py
+++ b/hypothesis-python/src/hypothesis/internal/charmap.py
@@ -72,7 +72,7 @@ CategoriesTuple: TypeAlias = tuple[CategoryName, ...]
 def charmap_file(fname: str = "charmap") -> Path:
     return storage_directory(
         "unicode_data", unicodedata.unidata_version, f"{fname}.json.gz"
-    )
+    ).path
 
 
 _charmap: dict[CategoryName, IntervalsT] | None = None
@@ -112,9 +112,9 @@ def charmap() -> dict[CategoryName, IntervalsT]:
 
             try:
                 # Write the Unicode table atomically
-                tmpdir = storage_directory("tmp")
-                tmpdir.mkdir(exist_ok=True, parents=True)
-                fd, tmpfile = tempfile.mkstemp(dir=tmpdir)
+                storage_dir = storage_directory("tmp")
+                storage_dir.create_if_missing()
+                fd, tmpfile = tempfile.mkstemp(dir=storage_dir.path)
                 os.close(fd)
                 # Explicitly set the mtime to get reproducible output
                 with gzip.GzipFile(tmpfile, "wb", mtime=1) as fp:
@@ -165,9 +165,9 @@ def intervals_from_codec(codec_name: str) -> IntervalSet:  # pragma: no cover
     res = res.union(res)
     try:
         # Write the Unicode table atomically
-        tmpdir = storage_directory("tmp")
-        tmpdir.mkdir(exist_ok=True, parents=True)
-        fd, tmpfile = tempfile.mkstemp(dir=tmpdir)
+        storage_dir = storage_directory("tmp")
+        storage_dir.create_if_missing()
+        fd, tmpfile = tempfile.mkstemp(dir=storage_dir.path)
         os.close(fd)
         # Explicitly set the mtime to get reproducible output
         with gzip.GzipFile(tmpfile, "wb", mtime=1) as f:

--- a/hypothesis-python/src/hypothesis/internal/constants_ast.py
+++ b/hypothesis-python/src/hypothesis/internal/constants_ast.py
@@ -210,9 +210,8 @@ def constants_from_module(module: ModuleType, *, limit: bool = True) -> Constant
 
     source_hash = hashlib.sha1(source_bytes).hexdigest()[:16]
     # separate cache files for each limit param. see discussion in pull/4398
-    cache_p = storage_directory("constants") / (
-        source_hash + ("" if limit else "_nolimit")
-    )
+    cache_dir = storage_directory("constants")
+    cache_p = cache_dir.path / (source_hash + ("" if limit else "_nolimit"))
     try:
         return _constants_from_source(cache_p.read_bytes(), limit=limit)
     except Exception:
@@ -231,7 +230,7 @@ def constants_from_module(module: ModuleType, *, limit: bool = True) -> Constant
         return Constants()
 
     try:
-        cache_p.parent.mkdir(parents=True, exist_ok=True)
+        cache_dir.create_if_missing()
         cache_p.write_text(
             f"# file: {module_file}\n# hypothesis_version: {hypothesis.__version__}\n\n"
             # somewhat arbitrary sort order. The cache file doesn't *have* to be

--- a/hypothesis-python/src/hypothesis/internal/observability.py
+++ b/hypothesis-python/src/hypothesis/internal/observability.py
@@ -487,8 +487,9 @@ def _deliver_to_file(
     from hypothesis.strategies._internal.utils import to_jsonable
 
     kind = "testcases" if observation.type == "test_case" else "info"
-    fname = storage_directory("observed", f"{date.today().isoformat()}_{kind}.jsonl")
-    fname.parent.mkdir(exist_ok=True, parents=True)
+    observed_dir = storage_directory("observed")
+    observed_dir.create_if_missing()
+    observation_p = observed_dir.path / f"{date.today().isoformat()}_{kind}.jsonl"
 
     observation_bytes = (
         json.dumps(to_jsonable(observation, avoid_realization=False)) + "\n"
@@ -500,8 +501,8 @@ def _deliver_to_file(
     # switch over to a queue if we detect multithreading, but it's tricky to get
     # right.
     with _deliver_to_file_lock:
-        _WROTE_TO.add(fname)
-        with fname.open(mode="a") as f:
+        _WROTE_TO.add(observation_p)
+        with observation_p.open(mode="a") as f:
             f.write(observation_bytes)
 
 
@@ -558,6 +559,6 @@ if (
 
     # Remove files more than a week old, to cap the size on disk
     max_age = (date.today() - timedelta(days=8)).isoformat()
-    for f in storage_directory("observed", intent_to_write=False).glob("*.jsonl"):
-        if f.stem < max_age:  # pragma: no branch
-            f.unlink(missing_ok=True)
+    for p in storage_directory("observed", intent_to_write=False).path.glob("*.jsonl"):
+        if p.stem < max_age:  # pragma: no branch
+            p.unlink(missing_ok=True)

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 import pytest
 
 from hypothesis import given, settings, strategies as st
+from hypothesis.configuration import StorageDirectory
 from hypothesis.internal.conjecture import providers
 from hypothesis.internal.conjecture.choice import choice_equal
 from hypothesis.internal.conjecture.providers import CONSTANTS_CACHE
@@ -85,7 +86,9 @@ def test_actual_collection(monkeypatch, tmp_path):
     # Reset to a guaranteed-empty storage directory to ensure consistent coverage.
     monkeypatch.setattr(
         "hypothesis.internal.constants_ast.storage_directory",
-        lambda *names, **kwargs: tmp_path.joinpath(*names),
+        lambda *names, **kwargs: StorageDirectory(
+            tmp_path.joinpath(*names), home_directory=tmp_path
+        ),
     )
 
     @given(st.integers())

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -53,12 +53,16 @@ def test_storage_directories_are_not_created_automatically(tmp_path):
 
 def _gitignore_storage_dir_script(*, home_dir=None):
     return textwrap.dedent(f"""
-        from hypothesis import given, strategies as st
+        from hypothesis import given, settings, strategies as st
         from hypothesis.configuration import set_hypothesis_home_dir
 
         home_dir = {repr(str(home_dir)) if home_dir is not None else None}
         if home_dir:
             set_hypothesis_home_dir(home_dir)
+
+        # in CI we use the "ci" profile which sets database=None. But we actually want
+        # disk writes to happen here so we can test the .hypothesis/.gitignore behavior.
+        settings.load_profile("default")
 
         @given(st.integers())
         def f(n):

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -66,7 +66,7 @@ def _gitignore_storage_dir_script(*, home_dir=None):
 
         @given(st.integers())
         def f(n):
-            # fail to guarantee we write a file to .hypothesis/examples
+            # fail, in order to guarantee we write a file to .hypothesis/examples
             raise ValueError()
 
         try:

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -9,6 +9,11 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
 
 from hypothesis import configuration as fs
 
@@ -17,7 +22,7 @@ previous_home_dir = None
 
 def setup_function(function):
     global previous_home_dir
-    previous_home_dir = fs.storage_directory()
+    previous_home_dir = fs.storage_directory().path
     fs.set_hypothesis_home_dir(None)
 
 
@@ -28,19 +33,74 @@ def teardown_function(function):
 
 
 def test_defaults_to_the_default():
-    assert fs.storage_directory() == fs.__hypothesis_home_directory_default
+    assert fs.storage_directory().path == fs.__hypothesis_home_directory_default
 
 
 def test_can_set_homedir(tmp_path):
     fs.set_hypothesis_home_dir(tmp_path)
-    assert fs.storage_directory("kittens") == tmp_path / "kittens"
+    assert fs.storage_directory("kittens").path == tmp_path / "kittens"
 
 
 def test_will_pick_up_location_from_env(monkeypatch, tmp_path):
     monkeypatch.setattr(os, "environ", {"HYPOTHESIS_STORAGE_DIRECTORY": str(tmp_path)})
-    assert fs.storage_directory() == tmp_path
+    assert fs.storage_directory().path == tmp_path
 
 
 def test_storage_directories_are_not_created_automatically(tmp_path):
     fs.set_hypothesis_home_dir(tmp_path)
-    assert not fs.storage_directory("badgers").exists()
+    assert not fs.storage_directory("badgers").path.exists()
+
+
+def _gitignore_storage_dir_script(*, home_dir=None):
+    return textwrap.dedent(f"""
+        from hypothesis import given, strategies as st
+        from hypothesis.configuration import set_hypothesis_home_dir
+
+        home_dir = {repr(str(home_dir)) if home_dir is not None else None}
+        if home_dir:
+            set_hypothesis_home_dir(home_dir)
+
+        @given(st.integers())
+        def f(n):
+            # fail to guarantee we write a file to .hypothesis/examples
+            raise ValueError()
+
+        try:
+            f()
+        except Exception:
+            pass
+        """)
+
+
+@pytest.mark.parametrize("set_home_dir", [False, True])
+def test_writes_gitignore_to_new_storage_dir(tmp_path, set_home_dir):
+    subprocess.check_call(["git", "init", str(tmp_path)])
+
+    home_dir = tmp_path / ("custom_storage_dir" if set_home_dir else ".hypothesis")
+    (tmp_path / "test_a.py").write_text(
+        _gitignore_storage_dir_script(home_dir=home_dir if set_home_dir else None),
+        encoding="utf-8",
+    )
+
+    subprocess.check_call([sys.executable, "test_a.py"], cwd=tmp_path)
+    assert home_dir.is_dir()
+    assert (home_dir / ".gitignore").exists()
+
+    status = subprocess.check_output(
+        ["git", "status", "--porcelain"], cwd=tmp_path, text=True
+    )
+    assert home_dir.name not in status
+
+
+@pytest.mark.parametrize("set_home_dir", [False, True])
+def test_skips_gitignore_for_existing_storage_dir(tmp_path, set_home_dir):
+    home_dir = tmp_path / ("custom_storage_dir" if set_home_dir else ".hypothesis")
+    home_dir.mkdir()
+
+    (tmp_path / "test_a.py").write_text(
+        _gitignore_storage_dir_script(home_dir=home_dir if set_home_dir else None),
+        encoding="utf-8",
+    )
+
+    subprocess.check_call([sys.executable, "test_a.py"], cwd=tmp_path)
+    assert not (home_dir / ".gitignore").exists()

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -17,6 +17,8 @@ import pytest
 
 from hypothesis import configuration as fs
 
+from tests.common.utils import skipif_emscripten
+
 previous_home_dir = None
 
 
@@ -76,6 +78,7 @@ def _gitignore_storage_dir_script(*, home_dir=None):
         """)
 
 
+@skipif_emscripten
 @pytest.mark.parametrize("set_home_dir", [False, True])
 def test_writes_gitignore_to_new_storage_dir(tmp_path, set_home_dir):
     subprocess.check_call(["git", "init", str(tmp_path)])
@@ -96,6 +99,7 @@ def test_writes_gitignore_to_new_storage_dir(tmp_path, set_home_dir):
     assert home_dir.name not in status
 
 
+@skipif_emscripten
 @pytest.mark.parametrize("set_home_dir", [False, True])
 def test_skips_gitignore_for_existing_storage_dir(tmp_path, set_home_dir):
     home_dir = tmp_path / ("custom_storage_dir" if set_home_dir else ".hypothesis")

--- a/hypothesis-python/tests/cover/test_filestorage.py
+++ b/hypothesis-python/tests/cover/test_filestorage.py
@@ -91,7 +91,7 @@ def test_writes_gitignore_to_new_storage_dir(tmp_path, set_home_dir):
     assert (home_dir / ".gitignore").exists()
 
     status = subprocess.check_output(
-        ["git", "status", "--porcelain"], cwd=tmp_path, text=True
+        ["git", "status", "--porcelain"], cwd=tmp_path, encoding="utf-8"
     )
     assert home_dir.name not in status
 


### PR DESCRIPTION
See discussion in https://github.com/hegeldev/hegel-go/pull/46#issuecomment-4224628391.

I don't love that this PR adds a new private subclass of `DirectoryBasedExampleDatabase`. The problem is this: `DirectoryBasedExampleDatabase.save` might be the first to create `.hypothesis`, and therefore needs to be aware of our logic for writing `.gitignore`. I don't see a good way around this other than to make `DirectoryBasedExampleDatabase` aware of that logic, but without altering its API for public consumers, which is what I've done here.