### PR TITLE
Fix AssertionError in Shrinker.explain() for unstable span labels

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes an internal :class:`AssertionError` in the ``explain``
+shrinking phase (:issue:`4708`), introduced in :version:`6.149.0`.  The
+assertion was triggered when a strategy inside a composite drew from
+:func:`~hypothesis.strategies.just` applied to a fresh instance of a
+user-defined class, because this causes the enclosing strategy to have a
+different label on each test invocation.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,8 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch fixes an internal :class:`AssertionError` in the ``explain``
-shrinking phase (:issue:`4708`), introduced in :version:`6.149.0`.  The
-assertion was triggered when a strategy inside a composite drew from
-:func:`~hypothesis.strategies.just` applied to a fresh instance of a
-user-defined class, because this causes the enclosing strategy to have a
-different label on each test invocation.
+This patch fixes a rare internal error during |Phase.explain| introduced in :version:`6.149.0` for certain strategies (:issue:`4708`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -539,7 +539,6 @@ class Shrinker:
                     ):
                         assert span1.start == span2.start
                         assert span1.start <= start
-                        assert span1.label == span2.label
                         if span1.start == start and span1.end == end:
                             result_end = span2.end
                             break

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -12,8 +12,9 @@ import traceback
 
 import pytest
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import Phase, given, settings, strategies as st
 
+from tests.common.debug import minimal
 from tests.common.utils import fails_with
 
 
@@ -263,14 +264,12 @@ def test_inquisitor_multi_level_nesting(bare, outer):
 
 
 def test_explain_does_not_crash_with_per_run_labels():
-    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/4708
+    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/4708.
     # If a strategy constructed inside a composite draws from st.just() of a
     # fresh instance of a user-defined class, the resulting OneOfStrategy has
     # a different label on each test invocation. The explain phase would
     # previously assert equal labels between the shrink target and a replayed
     # result, which is not guaranteed to hold.
-    from hypothesis import find, settings
-
     class W:
         def __init__(self, a):
             self.a = a
@@ -283,4 +282,8 @@ def test_explain_does_not_crash_with_per_run_labels():
     def wrapped(draw):
         return draw(st.one_of(st.just(W(None)), structured.map(W)))
 
