### PR TITLE
Fix decimals(places=...) generating values outside requested bounds

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.strategies.decimals` with ``places=``
+generating values outside the requested ``min_value`` / ``max_value``
+bounds when those bounds contain many significant digits (:issue:`4651`).
+The internal precision was derived from :func:`math.log10`, which
+captures only the order of magnitude and therefore under-allocated
+precision both for very small bounds (``log10`` becomes negative) and
+for bounds with many digits. We now count coefficient digits directly
+from :meth:`~decimal.Decimal.as_tuple`.

--- a/hypothesis-python/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis-python/src/hypothesis/strategies/_internal/core.py
@@ -1819,7 +1819,11 @@ def decimals(
         # Fixed-point decimals are basically integers with a scale factor
         def ctx(val):
             """Return a context in which this value is lossless."""
-            precision = ceil(math.log10(abs(val) or 1)) + places + 1
+            # math.log10 captures only the order of magnitude, which under-
+            # estimates precision both for tiny values (log10 goes negative)
+            # and for values with many significant digits beyond the leading
+            # magnitude. Count coefficient digits directly instead.
+            precision = len(Decimal(val).as_tuple().digits) + places + 1
             return Context(prec=max([precision, 1]))
 
         def int_to_decimal(val):

--- a/hypothesis-python/tests/cover/test_numerics.py
+++ b/hypothesis-python/tests/cover/test_numerics.py
@@ -165,6 +165,16 @@ def test_issue_739_regression(x):
     pass
 
 
+_min_4651 = decimal.Decimal("0." + "0" * 63 + "1")
+_max_4651 = decimal.Decimal("9" * 64 + "." + "9" * 64)
+
+
+@settings(max_examples=200)
+@given(decimals(min_value=_min_4651, max_value=_max_4651, places=2))
+def test_decimals_places_with_high_precision_bounds(x):
+    assert _min_4651 <= x <= _max_4651
+
+
 def test_consistent_decimal_error():
     bad = "invalid argument to Decimal"
     with pytest.raises(InvalidArgument) as excinfo:


### PR DESCRIPTION
Fixes #4651.

`ctx()` sized precision via `math.log10`, which under-counts for tiny values and for values with many significant digits past the leading magnitude. `divide(max_value, factor)` then rounds up and `max_num` ends up over the bound. Now counts coefficient digits via `Decimal.as_tuple()`.

In-browser reproduction (Pyodide): https://aletheia-works.github.io/vivarium/repro/hypothesis/4651/

<details><summary>Repro from issue</summary>

```python
min_ = decimal.Decimal(f"0.{'0'*63}1")
max_ = decimal.Decimal(f"{'9'*64}.{'9'*64}")

@given(decimals(min_value=min_, max_value=max_, places=2))
def f(d):
    assert min_ <= d <= max_
```

</details>