### PR TITLE
Improve FlakyStrategyDefinition error messages

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@ their individual contributions.
 * `Hal Blackburn <https://github.com/h4l>`_
 * `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Humberto Rocha <https://github.com/humrochagf>`_
+* `Ian Hunt-Isaak <https://github.com/ianhi>`_
 * `Ilya Lebedev <https://github.com/melevir>`_ (melevir@gmail.com)
 * `Israel Fruchter <https://github.com/fruch>`_
 * `Ivan Tham <https://github.com/pickfire>`_

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -3,7 +3,7 @@ RELEASE_TYPE: patch
 When Hypothesis detects that your data generation is flaky and raises
 ``FlakyStrategyDefinition``, the error message now describes *what* differed
 between the two runs - such as a different choice type, different constraints,
-or drawing more or less data - instead of only reporting that generation was
-inconsistent.
+or drawing more or less data - as well as the stack of strategies being drawn
+from, instead of only reporting that generation was inconsistent.
 
 Thanks to Ian Hunt-Isaak for this improvement!

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -4,6 +4,8 @@ When Hypothesis detects that your data generation is flaky and raises
 ``FlakyStrategyDefinition``, the error message now describes *what* differed
 between the two runs - such as a different choice type, different constraints,
 or drawing more or less data - as well as the stack of strategies being drawn
-from, instead of only reporting that generation was inconsistent.
+from, instead of only reporting that generation was inconsistent. In stateful
+tests, it also reports the steps leading up to the error when observability is
+enabled.
 
 Thanks to Ian Hunt-Isaak for this improvement!

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,7 +1,7 @@
 RELEASE_TYPE: patch
 
 When Hypothesis detects that your data generation is flaky and raises
-``FlakyStrategyDefinition``, the error message now describes *what* differed
+|FlakyStrategyDefinition|, the error message now describes *what* differed
 between the two runs - such as a different choice type, different constraints,
 or drawing more or less data - as well as the stack of strategies being drawn
 from, instead of only reporting that generation was inconsistent. In stateful

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+When Hypothesis detects that your data generation is flaky and raises
+``FlakyStrategyDefinition``, the error message now describes *what* differed
+between the two runs - such as a different choice type, different constraints,
+or drawing more or less data - instead of only reporting that generation was
+inconsistent.
+
+Thanks to Ian Hunt-Isaak for this improvement!

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -5,7 +5,6 @@ When Hypothesis detects that your data generation is flaky and raises
 between the two runs - such as a different choice type, different constraints,
 or drawing more or less data - as well as the stack of strategies being drawn
 from, instead of only reporting that generation was inconsistent. In stateful
-tests, it also reports the steps leading up to the error when observability is
-enabled.
+tests, it also reports the steps leading up to the error.
 
 Thanks to Ian Hunt-Isaak for this improvement!

--- a/hypothesis/docs/changelog.rst
+++ b/hypothesis/docs/changelog.rst
@@ -24,13 +24,26 @@ Hypothesis 6.x
 6.152.11 - 2026-05-26
 ---------------------
 
-This patch adds support for recursive forward references in
-:func:`~hypothesis.strategies.from_type`, such as
-``A = list[Union["A", str]]`` (:issue:`4542`).
-Previously, such recursive type aliases would raise a ``ResolutionFailed``
-error. Now, Hypothesis can automatically resolve the forward reference
-by looking it up in the caller's namespace. This also resolves forward
-references inside ``type[...]``, such as ``type["MyClass"]``.
+This patch adds support for resolving forward references in |st.from_type|
+(:issue:`4542`):
+
+.. code-block:: python
+
+    # this now works
+    A = list[Union["A", str]]
+    st.from_type(A).example()
+
+    # this also now works
+    s = st.from_type(list["B"])
+
+    @dataclass
+    class B:
+        v: int
+
+    s.example()
+
+Previously, these would raise an error. Now, Hypothesis automatically resolves
+the forward reference by looking it up in the caller's namespace.
 
 .. _v6.152.10:
 

