### PR TITLE
Fix pyodide build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,7 +254,7 @@ jobs:
       # Note that the versions below are updated by `update_pyodide_versions()` in our weekly cronjob.
       # The versions of pyodide-build and the Pyodide runtime may differ.
       PYODIDE_VERSION: 0.29.3
-      PYODIDE_BUILD_VERSION: 0.34.1
+      PYODIDE_BUILD_VERSION: 0.34.3
       # pyodide 0.29.0 (latest at time of writing) doesn't yet support 3.14
       PYTHON_VERSION: 3.13.2
     steps:


### PR DESCRIPTION
pyodide builds were failing on main after a recent dependency bump. This fixes them.

<details>
<summary>Diagnosis and fix details (AI-generated)</summary>

The `test-pyodide` job on master started failing in https://github.com/HypothesisWorks/hypothesis/actions/runs/25016634890/job/73266562805 with:

```
File ".venv-pyodide/lib/python3.13/site-packages/pip/_vendor/urllib3/__init__.py", line 209, in <module>
    from .contrib.emscripten import inject_into_urllib3  # noqa: 401
...
File ".venv-pyodide/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/emscripten/fetch.py", line 45, in <module>
    import js  # type: ignore[import-not-found]
ModuleNotFoundError: No module named 'js'
```

What changed: between the previous successful run and this one, a new `virtualenv` (21.3.0) was released that bundles pip 26.1, whose vendored urllib3 (>= 2.6) now imports its emscripten contrib whenever `sys.platform == "emscripten"`. `pyodide venv` deliberately sets `sys.platform = "emscripten"` in the pip wrapper before importing pip, so urllib3 takes the emscripten branch and `import js` fails on the host CPython.

This was fixed upstream in pyodide-build 0.34.2 (pyodide/pyodide-build#341 — "Pyodide venv: Import urllib3 before patching sys.platform"). Bumping `PYODIDE_BUILD_VERSION` from 0.34.1 to 0.34.3 (latest) picks up the fix.

`PYODIDE_VERSION` (the runtime, 0.29.3) is unchanged and still compatible with pyodide-build 0.34.3.
</details>