### PR TITLE
Shrink generated text via unicode normalization

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch adds a shrinking pass that tries natural text transformations -
+unicode decomposition (NFD/NFKD) and case mapping - on individual
+characters in string choices.  Failures involving e.g. ``"À" != "À".lower()``
+will now reliably shrink to ``"A"`` rather than sometimes getting stuck on
+the high-codepoint accented form (:issue:`4725`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
+import unicodedata
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -87,6 +88,46 @@ def sort_key(nodes: Sequence[ChoiceNode]) -> tuple[int, tuple[int, ...]]:
         len(nodes),
         tuple(choice_to_index(node.value, node.constraints) for node in nodes),
     )
+
+
+def _natural_simpler_chars(c, intervals):
+    """Return single-char replacements for ``c`` derived from natural text
+    transformations - case mapping (upper, lower, casefold) and unicode
+    decomposition (NFD, NFKD - taking just the base character).
+
+    Only candidates which are in ``intervals`` and which have a strictly
+    smaller index in shrink order than ``c`` are returned, sorted by that
+    shrink-order index.
+    """
+    if len(c) != 1:
+        return []
+    candidates = set()
+    for transformed in (c.upper(), c.lower(), c.casefold()):
+        if len(transformed) == 1:
+            candidates.add(transformed)
+    for form in ("NFKD", "NFD"):
+        decomp = unicodedata.normalize(form, c)
+        if decomp:
+            candidates.add(decomp[0])
+    candidates.discard(c)
+    if not candidates:
+        return []
+    try:
+        original_idx = intervals.index_from_char_in_shrink_order(c)
+    except ValueError:
+        return []
+    result = []
+    for cand in candidates:
+        if cand not in intervals:
+            continue
+        try:
+            cand_idx = intervals.index_from_char_in_shrink_order(cand)
+        except ValueError:
+            continue
+        if cand_idx < original_idx:
+            result.append((cand_idx, cand))
+    result.sort()
+    return [c for _, c in result]
 
 
 @dataclass(slots=True, frozen=False)
@@ -321,6 +362,7 @@ class Shrinker:
             ShrinkPass(self.redistribute_numeric_pairs),
             ShrinkPass(self.lower_integers_together),
             ShrinkPass(self.lower_duplicated_characters),
+            ShrinkPass(self.normalize_unicode_chars),
         ]
 
         # Because the shrinker is also used to `pareto_optimise` in the target phase,
@@ -1506,6 +1548,42 @@ class Shrinker:
                 + self.nodes[node2.index + 1 :]
             ),
         )
+
+    def normalize_unicode_chars(self, chooser):
+        """For string nodes, try replacing characters with simpler equivalents
+        from natural text transformations: unicode decomposition (NFD, NFKD)
+        and case mapping. For example, an accented latin letter is reduced
+        to its base form, a ligature is reduced to its first base character,
+        a mathematical alphanumeric symbol is reduced to its plain ascii
+        counterpart, and a lowercase letter is replaced with its uppercase
+        form (which has a smaller shrink-order index in the default
+        alphabet).
+
+        The codepoint shrinker is binary-search based, so it can get stuck on
+        a high codepoint whose simpler equivalents aren't reached by halving
+        / shifting / masking. This pass directly tries the natural simpler
+        forms one character at a time.
+        """
+        node = chooser.choose(
+            self.nodes,
+            lambda n: n.type == "string"
+            and any(
+                _natural_simpler_chars(c, n.constraints["intervals"]) for c in n.value
+            ),
+        )
+        intervals = node.constraints["intervals"]
+        i = chooser.choose(
+            range(len(node.value)),
+            lambda j: bool(_natural_simpler_chars(node.value[j], intervals)),
+        )
+        for replacement in _natural_simpler_chars(node.value[i], intervals):
+            new_value = node.value[:i] + replacement + node.value[i + 1 :]
+            if self.consider_new_nodes(
+                self.nodes[: node.index]
+                + (node.copy(with_value=new_value),)
+                + self.nodes[node.index + 1 :]
+            ):
+                return
 
     def minimize_nodes(self, nodes):
         choice_type = nodes[0].type

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -97,37 +97,21 @@ def _natural_simpler_chars(c, intervals):
 
     Only candidates which are in ``intervals`` and which have a strictly
     smaller index in shrink order than ``c`` are returned, sorted by that