--- a/hypothesis/docs/explanation/domain.rst
+++ b/hypothesis/docs/explanation/domain.rst
@@ -45,5 +45,6 @@ The test case distribution remains an active area of research and development, a
 * some are statically designed into strategies - for example, |st.integers| upweights range endpoints, and samples from a mixed distribution over integer bit-widths.
 * some are dynamic features of the engine - like replaying prior examples with subsections of the input 'cloned' or otherwise altered, for bugs which trigger only when different fields have the same value (which is otherwise exponentially unlikely).
 * some vary depending on the code under test - we collect interesting-looking constants from imported source files as seeds for test cases.
+* `swarm testing <https://www.cs.utah.edu/~regehr/papers/swarm12.pdf>`__ adds further randomization when choosing which rules to execute in stateful testing.
 
 And as if that wasn't enough, :ref:`alternative backends <alternative-backends>` can radically change the distribution again - for example :pypi:`hypofuzz` uses runtime feedback to modify the distribution of inputs as the test runs, to maximize the rate at which we trigger new behaviors in that particular test and code.  If Hypothesis' defaults aren't strong enough, we recommend trying Hypofuzz!

--- a/hypothesis/src/hypothesis/errors.py
+++ b/hypothesis/src/hypothesis/errors.py
@@ -8,10 +8,16 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from hypothesis.internal.compat import ExceptionGroup
+
+if TYPE_CHECKING:
+    from hypothesis.internal.conjecture.choice import ChoiceConstraintsT
+else:
+    ChoiceConstraintsT = Mapping
 
 
 class HypothesisException(Exception):
@@ -85,6 +91,13 @@ class FlakyReplay(Flaky):
         self._interesting_origins = interesting_origins
 
 
+def _render_constraints(show: Mapping[str, object], other: Mapping[str, object]) -> str:
+    assert show.keys() == other.keys()
+    return ", ".join(
+        f"{k}={'...' if v == other[k] else repr(v)}" for k, v in show.items()
+    )
+
+
 class FlakyStrategyDefinition(Flaky):
     """
     This function appears to cause inconsistent data generation.
@@ -101,7 +114,7 @@ class FlakyStrategyDefinition(Flaky):
 
     _BASE_MESSAGE = (
         "Inconsistent data generation! Data generation behaved differently "
-        "between different runs. Is your data generation depending on external "
+        "between test cases. Is your data generation depending on external "
         "state?"
     )
 
@@ -113,22 +126,22 @@ class FlakyStrategyDefinition(Flaky):
     def from_mismatch(
         cls,
         expected_type: str,
-        expected_constraints: object,
+        expected_constraints: ChoiceConstraintsT,
         actual_type: str,
-        actual_constraints: object,
+        actual_constraints: ChoiceConstraintsT,
     ) -> "FlakyStrategyDefinition":
         if actual_type != expected_type:
             detail = (
-                "The second run drew a different type of value than the first run.\n"
-                f"  first run:  {expected_type}\n"
-                f"  second run: {actual_type}\n"
+                "The second test case drew a different type of value than the first.\n"
+                f"  first:  {expected_type}\n"
+                f"  second: {actual_type}\n"
             )
         else:
             detail = (
-                f"The second run drew {actual_type} with different constraints "
-                "than the first run.\n"
-                f"  first run:  {expected_constraints}\n"
-                f"  second run: {actual_constraints}\n"
+                f"The second test case drew type {actual_type} with different constraints "
+                "than the first.\n"
+                f"  first:  {_render_constraints(expected_constraints, actual_constraints)}\n"
+                f"  second: {_render_constraints(actual_constraints, expected_constraints)}\n"
             )
         return cls.with_detail(detail)
 

--- a/hypothesis/src/hypothesis/errors.py
+++ b/hypothesis/src/hypothesis/errors.py
@@ -99,6 +99,39 @@ class FlakyStrategyDefinition(Flaky):
         See also the :doc:`flaky failures tutorial </tutorial/flaky>`.
     """
 
