### PR TITLE
Try targeted candidates in explain phase before random sampling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,3 +43,7 @@ When creating a PR that changes `hypothesis-python/src/`:
    - **Minimally commented** - code should be self-documenting; only add comments where truly needed
 2. **Run `./build.sh format; ./build.sh lint`** immediately before committing to auto-format and lint code
 3. **Do not reference issues or PRs in commit messages** (e.g., avoid `Fixes #1234` or `See #5678`) - this clutters the issue timeline with unnecessary links
+
+## Before Pushing to a PR
+
+**Always run `./build.sh format` before `git push`.** The CI `check-format` job runs `shed` against every file your branch touches and asserts no diff — so if any tool other than the pinned `shed` (e.g. `ruff format`) has been used on those files, or if pre-existing lines in a touched file aren't already shed-formatted, the job fails. Running `./build.sh format` uses the pinned tool versions and is the only way to be sure the check will pass.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -3,5 +3,4 @@ RELEASE_TYPE: patch
 This patch improves the |Phase.explain| phase so that simple cases like
 ``assert n1 == n2`` no longer get a misleading ``# or any other generated value``
 comment (:issue:`4715`). Before falling back to random sampling, we now also
-try the minimal value, the smallest non-minimal value, and values borrowed
-from each other arg slice with matching shape.
+try borrowing values from each other arg slice with matching shape.

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch improves the |Phase.explain| phase so that simple cases like
+``assert n1 == n2`` no longer get a misleading ``# or any other generated value``
+comment (:issue:`4715`). Before falling back to random sampling, we now also
+try the minimal value, the smallest non-minimal value, and values borrowed
+from each other arg slice with matching shape.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -624,62 +624,27 @@ class Shrinker:
     ) -> "Iterator[tuple[ChoiceT, ...]]":
         """Yield deterministic candidate replacements for ``nodes[start:end]``.
 
-        Pure random sampling can miss simple cases like ``assert n1 == n2``,
-        where the only passing value of ``n1`` happens to equal ``n2``. We try
-        the minimal and smallest non-minimal values, plus values borrowed from
-        each other arg slice with matching length and types.
+        Random sampling alone misses cases like ``assert n1 == n2``, where the
+        only passing value of ``n1`` is exactly ``n2``'s value. We try
+        substituting values from each other arg slice with matching length and
+        types, which catches such comparisons. Invalid borrowed values just
+        produce an irrelevant test result the outer loop discards.
         """
         nodes = self.nodes
-        current = tuple(nodes[i].value for i in range(start, end))
-        seen: set[tuple[Any, ...]] = {tuple(choice_key(v) for v in current)}
-
-        def emit(replacement: list[ChoiceT]) -> "Iterator[tuple[ChoiceT, ...]]":
-            candidate = tuple(replacement)
-            key = tuple(choice_key(v) for v in candidate)
-            if key not in seen:
-                seen.add(key)
-                yield candidate
-
-        # Try the minimal value of each constraint, and the smallest non-minimal
-        # value (e.g. 0 and 1 for unbounded integers, False and True for booleans).
-        for idx in (0, 1):
-            replacement: list[ChoiceT] = []
-            for i in range(start, end):
-                node = nodes[i]
-                if node.was_forced:
-                    replacement.append(node.value)
-                    continue
-                try:
-                    value = choice_from_index(idx, node.type, node.constraints)
-                except (NotImplementedError, AssertionError, IndexError):
-                    break
-                if not choice_permitted(value, node.constraints):
-                    break
-                replacement.append(value)
-            else:
-                yield from emit(replacement)
-
-        # Try substituting values from each other arg slice with the same length
-        # and types. This catches comparisons like ``assert n1 == n2``: replacing
-        # n1 with n2's value (or vice versa) will make the test pass.
         target_types = tuple(nodes[i].type for i in range(start, end))
+        current_keys = tuple(choice_key(nodes[i].value) for i in range(start, end))
+        seen: set[tuple[Any, ...]] = {current_keys}
         for s2, e2 in sorted(self.shrink_target.arg_slices):
             if (s2, e2) == (start, end) or (e2 - s2) != (end - start):
                 continue
             if tuple(nodes[s2 + j].type for j in range(end - start)) != target_types:
                 continue
