### PR TITLE
Bias large bounded integer ranges around the shrink target

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch improves the distribution of :func:`~hypothesis.strategies.integers`
+when called with very wide bounds, such as ``st.integers(-2**63, 2**63)``.
+Previously the distribution was strongly biased toward the lower bound; we now
+generate values centred around ``shrink_towards`` (default ``0``), giving a
+shape much closer to that of unbounded integers (:issue:`4624`, :issue:`4722`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -845,7 +845,7 @@ class HypothesisProvider(PrimitiveProvider):
             assert isinstance(constant, int)
             return constant
 
-        center = 0
+        center = shrink_towards
         if min_value is not None:
             center = max(min_value, center)
         if max_value is not None:
@@ -871,12 +871,12 @@ class HypothesisProvider(PrimitiveProvider):
             idx = sampler.sample(self._cd)
 
             if idx == 0:
-                return self._draw_bounded_integer(min_value, max_value)
+                return self._draw_bounded_integer(min_value, max_value, center=center)
             # implicit reliance on dicts being sorted for determinism
             return list(weights)[idx - 1]
 
         if min_value is None and max_value is None:
-            return self._draw_unbounded_integer()
+            return center + self._draw_unbounded_integer()
 
         if min_value is None:
             assert max_value is not None
@@ -892,7 +892,7 @@ class HypothesisProvider(PrimitiveProvider):
                 probe = center + self._draw_unbounded_integer()
             return probe
 
-        return self._draw_bounded_integer(min_value, max_value)
+        return self._draw_bounded_integer(min_value, max_value, center=center)
 
     def draw_float(
         self,
@@ -1067,6 +1067,7 @@ class HypothesisProvider(PrimitiveProvider):
         upper: int,
         *,
         vary_size: bool = True,
+        center: int = 0,
     ) -> int:
         assert lower <= upper
         assert self._cd is not None
@@ -1075,15 +1076,25 @@ class HypothesisProvider(PrimitiveProvider):
         if lower == upper:
             return lower
 
+        center = max(lower, min(upper, center))
         bits = (upper - lower).bit_length()
         if bits > 24 and vary_size and self._random.random() < 7 / 8:
-            # For large ranges, we combine the uniform random distribution
-            # with a weighting scheme with moderate chance.  Cutoff at 2 ** 24 so that our
-            # choice of unicode characters is uniform but the 32bit distribution is not.
+            # For large ranges, we combine the uniform random distribution with
+            # a weighting scheme with moderate chance.  Cutoff at 2**24 so that
+            # our choice of unicode characters is uniform but the 32bit
+            # distribution is not.  The window is placed around ``center``
+            # rather than at ``lower``, so we don't bias toward the lower bound.
             idx = INT_SIZES_SAMPLER.sample(self._cd)
             cap_bits = min(bits, INT_SIZES[idx])
-            upper = min(upper, lower + 2**cap_bits - 1)
-            return self._random.randint(lower, upper)
+            window = 1 << cap_bits
+            half = window >> 1
+            new_lower = max(lower, center - half)
+            new_upper = min(upper, center + half - 1)
+            if new_lower == lower:
+                new_upper = min(upper, new_lower + window - 1)
+            elif new_upper == upper:
+                new_lower = max(lower, new_upper - window + 1)
+            return self._random.randint(new_lower, new_upper)
 
         return self._random.randint(lower, upper)
 

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -56,7 +56,6 @@ def test_large_symmetric_bounded_integers_are_symmetric_issue_4624_regression():
     ), f"Expected roughly symmetric distribution, got {negatives}/{len(values)} negative"
 
 
-@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_can_find_small_magnitude_in_large_bounded_range_issue_4722_regression():
     # See https://github.com/HypothesisWorks/hypothesis/issues/4722 - small
     # magnitude values should be reachable in large bounded ranges, just as
@@ -64,7 +63,6 @@ def test_can_find_small_magnitude_in_large_bounded_range_issue_4722_regression()
     find(st.integers(-(2**63), 2**63), lambda x: 10 < abs(x) < 10000)
 
 
-@xfail_on_crosshair(Why.symbolic_outside_context)
 def test_large_bounded_range_can_generate_small_values_issue_4722_regression():
     # We should be able to generate values with small absolute magnitude in a
     # very large bounded range.

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -8,9 +8,10 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from hypothesis import given, settings
+from hypothesis import find, given, settings, strategies as st
 from hypothesis.strategies import integers
 
+from tests.common.debug import find_any
 from tests.common.utils import Why, xfail_on_crosshair
 
 
@@ -31,3 +32,40 @@ def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():
     huge = sum(x > 1e97 for x in values)
     assert huge != 0 or len(values) < 800
     assert huge <= 0.5 * len(values)  # expected ~1/8
+
+
+@xfail_on_crosshair(Why.symbolic_outside_context)
+def test_large_symmetric_bounded_integers_are_symmetric_issue_4624_regression():
+    # See https://github.com/HypothesisWorks/hypothesis/issues/4624 - we used to
+    # cap large bounded ranges to ``[lower, lower + 2**cap_bits - 1]``, which
+    # heavily biased the distribution towards the lower bound.
+    values = []
+
+    @settings(database=None, max_examples=2000)
+    @given(integers(-(2**63), 2**63))
+    def test(x):
+        values.append(x)
+
+    test()
+
+    negatives = sum(1 for v in values if v < 0)
+    # We expect roughly 50% negative values; allow generous slack for noise.
+    # Pre-fix, this was around 80%.
+    assert (
+        0.3 * len(values) < negatives < 0.7 * len(values)
+    ), f"Expected roughly symmetric distribution, got {negatives}/{len(values)} negative"
+
+
+@xfail_on_crosshair(Why.symbolic_outside_context)
+def test_can_find_small_magnitude_in_large_bounded_range_issue_4722_regression():
+    # See https://github.com/HypothesisWorks/hypothesis/issues/4722 - small
+    # magnitude values should be reachable in large bounded ranges, just as
+    # they are in unbounded ranges.
+    find(st.integers(-(2**63), 2**63), lambda x: 10 < abs(x) < 10000)
+
+
+@xfail_on_crosshair(Why.symbolic_outside_context)
+def test_large_bounded_range_can_generate_small_values_issue_4722_regression():
+    # We should be able to generate values with small absolute magnitude in a
+    # very large bounded range.
+    find_any(st.integers(-(2**63), 2**63), lambda x: abs(x) < 1000)


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/4624 and https://github.com/HypothesisWorks/hypothesis/issues/4722.

(Totally AI generated but I have reviewed the code and believe it to be sensible)

pyodide failure is unrelated. See #4724 

<!-- Human-provided description goes here. -->

<details>
<summary>Implementation details</summary>

## Summary
- Replaces the lower-bound-anchored bit-width cap in `_draw_bounded_integer` with a window centred on `shrink_towards` (clamped into `[lower, upper]`), so wide bounded ranges no longer bias toward `lower`.
- Adds regression tests for #4624 (symmetric distribution on `integers(-2**63, 2**63)`) and #4722 (`find` reaches small-magnitude values in large bounded ranges).
- Adds a patch `RELEASE.rst`.

Fixes the asymmetry reported in #4624 and the unreachable-small-values behaviour in #4722.

## Test plan
- [ ] `./build.sh check-coverage`
- [ ] `pytest hypothesis-python/tests/nocover/test_integer_ranges.py hypothesis-python/tests/quality/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>