+    _BASE_MESSAGE = (
+        "Inconsistent data generation! Data generation behaved differently "
+        "between different runs. Is your data generation depending on external "
+        "state?"
+    )
+
+    @classmethod
+    def with_detail(cls, detail: str) -> "FlakyStrategyDefinition":
+        return cls(f"{cls._BASE_MESSAGE}\n\n{detail}")
+
+    @classmethod
+    def from_mismatch(
+        cls,
+        expected_type: str,
+        expected_constraints: object,
+        actual_type: str,
+        actual_constraints: object,
+    ) -> "FlakyStrategyDefinition":
+        if actual_type != expected_type:
+            detail = (
+                "The second run drew a different type of value than the first run.\n"
+                f"  first run:  {expected_type}\n"
+                f"  second run: {actual_type}\n"
+            )
+        else:
+            detail = (
+                f"The second run drew {actual_type} with different constraints "
+                "than the first run.\n"
+                f"  first run:  {expected_constraints}\n"
+                f"  second run: {actual_constraints}\n"
+            )
+        return cls.with_detail(detail)
+
 
 class _WrappedBaseException(Exception):
     """Used internally for wrapping BaseExceptions as components of FlakyFailure."""

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -30,6 +30,7 @@ from typing import (
 from hypothesis.errors import (
     CannotProceedScopeT,
     ChoiceTooLarge,
+    FlakyStrategyDefinition,
     Frozen,
     InvalidArgument,
     StopTest,
@@ -1202,7 +1203,15 @@ class ConjectureData:
         self.start_span(label=label)
         try:
             if not at_top_level:
-                return unwrapped.do_draw(self)
+                try:
+                    return unwrapped.do_draw(self)
+                except FlakyStrategyDefinition as err:
+                    # Record the strategy stack as the error unwinds, so that an
+                    # inconsistent-generation failure is explained in terms of the
+                    # strategies being drawn from, not just the choice sequence.
+                    # The top-level draw adds its own "while generating ..." note.
+                    add_note(err, f"while drawing from {strategy!r}")
+                    raise
             assert start_time is not None
             key = observe_as or f"generate:unlabeled_{len(self.draw_times)}"
             try:

--- a/hypothesis/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/datatree.py
@@ -53,13 +53,6 @@ class PreviouslyUnseenBehaviour(HypothesisException):
     pass
 
 
-_FLAKY_STRAT_MSG = (
-    "Inconsistent data generation! Data generation behaved differently "
-    "between different runs. Is your data generation depending on external "
-    "state?"
-)
-
-
 EMPTY: frozenset[int] = frozenset()
 
 
@@ -442,7 +435,7 @@ class TreeNode:
             self.__forced = set()
         self.__forced.add(i)
 
-    def split_at(self, i: int) -> None:
+    def split_at(self, i: int, *, new_value: object = None) -> None:
         """
         Splits the tree so that it can incorporate a decision at the draw call
         corresponding to the node at position i.
@@ -451,7 +444,11 @@ class TreeNode:
         """
 
         if i in self.forced:
-            raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+            raise FlakyStrategyDefinition.with_detail(
+                f"The {self.choice_types[i]} value was forced to "
+                f"{self.values[i]!r} in the first run, but the second run "
+                f"drew {new_value!r}.\n"
+            )
 
         assert not self.is_exhausted
 
@@ -1050,7 +1047,12 @@ class TreeRecordingObserver(DataObserver):
                 choice_type != node.choice_types[i]
                 or constraints != node.constraints[i]
             ):
-                raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                raise FlakyStrategyDefinition.from_mismatch(
+                    node.choice_types[i],
+                    node.constraints[i],
+                    choice_type,
+                    constraints,
+                )
             # Note that we don't check whether a previously
             # forced value is now free. That will be caught
             # if we ever split the node there, but otherwise
@@ -1058,9 +1060,12 @@ class TreeRecordingObserver(DataObserver):
             # means we skip a hash set lookup on every
             # draw and that's a pretty niche failure mode.
             if was_forced and i not in node.forced:
-                raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                raise FlakyStrategyDefinition.with_detail(
+                    f"The {choice_type} value was forced to a specific value "
+                    f"but was not forced on the first run.\n"
+                )
             if value != node.values[i]:
-                node.split_at(i)
+                node.split_at(i, new_value=value)
                 assert i == len(node.values)
                 new_node = TreeNode()
                 assert isinstance(node.transition, Branch)
@@ -1095,7 +1100,7 @@ class TreeRecordingObserver(DataObserver):
                     compute_max_children(choice_type, constraints) == 1
                     and not was_forced
                 ):