-            replacement = []
-            for j in range(end - start):
-                node = nodes[start + j]
-                if node.was_forced:
-                    replacement.append(node.value)
-                    continue
-                other = nodes[s2 + j].value
-                if not choice_permitted(other, node.constraints):
-                    break
-                replacement.append(other)
-            else:
-                yield from emit(replacement)
+            borrowed = tuple(nodes[s2 + j].value for j in range(end - start))
+            key = tuple(choice_key(v) for v in borrowed)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield borrowed
 
     def greedy_shrink(self) -> None:
         """Run a full set of greedy shrinks (that is, ones that will only ever
@@ -1435,13 +1400,15 @@ class Shrinker:
         )
         node2 = chooser.choose(
             self.nodes,
-            lambda node: can_choose_node(node)
-            # Note that it's fine for node2 to be trivial, because we're going to
-            # explicitly make it *not* trivial by adding to its value.
-            and not node.was_forced
-            # to avoid quadratic behavior, scan ahead only a small amount for
-            # the related node.
-            and node1.index < node.index <= node1.index + 4,
+            lambda node: (
+                can_choose_node(node)
+                # Note that it's fine for node2 to be trivial, because we're going to
+                # explicitly make it *not* trivial by adding to its value.
+                and not node.was_forced
+                # to avoid quadratic behavior, scan ahead only a small amount for
+                # the related node.
+                and node1.index < node.index <= node1.index + 4
+            ),
         )
 
         m: int | float = node1.value
@@ -1493,8 +1460,9 @@ class Shrinker:
         node2 = self.nodes[
             chooser.choose(
                 range(node1.index + 1, min(len(self.nodes), node1.index + 3 + 1)),
-                lambda i: self.nodes[i].type == "integer"
-                and not self.nodes[i].was_forced,
+                lambda i: (
+                    self.nodes[i].type == "integer" and not self.nodes[i].was_forced
+                ),
             )
         ]
 
@@ -1547,9 +1515,12 @@ class Shrinker:
         node2 = self.nodes[
             chooser.choose(
                 range(node1.index + 1, min(len(self.nodes), node1.index + 1 + 4)),
-                lambda i: self.nodes[i].type == "string" and not self.nodes[i].trivial
-                # select nodes which have at least one of the same character present
-                and set(node1.value) & set(self.nodes[i].value),
+                lambda i: (
+                    self.nodes[i].type == "string"
+                    and not self.nodes[i].trivial
+                    # select nodes which have at least one of the same character present
+                    and set(node1.value) & set(self.nodes[i].value)
+                ),
             )
         ]
 

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -10,7 +10,7 @@
 
 import math
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -501,27 +501,36 @@ class Shrinker:
             ):
                 continue
 
+            # Try a few targeted candidates before falling back to random sampling,
+            # so that simple cases like ``assert n1 == n2`` -- where the only
+            # passing value of ``n1`` is exactly ``n2``'s value -- aren't reported
+            # as freely-variable just because random sampling missed it.
+            candidates = list(self._explain_candidates(start, end))
+
             # Run our experiments
             n_same_failures = 0
             note = "or any other generated value"
             # TODO: is 100 same-failures out of 500 attempts a good heuristic?
-            for n_attempt in range(500):  # pragma: no branch
+            for n_attempt in range(500 + len(candidates)):  # pragma: no branch
                 # no-branch here because we don't coverage-test the abort-at-500 logic.
 
-                if n_attempt - 10 > n_same_failures * 5:
+                if n_attempt - 10 - len(candidates) > n_same_failures * 5:
                     # stop early if we're seeing mostly invalid examples
                     break  # pragma: no cover
 
-                # replace start:end with random values
-                replacement = []
-                for i in range(start, end):
-                    node = nodes[i]
-                    if not node.was_forced:
-                        value = draw_choice(
-                            node.type, node.constraints, random=self.random
-                        )
-                        node = node.copy(with_value=value)
-                    replacement.append(node.value)
+                if n_attempt < len(candidates):
+                    replacement = list(candidates[n_attempt])
+                else:
+                    # replace start:end with random values
+                    replacement = []
+                    for i in range(start, end):
+                        node = nodes[i]
+                        if not node.was_forced:
+                            value = draw_choice(
+                                node.type, node.constraints, random=self.random
+                            )
+                            node = node.copy(with_value=value)
+                        replacement.append(node.value)
 
                 attempt = choices[:start] + tuple(replacement) + choices[end:]
                 result = self.engine.cached_test_function(attempt, extend="full")
@@ -609,6 +618,68 @@ class Shrinker:
                         "The test always failed when commented parts were varied together."
                     )
                     break
+
+    def _explain_candidates(
+        self, start: int, end: int
+    ) -> "Iterator[tuple[ChoiceT, ...]]":
+        """Yield deterministic candidate replacements for ``nodes[start:end]``.
+
+        Pure random sampling can miss simple cases like ``assert n1 == n2``,
+        where the only passing value of ``n1`` happens to equal ``n2``. We try
+        the minimal and smallest non-minimal values, plus values borrowed from
+        each other arg slice with matching length and types.
+        """
+        nodes = self.nodes
+        current = tuple(nodes[i].value for i in range(start, end))
+        seen: set[tuple[Any, ...]] = {tuple(choice_key(v) for v in current)}
+
+        def emit(replacement: list[ChoiceT]) -> "Iterator[tuple[ChoiceT, ...]]":
+            candidate = tuple(replacement)
+            key = tuple(choice_key(v) for v in candidate)
+            if key not in seen:
+                seen.add(key)
+                yield candidate
+
+        # Try the minimal value of each constraint, and the smallest non-minimal
+        # value (e.g. 0 and 1 for unbounded integers, False and True for booleans).
+        for idx in (0, 1):
+            replacement: list[ChoiceT] = []
+            for i in range(start, end):
+                node = nodes[i]
+                if node.was_forced:
+                    replacement.append(node.value)
+                    continue
+                try:
+                    value = choice_from_index(idx, node.type, node.constraints)
+                except (NotImplementedError, AssertionError, IndexError):
+                    break
+                if not choice_permitted(value, node.constraints):
+                    break
+                replacement.append(value)
+            else:
+                yield from emit(replacement)
+
+        # Try substituting values from each other arg slice with the same length
+        # and types. This catches comparisons like ``assert n1 == n2``: replacing
+        # n1 with n2's value (or vice versa) will make the test pass.
+        target_types = tuple(nodes[i].type for i in range(start, end))
+        for s2, e2 in sorted(self.shrink_target.arg_slices):
+            if (s2, e2) == (start, end) or (e2 - s2) != (end - start):
+                continue
+            if tuple(nodes[s2 + j].type for j in range(end - start)) != target_types:
+                continue
+            replacement = []
+            for j in range(end - start):
+                node = nodes[start + j]
+                if node.was_forced:
+                    replacement.append(node.value)
+                    continue
+                other = nodes[s2 + j].value
+                if not choice_permitted(other, node.constraints):
+                    break
+                replacement.append(other)
+            else:
+                yield from emit(replacement)
 
     def greedy_shrink(self) -> None:
         """Run a full set of greedy shrinks (that is, ones that will only ever

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -110,6 +110,23 @@ def test_issue_3755_regression(start_date, data):
     raise ZeroDivisionError
 
 
+@fails_with_output(
+    """
+Falsifying example: test_inquisitor_no_misleading_comment_for_eq_args(
+    n1=0,
+    n2=1,
+)
+"""
+)
+@settings(print_blob=False, derandomize=True)
+@given(st.integers(), st.integers())
+def test_inquisitor_no_misleading_comment_for_eq_args(n1, n2):
+    # Neither argument can vary freely: each one's "passing" value is the
+    # other's current value. Random sampling alone almost never finds this,
+    # so we explicitly try borrowing values from sibling slices.
+    assert n1 == n2
+
+
 # Tests for sub-argument explanations
 
 

--- a/hypothesis-python/tests/conjecture/test_inquisitor.py
+++ b/hypothesis-python/tests/conjecture/test_inquisitor.py
@@ -110,14 +110,12 @@ def test_issue_3755_regression(start_date, data):
     raise ZeroDivisionError
 
 
-@fails_with_output(
-    """
+@fails_with_output("""
 Falsifying example: test_inquisitor_no_misleading_comment_for_eq_args(
     n1=0,
     n2=1,
 )
-"""
-)
+""")
 @settings(print_blob=False, derandomize=True)
 @given(st.integers(), st.integers())
 def test_inquisitor_no_misleading_comment_for_eq_args(n1, n2):


### PR DESCRIPTION
When the explain phase tries to determine whether an arg slice can vary freely without affecting failure, it currently relies on pure random sampling. For tests like ``assert n1 == n2`` that misses the only passing value (the other arg's current value), so we'd report a misleading ``# or any other generated value`` comment.

Before falling back to random sampling, we now try a few deterministic candidates: the minimal value, the smallest non-minimal value, and the values borrowed from each other arg slice with matching length and types. This catches the equality-comparison case, while leaving the existing behaviour for genuinely free arg slices.

Fixes #4715.