### PR TITLE
Upgrade PyPI CI deployment to use Trusted Publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,6 +312,11 @@ jobs:
         task:
           - deploy
       fail-fast: false
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/hypothesis
     steps:
     - uses: actions/checkout@v3
       with:
@@ -323,6 +328,5 @@ jobs:
     - name: Deploy package
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         TASK=${{ matrix.task }} ./build.sh

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -150,8 +150,12 @@ def deploy():
         print("Not deploying due to not being on master")
         sys.exit(0)
 
-    if "TWINE_PASSWORD" not in os.environ:
-        print("Running without access to secure variables, so no deployment")
+    if not (
+        "TWINE_PASSWORD" in os.environ or "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in os.environ
+    ):
+        print(
+            "No PyPI publishing credentials available (OIDC or token), skipping deployment"
+        )
         sys.exit(0)
 
     tools.configure_git()

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -150,12 +150,8 @@ def deploy():
         print("Not deploying due to not being on master")
         sys.exit(0)
 
-    if not (
-        "TWINE_PASSWORD" in os.environ or "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in os.environ
-    ):
-        print(
-            "No PyPI publishing credentials available (OIDC or token), skipping deployment"
-        )
+    if "ACTIONS_ID_TOKEN_REQUEST_TOKEN" not in os.environ:
+        print("Running without access to secure variables, so no deployment")
         sys.exit(0)
 
     tools.configure_git()

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -206,6 +206,16 @@ def build_distribution():
 def upload_distribution():
     tools.assert_can_release()
 
+    if "TWINE_PASSWORD" in os.environ:
+        auth_args = ["--username=__token__"]
+    elif "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in os.environ:
+        # OIDC token will be used in GitHub Actions
+        auth_args = []
+    else:
+        raise RuntimeError(
+            "No publishing credentials found: TWINE_PASSWORD unset and OIDC unavailable"
+        )
+
     subprocess.check_call(
         [
             sys.executable,
@@ -213,7 +223,7 @@ def upload_distribution():
             "twine",
             "upload",
             "--skip-existing",
-            "--username=__token__",
+            *auth_args,
             os.path.join(DIST, "*"),
         ]
     )

--- a/tooling/src/hypothesistooling/projects/hypothesispython.py
+++ b/tooling/src/hypothesistooling/projects/hypothesispython.py
@@ -206,15 +206,8 @@ def build_distribution():
 def upload_distribution():
     tools.assert_can_release()
 
-    if "TWINE_PASSWORD" in os.environ:
-        auth_args = ["--username=__token__"]
-    elif "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in os.environ:
-        # OIDC token will be used in GitHub Actions
-        auth_args = []
-    else:
-        raise RuntimeError(
-            "No publishing credentials found: TWINE_PASSWORD unset and OIDC unavailable"
-        )
+    # used for trusted publishing
+    assert "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in os.environ
 
     subprocess.check_call(
         [
@@ -223,7 +216,6 @@ def upload_distribution():
             "twine",
             "upload",
             "--skip-existing",
-            *auth_args,
             os.path.join(DIST, "*"),
         ]
     )


### PR DESCRIPTION
- Background: #4691

Migrates PyPI publishing from a long-lived API token to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), motivated by recent supply chain attacks ([litellm](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/), [lightning](https://cybersecuritynews.com/python-package-lightning-hacked/)). As the [82nd most depended-on](https://lmmx.github.io/clickpydeps/) Python package by dependency count, a compromise of hypothesis would have a wide blast radius (at least 263 dependents by my count).

The code changes here retain backward compatibility with `TWINE_PASSWORD`, and require some further (trivial) setup on the PyPI-side. Specifically, the PyPI admin (not just maintainer) needs to register the trusted publisher on PyPI with:

- Owner: `HypothesisWorks`
- Repo: `hypothesis`  
- Workflow: `main.yml`
- Environment: `pypi`

After that's configured and this is merged, the `PYPI_TOKEN` secret can be deleted from the repo and invalidated on PyPI.