-                    node.split_at(i)
+                    node.split_at(i, new_value=value)
                     assert isinstance(node.transition, Branch)
                     self._current_node = node.transition.children[value]
                     self._index_in_current_node = 0
@@ -1103,11 +1108,18 @@ class TreeRecordingObserver(DataObserver):
                 assert trans.status != Status.OVERRUN
                 # We tried to draw where history says we should have
                 # stopped
-                raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                raise FlakyStrategyDefinition.with_detail(
+                    "The second run drew more data than the first run.\n"
+                )
             else:
                 assert isinstance(trans, Branch), trans
                 if choice_type != trans.choice_type or constraints != trans.constraints:
-                    raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+                    raise FlakyStrategyDefinition.from_mismatch(
+                        trans.choice_type,
+                        trans.constraints,
+                        choice_type,
+                        constraints,
+                    )
                 try:
                     self._current_node = trans.children[value]
                 except KeyError:
@@ -1127,7 +1139,10 @@ class TreeRecordingObserver(DataObserver):
             self._current_node.transition is not None
             and not isinstance(self._current_node.transition, Killed)
         ):
-            raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+            raise FlakyStrategyDefinition.with_detail(
+                "The second run stopped drawing earlier than the first run, "
+                "which continued to draw more data.\n"
+            )
 
         if self._current_node.transition is None:
             self._current_node.transition = Killed(TreeNode())
@@ -1148,7 +1163,10 @@ class TreeRecordingObserver(DataObserver):
         node = self._current_node
 
         if i < len(node.values) or isinstance(node.transition, Branch):
-            raise FlakyStrategyDefinition(_FLAKY_STRAT_MSG)
+            raise FlakyStrategyDefinition.with_detail(
+                "The second run stopped drawing earlier than the first run, "
+                "which continued to draw more data.\n"
+            )
 
         new_transition = Conclusion(status, interesting_origin)
 

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -565,23 +565,13 @@ class ConjectureRunner:
             return
         except BaseException as err:
             data.freeze()
-            if (
-                isinstance(err, FlakyStrategyDefinition)
-                and data._stateful_repr_parts is not None
-            ):
+            if isinstance(err, FlakyStrategyDefinition) and data._stateful_repr_parts:
                 # In a stateful test, surface the steps leading up to the
