### PR TITLE
Fix flatmapped bundle consumers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -138,6 +138,7 @@ their individual contributions.
 * `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (maxim.kulkin@gmail.com)
 * `Mel Seto <https://github.com/mel-seto>`_
 * `Michel Alexandre Salim <https://github.com/michel-slm>`_ (michel@michel-slm.name)
+* `Mirochill <https://github.com/Mirochill>`_
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Munir Abdinur <https://www.github.com/mabdinur>`_
 * `Nathan Goldbaum <https://www/github.com/ngoldbaum>`_

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`hypothesis.stateful.consumes` so that values consumed
+from bundles can be used with :func:`~hypothesis.strategies.SearchStrategy.flatmap`
+without raising a ``TypeError`` (:issue:`4427`).
+
+Thanks to Mirochill for this fix!

--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -639,7 +639,7 @@ class Bundle(SearchStrategy[Ex]):
 
     def flatmap(self, expand):
         if self.draw_references:
-            return type(self)(
+            return Bundle(
                 self.name,
                 consume=self.__reference_strategy.consume,
                 draw_references=False,

--- a/hypothesis-python/tests/cover/test_stateful_consumes.py
+++ b/hypothesis-python/tests/cover/test_stateful_consumes.py
@@ -1,0 +1,38 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+from hypothesis import settings as Settings, strategies as st
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    consumes,
+    initialize,
+    rule,
+    run_state_machine_as_test,
+)
+
+
+def test_flatmap_consumed_bundle():
+    class Machine(RuleBasedStateMachine):
+        my_bundle = Bundle("my_bundle")
+
+        @initialize(target=my_bundle)
+        def set_initial(self, /) -> str:
+            return "sample text"
+
+        @rule(
+            character=consumes(my_bundle).flatmap(lambda value: st.sampled_from(value))
+        )
+        def check(self, /, *, character: str):
+            assert isinstance(character, str)
+            assert len(character) == 1
+
+    Machine.TestCase.settings = Settings(stateful_step_count=1, max_examples=10)
+    run_state_machine_as_test(Machine)


### PR DESCRIPTION
Fixes #4427.

This updates `Bundle.flatmap()` to rebuild the intermediate bundle with `Bundle(...)` directly instead of `type(self)(...)`. `BundleConsumer` has a narrower constructor, so `consumes(bundle).flatmap(...)` previously failed before the strategy could run.

I also added a stateful regression covering `consumes(my_bundle).flatmap(...)`, plus the required `RELEASE.rst` and AUTHORS entry.

Validation:
- Static whitespace check: `git diff --check HEAD~1..HEAD`
- Remote CI run: https://github.com/HypothesisWorks/hypothesis/actions/runs/26180222668
  - Passed: the `basic` and `req` job groups, `test-pyodide`, Read the Docs, and all visible cross jobs except one.
  - Remaining red: `cross (macos-latest, 3.11, alt-nocover)` fails in `hypothesis-python/tests/nocover/test_scrutineer.py` with `KeyError: 'blib2to3.pygram'`; `check-required` fails because `cross -> failure`.
  - Assessment: that remaining failure is outside this PR's changed files (`hypothesis-python/src/hypothesis/stateful.py`, `hypothesis-python/tests/cover/test_stateful_consumes.py`, `hypothesis-python/RELEASE.rst`, and `AUTHORS.rst`).
- Not run locally