-    shrink-order index.
+    shrink-order index. Callers must pass a single character that is itself
+    in ``intervals``.
     """
-    if len(c) != 1:
-        return []
-    candidates = set()
+    candidates = {unicodedata.normalize(form, c)[0] for form in ("NFKD", "NFD")}
     for transformed in (c.upper(), c.lower(), c.casefold()):
         if len(transformed) == 1:
             candidates.add(transformed)
-    for form in ("NFKD", "NFD"):
-        decomp = unicodedata.normalize(form, c)
-        if decomp:
-            candidates.add(decomp[0])
     candidates.discard(c)
-    if not candidates:
-        return []
-    try:
-        original_idx = intervals.index_from_char_in_shrink_order(c)
-    except ValueError:
-        return []
-    result = []
-    for cand in candidates:
-        if cand not in intervals:
-            continue
-        try:
-            cand_idx = intervals.index_from_char_in_shrink_order(cand)
-        except ValueError:
-            continue
-        if cand_idx < original_idx:
-            result.append((cand_idx, cand))
-    result.sort()
-    return [c for _, c in result]
+    original_idx = intervals.index_from_char_in_shrink_order(c)
+    result = sorted(
+        (intervals.index_from_char_in_shrink_order(cand), cand)
+        for cand in candidates
+        if cand in intervals
+    )
+    return [cand for idx, cand in result if idx < original_idx]
 
 
 @dataclass(slots=True, frozen=False)

--- a/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/shrinker.py
@@ -13,6 +13,7 @@ import unicodedata
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -90,20 +91,24 @@ def sort_key(nodes: Sequence[ChoiceNode]) -> tuple[int, tuple[int, ...]]:
     )
 
 
+@lru_cache(maxsize=4096)
 def _natural_simpler_chars(c, intervals):
     """Return single-char replacements for ``c`` derived from natural text
     transformations - case mapping (upper, lower, casefold) and unicode