-    find(wrapped(), lambda x: isinstance(x.a, list), settings=settings(database=None))
+    minimal(
+        wrapped(),
+        lambda x: isinstance(x.a, list),
+        settings=settings(phases=(Phase.generate, Phase.shrink, Phase.explain)),
+    )

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -38,8 +38,7 @@ def fails_with_output(expected):
     return _inner
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_comments_basic_fail_if_either(
     # The test always failed when commented parts were varied together.
     a=False,  # or any other generated value
@@ -48,24 +47,21 @@ Falsifying example: test_inquisitor_comments_basic_fail_if_either(
     d=True,
     e=False,  # or any other generated value
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.booleans(), st.booleans(), st.lists(st.none()), st.booleans(), st.booleans())
 def test_inquisitor_comments_basic_fail_if_either(a, b, c, d, e):
     assert not (b and d)
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_comments_basic_fail_if_not_all(
     # The test sometimes passed when commented parts were varied together.
     a='',  # or any other generated value
     b='',  # or any other generated value
     c='',  # or any other generated value
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.text(), st.text(), st.text())
 def test_inquisitor_comments_basic_fail_if_not_all(a, b, c):
@@ -73,14 +69,12 @@ def test_inquisitor_comments_basic_fail_if_not_all(a, b, c):
     assert condition
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_no_together_comment_if_single_argument(
     a='',
     b='',  # or any other generated value
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.text(), st.text())
 def test_inquisitor_no_together_comment_if_single_argument(a, b):
@@ -95,14 +89,12 @@ def ints_with_forced_draw(draw):
     return n
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_doesnt_break_on_varying_forced_nodes(
     n1=100,
     n2=0,  # or any other generated value
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.integers(), ints_with_forced_draw())
 def test_inquisitor_doesnt_break_on_varying_forced_nodes(n1, n2):
@@ -126,72 +118,63 @@ class MyClass:
         self.y = y
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_builds_subargs(
     obj=MyClass(
         0,  # or any other generated value
         True,
     ),
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.builds(MyClass, st.integers(), st.booleans()))
 def test_inquisitor_builds_subargs(obj):
     assert not obj.y
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_builds_kwargs_subargs(
     obj=MyClass(
         x=0,  # or any other generated value
         y=True,
     ),
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.builds(MyClass, x=st.integers(), y=st.booleans()))
 def test_inquisitor_builds_kwargs_subargs(obj):
     assert not obj.y
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_tuple_subargs(
     t=(
         0,  # or any other generated value
         True,
     ),
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.tuples(st.integers(), st.booleans()))
 def test_inquisitor_tuple_subargs(t):
     assert not t[1]
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_fixeddict_subargs(
     d={
         'x': 0,  # or any other generated value
         'y': True,
     },
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.fixed_dictionaries({"x": st.integers(), "y": st.booleans()}))
 def test_inquisitor_fixeddict_subargs(d):
     assert not d["y"]
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_tuple_multiple_varying(
     t=(
         0,  # or any other generated value
@@ -199,8 +182,7 @@ Falsifying example: test_inquisitor_tuple_multiple_varying(
         True,
     ),
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.tuples(st.integers(), st.text(), st.booleans()))
 def test_inquisitor_tuple_multiple_varying(t):
@@ -209,16 +191,14 @@ def test_inquisitor_tuple_multiple_varying(t):
     assert not t[2]
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_skip_subset_slices(
     obj=MyClass(
         (0, False),  # or any other generated value
         y=False,
     ),
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.builds(MyClass, st.tuples(st.integers(), st.booleans()), y=st.booleans()))
 def test_inquisitor_skip_subset_slices(obj):
@@ -228,8 +208,7 @@ def test_inquisitor_skip_subset_slices(obj):
 
 
 # Test for duplicate param names at different nesting levels
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_duplicate_param_names(
     kw=0,  # or any other generated value
     b={
@@ -237,8 +216,7 @@ Falsifying example: test_inquisitor_duplicate_param_names(
         'c': True,
     },
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(kw=st.integers(), b=st.fixed_dictionaries({"kw": st.text(), "c": st.booleans()}))
 def test_inquisitor_duplicate_param_names(kw, b):
@@ -260,8 +238,7 @@ class Inner:
         self.x = x
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_multi_level_nesting(
     bare=0,  # or any other generated value
     outer=Outer(
@@ -269,8 +246,7 @@ Falsifying example: test_inquisitor_multi_level_nesting(
         value=True,
     ),
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(
     bare=st.integers(),
@@ -284,3 +260,27 @@ def test_inquisitor_multi_level_nesting(bare, outer):
     # comment appears only once on inner. outer.value doesn't get a comment
     # because it's the critical value that determines the failure.
     assert not outer.value
+
+
+def test_explain_does_not_crash_with_per_run_labels():
+    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/4708
+    # If a strategy constructed inside a composite draws from st.just() of a
+    # fresh instance of a user-defined class, the resulting OneOfStrategy has
+    # a different label on each test invocation. The explain phase would
+    # previously assert equal labels between the shrink target and a replayed
+    # result, which is not guaranteed to hold.
+    from hypothesis import find, settings
+
+    class W:
+        def __init__(self, a):
+            self.a = a
+
+    inner = st.one_of(st.integers(), st.tuples(st.integers(), st.integers()))
+    elements = st.tuples(inner, st.just(0))
+    structured = st.lists(elements, min_size=1, max_size=3)
+
+    @st.composite
+    def wrapped(draw):
+        return draw(st.one_of(st.just(W(None)), structured.map(W)))
+
+    find(wrapped(), lambda x: isinstance(x.a, list), settings=settings(database=None))

--- a/hypothesis-python/tests/snapshots/__snapshots__/test_explain.ambr
+++ b/hypothesis-python/tests/snapshots/__snapshots__/test_explain.ambr
@@ -112,3 +112,13 @@
   )
   '''
 # ---
+# name: test_explain_unstable_one_of_labels
+  '''
+  Falsifying example: inner(
+      w=W([(
+               0,  # or any other generated value
+               0,
+           )]),
+  )
+  '''
+# ---

--- a/hypothesis-python/tests/snapshots/test_explain.py
+++ b/hypothesis-python/tests/snapshots/test_explain.py
@@ -143,3 +143,29 @@ def test_explain_multi_level_nesting(snapshot):
         assert not outer.value
 
     assert run_test_for_falsifying_example(inner) == snapshot
+
+
+# Regression for https://github.com/HypothesisWorks/hypothesis/issues/4708.
+# The composite reconstructs ``st.one_of(st.just(W(None)), ...)`` per call,
+# so the OneOfStrategy's label is unstable across runs. Previously this
+# tripped an assertion in the explain phase.
+class W:
+    def __init__(self, a):
+        self.a = a
+
+
+@st.composite
+def _wrapped_4708(draw):
+    inner = st.one_of(st.integers(), st.tuples(st.integers(), st.integers()))
+    elements = st.tuples(inner, st.just(0))
+    structured = st.lists(elements, min_size=1, max_size=3)
+    return draw(st.one_of(st.just(W(None)), structured.map(W)))
+
+
+def test_explain_unstable_one_of_labels(snapshot):
+    @EXPLAIN_SETTINGS
+    @given(_wrapped_4708())
+    def inner(w):
+        assert not isinstance(w.a, list)
+
+    assert run_test_for_falsifying_example(inner) == snapshot


### PR DESCRIPTION
The explain phase asserted that spans at the same index between the shrink target and a replayed result share a label, but labels are not necessarily stable between runs (e.g. they aren't for `just` if the type inherits hash from object).

Fixes #4708 