### PR TITLE
claude: xfail KeyError form of upstream mypyc/black desync

### DIFF
--- a/hypothesis-python/tests/nocover/test_scrutineer.py
+++ b/hypothesis-python/tests/nocover/test_scrutineer.py
@@ -60,9 +60,17 @@ def get_reports(file_contents, *, testdir):
     test_file = str(testdir.makepyfile(file_contents))
     pytest_stdout = str(testdir.runpytest_inprocess(test_file, "--tb=native").stdout)
 
-    crash = "AttributeError: module 'blib2to3.pygram' has no attribute 'python_symbols'"
-    if crash in pytest_stdout:
-        pytest.xfail(reason="upstream error in Black")
+    # mypyc-compiled black/blib2to3 caches module references at the C level,
+    # which can desync from sys.modules after pytester's
+    # SysModulesSnapshot.restore() evicts blib2to3.pygram. The next
+    # `from . import pygram` then raises KeyError (newer mypyc) or
+    # AttributeError (older mypyc).
+    upstream_crashes = (
+        "AttributeError: module 'blib2to3.pygram' has no attribute 'python_symbols'",
+        "KeyError: 'blib2to3.pygram'",
+    )
+    if any(c in pytest_stdout for c in upstream_crashes):
+        pytest.xfail(reason="upstream error in Black/mypyc")
 
     explanations = {
         i: {(test_file, i)}


### PR DESCRIPTION
I haven't looked into claude's hypothesis here in detail, but it seems pretty plausible to me. Since the offending scenario is test-only, I'm happy to xfail for now.

<details><summary>Claude-written description</summary>

Widens the existing xfail in `tests/nocover/test_scrutineer.py::get_reports` to also match `KeyError: 'blib2to3.pygram'`, which is how a newer mypyc surfaces the same upstream desync that previously produced `AttributeError: module 'blib2to3.pygram' has no attribute 'python_symbols'`.

### What's happening

`test_explanations`, `test_no_explanations_if_deadline_exceeded`, and `test_skips_uninformative_locations` use pytester's `runpytest_inprocess` to run an inner pytest whose hypothesis test fails — exercising `_patching.py`'s call to `black.format_str`, which eventually calls `blib2to3.pytree.type_repr`, which on its cache-miss path runs `from . import pygram`.

mypyc commit `b137e4ed41` ("Speed up native-to-native imports within the same group") compiles `from . import pygram` (when both modules are in the same compilation group, as they are inside black's `__mypyc.so`) to roughly:

```
if module_static_for_blib2to3_pygram is NULL:
    native_import("blib2to3.pygram")          # populates sys.modules and sets the static
globals["pygram"] = sys.modules["blib2to3.pygram"]   # raw __getitem__
```

The first branch checks a C-level process-global static; the second is a raw `__getitem__` on `sys.modules`. These can disagree: pytester's `SysModulesSnapshot.restore()` does `sys.modules.clear(); sys.modules.update(saved_snapshot)`, evicting anything imported during the inner pytest while leaving the C statics intact. On a subsequent call where `_type_reprs` happens to be empty, the static-check fast-paths past the actual import and the raw dict access then raises `KeyError: 'blib2to3.pygram'`. That bubbles out of `pytest_runtest_makereport` as an `INTERNALERROR`, which corrupts the inner pytest's stdout and causes the outer assertion to fail.

The older mypyc fast path looked the attribute up on the parent module (`getattr(blib2to3, 'pygram')`), so the same desync used to manifest as `AttributeError` — which is what commit `8d0e331a2` xfailed against in March 2024.

### Why just widen the xfail

The bug only reaches Hypothesis through pytester-style test infrastructure that wipes `sys.modules` out from under mypyc-compiled black. Real-world Hypothesis users won't reach this desync through normal `_patching.py` use, so a source-side defensive catch in the plugin would be load-bearing only for our own test infrastructure. Keeping the workaround in test code matches the precedent set by the existing xfail and avoids a source change / `RELEASE.rst` for a purely test-only flake.

The proper fix lives upstream in mypyc (the optimized native-same-group `from . import` IR shouldn't trust `sys.modules` after a static-check-skipped import path).

</details>
