### PR TITLE
Bound n in binomialvariate test strategy

### DIFF
--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -52,7 +52,9 @@ def define_method_strategy(name, **kwargs):
 
 
 define_method_strategy("betavariate", alpha=beta_param, beta=beta_param)
-define_method_strategy("binomialvariate", n=st.integers(min_value=1), p=st.floats(0, 1))
+# bound n so that float(n) doesn't overflow inside random.binomialvariate's
+# `if n * p < 10.0` check (int * float forces n through float()).
+define_method_strategy("binomialvariate", n=st.integers(1, 2**1023), p=st.floats(0, 1))
 define_method_strategy("gammavariate", alpha=beta_param, beta=beta_param)
 define_method_strategy("weibullvariate", alpha=beta_param, beta=beta_param)
 define_method_strategy("choice", seq=seq_param)

--- a/hypothesis-python/tests/cover/test_randoms.py
+++ b/hypothesis-python/tests/cover/test_randoms.py
@@ -52,9 +52,9 @@ def define_method_strategy(name, **kwargs):
 
 
 define_method_strategy("betavariate", alpha=beta_param, beta=beta_param)
-# bound n so that float(n) doesn't overflow inside random.binomialvariate's
-# `if n * p < 10.0` check (int * float forces n through float()).
-define_method_strategy("binomialvariate", n=st.integers(1, 2**1023), p=st.floats(0, 1))
+# bound n so that random.binomialvariate's internal float coercions and
+# lgamma(n + 1) call (in the BTRS path on 3.14+) don't overflow.
+define_method_strategy("binomialvariate", n=st.integers(1, 2**256), p=st.floats(0, 1))
 define_method_strategy("gammavariate", alpha=beta_param, beta=beta_param)
 define_method_strategy("weibullvariate", alpha=beta_param, beta=beta_param)
 define_method_strategy("choice", seq=seq_param)


### PR DESCRIPTION
See failure: https://github.com/HypothesisWorks/hypothesis/actions/runs/26166616982/job/76973185512?pr=4716

```
FAILED tests/cover/test_randoms.py::test_call_all_methods[binomialvariate] - OverflowError: int too large to convert to float
```

<details><summary>Claude-written description</summary>

`tests/cover/test_randoms.py::test_call_all_methods[binomialvariate]` started failing under the `crosshair-custom` CI job with `OverflowError: int too large to convert to float`. The strategy used `n=st.integers(min_value=1)` — unbounded above — and Crosshair's symbolic search picked `n ≈ 10^285`, which overflows in CPython's `random.binomialvariate` on `if n * p < 10.0:` (int × float forces `n` through `float()`).

Bound `n` to `2**1023` and added a brief comment pointing at the float-coercion site. `2**1023` is the largest clean power of two whose `float()` doesn't overflow; this is well above what the Hypothesis backend would generate on its own (the new integers distribution caps unbounded ranges at `2**128`) and only matters for symbolic backends like Crosshair.

Test-only change, so no `RELEASE.rst`.

</details>
