### PR TITLE
Implement new integers distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,16 @@
 .DS_Store
 .hypothesis
 .vscode/
-.claude/settings.local.json
 CLAUDE.local.md
+
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
+!.claude/commands/
+.claude/commands/*
+!.claude/commands/hypothesis.md
 
 # generic build components
 

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release substantially improves our internal distribution for generating integers. This release has the most visible effect on |st.integers|, but may incidentally improve other strategies which draw integers internally.
+
+Our integers distribution had two problems. First, it had jagged discontinuities at certain values where we switched sampling approaches. Second, it used a different distribution for bounded and unbounded ranges, which resulted in ``st.integers()`` and ``st.integers(-2**64, 2**64)`` producing very different distributions despite being semantically similar.
+
+We now use a smooth distribution for both ``st.integers()`` and ``st.integers(a, b)``, which fixes both of these issues. This should substantially improve our testing power in certain cases.
+
+The only way this release should be user-visible is that it finds more bugs! If this release is user-visible in other ways - for example, because it is slower, or produces a worse distribution in some cases - please open an issue.

--- a/hypothesis-python/scripts/other-tests.sh
+++ b/hypothesis-python/scripts/other-tests.sh
@@ -29,6 +29,10 @@ pip install attrs
 $PYTEST tests/attrs/
 pip uninstall -y attrs
 
+pip install scipy
+$PYTEST tests/scipy/
+pip uninstall -y scipy
+
 # use pinned redis version instead of inheriting from fakeredis
 pip install "$(grep '^redis==' ../requirements/coverage.txt)"
 pip install "$(grep 'fakeredis==' ../requirements/coverage.txt)"

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -903,10 +903,11 @@ class HypothesisProvider(PrimitiveProvider):
             except OverflowError:
                 safe_bounds = False
 
-        if min_value is not None:
+        if safe_bounds and min_value is not None:
             lo = dist.cdf(cdf_min)
-        if max_value is not None:
+        if safe_bounds and max_value is not None:
             hi = dist.cdf(cdf_max)
+
         # if the bounds in CDF-space are too close together, there isn't enough room to
         # stably sample between hi and lo. For example, in the extreme case of hi = lo
         # (which can happen even if min_value != max_value due to either float imprecision
@@ -914,13 +915,14 @@ class HypothesisProvider(PrimitiveProvider):
         # the sample value.
         #
         # The choice of 1e-13 here is somewhat arbitrary. At 1.0, epsilon in float64 is
-        # 2^53 ~= 1e16. We want some breathing room from epsilon, because we need some
+        # 2^-53 ~= 1e-16. We want some breathing room from epsilon, because we need some
         # variation to actually sample in. I haven't put much thought into where the
         # correct tradeoff lies. The downside risk to choosing a too-aggressive bound is
         # some integers may literally not be representable in the `hi - lo` sampling space.
         # The downside risk to a too-conservative bound is switching off our good distribution
         # too early.
-        safe_bounds = hi - lo >= 1e-13
+        if safe_bounds and hi - lo < 1e-13:
+            safe_bounds = False
 
         if safe_bounds:
             n = round(dist.inverse_cdf(lo + self._random.random() * (hi - lo)))
@@ -943,7 +945,12 @@ class HypothesisProvider(PrimitiveProvider):
             # dist.inverse_cdf(0.5) = 0, we can sample from the appropriate half and then
             # apply the right sign.
             offset = round(dist.inverse_cdf(0.5 + 0.5 * self._random.random()))
-            return min_value + offset if min_value is not None else max_value - offset
+            # written slightly weirdly so we can add an assert to help mypy
+            if min_value is not None:
+                return min_value + offset
+            else:
+                assert max_value is not None
+                return max_value - offset
 
     def draw_float(
         self,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -55,6 +55,7 @@ from hypothesis.internal.constants_ast import (
 )
 from hypothesis.internal.floats import (
     SIGNALING_NAN,
+    clamp,
     float_to_int,
     make_float_clamper,
     next_down,
@@ -885,44 +886,56 @@ class HypothesisProvider(PrimitiveProvider):
         self, min_value: int | None, max_value: int | None
     ) -> int:
         assert self._random is not None
-
         dist = INTEGERS_DISTRIBUTION
+
+        # Our integers distribution is defined over the full float64 range. If the user
+        # has not placed a lower and/or upper bound, we don't actually want to sample
+        # from this full range, because we might otherwise generate integers
+        # that are so large as to cause problems. For example python errors when passing
+        # a too-large integer to c APIs (common and implicit in some python stdlib APIs).
+        #
+        # * If the user asks for an unbounded range, we bound at [-2**128, 2**128].
+        # * If the user asks for a half-bounded range starting at n, we bound at
+        #   [n, 2**128] for n < 2**127, and [n, 2n] otherwise, so we always support
+        #   generating large integers if a user explicitly asks for integers around that
+        #   magnitude. The choice of a factor of two here is arbitrary.
+        if min_value is None and max_value is None:
+            min_value = -(2**128)
+            max_value = 2**128
+        elif min_value is None:
+            assert max_value is not None
+            min_value = -max(2**128, 2 * abs(max_value))
+        elif max_value is None:
+            max_value = max(2**128, 2 * abs(min_value))
+
         lo = 0.0
         hi = 1.0
         safe_bounds = True
+        try:
+            cdf_min = min_value - 0.5
+            cdf_max = max_value + 0.5
+        except OverflowError:
+            safe_bounds = False
 
-        if min_value is not None:
-            try:
-                cdf_min = min_value - 0.5
-            except OverflowError:
-                safe_bounds = False
-
-        if max_value is not None:
-            try:
-                cdf_max = max_value + 0.5
-            except OverflowError:
-                safe_bounds = False
-
-        if safe_bounds and min_value is not None:
+        if safe_bounds:
             lo = dist.cdf(cdf_min)
-        if safe_bounds and max_value is not None:
             hi = dist.cdf(cdf_max)
 
-        # if the bounds in CDF-space are too close together, there isn't enough room to
-        # stably sample between hi and lo. For example, in the extreme case of hi = lo
-        # (which can happen even if min_value != max_value due to either float imprecision
-        # or numerical instability), our sampling algorithm would collapse to always return
-        # the sample value.
-        #
-        # The choice of 1e-13 here is somewhat arbitrary. At 1.0, epsilon in float64 is
-        # 2^-53 ~= 1e-16. We want some breathing room from epsilon, because we need some
-        # variation to actually sample in. I haven't put much thought into where the
-        # correct tradeoff lies. The downside risk to choosing a too-aggressive bound is
-        # some integers may literally not be representable in the `hi - lo` sampling space.
-        # The downside risk to a too-conservative bound is switching off our good distribution
-        # too early.
-        if safe_bounds and hi - lo < 1e-13:
-            safe_bounds = False
+            # if the bounds in CDF-space are too close together, there isn't enough room
+            # to stably sample between hi and lo. For example, in the extreme case of
+            # hi = lo (which can happen even if min_value != max_value due to either float
+            # imprecision or numerical instability), our sampling algorithm would collapse
+            # to always return the sample value.
+            #
+            # The choice of 1e-13 here is somewhat arbitrary. At 1.0, epsilon in float64
+            # is 2^-53 ~= 1e-16. We want some breathing room from epsilon, because we need
+            # some variation to actually sample in. I haven't put much thought into where
+            # the correct tradeoff lies. The downside risk to choosing a too-aggressive
+            # bound is some integers may literally not be representable in the `hi - lo`
+            # sampling space. The downside risk to a too-conservative bound is switching
+            # off our good distribution too early.
+            if hi - lo < 1e-13:
+                safe_bounds = False
 
         if safe_bounds:
             # inverse_cdf requires strictly 0 < p < 1. Resample until we get it.
@@ -932,31 +945,13 @@ class HypothesisProvider(PrimitiveProvider):
             # As an extra measure of safety, clamp our generated value to the requested
             # range. It would of course be nice if we provably satisfied this by
             # construction - I'm just not 100% confident that we do.
-            if min_value is not None and n < min_value:
-                n = min_value
-            if max_value is not None and n > max_value:
-                n = max_value
+            n = clamp(min_value, n, max_value)
             return n
 
         # We have determined the bounds [min_value, max_value] are not numerically safe
-        # to use. Fall back to a simpler and safer distribution.
-        #
-        # * For bounded ranges: sample from the uniform distribution on [min_value, max_value].
-        # * For half-bounded ranges: sample from our unbounded integer distribution,
-        #   treating the drawn value as an offset from the bound.
-        if min_value is not None and max_value is not None:
-            return self._random.randint(min_value, max_value)
-        else:
-            # note that `dist` is guaranteed to be symmetric around 0. Since this implies
-            # dist.inverse_cdf(0.5) = 0, we can sample from the appropriate half and then
-            # apply the right sign.
-            offset = round(dist.inverse_cdf(0.5 + 0.5 * self._random.random()))
-            # written slightly weirdly so we can add an assert to help mypy
-            if min_value is not None:
-                return min_value + offset
-            else:
-                assert max_value is not None
-                return max_value - offset
+        # to use. Fall back to a simpler and safer distribution: a uniform distribution
+        # on [min_value, max_value].
+        return self._random.randint(min_value, max_value)
 
     def draw_float(
         self,

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -925,7 +925,13 @@ class HypothesisProvider(PrimitiveProvider):
             safe_bounds = False
 
         if safe_bounds:
-            n = round(dist.inverse_cdf(lo + self._random.random() * (hi - lo)))
+            # inverse_cdf requires strictly 0 < p < 1. Resample until we get it.
+            while (p := lo + self._random.random() * (hi - lo)) in {0, 1}:
+                pass
+            n = round(dist.inverse_cdf(p))
+            # As an extra measure of safety, clamp our generated value to the requested
+            # range. It would of course be nice if we provably satisfied this by
+            # construction - I'm just not 100% confident that we do.
             if min_value is not None and n < min_value:
                 n = min_value
             if max_value is not None and n > max_value:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -45,8 +45,6 @@ from hypothesis.internal.conjecture.choice import (
 from hypothesis.internal.conjecture.floats import lex_to_float
 from hypothesis.internal.conjecture.junkdrawer import bits_to_bytes
 from hypothesis.internal.conjecture.utils import (
-    INT_SIZES,
-    INT_SIZES_SAMPLER,
     Sampler,
     many,
 )
@@ -64,6 +62,11 @@ from hypothesis.internal.floats import (
 )
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.internal.observability import InfoObservationType, TestCaseObservation
+from hypothesis.internal.statistics import (
+    LogStudentTDistribution,
+    PiecewiseDistribution,
+    UniformDistribution,
+)
 
 if TYPE_CHECKING:
     from hypothesis.internal.conjecture.data import ConjectureData
@@ -72,6 +75,13 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 LifetimeT: TypeAlias = Literal["test_case", "test_function"]
 COLLECTION_DEFAULT_MAX_SIZE = 10**10  # "arbitrarily large"
+
+# see https://github.com/HypothesisWorks/hypothesis/pull/4728 for details
+INTEGERS_DISTRIBUTION = PiecewiseDistribution(
+    inner=UniformDistribution(half_width=256),
+    outer=LogStudentTDistribution(scale_bits=13, df=2),
+    switchover=256,
+)
 
 
 #: Registered Hypothesis backends. This is a dictionary where keys are the name
@@ -845,12 +855,6 @@ class HypothesisProvider(PrimitiveProvider):
             assert isinstance(constant, int)
             return constant
 
-        center = 0
-        if min_value is not None:
-            center = max(min_value, center)
-        if max_value is not None:
-            center = min(max_value, center)
-
         if weights is not None:
             assert min_value is not None
             assert max_value is not None
@@ -871,28 +875,75 @@ class HypothesisProvider(PrimitiveProvider):
             idx = sampler.sample(self._cd)
 
             if idx == 0:
-                return self._draw_bounded_integer(min_value, max_value)
+                return self._draw_integer_from_distribution(min_value, max_value)
             # implicit reliance on dicts being sorted for determinism
             return list(weights)[idx - 1]
 
-        if min_value is None and max_value is None:
-            return self._draw_unbounded_integer()
+        return self._draw_integer_from_distribution(min_value, max_value)
 
-        if min_value is None:
-            assert max_value is not None
-            probe = max_value + 1
-            while max_value < probe:
-                probe = center + self._draw_unbounded_integer()
-            return probe
+    def _draw_integer_from_distribution(
+        self, min_value: int | None, max_value: int | None
+    ) -> int:
+        assert self._random is not None
 
-        if max_value is None:
-            assert min_value is not None
-            probe = min_value - 1
-            while probe < min_value:
-                probe = center + self._draw_unbounded_integer()
-            return probe
+        dist = INTEGERS_DISTRIBUTION
+        lo = 0.0
+        hi = 1.0
+        safe_bounds = True
 
-        return self._draw_bounded_integer(min_value, max_value)
+        if min_value is not None:
+            try:
+                cdf_min = min_value - 0.5
+            except OverflowError:
+                safe_bounds = False
+
+        if max_value is not None:
+            try:
+                cdf_max = max_value + 0.5
+            except OverflowError:
+                safe_bounds = False
+
+        if min_value is not None:
+            lo = dist.cdf(cdf_min)
+        if max_value is not None:
+            hi = dist.cdf(cdf_max)
+        # if the bounds in CDF-space are too close together, there isn't enough room to
+        # stably sample between hi and lo. For example, in the extreme case of hi = lo
+        # (which can happen even if min_value != max_value due to either float imprecision
+        # or numerical instability), our sampling algorithm would collapse to always return
+        # the sample value.
+        #
+        # The choice of 1e-13 here is somewhat arbitrary. At 1.0, epsilon in float64 is
+        # 2^53 ~= 1e16. We want some breathing room from epsilon, because we need some
+        # variation to actually sample in. I haven't put much thought into where the
+        # correct tradeoff lies. The downside risk to choosing a too-aggressive bound is
+        # some integers may literally not be representable in the `hi - lo` sampling space.
+        # The downside risk to a too-conservative bound is switching off our good distribution
+        # too early.
+        safe_bounds = hi - lo >= 1e-13
+
+        if safe_bounds:
+            n = round(dist.inverse_cdf(lo + self._random.random() * (hi - lo)))
+            if min_value is not None and n < min_value:
+                n = min_value
+            if max_value is not None and n > max_value:
+                n = max_value
+            return n
+
+        # We have determined the bounds [min_value, max_value] are not numerically safe
+        # to use. Fall back to a simpler and safer distribution.
+        #
+        # * For bounded ranges: sample from the uniform distribution on [min_value, max_value].
+        # * For half-bounded ranges: sample from our unbounded integer distribution,
+        #   treating the drawn value as an offset from the bound.
+        if min_value is not None and max_value is not None:
+            return self._random.randint(min_value, max_value)
+        else:
+            # note that `dist` is guaranteed to be symmetric around 0. Since this implies
+            # dist.inverse_cdf(0.5) = 0, we can sample from the appropriate half and then
+            # apply the right sign.
+            offset = round(dist.inverse_cdf(0.5 + 0.5 * self._random.random()))
+            return min_value + offset if min_value is not None else max_value - offset
 
     def draw_float(
         self,
@@ -1047,45 +1098,6 @@ class HypothesisProvider(PrimitiveProvider):
         f = lex_to_float(self._random.getrandbits(64))
         sign = 1 if self._random.getrandbits(1) else -1
         return sign * f
-
-    def _draw_unbounded_integer(self) -> int:
-        assert self._cd is not None
-        assert self._random is not None
-
-        size = INT_SIZES[INT_SIZES_SAMPLER.sample(self._cd)]
-
-        r = self._random.getrandbits(size)
-        sign = r & 1
-        r >>= 1
-        if sign:
-            r = -r
-        return r
-
-    def _draw_bounded_integer(
-        self,
-        lower: int,
-        upper: int,
-        *,
-        vary_size: bool = True,
-    ) -> int:
-        assert lower <= upper
-        assert self._cd is not None
-        assert self._random is not None
-
-        if lower == upper:
-            return lower
-
-        bits = (upper - lower).bit_length()
-        if bits > 24 and vary_size and self._random.random() < 7 / 8:
-            # For large ranges, we combine the uniform random distribution
-            # with a weighting scheme with moderate chance.  Cutoff at 2 ** 24 so that our
-            # choice of unicode characters is uniform but the 32bit distribution is not.
-            idx = INT_SIZES_SAMPLER.sample(self._cd)
-            cap_bits = min(bits, INT_SIZES[idx])
-            upper = min(upper, lower + 2**cap_bits - 1)
-            return self._random.randint(lower, upper)
-
-        return self._random.randint(lower, upper)
 
 
 # Masks for masking off the first byte of an n-bit buffer.

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -945,8 +945,7 @@ class HypothesisProvider(PrimitiveProvider):
             # As an extra measure of safety, clamp our generated value to the requested
             # range. It would of course be nice if we provably satisfied this by
             # construction - I'm just not 100% confident that we do.
-            n = clamp(min_value, n, max_value)
-            return n
+            return clamp(min_value, n, max_value)
 
         # We have determined the bounds [min_value, max_value] are not numerically safe
         # to use. Fall back to a simpler and safer distribution: a uniform distribution

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -940,7 +940,7 @@ class HypothesisProvider(PrimitiveProvider):
         if safe_bounds:
             # inverse_cdf requires strictly 0 < p < 1. Resample until we get it.
             while (p := lo + self._random.random() * (hi - lo)) in {0, 1}:
-                pass
+                pass  # pragma: no cover
             n = round(dist.inverse_cdf(p))
             # As an extra measure of safety, clamp our generated value to the requested
             # range. It would of course be nice if we provably satisfied this by

--- a/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/utils.py
@@ -245,10 +245,6 @@ class Sampler:
             return base
 
 
-INT_SIZES = (8, 16, 32, 64, 128)
-INT_SIZES_SAMPLER = Sampler((4.0, 8.0, 1.0, 1.0, 0.5), observe=False)
-
-
 class many:
     """Utility class for collections. Bundles up the logic we use for "should I
     keep drawing more values?" and handles starting and stopping examples in

--- a/hypothesis-python/src/hypothesis/internal/floats.py
+++ b/hypothesis-python/src/hypothesis/internal/floats.py
@@ -12,7 +12,7 @@ import math
 import struct
 from collections.abc import Callable
 from sys import float_info
-from typing import Literal, SupportsFloat, TypeAlias
+from typing import Literal, SupportsFloat, TypeAlias, overload
 
 SignedIntFormat: TypeAlias = Literal["!h", "!i", "!q"]
 UnsignedIntFormat: TypeAlias = Literal["!H", "!I", "!Q"]
@@ -191,6 +191,10 @@ def sign_aware_lte(x: float | int, y: float | int) -> bool:
         return x <= y
 
 
+@overload
+def clamp(lower: int, value: int, upper: int) -> int: ...
+@overload
+def clamp(lower: float, value: float, upper: float) -> float: ...
 def clamp(lower: float | int, value: float | int, upper: float | int) -> float | int:
     """Given a value and lower/upper bounds, 'clamp' the value so that
     it satisfies lower <= value <= upper.  NaN is mapped to lower."""

--- a/hypothesis-python/src/hypothesis/internal/statistics.py
+++ b/hypothesis-python/src/hypothesis/internal/statistics.py
@@ -21,7 +21,7 @@ from hypothesis.internal.floats import clamp
 # accept this code without deeply understanding it.
 
 
-def stdtr(df: int, t: float) -> float:
+def stdtr(df: int, t: float) -> float:  # pragma: no cover  # covered by tests/scipy
     """Student's t CDF for integer df >= 1, evaluated at t.
 
     Closed-form finite sum from Abramowitz & Stegun 26.7.7-8.
@@ -60,7 +60,9 @@ def stdtr(df: int, t: float) -> float:
     return 0.5 - 0.5 * p if t < 0 else 0.5 + 0.5 * p
 
 
-def stdtrit(df: int, p: float, *, eps: float = 1e-10, max_iter: int = 50) -> float:
+def stdtrit(
+    df: int, p: float, *, eps: float = 1e-10, max_iter: int = 50
+) -> float:  # pragma: no cover  # covered by tests/scipy
     """Inverse Student's t CDF (quantile) for integer df >= 1.
 
     df ∈ {1, 2}: closed-form analytic quantile (Shaw 2006, eq 35-36).
@@ -225,11 +227,10 @@ class PiecewiseDistribution:
         # plus total mass 1; solve for (alpha, beta).
         inner_pdf = inner.pdf(switchover)
         outer_pdf = outer.pdf(switchover)
-        if inner_pdf == 0:
-            raise ValueError(
-                f"inner.pdf(switchover={switchover}) == 0; cannot density-match. inner "
-                "must have support at the boundary."
-            )
+        assert inner_pdf != 0, (
+            f"inner.pdf(switchover={switchover}) == 0; cannot density-match. inner "
+            "must have support at the boundary."
+        )
         self._alpha = 1 / (outer_pdf * inner_inner_mass / inner_pdf + outer_outer_mass)
         self._beta = self._alpha * outer_pdf / inner_pdf
         self._inner_mass = self._beta * inner_inner_mass

--- a/hypothesis-python/src/hypothesis/internal/statistics.py
+++ b/hypothesis-python/src/hypothesis/internal/statistics.py
@@ -1,0 +1,259 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import abc
+import math
+
+from hypothesis.internal.floats import clamp
+
+# Liam: please be aware that an LLM wrote the stdtr and stdtrit functions, with some
+# guidance from me on comparing to scipy's existing implementation.
+#
+# This code is strongly in-distribution for AI, and is tested against a strong
+# oracle (scipy's implementation), which are the only reasons I am willing to
+# accept this code without deeply understanding it.
+
+
+def stdtr(df: int, t: float) -> float:
+    """Student's t CDF for integer df >= 1, evaluated at t.
+
+    Closed-form finite sum from Abramowitz & Stegun 26.7.7-8.
+    """
+    assert isinstance(df, int)
+    if df < 1:
+        raise ValueError(f"stdtr requires integer df >= 1, got {df}")
+    if t == 0.0:
+        return 0.5
+    abs_t = abs(t)
+    z = 1.0 + abs_t * abs_t / df
+    if df % 2 == 1:
+        # odd: includes an arctan term
+        u = abs_t / math.sqrt(df)
+        p = math.atan(u)
+        if df > 1:
+            f = 1.0
+            tz = 1.0
+            j = 3
+            while j <= df - 2:
+                tz *= (j - 1) / (z * j)
+                f += tz
+                j += 2
+            p += f * u / z
+        p *= 2.0 / math.pi
+    else:
+        # even: simple finite sum, no arctan
+        f = 1.0
+        tz = 1.0
+        j = 2
+        while j <= df - 2:
+            tz *= (j - 1) / (z * j)
+            f += tz
+            j += 2
+        p = f * abs_t / math.sqrt(z * df)
+    return 0.5 - 0.5 * p if t < 0 else 0.5 + 0.5 * p
+
+
+def stdtrit(df: int, p: float, *, eps: float = 1e-10, max_iter: int = 50) -> float:
+    """Inverse Student's t CDF (quantile) for integer df >= 1.
+
+    df ∈ {1, 2}: closed-form analytic quantile (Shaw 2006, eq 35-36).
+
+    df >= 3: bracketed Newton iteration on stdtr — doubling search from t=1
+    to bracket the target, then Newton steps with bisection fallback. Always
+    converges; ~5-10 iterations typical.
+    """
+    if df < 1:
+        raise ValueError(f"stdtrit requires integer df >= 1, got {df}")
+    if p == 0.5:
+        return 0.0
+    if not 0.0 < p < 1.0:
+        raise ValueError(f"stdtrit requires 0 < p < 1, got {p}")
+    if df == 1:
+        # Cauchy: F^{-1}(p) = -cot(pi p). Reflect via 1-p when p > 0.5 because
+        # sin(pi p) near pi suffers cancellation; sin(pi (1-p)) near 0 is exact.
+        if p > 0.5:
+            return math.cos(math.pi * (1 - p)) / math.sin(math.pi * (1 - p))
+        return -math.cos(math.pi * p) / math.sin(math.pi * p)
+    if df == 2:
+        return (2 * p - 1) / math.sqrt(2 * p * (1 - p))
+
+    sign = 1.0 if p > 0.5 else -1.0
+    q = p if p > 0.5 else 1 - p
+
+    lo, hi = 0.0, 1.0
+    while stdtr(df, hi) < q:
+        hi *= 2
+
+    log_norm = (
+        math.lgamma(0.5 * (df + 1))
+        - 0.5 * math.log(df * math.pi)
+        - math.lgamma(0.5 * df)
+    )
+    t = 0.5 * (lo + hi)
+    for _ in range(max_iter):
+        F = stdtr(df, t)
+        if F < q:
+            lo = t
+        else:
+            hi = t
+        log_f = log_norm - 0.5 * (df + 1) * math.log1p(t * t / df)
+        f = math.exp(log_f)
+        if f == 0.0:
+            t = 0.5 * (lo + hi)
+        else:
+            t_newton = t - (F - q) / f
+            t = t_newton if lo <= t_newton <= hi else 0.5 * (lo + hi)
+        if hi - lo < eps * (1 + abs(t)):
+            break
+    return sign * t
+
+
+# Liam: I'm not convinced this abstraction pays for itself. If it's a hindrance in the
+# future, feel free to refactor. This class is mainly here to concretize the minimal set
+# of abstractions our integer sampling code expects a distribution to define, and to
+# provide stronger guardrails around composition.
+#
+# Note that our code makes the explicit assumption that any _Distribution
+# implementation is symmetric around 0. This implies inverse_cdf(0.5) = 0, for example.
+# Do not break this assumption without verifying carefully against callers.
+class _Distribution(abc.ABC):
+    @abc.abstractmethod
+    def cdf(self, x: float) -> float:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def inverse_cdf(self, u: float) -> float:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def pdf(self, x: float) -> float:
+        raise NotImplementedError
+
+
+class UniformDistribution(_Distribution):
+    """Uniform distribution on [-half_width, half_width]."""
+
+    def __init__(self, *, half_width: float) -> None:
+        self.half_width = half_width
+
+    def cdf(self, x: float) -> float:
+        if x < -self.half_width:
+            return 0.0
+        if x > self.half_width:
+            return 1.0
+        return (x + self.half_width) / (2 * self.half_width)
+
+    def inverse_cdf(self, u: float) -> float:
+        return -self.half_width + 2 * self.half_width * u
+
+    def pdf(self, x: float) -> float:
+        if -self.half_width <= x <= self.half_width:
+            return 1 / (2 * self.half_width)
+        return 0.0
+
+
+class LogStudentTDistribution(_Distribution):
+    """Student's t distribution, in the transformed domain of log_2(x).
+
+    Y = sign(x) * log_2(1 + |x|) ~ scale_bits * t(df).
+
+    Note that we only support integer df. This is to reduce surface area in the vendored
+    mathematical functions, which are simpler when df is an integer. There is no
+    fundamental difficulty to supporting float df, other than the necessary due diligence
+    for the vendored code.
+    """
+
+    LN2 = math.log(2)
+
+    def __init__(self, *, scale_bits: float, df: int) -> None:
+        self.scale_bits = scale_bits
+        self.df = df
+        self._t_coef = math.gamma((df + 1) / 2) / (
+            math.sqrt(df * math.pi) * math.gamma(df / 2)
+        )
+
+    def cdf(self, x: float) -> float:
+        y = math.copysign(math.log2(1 + abs(x)), x) / self.scale_bits
+        return float(stdtr(self.df, y))
+
+    def inverse_cdf(self, u: float) -> float:
+        y = self.scale_bits * float(stdtrit(self.df, u))
+        # 2^1023 is the largest power of 2 below sys.float_info.max. This makes y=1023
+        # the largest value we can turn into a float to return here without overflowing.
+        #
+        # In the rare case that we draw such an extreme value, clamp to the bounds.
+        y = clamp(-1023, y, 1023)
+        return math.copysign(math.expm1(abs(y) * self.LN2), y)
+
+    def pdf(self, x: float) -> float:
+        y = math.copysign(math.log2(1 + abs(x)), x) / self.scale_bits
+        f_t = self._t_coef * (1 + y * y / self.df) ** (-(self.df + 1) / 2)
+        return f_t / (self.scale_bits * (1 + abs(x)) * self.LN2)
+
+
+class PiecewiseDistribution:
+    """Two-region splice: `inner` on (-switchover, switchover),
+    `outer` on |x| >= switchover.
+
+    Each region is normalized so that the resulting density is continuous at
+    ±switchover and integrates to 1. Both inner and outer must be symmetric around 0.
+    """
+
+    def __init__(
+        self, *, inner: _Distribution, outer: _Distribution, switchover: float
+    ) -> None:
+        # Note that this code could be made simpler by taking advantage of our assumption that
+        # `inner` and `outer` are symmetric around 0. The code is currently generic enough
+        # to support asymmetric distributions, but doesn't need to be,
+        self.inner = inner
+        self.outer = outer
+        self.switchover = switchover
+        self._inner_g_neg = inner.cdf(-switchover)
+        self._inner_g_pos = inner.cdf(switchover)
+        self._outer_g_neg = outer.cdf(-switchover)
+        self._outer_g_pos = outer.cdf(switchover)
+        outer_outer_mass = 1 - (self._outer_g_pos - self._outer_g_neg)
+        inner_inner_mass = self._inner_g_pos - self._inner_g_neg
+        # density continuity: beta * inner.pdf(c) = alpha * outer.pdf(c)
+        # plus total mass 1; solve for (alpha, beta).
+        inner_pdf = inner.pdf(switchover)
+        outer_pdf = outer.pdf(switchover)
+        if inner_pdf == 0:
+            raise ValueError(
+                f"inner.pdf(switchover={switchover}) == 0; cannot density-match. inner "
+                "must have support at the boundary."
+            )
+        self._alpha = 1 / (outer_pdf * inner_inner_mass / inner_pdf + outer_outer_mass)
+        self._beta = self._alpha * outer_pdf / inner_pdf
+        self._inner_mass = self._beta * inner_inner_mass
+        self._left_mass = self._alpha * self._outer_g_neg
+
+    def cdf(self, x: float) -> float:
+        if x <= -self.switchover:
+            return self._alpha * self.outer.cdf(x)
+        if x < self.switchover:
+            return self._left_mass + self._beta * (
+                self.inner.cdf(x) - self._inner_g_neg
+            )
+        return (
+            self._left_mass
+            + self._inner_mass
+            + self._alpha * (self.outer.cdf(x) - self._outer_g_pos)
+        )
+
+    def inverse_cdf(self, u: float) -> float:
+        if u <= self._left_mass:
+            return self.outer.inverse_cdf(u / self._alpha)
+        if u < self._left_mass + self._inner_mass:
+            target = self._inner_g_neg + (u - self._left_mass) / self._beta
+            return self.inner.inverse_cdf(target)
+        return self.outer.inverse_cdf(
+            (u - self._left_mass - self._inner_mass) / self._alpha + self._outer_g_pos
+        )

--- a/hypothesis-python/src/hypothesis/internal/statistics.py
+++ b/hypothesis-python/src/hypothesis/internal/statistics.py
@@ -147,9 +147,9 @@ class UniformDistribution(_Distribution):
 
     def cdf(self, x: float) -> float:
         if x < -self.half_width:
-            return 0.0
+            return 0.0  # pragma: no cover
         if x > self.half_width:
-            return 1.0
+            return 1.0  # pragma: no cover
         return (x + self.half_width) / (2 * self.half_width)
 
     def inverse_cdf(self, u: float) -> float:
@@ -158,7 +158,7 @@ class UniformDistribution(_Distribution):
     def pdf(self, x: float) -> float:
         if -self.half_width <= x <= self.half_width:
             return 1 / (2 * self.half_width)
-        return 0.0
+        return 0.0  # pragma: no cover
 
 
 class LogStudentTDistribution(_Distribution):

--- a/hypothesis-python/tests/conjecture/test_engine.py
+++ b/hypothesis-python/tests/conjecture/test_engine.py
@@ -1819,3 +1819,14 @@ def test_discards_invalid_db_entries_pareto():
     assert not set(db.fetch(runner.database_key))
     assert not set(db.fetch(runner.pareto_key))
     assert runner.call_count == 0
+
+
+# coverage tests for a few rare code paths in draw_integer
+@given(st.integers(min_value=2**2000))
+def test_integer_overflow_fallback(n):
+    assert n >= 2**2000
+
+
+@given(st.integers(2**500, 2**500 + 10))
+def test_integer_narrow_tail_fallback(n):
+    assert 2**500 <= n <= 2**500 + 10

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -58,7 +58,7 @@ def test_integer_bounds(bounds):
 
 
 # this test depends on internal HypothesisProvider distribution behavior
-@xfail_on_crosshair(Why.other)
+@xfail_on_crosshair(Why.other, strict=False)
 @pytest.mark.parametrize(
     "min_value, max_value, lower, upper",
     [

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -57,6 +57,8 @@ def test_integer_bounds(bounds):
     f()
 
 
+# this test depends on internal HypothesisProvider distribution behavior
+@xfail_on_crosshair(Why.other)
 @pytest.mark.parametrize(
     "min_value, max_value, lower, upper",
     [

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -26,8 +26,7 @@ def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():
 
     test()
 
-    # We draw from a shaped distribution up to 128bit ~7/8 of the time, and
-    # uniformly the rest.  So we should get some very large but not too many.
-    huge = sum(x > 1e97 for x in values)
-    assert huge != 0 or len(values) < 800
-    assert huge <= 0.5 * len(values)  # expected ~1/8
+    # We draw from a shaped distribution up to 128bit, so we should get some very large
+    # but not too many.
+    huge = sum(x > 1e25 for x in values)
+    assert 1 < huge <= 100

--- a/hypothesis-python/tests/nocover/test_integer_ranges.py
+++ b/hypothesis-python/tests/nocover/test_integer_ranges.py
@@ -8,8 +8,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from hypothesis import given, settings
-from hypothesis.strategies import integers
+import pytest
+
+from hypothesis import given, settings, strategies as st
 
 from tests.common.utils import Why, xfail_on_crosshair
 
@@ -19,7 +20,7 @@ def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():
     values = []
 
     @settings(database=None, max_examples=1000)
-    @given(integers(0, 1e100))
+    @given(st.integers(0, 1e100))
     def test(x):
         if 2 <= x <= int(1e100) - 2:  # skip forced-endpoints
             values.append(x)
@@ -30,3 +31,54 @@ def test_bounded_integers_distribution_of_bit_width_issue_1387_regression():
     # but not too many.
     huge = sum(x > 1e25 for x in values)
     assert 1 < huge <= 100
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        (-(2**300), 2**500),
+        (2**500, 2**501),
+        (2**500, 2**500 + 10),
+        (2**2000, None),
+        (None, -(2**2000)),
+        (2**2000, 2**2000 + 100),
+    ],
+)
+def test_integer_bounds(bounds):
+    min_value, max_value = bounds
+
+    @given(st.integers(min_value, max_value))
+    def f(n):
+        if min_value is not None:
+            assert min_value <= n
+        if max_value is not None:
+            assert n <= max_value
+
+    f()
+
+
+@pytest.mark.parametrize(
+    "min_value, max_value, lower, upper",
+    [
+        # unbounded: use (-2**128, 2**128).
+        (None, None, -(2**128), 2**128),
+        # half-bounded at n < 2^127: use (n, 2^128).
+        (0, None, 0, 2**128),
+        (None, 0, -(2**128), 0),
+        (-1000, None, -1000, 2**128),
+        (None, 1000, -(2**128), 1000),
+        (2**127, None, 2**127, 2**128),
+        (None, -(2**127), -(2**128), -(2**127)),
+        # half-bounded at n > 2^127: use (n, 2n).
+        (2**200, None, 2**200, 2**201),
+        (None, -(2**200), -(2**201), -(2**200)),
+        (-(2**200), None, -(2**200), 2**201),
+        (None, 2**200, -(2**201), 2**200),
+    ],
+)
+def test_integers_unbounded_and_half_bounded(min_value, max_value, lower, upper):
+    @given(st.integers(min_value, max_value))
+    def f(n):
+        assert lower <= n <= upper
+
+    f()

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -126,30 +126,10 @@ test_can_produce_65_bit_integer = define_test(
     integers(), lambda x: x.bit_length() == 65, p=0.01
 )
 test_can_produce_very_large_integers = define_test(
-    integers(min_value=2**500), lambda x: x >= 2**501
+    integers(min_value=2**500), lambda x: x >= 2**500 + 2**499
 )
 test_can_produce_very_large_negative_integers = define_test(
-    integers(max_value=-(2**500)), lambda x: x <= 2**501
-)
-# These tests don't really belong in this file. They check that extreme ranges to `integers`
-# don't error, not anything about findability.
-test_can_produce_very_large_integers_bounded_1 = define_test(
-    integers(-(2**300), 2**500), lambda n: True
-)
-test_can_produce_very_large_integers_bounded_2 = define_test(
-    integers(2**500, 2**501), lambda n: True
-)
-test_can_produce_very_large_integers_bounded_3 = define_test(
-    integers(2**500, 2**500 + 10), lambda n: True
-)
-test_can_produce_integers_min_beyond_float_max = define_test(
-    integers(min_value=2**2000), lambda n: n >= 2**2000
-)
-test_can_produce_integers_max_beyond_float_min = define_test(
-    integers(max_value=-(2**2000)), lambda n: n <= -(2**2000)
-)
-test_can_produce_integers_bounded_beyond_float_max = define_test(
-    integers(2**2000, 2**2000 + 100), lambda n: True
+    integers(max_value=-(2**500)), lambda x: x <= -(2**500) - 2**499
 )
 
 

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -122,6 +122,26 @@ test_can_produce_large_magnitude_integers = define_test(
 )
 test_can_produce_large_positive_integers = define_test(integers(), lambda x: x > 1000)
 test_can_produce_large_negative_integers = define_test(integers(), lambda x: x < -1000)
+test_can_produce_65_bit_integer = define_test(
+    integers(), lambda x: x.bit_length() == 65, p=0.01
+)
+test_can_produce_very_large_integers = define_test(
+    integers(min_value=2**500), lambda x: x >= 2**501
+)
+test_can_produce_very_large_negative_integers = define_test(
+    integers(max_value=-(2**500)), lambda x: x <= 2**501
+)
+# These tests don't really belong in this file. They check that extreme ranges to `integers`
+# don't error, not anything about findability.
+test_can_produce_very_large_integers_bounded_1 = define_test(
+    integers(-(2**300), 2**500), lambda n: True
+)
+test_can_produce_very_large_integers_bounded_2 = define_test(
+    integers(2**500, 2**501), lambda n: True
+)
+test_can_produce_very_large_integers_bounded_3 = define_test(
+    integers(2**500, 2**500 + 10), lambda n: True
+)
 
 
 _factorials = {math.factorial(n) for n in range(9, 21)}

--- a/hypothesis-python/tests/quality/test_discovery_ability.py
+++ b/hypothesis-python/tests/quality/test_discovery_ability.py
@@ -142,6 +142,15 @@ test_can_produce_very_large_integers_bounded_2 = define_test(
 test_can_produce_very_large_integers_bounded_3 = define_test(
     integers(2**500, 2**500 + 10), lambda n: True
 )
+test_can_produce_integers_min_beyond_float_max = define_test(
+    integers(min_value=2**2000), lambda n: n >= 2**2000
+)
+test_can_produce_integers_max_beyond_float_min = define_test(
+    integers(max_value=-(2**2000)), lambda n: n <= -(2**2000)
+)
+test_can_produce_integers_bounded_beyond_float_max = define_test(
+    integers(2**2000, 2**2000 + 100), lambda n: True
+)
 
 
 _factorials = {math.factorial(n) for n in range(9, 21)}

--- a/hypothesis-python/tests/scipy/__init__.py
+++ b/hypothesis-python/tests/scipy/__init__.py
@@ -1,0 +1,9 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.

--- a/hypothesis-python/tests/scipy/test_statistics.py
+++ b/hypothesis-python/tests/scipy/test_statistics.py
@@ -9,10 +9,15 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import pytest
+import scipy
 import scipy.special
 
 from hypothesis import given, strategies as st
 from hypothesis.internal.statistics import stdtr, stdtrit
+
+# Older scipy had a less accurate stdrit path. Our CI uses older scipy in some of our
+# older python jobs like python3.10. Just skip them and only test against newer scipy.
+SCIPY_VERSION = tuple(int(x) for x in scipy.__version__.split("."))
 
 
 @given(st.integers(1, 100), st.floats(-1e150, 1e150))
@@ -39,6 +44,9 @@ def test_stdtr_explicit(df, t):
 #
 # If we ever change our df use in production, we should revisit these tests and tolerances
 # accordingly.
+@pytest.mark.skipif(
+    SCIPY_VERSION < (1, 17), reason="older scipy has inaccurate stdtrit"
+)
 @given(st.sampled_from([1, 2]), st.floats(1e-300, 1 - 1e-15))
 def test_stdtrit_matches_scipy_strict(df, p):
     # df ∈ {1, 2} use the same closed-form formulas Boost/scipy use, so we

--- a/hypothesis-python/tests/scipy/test_statistics.py
+++ b/hypothesis-python/tests/scipy/test_statistics.py
@@ -1,0 +1,55 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+import scipy.special
+
+from hypothesis import given, strategies as st
+from hypothesis.internal.statistics import stdtr, stdtrit
+
+
+@given(st.integers(1, 100), st.floats(-1e150, 1e150))
+def test_stdtr_matches_scipy(df, t):
+    assert stdtr(df, t) == pytest.approx(
+        scipy.special.stdtr(df, t), rel=1e-12, abs=1e-15
+    )
+
+
+@pytest.mark.parametrize("df", [1, 2, 3, 4, 10, 100])
+@pytest.mark.parametrize("t", [-100.0, -1.0, -0.5, 0.0, 0.5, 1.0, 100.0])
+def test_stdtr_explicit(df, t):
+    assert stdtr(df, t) == pytest.approx(
+        scipy.special.stdtr(df, t), rel=1e-12, abs=1e-15
+    )
+
+
+# note we split our tests for stdtrit in two:
+# * a very aggressive tolerance test for df = 1, 2
+# * a less aggressive tolerance test for df > 2
+#
+# The first test is what we currently care most about, because we use only df=2 in production.
+# The second test is currently a sanity check, which is why we're okay with a laxer tolerance.
+#
+# If we ever change our df use in production, we should revisit these tests and tolerances
+# accordingly.
+@given(st.sampled_from([1, 2]), st.floats(1e-300, 1 - 1e-15))
+def test_stdtrit_matches_scipy_strict(df, p):
+    # df ∈ {1, 2} use the same closed-form formulas Boost/scipy use, so we
+    # expect bit-for-bit (or last-ULP) agreement across the entire p domain.
+    assert stdtrit(df, p) == pytest.approx(scipy.special.stdtrit(df, p), rel=1e-15)
+
+
+@given(st.integers(1, 100), st.floats(1e-9, 1 - 1e-9))
+def test_stdtrit_matches_scipy_lax(df, p):
+    # df ∈ {1, 2} use closed-form quantiles (last-ULP). df >= 3 uses
+    # Newton-on-stdtr instead of scipy's Halley-on-ibeta.
+    assert stdtrit(df, p) == pytest.approx(
+        scipy.special.stdtrit(df, p), rel=1e-7, abs=1e-9
+    )

--- a/hypothesis-python/tox.ini
+++ b/hypothesis-python/tox.ini
@@ -32,7 +32,7 @@ commands =
     full: bash scripts/basic-test.sh
     brief: python -bb -X dev -m pytest -n auto tests/cover/test_testdecorators.py {posargs}
     cover: python -bb -X dev -m pytest -n auto tests/cover/ tests/pytest/ tests/conjecture/ {posargs}
-    rest: python -bb -X dev -m pytest -n auto tests/ --ignore=tests/cover/ --ignore=tests/pytest/ --ignore=tests/conjecture/ --ignore=tests/nocover/ --ignore=tests/quality/ --ignore=tests/ghostwriter/ --ignore=tests/patching/ --ignore=tests/crosshair/test_crosshair.py --ignore=tests/snapshots/ {posargs}
+    rest: python -bb -X dev -m pytest -n auto tests/ --ignore=tests/cover/ --ignore=tests/pytest/ --ignore=tests/conjecture/ --ignore=tests/nocover/ --ignore=tests/quality/ --ignore=tests/ghostwriter/ --ignore=tests/patching/ --ignore=tests/crosshair/test_crosshair.py --ignore=tests/scipy/ --ignore=tests/snapshots/ {posargs}
     conjecture: python -bb -X dev -m pytest -n auto tests/conjecture/ {posargs}
     nocover: python -bb -X dev -m pytest -n auto tests/nocover/ {posargs}
     niche: bash scripts/other-tests.sh


### PR DESCRIPTION
Closes https://github.com/HypothesisWorks/hypothesis/issues/4624. Closes https://github.com/HypothesisWorks/hypothesis/issues/4722. Supersedes https://github.com/HypothesisWorks/hypothesis/pull/4723.

This PR started as addressing the two issues above. Along the way, I saw an opportunity to foundationally change our integer distribution for the better, which has turned into this PR.

`integers` is the most used strategy in Hypothesis, by a lot.[^3] It's worth a corresponding amount of effort to get that distribution right.

This PR description is a somewhat rambly series of justifications. As an alternative high level summary, in this PR I:

- Replace our unbounded distribution from bucketed bit sizes (P_0 below) to a student's t distribution (P_4 below).
- Change our half bounded and bounded distribution from (IMO) unprincipled and unsynchronized variations on P_0, to P_4 restricted to the requested domain.
- Any normal person would implement student's t sampling using scipy. I am strongly against pulling in a scipy dependency, so I have "vendored" the necessary code.
  - It's honestly not too bad. Downside: an LLM wrote it, and I don't understand the code at all. Upside: this is in distribution for AI, and we have a strong oracle (scipy's impl) to test against.

If you want to eyeball the changes, I recommend running the following script on both master and this PR:

<details>

```python
from hypothesis import strategies as st

for _ in range(100):
    print(st.integers(2**64, 2**128).example())

print("\n" * 20)

for _ in range(100):
    print(st.integers(2**64, 2**128).example())

for _ in range(100):
    print(st.integers(10**60, 10**61).example())

print("\n" * 20)

for _ in range(100):
    print(st.integers().example())

print("\n" * 20)

for _ in range(100):
    print(st.integers(10**60, 10**61).example())

print("\n" * 20)

for _ in range(100):
    print(st.integers(2**40, 2**42).example())

for _ in range(100):
    print(st.integers(10**200, 10**210).example())
```

</details>

## Section 1: Unbounded ranges

*(Everything in this section assumes unbounded integer ranges only. Bounded and half-bounded ranges are in the next section.)*

The current integer distribution on master is a step function, which first chooses the bucket size in bits with some probability, and then draws uniformly from within that bucket. Call this distribution P_0.

Here are the buckets and their probabilities for P_0:

```
INT_SIZES = (8, 16, 32, 64, 128)  # in bits
INT_SIZES_SAMPLER = Sampler((4.0, 8.0, 1.0, 1.0, 0.5), observe=False)
```

Here's the PDF of P_0, as drawn by claude (do *not* take the numbers in this graph as accurate, I have not double checked. The shape is what's important here):

```
  2.17e-03 |●                                                                    ← v = 0
  1.09e-03 | ████                                                                ← |v| ∈ [1, 127]      (bits 1–7)
  8.42e-06 |     ████                                                            ← |v| ∈ [128, 32767]  (bits 8–15)
  1.61e-11 |         ████████                                                    ← |v| ∈ [2^15, 2^31)  (bits 16–31)
  3.74e-21 |                 ████████████████                                    ← |v| ∈ [2^31, 2^63)  (bits 32–63)
  1.01e-40 |                                 ████████████████████████████████    ← |v| ∈ [2^63, 2^127) (bits 64–127)
           |
           0   7   15      31              63                              127   ← bit_length(|v|)
```

This might look and feel like a good distribution; probabilities are going down and to the right somewhat smoothly. Well, drawing this on a log_2 x and y axis is obscuring a big problem with this distribution, which is the bit length immediately after each cliff is many, many orders of magnitude less likely to be sampled than right before each cliff. The overwhelming majority of the probability mass in each strata is taken up by the highest few bits. The highest bit is fully half of that strata, eg.

Here's the probability for sampling an integer of each bit length. Look how stark and bad the transitions of `b~=32` and `b~=64` are!

<details>

  ```
┌─────┬───────────┬─────┬───────────┬─────┬───────────┬─────┬───────────┐
  │  b  │  P(B=b)   │  b  │  P(B=b)   │  b  │  P(B=b)   │  b  │  P(B=b)   │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   0 │ 2.172e-03 │  32 │ 1.606e-11 │  64 │ 1.869e-21 │  96 │ 8.029e-12 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   1 │ 2.172e-03 │  33 │ 3.211e-11 │  65 │ 3.739e-21 │  97 │ 1.606e-11 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   2 │ 4.344e-03 │  34 │ 6.423e-11 │  66 │ 7.477e-21 │  98 │ 3.211e-11 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   3 │ 8.688e-03 │  35 │ 1.285e-10 │  67 │ 1.495e-20 │  99 │ 6.423e-11 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   4 │ 1.738e-02 │  36 │ 2.569e-10 │  68 │ 2.991e-20 │ 100 │ 1.285e-10 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   5 │ 3.475e-02 │  37 │ 5.138e-10 │  69 │ 5.982e-20 │ 101 │ 2.569e-10 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   6 │ 6.950e-02 │  38 │ 1.028e-09 │  70 │ 1.196e-19 │ 102 │ 5.138e-10 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   7 │ 1.390e-01 │  39 │ 2.055e-09 │  71 │ 2.393e-19 │ 103 │ 1.028e-09 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   8 │ 2.155e-03 │  40 │ 4.111e-09 │  72 │ 4.785e-19 │ 104 │ 2.055e-09 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │   9 │ 4.310e-03 │  41 │ 8.221e-09 │  73 │ 9.571e-19 │ 105 │ 4.111e-09 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  10 │ 8.621e-03 │  42 │ 1.644e-08 │  74 │ 1.914e-18 │ 106 │ 8.221e-09 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  11 │ 1.724e-02 │  43 │ 3.289e-08 │  75 │ 3.828e-18 │ 107 │ 1.644e-08 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  12 │ 3.448e-02 │  44 │ 6.577e-08 │  76 │ 7.657e-18 │ 108 │ 3.289e-08 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  13 │ 6.897e-02 │  45 │ 1.315e-07 │  77 │ 1.531e-17 │ 109 │ 6.577e-08 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  14 │ 1.379e-01 │  46 │ 2.631e-07 │  78 │ 3.063e-17 │ 110 │ 1.315e-07 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  15 │ 2.759e-01 │  47 │ 5.262e-07 │  79 │ 6.125e-17 │ 111 │ 2.631e-07 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  16 │ 1.052e-06 │  48 │ 1.052e-06 │  80 │ 1.225e-16 │ 112 │ 5.262e-07 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  17 │ 2.105e-06 │  49 │ 2.105e-06 │  81 │ 2.450e-16 │ 113 │ 1.052e-06 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  18 │ 4.209e-06 │  50 │ 4.209e-06 │  82 │ 4.900e-16 │ 114 │ 2.105e-06 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  19 │ 8.419e-06 │  51 │ 8.419e-06 │  83 │ 9.801e-16 │ 115 │ 4.209e-06 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  20 │ 1.684e-05 │  52 │ 1.684e-05 │  84 │ 1.960e-15 │ 116 │ 8.419e-06 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  21 │ 3.367e-05 │  53 │ 3.367e-05 │  85 │ 3.920e-15 │ 117 │ 1.684e-05 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  22 │ 6.735e-05 │  54 │ 6.735e-05 │  86 │ 7.840e-15 │ 118 │ 3.367e-05 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  23 │ 1.347e-04 │  55 │ 1.347e-04 │  87 │ 1.568e-14 │ 119 │ 6.735e-05 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  24 │ 2.694e-04 │  56 │ 2.694e-04 │  88 │ 3.136e-14 │ 120 │ 1.347e-04 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  25 │ 5.388e-04 │  57 │ 5.388e-04 │  89 │ 6.272e-14 │ 121 │ 2.694e-04 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  26 │ 1.078e-03 │  58 │ 1.078e-03 │  90 │ 1.254e-13 │ 122 │ 5.388e-04 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  27 │ 2.155e-03 │  59 │ 2.155e-03 │  91 │ 2.509e-13 │ 123 │ 1.078e-03 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  28 │ 4.310e-03 │  60 │ 4.310e-03 │  92 │ 5.018e-13 │ 124 │ 2.155e-03 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  29 │ 8.621e-03 │  61 │ 8.621e-03 │  93 │ 1.004e-12 │ 125 │ 4.310e-03 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  30 │ 1.724e-02 │  62 │ 1.724e-02 │  94 │ 2.007e-12 │ 126 │ 8.621e-03 │
  ├─────┼───────────┼─────┼───────────┼─────┼───────────┼─────┼───────────┤
  │  31 │ 3.448e-02 │  63 │ 3.448e-02 │  95 │ 4.014e-12 │ 127 │ 1.724e-02 │
  └─────┴───────────┴─────┴───────────┴─────┴───────────┴─────┴───────────┘
```

</details>

So, P_0 is:

* Good: Kind of the right distribution, in aggregate. Small numbers are common, large numbers are less common.
* Bad: Jaggedly discontinuous.

Clearly we need to fix the continuity. One thought: consider a distribution P_1 with a uniform probability of generating each bit length, such that if you plotted P_1 on a log_2 x-axis, you would get a straight horizontal line. P_1 is nicely smooth and continuous. But it's not actually the distribution we want, because it produces 64-128 bit integers as often as 0-64 bit integers (assuming we constrain P_1 to the bit range [-128, 128]). [^1]

P_1 is:

* Good: Continuous.
* Bad: The wrong distribution.

Okay. But thinking in terms of a log_2 x axis is the right framing. We clearly don't want a uniform distribution in the log_2 domain. Let's try a normal distribution in the log_2 domain, ie a log-2-normal distribution. Call it P_2.

* Good: Continuous.
* Good: Close to the right shape.
* Bad: Generates large (64-128 bit) integers much, much less frequently than master. (Or P_1. Not that I ever seriously considered P_1 as a contender). The probability of generating a 128 bit integer with any reasonably-shaped normal distribution we would consider using was effectively zero.

OK. But P_2 was closer than P_1. Can we control how often P_2 generates large numbers? Yes! There is a generalization of the normal distribution called the student's t distribution, parametrized by scale (plays a similar role as stddev in a normal distribution) and degrees of freedom (how much probability mass is allocated to the tails). Relations to other distributions: `t(df=inf)` is a normal distribution. `t(df=1)` is the cauchy distribution.

Call this distribution P_3.

* Good: Continuous.
* Good: The right distribution.
Bad: Actually, not quite the right distribution. Normal distributions in a log domain assign *exponentially more mass* to the center (ie, around 0)! Under P_3, we would be assigning ~99% probability to the [-50, 50] range.

I don't know of any principled distribution that solves this. We basically want lognormal in x, except switching to something closer to normal for the center of the distribution.

At this point I decided I wanted a pragmatic solution, and combined P_3 with a uniform distribution for small ranges. (I am reminded of symlog, which is this same piecewise hack).

Call this distribution P_4. P_4 is a student's t distribution in the log_2 domain with `scale=13` and `df=2`, piecewise combined with a uniform distribution on [-256, 256]. The scale, df, and piecewise switchover numbers were chosen by me after playing around on various graphs and eyeballing.

* Good: Continuous.
* Good: The actually-right distribution.
* Bad: Piecewise, slightly annoying to define and use.

P_4 is what's in this PR. I'm happy with it and think is close to the best we're going to get.

## Section 2: bounded ranges

Our sampling algorithm on master has one problem, which is the sharp cliffs of P_0 at certain bit lengths. The sampling algorithm has another problem (well, IMO), which is it uses a different distribution for bounded ranges than unbounded ranges. This distribution is:

* Half-bounded ranges: P_0 centered on the specified bound
* Small bounded ranges: uniform
* Large bounded ranges: 7/8 P_0 + 1/8 uniform

IMO, a better distribution for bounded ranges is simply the restriction of our unbounded distribution to that domain. That change is also in this PR, and is (I believe) what actually fixes https://github.com/HypothesisWorks/hypothesis/issues/4722 and https://github.com/HypothesisWorks/hypothesis/issues/4624.

Here is my ideal behavior for a few distributions:

* For `st.integers(1_000, 100_000)`: I want to produce smaller values more often, but not too often. 
  * Master: no; uniform. This PR: yes.
* For `st.integers(2**40, 2**41)`: I want to be basically uniform. 
  * Master, this PR: yes.
* For `st.integers(2**64, 2**128)`: I want to produce smaller values more often, but not too often. 
  * Master: no; huge bias towards 2**128. This PR: yes.[^2]
* For `st.integers(min_value=2**25)`: I want to produce smaller values more often, but I *don't* want `2**25` to be treated as the new distribution center. `[2**25, 2**25 + 1024]` is not as special as `[0, 1024]`. 
  * Master: no; treats `min_value` as center. This PR: yes.

I don't mean to imply that I think the ideal distribution for `st.integers(a, b)` is the same as the distribution for `st.integers()` restricted to `[a, b]`. I think it's clear the user is imbuing additional semantics when they ask for a bounded range, and we may want to change the distribution accordingly. But figuring out what *that* distribution should be is certainly a task for another PR. I only claim here that restricting the domain is better than what we currently have.

## Graphs

Here are some graphs. `new` is sampled from P_4. `new (expected)` is the analytically-computed expected plot of P_4.

<img width="1095" height="942" alt="image" src="https://github.com/user-attachments/assets/6b8283bc-51bf-48fa-b0fe-81f8e1a9c4c5" />

I think the uniform part showing as lower y in the plots is correct and fine, because there's so few x axis numbers to go around that we do want the total probability mass assigned to that range to be small. It does look unintuitive though.

[^1]: claude had this to say about how we might define P_1, which I have not looked into or validated:

    ```
    ❯ what distribution would give us a uniform probability of generating each bit length?
    
    ⏺ Short answer: a log-uniform distribution on magnitude
    
      Equivalently:
    
      P(|X| = m) ∝ 1/m       for m in [1, 2^B - 1]
      P(X = 0)   = 1/(B+1)   (one bit-length-0 value, balanced as one bin)
    
      This is the reciprocal distribution / Jeffreys prior for a scale parameter / discrete Zipf with exponent 1. It's
      "scale invariant": every doubling of magnitude carries the same probability mass.
    ```

[^2]: Note that master currently does something else (and worse) than this, I think because of #4624. I believe I describe here the platonic behavior of master assuming we fixed that bug.

[^3]: I don't have an updated graph for this, but you could relatively easily make one from the [Hypothesis Corpus](https://huggingface.co/datasets/HypothesisWorks/Hypothesis-Corpus-2026) if you accept a regex search as good enough vs AST parsing.

## Appendix

Plotting code:

<details>

```python
import math
import random

import matplotlib.pyplot as plt
import numpy as np
from scipy.special import ndtri

from hypothesis.internal.conjecture.data import ConjectureData
from hypothesis.internal.statistics import stdtr, stdtrit

log = False
n_samples = 50_000
do_truncated = True
do_hypothesis = True

# === distributions ===
#
# Minimal interface for a distribution to plug into the integer sampler:
#
#   cdf(x: float) -> float        # continuous CDF on R, into [0, 1]
#   inverse_cdf(u: float) -> float    # inverse CDF on (0, 1)
#
# Everything below — rejection sampler, truncated sampler, expected-count
# overlay — is built generically against this interface. Add a new class
# with these two methods and you can plug it in by reassigning `dist`.


class Lognormal:
    """Two-sided lognormal: log(1 + |T|) = sigma * |Z|, Z ~ N(0, 1), uniform sign."""

    def __init__(self, sigma: float):
        self.sigma = sigma

    def cdf(self, x: float) -> float:
        z = math.copysign(math.log1p(abs(x)), x) / self.sigma
        return 0.5 * (1.0 + math.erf(z / math.sqrt(2)))

    def inverse_cdf(self, u: float) -> float:
        z = float(ndtri(u))
        return math.copysign(math.expm1(self.sigma * abs(z)), z)

    def __str__(self) -> str:
        return f"lognormal(sigma={self.sigma:g})"


class StudentT:
    """Scaled Student's t with `df` degrees of freedom.

    df=1 is Cauchy; df -> infinity approaches Normal. Tail decays as 1/|x|^(df+1).
    Approximately uniform on |x| << scale, regardless of df.
    """

    def __init__(self, scale: float, df: int):
        self.scale = scale
        self.df = df

    def cdf(self, x: float) -> float:
        return float(stdtr(self.df, x / self.scale))

    def inverse_cdf(self, u: float) -> float:
        return self.scale * float(stdtrit(self.df, u))

    def __str__(self) -> str:
        return f"student-t(scale={self.scale:g}, df={self.df:g})"


class LogStudentT:
    """Student's t in signed log_2 magnitude.

    Y = sign(x) * log_2(1 + |x|) ~ scale_bits * t(df).
    Smooth analog of hypothesis's bit-band mixture: log-magnitude has a
    Student's t shape with scale measured in bits and tail exponent `df`.
    Conditional on small bounded ranges containing 0, the distribution is
    approximately 1/|x| (peaked at 0) — same Jacobian behavior as Lognormal.
    """

    LN2 = math.log(2)

    def __init__(self, scale_bits: float, df: int):
        self.scale_bits = scale_bits
        self.df = df
        # standard t pdf normalization (cached so pdf() is cheap)
        self._t_coef = math.gamma((df + 1) / 2) / (
            math.sqrt(df * math.pi) * math.gamma(df / 2)
        )

    def cdf(self, x: float) -> float:
        y = math.copysign(math.log2(1 + abs(x)), x) / self.scale_bits
        return float(stdtr(self.df, y))

    def inverse_cdf(self, u: float) -> float:
        y = self.scale_bits * float(stdtrit(self.df, u))
        # math.expm1(|y| * ln 2) == 2**|y| - 1, but raises OverflowError cleanly
        # for huge |y| (caught by sample_rejection).
        return math.copysign(math.expm1(abs(y) * self.LN2), y)

    def pdf(self, x: float) -> float:
        y = math.copysign(math.log2(1 + abs(x)), x) / self.scale_bits
        f_t = self._t_coef * (1 + y * y / self.df) ** (-(self.df + 1) / 2)
        return f_t / (self.scale_bits * (1 + abs(x)) * self.LN2)

    def __str__(self) -> str:
        return f"log-student-t(s={self.scale_bits:g} bits, df={self.df:g})"


class Uniform:
    """Uniform on (-half_width, half_width)."""

    def __init__(self, half_width: float):
        self.half_width = half_width

    def cdf(self, x: float) -> float:
        if x <= -self.half_width:
            return 0.0
        if x >= self.half_width:
            return 1.0
        return (x + self.half_width) / (2 * self.half_width)

    def inverse_cdf(self, u: float) -> float:
        return -self.half_width + 2 * self.half_width * u

    def pdf(self, x: float) -> float:
        # use the closed interval so density continuity matches at the boundary
        if -self.half_width <= x <= self.half_width:
            return 1 / (2 * self.half_width)
        return 0.0

    def __str__(self) -> str:
        return f"uniform(±{self.half_width:g})"


class Piecewise:
    """Two-region splice: `inner` on (-cutoff, cutoff), `outer` on |x| >= cutoff.

    Each region is normalized so that the resulting density is continuous at
    ±cutoff and integrates to 1. Both inner and outer must be symmetric around
    0 and implement cdf, inverse_cdf, pdf.

    Concretely, density on (-cutoff, cutoff) is beta * inner.pdf(x) and density
    on |x| >= cutoff is alpha * outer.pdf(x), with alpha and beta chosen by
    solving:
        beta  * inner.pdf(cutoff) = alpha * outer.pdf(cutoff)        (continuity)
        beta  * inner.P([-c, c])  + alpha * outer.P(|x| >= c) = 1     (total mass)
    """

    def __init__(self, inner, outer, cutoff: float):
        self.inner = inner
        self.outer = outer
        self.cutoff = cutoff
        # mass under each base distribution restricted to its region
        self._inner_g_neg = inner.cdf(-cutoff)
        self._inner_g_pos = inner.cdf(cutoff)
        inner_inner_mass = self._inner_g_pos - self._inner_g_neg
        self._outer_g_neg = outer.cdf(-cutoff)
        self._outer_g_pos = outer.cdf(cutoff)
        outer_outer_mass = 1 - (self._outer_g_pos - self._outer_g_neg)
        # density continuity: beta * inner.pdf(c) = alpha * outer.pdf(c)
        # => beta = alpha * outer.pdf(c) / inner.pdf(c)
        # solve total mass for alpha:
        ipdf = inner.pdf(cutoff)
        opdf = outer.pdf(cutoff)
        if ipdf == 0:
            raise ValueError(
                f"inner.pdf(cutoff={cutoff}) == 0; cannot density-match. "
                "ensure inner has support at the boundary."
            )
        self._alpha = 1 / (opdf * inner_inner_mass / ipdf + outer_outer_mass)
        self._beta = self._alpha * opdf / ipdf
        self._inner_mass = self._beta * inner_inner_mass
        self._left_mass = self._alpha * self._outer_g_neg

    def cdf(self, x: float) -> float:
        if x <= -self.cutoff:
            return self._alpha * self.outer.cdf(x)
        if x < self.cutoff:
            return self._left_mass + self._beta * (
                self.inner.cdf(x) - self._inner_g_neg
            )
        return (
            self._left_mass
            + self._inner_mass
            + self._alpha * (self.outer.cdf(x) - self._outer_g_pos)
        )

    def inverse_cdf(self, u: float) -> float:
        if u <= self._left_mass:
            return self.outer.inverse_cdf(u / self._alpha)
        if u < self._left_mass + self._inner_mass:
            target = self._inner_g_neg + (u - self._left_mass) / self._beta
            return self.inner.inverse_cdf(target)
        return self.outer.inverse_cdf(
            (u - self._left_mass - self._inner_mass) / self._alpha + self._outer_g_pos
        )

    def pdf(self, x: float) -> float:
        if abs(x) < self.cutoff:
            return self._beta * self.inner.pdf(x)
        return self._alpha * self.outer.pdf(x)

    def __str__(self) -> str:
        return (
            f"piecewise(inner={self.inner}, outer={self.outer}, cutoff={self.cutoff})"
        )


# dist = Lognormal(sigma=20)
# dist = StudentT(scale=10_000_000, df=3)
# dist = LogStudentT(scale_bits=13, df=2)
dist = Piecewise(
    inner=Uniform(half_width=256),
    outer=LogStudentT(scale_bits=13, df=2),
    cutoff=256,
)


# === samplers ===


def make_truncated_sampler(a: int, b: int):
    lo = dist.cdf(a - 0.5)
    hi = dist.cdf(b + 0.5)

    def sample() -> int:
        v = lo + random.random() * (hi - lo)
        return max(a, min(b, round(dist.inverse_cdf(v))))

    return sample


def sample_hypothesis(a: int, b: int) -> int:
    cd = ConjectureData(random=random._inst)
    return cd.draw_integer(min_value=a, max_value=b)


# --- plotting ---

LINTHRESH = 10


def expected_counts(bin_edges: np.ndarray, a: int, b: int) -> np.ndarray:
    """Expected sample count per bin under the truncated `dist` on [a, b]."""
    Z = dist.cdf(b + 0.5) - dist.cdf(a - 0.5)
    if Z <= 0:
        return np.zeros(len(bin_edges) - 1)
    counts = np.empty(len(bin_edges) - 1)
    for i, (left, right) in enumerate(zip(bin_edges[:-1], bin_edges[1:])):
        lo = max(float(left), a - 0.5)
        hi = min(float(right), b + 0.5)
        counts[i] = 0.0 if lo >= hi else n_samples * (dist.cdf(hi) - dist.cdf(lo)) / Z
    return counts


def make_symlog_bins(a: int, b: int, n_log: int = 40) -> np.ndarray:
    """Bins matching a symlog x-axis: linear in [-LINTHRESH, LINTHRESH], log outside."""
    edges: list[float] = []
    if a < -LINTHRESH:
        upper = min(-LINTHRESH, b)
        edges.extend(-np.geomspace(float(abs(upper)), float(abs(a)), num=n_log))
    lin_lo, lin_hi = max(a, -LINTHRESH), min(b, LINTHRESH)
    if lin_lo <= lin_hi:
        edges.extend(np.arange(lin_lo - 0.5, lin_hi + 1.5, 1.0))
    if b > LINTHRESH:
        lower = max(LINTHRESH, a)
        edges.extend(np.geomspace(float(lower), float(b), num=n_log))
    return np.unique(np.array(edges, dtype=float))


def plot_case(
    ax,
    a: int,
    b: int,
    *,
    log_x: bool | None = None,
    log_y: bool | None = None,
    title: str | None = None,
) -> None:
    if log_x is None:
        log_x = log
    if log_y is None:
        log_y = log

    smart_samples: list[int] | None = None
    if do_truncated:
        sample_smart = make_truncated_sampler(a, b)
        smart_samples = [sample_smart() for _ in range(n_samples)]

    hyp_samples: list[int] | None = None
    if do_hypothesis:
        hyp_samples = [sample_hypothesis(a, b) for _ in range(n_samples)]

    if log_x:
        bins = make_symlog_bins(a, b)
    elif b - a + 1 <= 2_000:
        bins = np.arange(a - 0.5, b + 1.5)
    else:
        bins = np.linspace(a - 0.5, b + 0.5, 201)
    # cast to float because samples can exceed int64 for huge ranges; object
    # dtype breaks np.isfinite inside np.histogram.
    if smart_samples is not None:
        ax.hist(
            np.asarray(smart_samples, dtype=float),
            bins=bins,
            alpha=0.45,
            color="C0",
            label="new",
        )
    ax.stairs(
        expected_counts(bins, a, b),
        bins,
        color="red",
        linewidth=1.2,
        label="new (expected)",
    )
    # if hyp_samples is not None:
    #     ax.hist(
    #         np.asarray(hyp_samples, dtype=float),
    #         bins=bins,
    #         alpha=0.45,
    #         color="C2",
    #         label="master",
    #     )

    if log_x:
        ax.set_xscale("symlog", linthresh=LINTHRESH, base=2)
    if log_y:
        ax.set_yscale("log")
        ax.set_ylim(bottom=0.5)

    suffix = " (log)" if log_x or log_y else ""
    ax.set_title((title or f"[{a}, {b}]") + suffix, fontsize=9)
    ax.tick_params(labelsize=8)
    ax.legend(fontsize=7)


if __name__ == "__main__":
    # (a, b, log, title): log=None defers to the global `log` flag; log=True
    # forces symlog on both axes (used for the wide bit-band plots).
    # title=None falls back to the default "[a, b]" formatting.
    cases = [
        (-500, 500, None, None),
        (-200, 1000, None, None),
        (500, 5000, None, None),
        None,
        (-(2**15), 2**15, True, "[-2^15, 2^15]"),
        (-(2**15), 2**15, None, "[-2^15, 2^15]"),
        (-(2**25), 2**25, True, "[-2^25, 2^25]"),
        (-(2**25), 2**25, None, "[-2^25, 2^25]"),
        (-(2**35), 2**35, True, "[-2^35, 2^35]"),
        (-(2**35), 2**35, None, "[-2^35, 2^35]"),
        (-(2**45), 2**45, True, "[-2^45, 2^45]"),
        (-(2**45), 2**45, None, "[-2^45, 2^45]"),
        (-(2**100), 2**100, True, "[-2^100, 2^100]"),
        (-(2**100), 2**100, None, "[-2^100, 2^100]"),
    ]

    ncols = 2
    nrows = (len(cases) + ncols - 1) // ncols
    fig = plt.figure(figsize=(11, min(2.6 * nrows, 9)))
    fig.suptitle(str(dist), fontsize=10)
    gs = fig.add_gridspec(nrows, ncols)
    for i, case in enumerate(cases):
        if case is None:
            continue
        a, b, log_scale, title = case
        ax = fig.add_subplot(gs[i // ncols, i % ncols])
        plot_case(ax, a, b, log_x=log_scale, log_y=log_scale, title=title)
    fig.tight_layout()
    plt.show()
```

</details>

Here's a comparison tool I had claude cook up for me:  [distribution_family_explorer_v2.html](https://github.com/user-attachments/files/27585949/distribution_family_explorer_v2.html)