-    decomposition (NFD, NFKD - taking just the base character).
+    decomposition (NFD, NFKD). We take each individual character of the
+    transformed form so that e.g. ``ß`` can shrink to ``s`` via casefold
+    even though the full case-folded form is two characters.
 
     Only candidates which are in ``intervals`` and which have a strictly
     smaller index in shrink order than ``c`` are returned, sorted by that
     shrink-order index. Callers must pass a single character that is itself
     in ``intervals``.
     """
-    candidates = {unicodedata.normalize(form, c)[0] for form in ("NFKD", "NFD")}
+    candidates: set[str] = set()
+    for form in ("NFKD", "NFD"):
+        candidates.update(unicodedata.normalize(form, c))
     for transformed in (c.upper(), c.lower(), c.casefold()):
-        if len(transformed) == 1:
-            candidates.add(transformed)
+        candidates.update(transformed)
     candidates.discard(c)
     original_idx = intervals.index_from_char_in_shrink_order(c)
     result = sorted(

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -804,6 +804,10 @@ def test_redistribute_numeric_pairs_shrink_towards_integer(
         ("Ｂ", "B"),
         # Ligatures decompose to their first base char under NFKD.
         ("ﬁ", "f"),
+        # Case mapping that produces multiple chars: ``ß.casefold() == "ss"``,
+        # and we accept any of the individual characters of the case-mapped
+        # form as a single-char replacement.
+        ("ß", "s"),
         # Case mapping: uppercase has a smaller shrink-order index than
         # lowercase, so we can swap a→A.
         ("a", "A"),

--- a/hypothesis-python/tests/conjecture/test_shrinker.py
+++ b/hypothesis-python/tests/conjecture/test_shrinker.py
@@ -787,3 +787,70 @@ def test_redistribute_numeric_pairs_shrink_towards_integer(
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.redistribute_numeric_pairs)])
     assert shrinker.choices == (shrink_towards, target - shrink_towards)
+
+
+@pytest.mark.parametrize(
+    "start, expected",
+    [
+        # NFKD decomposition + drop combining: latin letters with diacritics.
+        ("À", "A"),
+        ("é", "e"),
+        ("Ñ", "N"),
+        # Compatibility decomposition: superscripts, mathematical alphabets,
+        # circled forms, fullwidth.
+        ("²", "2"),
+        ("𝕿", "T"),
+        ("Ⓐ", "A"),
+        ("Ｂ", "B"),
+        # Ligatures decompose to their first base char under NFKD.
+        ("ﬁ", "f"),
+        # Case mapping: uppercase has a smaller shrink-order index than
+        # lowercase, so we can swap a→A.
+        ("a", "A"),
+        # Multi-character: the pass operates one character at a time, so a
+        # mixed string should reduce each accented char independently.
+        ("Àé", "Ae"),
+    ],
+)
+def test_normalize_unicode_chars_pass(start, expected):
+    @shrinking_from([start])
+    def shrinker(data: ConjectureData):
+        s = data.draw(st.text(min_size=1))
+        # Accept any string where each character is either the original or the
+        # natural-simpler replacement at that position. The pass replaces
+        # characters one at a time, so it must be able to reach `expected` via
+        # a sequence of single-character substitutions.
+        if len(s) == len(start) and all(
+            c in (sc, ec) for c, sc, ec in zip(s, start, expected, strict=True)
+        ):
+            data.mark_interesting(interesting_origin())
+
+    shrinker.fixate_shrink_passes([ShrinkPass(shrinker.normalize_unicode_chars)])
+    assert shrinker.choices == (expected,)
+
+
+def test_normalize_unicode_chars_respects_intervals():
+    # When the strategy's allowed alphabet excludes the simpler ascii form,
+    # the pass must not produce out-of-alphabet replacements. A range that
+    # contains 'À' but not 'A' should leave 'À' alone.
+    alphabet = st.characters(min_codepoint=0xC0, max_codepoint=0xFF)
+
+    @shrinking_from(["À"])
+    def shrinker(data: ConjectureData):
+        data.draw(st.text(min_size=1, alphabet=alphabet))
+        data.mark_interesting(interesting_origin())
+
+    shrinker.fixate_shrink_passes([ShrinkPass(shrinker.normalize_unicode_chars)])
+    assert shrinker.choices == ("À",)
+
+
+def test_normalize_unicode_chars_skips_when_no_simplification():
+    # Plain ascii 'A' has no natural simplification (it is already a base
+    # uppercase letter), so the pass should leave it untouched.
+    @shrinking_from(["A"])
+    def shrinker(data: ConjectureData):
+        data.draw(st.text(min_size=1))
+        data.mark_interesting(interesting_origin())
+
+    shrinker.fixate_shrink_passes([ShrinkPass(shrinker.normalize_unicode_chars)])
+    assert shrinker.choices == ("A",)

--- a/hypothesis-python/tests/quality/test_shrink_quality.py
+++ b/hypothesis-python/tests/quality/test_shrink_quality.py
@@ -539,6 +539,40 @@ def test_nasty_string_shrinks():
     )
 
 
+def test_shrink_text_differs_from_lower_to_ascii():
+    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/4725
+    # Text shrinking would previously sometimes get stuck on a high-codepoint
+    # accented letter such as 'À' instead of converging to 'A'.
+    assert minimal(st.text(min_size=1), lambda s: s != s.lower()) == "A"
+
+
+def test_shrink_text_differs_from_upper_to_ascii():
+    assert minimal(st.text(min_size=1), lambda s: s != s.upper()) == "a"
+
+
+def test_shrink_strips_accent_to_ascii_letter():
+    # Removing the accent from any accented latin letter should shrink that
+    # letter to its base ascii form.
+    assert minimal(st.text(min_size=1), lambda s: "e" in s.lower() or "E" in s) == "E"
+
+
+def test_shrink_decomposes_compatibility_form_to_ascii():
+    # A character that NFKD-decomposes to an ascii letter (eg a Mathematical
+    # Bold Capital T, or a ligature) should reduce to that base letter when
+    # the predicate also matches the base letter.
+    assert (
+        minimal(st.text(min_size=1), lambda s: any(c.lower() == "t" for c in s)) == "T"
+    )
+
+
+def test_shrink_ligature_to_base_character():
+    # The ligature ﬁ NFKD-decomposes to "fi"; when the predicate accepts any
+    # 'f' character, we should reduce to plain "F".
+    assert (
+        minimal(st.text(min_size=1), lambda s: any(c.lower() == "f" for c in s)) == "F"
+    )
+
+
 def test_bound5():
     # redistribute_numeric_pairs should work for negative integers too
     bounded_ints = st.lists(st.integers(-100, 0), max_size=1)


### PR DESCRIPTION
Fixes #4725

<details>
<summary>Implementation notes</summary>

Adds a `normalize_unicode_chars` shrink pass that walks each character of every string choice and tries replacing it with a "natural" simpler equivalent: NFD/NFKD base character, or case-mapped (`upper`/`lower`/`casefold`) form. Candidates are filtered to those that are (a) single characters, (b) inside the choice's `IntervalSet`, and (c) strictly smaller in the alphabet's shrink-order index than the original.

This sidesteps the Integer-shrinker getting stuck on a high-codepoint character whose simpler ASCII equivalent isn't reached by halving / shifting / masking — `find(text(min_size=1), lambda a: a != a.lower())` previously got stuck on `À` ~50% of the time and now reliably converges to `A`.

The pass operates one character at a time, so a string like `Àé` is reduced via `Aé → AE` (each character independently); strings that need a multi-character expansion (e.g. `ß → ss`) are out of scope because such a transition increases the choice's shrink-order index and is rejected by the framework.

### Tests

- `tests/conjecture/test_shrinker.py`: 12 direct shrink-pass tests covering NFKD-decomposable accented letters, compatibility forms (`²`, mathematical alphabets, circled, fullwidth), ligatures, case mapping, multi-character strings, restricted alphabets, and the no-op case.
- `tests/quality/test_shrink_quality.py`: 5 end-to-end `minimal()` tests for the issue's example and related case/decomposition predicates.

</details>