### PR TITLE
Don't read from `/dev/urandom` with buffering in `hypothesis-urandom` backend

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The ``hypothesis-urandom`` :ref:`backend <alternative-backends>` now reads from ``/dev/urandom`` with buffering disabled, which improves the control of those hooking ``/dev/urandom`` to change or read Hypothesis's random decisions.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -1193,7 +1193,12 @@ class URandom(Random):
 
     @staticmethod
     def _urandom(size: int) -> bytes:
-        with open("/dev/urandom", "rb") as f:
+        # By default, we buffer more data from /dev/urandom than the actual `size` number
+        # of bytes we requested. This trips up anyone (and particularly Antithesis)
+        # hooking /dev/urandom reads to control randomness.
+        #
+        # buffering=0 disables this behavior.
+        with open("/dev/urandom", "rb", buffering=0) as f:
             return f.read(size)
 
     def getrandbits(self, k: int) -> int:


### PR DESCRIPTION
This is a fun one: python reads from files in a buffered mode by default, which means we consume way more entropy from `/dev/urandom` than we actually intended to, throwing off Antithesis and anyone else controlling those bytes.

<details><summary>Claude-written description</summary>

`URandomProvider` opened `/dev/urandom` with default buffering, so each `_urandom(size)` call actually pulled up to 64 KiB from the device through `BufferedReader` — even when `size` was 4 or 8 bytes — and discarded the surplus when the file was closed.

This breaks the integration the backend exists for. The docstring says Antithesis "interprets calls to /dev/urandom as the randomness to mutate" so it can drive Hypothesis's choices, but over-reading meant Hypothesis was consuming thousands of Antithesis-controlled bytes per logical decision, leaving Antithesis without precise control over what Hypothesis generated.

Passing `buffering=0` returns a raw `FileIO` that reads exactly the requested number of bytes. As a side effect, the backend gets ~10x faster end-to-end, because the kernel no longer has to produce 64 KiB of CSPRNG output per draw:

| op (size) | buffered | `buffering=0` | speedup |
|---|---|---|---|
| `_urandom(4)` | 132 µs | 12 µs | 10.9× |
| `_urandom(8)` | 137 µs | 14 µs | 10.0× |
| `_urandom(16)` | 147 µs | 13 µs | 11.3× |
| `_urandom(1024)` | 137 µs | 14 µs | 9.9× |
| `getrandbits(64)+getrandbits(32)+random()` | 392 µs | 35 µs | 11.1× |

Verified the over-read directly via `BufferedReader.peek()` on macOS: a 16-byte `read()` leaves 65520 unread bytes sitting in the buffer.

</details>