-                # inconsistency - recorded only when observability is enabled -
-                # or otherwise point at how to capture them.
-                if data._stateful_repr_parts:
-                    report(
-                        "Steps leading up to this error:\n"
-                        + "\n".join(f"  {s}" for s in data._stateful_repr_parts)
-                    )
-                else:
-                    report(
-                        "Tip: to see which steps led to this error, re-run with "
-                        "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1"
-                    )
+                # inconsistency.
+                report(
+                    "Steps leading up to this error:\n"
+                    + "\n".join(f"  {s}" for s in data._stateful_repr_parts)
+                )
             if self.settings.backend != "hypothesis":
                 try:
                     realize_choices(data, for_failure=True)

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -27,6 +27,7 @@ from hypothesis.database import ExampleDatabase, choices_from_bytes, choices_to_
 from hypothesis.errors import (
     BackendCannotProceed,
     FlakyBackendFailure,
+    FlakyStrategyDefinition,
     HypothesisException,
     InvalidArgument,
     StopTest,
@@ -562,8 +563,25 @@ class ConjectureRunner:
             interrupted = True
             data.freeze()
             return
-        except BaseException:
+        except BaseException as err:
             data.freeze()
+            if (
+                isinstance(err, FlakyStrategyDefinition)
+                and data._stateful_repr_parts is not None
+            ):
+                # In a stateful test, surface the steps leading up to the
+                # inconsistency - recorded only when observability is enabled -
+                # or otherwise point at how to capture them.
+                if data._stateful_repr_parts:
+                    report(
+                        "Steps leading up to this error:\n"
+                        + "\n".join(f"  {s}" for s in data._stateful_repr_parts)
+                    )
+                else:
+                    report(
+                        "Tip: to see which steps led to this error, re-run with "
+                        "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1"
+                    )
             if self.settings.backend != "hypothesis":
                 try:
                     realize_choices(data, for_failure=True)

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -132,8 +132,7 @@ def get_state_machine_test(
         def output(s):
             if print_steps:
                 report(s)
-            if observability_enabled():
-                cd._stateful_repr_parts.append(s)
+            cd._stateful_repr_parts.append(s)
 
         try:
             output(f"state = {machine.__class__.__name__}()")

--- a/hypothesis/tests/conjecture/test_data_tree.py
+++ b/hypothesis/tests/conjecture/test_data_tree.py
@@ -226,7 +226,7 @@ def test_concluding_at_prefix_is_flaky():
         data.conclude_test(Status.INTERESTING)
 
     data = ConjectureData.for_choices([], observer=tree.new_observer())
-    with pytest.raises(Flaky):
+    with pytest.raises(Flaky, match="stopped drawing earlier"):
         data.conclude_test(Status.INVALID)
 
 
@@ -250,7 +250,7 @@ def test_changing_n_bits_is_flaky_in_prefix():
         data.conclude_test(Status.INTERESTING)
 
     data = ConjectureData.for_choices((1,), observer=tree.new_observer())
-    with pytest.raises(Flaky):
+    with pytest.raises(Flaky, match="different constraints"):
         data.draw_integer(0, 3)
 
 
@@ -264,7 +264,7 @@ def test_changing_n_bits_is_flaky_in_branch():
             data.conclude_test(Status.INTERESTING)
 
     data = ConjectureData.for_choices((1,), observer=tree.new_observer())
-    with pytest.raises(Flaky):
+    with pytest.raises(Flaky, match="different constraints"):
         data.draw_integer(0, 3)
 
 
@@ -278,7 +278,7 @@ def test_extending_past_conclusion_is_flaky():
     data = ConjectureData.for_choices((True, False), observer=tree.new_observer())
     data.draw_boolean()
 
-    with pytest.raises(Flaky):
+    with pytest.raises(Flaky, match="more data"):
         data.draw_boolean()
 
 
@@ -291,7 +291,7 @@ def test_changing_to_forced_is_flaky():
 
     data = ConjectureData.for_choices((True, False), observer=tree.new_observer())
 
-    with pytest.raises(Flaky):
+    with pytest.raises(Flaky, match="was not forced on the first run"):
         data.draw_boolean(forced=True)
 
 
@@ -304,8 +304,20 @@ def test_changing_value_of_forced_is_flaky():
 
     data = ConjectureData.for_choices((True, False), observer=tree.new_observer())
 
-    with pytest.raises(Flaky):
+    with pytest.raises(Flaky, match=r"forced to True.*drew False"):
         data.draw_boolean(forced=False)
+
+
+def test_drawing_different_type_is_flaky():
+    tree = DataTree()
+    data = ConjectureData.for_choices((1,), observer=tree.new_observer())
+    data.draw_integer(0, 1)
+    with pytest.raises(StopTest):
+        data.conclude_test(Status.INTERESTING)
+
+    data = ConjectureData.for_choices((True,), observer=tree.new_observer())
+    with pytest.raises(Flaky, match="different type"):
+        data.draw_boolean()
 
 
 def test_does_not_truncate_if_unseen():

--- a/hypothesis/tests/conjecture/test_engine.py
+++ b/hypothesis/tests/conjecture/test_engine.py
@@ -48,10 +48,11 @@ from hypothesis.internal.conjecture.junkdrawer import startswith
 from hypothesis.internal.conjecture.pareto import DominanceRelation, dominance
 from hypothesis.internal.conjecture.shrinker import Shrinker, ShrinkPass
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
+from hypothesis.strategies._internal.strategies import SearchStrategy
 
 from tests.common.debug import minimal
 from tests.common.strategies import SLOW, HardToShrink
-from tests.common.utils import no_shrink, skipif_time_unpatched
+from tests.common.utils import capture_out, no_shrink, skipif_time_unpatched
 from tests.conjecture.common import (
     SOME_LABEL,
     buffer_size_limit,
@@ -1830,3 +1831,45 @@ def test_integer_overflow_fallback(n):
 @given(st.integers(2**500, 2**500 + 10))
 def test_integer_narrow_tail_fallback(n):
     assert 2**500 <= n <= 2**500 + 10
+
+
+class _RaisesFlaky(SearchStrategy):
+    def do_draw(self, data):
+        raise FlakyStrategyDefinition.with_detail("inner detail")
+
+
+class _DrawsFrom(SearchStrategy):
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    def do_draw(self, data):
+        return data.draw(self.inner)
+
+
+def test_flaky_strategy_definition_records_strategy_stack():
+    # A FlakyStrategyDefinition raised inside a nested strategy draw accumulates
+    # "while drawing from ..." notes as it unwinds, naming the strategies drawn
+    # from rather than just the low-level choice sequence.
+    def test(data):
+        data.draw(_DrawsFrom(_RaisesFlaky()))
+
+    with pytest.raises(FlakyStrategyDefinition) as excinfo:
+        ConjectureRunner(test, settings=settings(database=None)).run()
+    notes = getattr(excinfo.value, "__notes__", [])
+    assert any("while drawing from" in note for note in notes)
+
+
+def test_flaky_strategy_definition_reports_stateful_steps(monkeypatch):
+    # In a stateful test the engine reports the recorded steps leading up to the
+    # inconsistency. We set _stateful_repr_parts directly to avoid pulling in the
+    # stateful machinery here.
+    monkeypatch.setattr("hypothesis.core.running_under_pytest", False)
+
+    def test(data):
+        data._stateful_repr_parts = ["state = Machine()", "state.step()"]
+        raise FlakyStrategyDefinition.with_detail("inconsistent")
+
+    with capture_out() as out, pytest.raises(FlakyStrategyDefinition):
+        ConjectureRunner(test, settings=settings(database=None)).run()
+    assert "Steps leading up to this error" in out.getvalue()

--- a/hypothesis/tests/cover/test_flakiness.py
+++ b/hypothesis/tests/cover/test_flakiness.py
@@ -9,18 +9,27 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import sys
+from random import Random
 
 import pytest
 
 from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
 from hypothesis.core import StateForActualGivenExecution
-from hypothesis.errors import Flaky, FlakyFailure, Unsatisfiable, UnsatisfiedAssumption
+from hypothesis.errors import (
+    Flaky,
+    FlakyFailure,
+    FlakyStrategyDefinition,
+    Unsatisfiable,
+    UnsatisfiedAssumption,
+)
 from hypothesis.internal.compat import ExceptionGroup
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.internal.scrutineer import Tracer
 from hypothesis.strategies import booleans, composite, integers, lists, random_module
+from hypothesis.strategies._internal.strategies import SearchStrategy
 
 from tests.common.utils import Why, no_shrink, skipif_threading, xfail_on_crosshair
+from tests.conjecture.common import fresh_data
 
 
 class Nope(Exception):
@@ -210,3 +219,28 @@ def test_failure_sequence_inducing(building, testing, rnd):
         pass
     except UnsatisfiedAssumption:
         raise SatisfyMe from None
+
+
+class _RaisesFlaky(SearchStrategy):
+    def do_draw(self, data):
+        raise FlakyStrategyDefinition.with_detail("inner detail")
+
+
+class _DrawsFrom(SearchStrategy):
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    def do_draw(self, data):
+        return data.draw(self.inner)
+
+
+def test_flaky_strategy_definition_records_strategy_stack():
+    # A FlakyStrategyDefinition raised inside a nested strategy draw accumulates
+    # "while drawing from ..." notes as it unwinds, so that the failure is
+    # explained in terms of the strategies drawn from, not just the choices.
+    data = fresh_data(random=Random(0))
+    with pytest.raises(FlakyStrategyDefinition) as excinfo:
+        data.draw(_DrawsFrom(_RaisesFlaky()))
+    notes = getattr(excinfo.value, "__notes__", [])
+    assert any("while drawing from" in note for note in notes)

--- a/hypothesis/tests/cover/test_flakiness.py
+++ b/hypothesis/tests/cover/test_flakiness.py
@@ -9,11 +9,21 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import sys
+import time
 from random import Random
 
 import pytest
 
-from hypothesis import HealthCheck, Verbosity, assume, example, given, reject, settings
+from hypothesis import (
+    HealthCheck,
+    Verbosity,
+    assume,
+    core,
+    example,
+    given,
+    reject,
+    settings,
+)
 from hypothesis.core import StateForActualGivenExecution
 from hypothesis.errors import (
     Flaky,
@@ -25,10 +35,25 @@ from hypothesis.errors import (
 from hypothesis.internal.compat import ExceptionGroup
 from hypothesis.internal.conjecture.engine import MIN_TEST_CALLS
 from hypothesis.internal.scrutineer import Tracer
-from hypothesis.strategies import booleans, composite, integers, lists, random_module
+from hypothesis.stateful import RuleBasedStateMachine, rule
+from hypothesis.strategies import (
+    booleans,
+    composite,
+    data,
+    integers,
+    lists,
+    random_module,
+)
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
-from tests.common.utils import Why, no_shrink, skipif_threading, xfail_on_crosshair
+from tests.common.utils import (
+    Why,
+    capture_observations,
+    capture_out,
+    no_shrink,
+    skipif_threading,
+    xfail_on_crosshair,
+)
 from tests.conjecture.common import fresh_data
 
 
@@ -244,3 +269,33 @@ def test_flaky_strategy_definition_records_strategy_stack():
         data.draw(_DrawsFrom(_RaisesFlaky()))
     notes = getattr(excinfo.value, "__notes__", [])
     assert any("while drawing from" in note for note in notes)
+
+
+class FlakyTimeStateMachine(RuleBasedStateMachine):
+    @rule(data=data())
+    def step(self, data):
+        # time advances between runs, so the integers() constraints differ when
+        # the same choice sequence is replayed - an inconsistent-generation flake.
+        data.draw(integers(time.time_ns(), time.time_ns() + 2))
+
+
+@pytest.mark.parametrize("observability", [False, True])
+def test_flaky_stateful_reports_steps_or_tip(monkeypatch, observability):
+    # ensure report() prints to stdout (rather than via the pytest plugin)
+    monkeypatch.setattr(core, "running_under_pytest", False)
+    FlakyTimeStateMachine.TestCase.settings = settings(
+        max_examples=200, database=None, stateful_step_count=5
+    )
+
+    def run():
+        with capture_out() as out, pytest.raises(FlakyStrategyDefinition):
+            FlakyTimeStateMachine.TestCase().runTest()
+        return out.getvalue()
+
+    if observability:
+        with capture_observations():
+            output = run()
+        assert "Steps leading up to this error" in output
+    else:
+        output = run()
+        assert "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1" in output

--- a/hypothesis/tests/cover/test_flakiness.py
+++ b/hypothesis/tests/cover/test_flakiness.py
@@ -48,7 +48,6 @@ from hypothesis.strategies._internal.strategies import SearchStrategy
 
 from tests.common.utils import (
     Why,
-    capture_observations,
     capture_out,
     no_shrink,
     skipif_threading,
@@ -279,23 +278,14 @@ class FlakyTimeStateMachine(RuleBasedStateMachine):
         data.draw(integers(time.time_ns(), time.time_ns() + 2))
 
 
-@pytest.mark.parametrize("observability", [False, True])
-def test_flaky_stateful_reports_steps_or_tip(monkeypatch, observability):
+def test_flaky_stateful_reports_steps(monkeypatch):
+    # Steps are recorded regardless of observability, so a flaky stateful test
+    # always reports the steps leading up to the error.
     # ensure report() prints to stdout (rather than via the pytest plugin)
     monkeypatch.setattr(core, "running_under_pytest", False)
     FlakyTimeStateMachine.TestCase.settings = settings(
         max_examples=200, database=None, stateful_step_count=5
     )
-
-    def run():
-        with capture_out() as out, pytest.raises(FlakyStrategyDefinition):
-            FlakyTimeStateMachine.TestCase().runTest()
-        return out.getvalue()
-
-    if observability:
-        with capture_observations():
-            output = run()
-        assert "Steps leading up to this error" in output
-    else:
-        output = run()
-        assert "HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY=1" in output
+    with capture_out() as out, pytest.raises(FlakyStrategyDefinition):
+        FlakyTimeStateMachine.TestCase().runTest()
+    assert "Steps leading up to this error" in out.getvalue()

--- a/hypothesis/tests/cover/test_flakiness.py
+++ b/hypothesis/tests/cover/test_flakiness.py
@@ -10,7 +10,6 @@
 
 import sys
 import time
-from random import Random
 
 import pytest
 
@@ -44,7 +43,6 @@ from hypothesis.strategies import (
     lists,
     random_module,
 )
-from hypothesis.strategies._internal.strategies import SearchStrategy
 
 from tests.common.utils import (
     Why,
@@ -53,7 +51,6 @@ from tests.common.utils import (
     skipif_threading,
     xfail_on_crosshair,
 )
-from tests.conjecture.common import fresh_data
 
 
 class Nope(Exception):
@@ -243,31 +240,6 @@ def test_failure_sequence_inducing(building, testing, rnd):
         pass
     except UnsatisfiedAssumption:
         raise SatisfyMe from None
-
-
-class _RaisesFlaky(SearchStrategy):
-    def do_draw(self, data):
-        raise FlakyStrategyDefinition.with_detail("inner detail")
-
-
-class _DrawsFrom(SearchStrategy):
-    def __init__(self, inner):
-        super().__init__()
-        self.inner = inner
-
-    def do_draw(self, data):
-        return data.draw(self.inner)
-
-
-def test_flaky_strategy_definition_records_strategy_stack():
-    # A FlakyStrategyDefinition raised inside a nested strategy draw accumulates
-    # "while drawing from ..." notes as it unwinds, so that the failure is
-    # explained in terms of the strategies drawn from, not just the choices.
-    data = fresh_data(random=Random(0))
-    with pytest.raises(FlakyStrategyDefinition) as excinfo:
-        data.draw(_DrawsFrom(_RaisesFlaky()))
-    notes = getattr(excinfo.value, "__notes__", [])
-    assert any("while drawing from" in note for note in notes)
 
 
 class FlakyTimeStateMachine(RuleBasedStateMachine):


### PR DESCRIPTION
Extracted from #4676 — just the `FlakyStrategyDefinition` error-message improvements; the rest of it we can consider separately if motivated to rebase and reopen.  Fixes #4673, closes #4676.

Inconsistent-generation (flaky strategy) errors now explain:

- **what** differed between the two runs — a different choice type, different constraints, a forced/unforced mismatch, or drawing more or less data;
- **where**, in strategy terms — the stack of strategies being drawn from (`while drawing from ...`), alongside the existing top-level note;
- and in **stateful** tests, the steps leading up to the error.

(also sneakily closes #4683, via 1ecaa45436cb7bd0658b86d017fe9a940917606b)