### PR TITLE
Fix not emitting newline markers in patches

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where we emitted incorrect git patch files when one file did not have a trailing newline (:issue:`4744`).

--- a/hypothesis/src/hypothesis/extra/_patching.py
+++ b/hypothesis/src/hypothesis/extra/_patching.py
@@ -317,7 +317,18 @@ def make_patch(
             fromfile=f"./{fname}",  # git strips the first part of the path by default
             tofile=f"./{fname}",
         )
-        diffs.append("".join(ud))
+        # difflib.unified_diff omits the `\ No newline at end of file` marker
+        # that git requires; add it ourselves. We check every line because the
+        # marker may apply to a `-` line that isn't the last line of the diff.
+        # See https://github.com/HypothesisWorks/hypothesis/issues/4744.
+        lines = []
+        for line in ud:
+            if line.endswith("\n"):
+                lines.append(line)
+            else:
+                lines.append(line + "\n")
+                lines.append("\\ No newline at end of file\n")
+        diffs.append("".join(lines))
     return "".join(diffs)
 
 

--- a/hypothesis/tests/patching/test_patching.py
+++ b/hypothesis/tests/patching/test_patching.py
@@ -236,6 +236,50 @@ ADDED_LINES = """
 """
 
 
+def test_make_patch_handles_missing_trailing_newline(tmp_path):
+    # see https://github.com/HypothesisWorks/hypothesis/issues/4744
+    p = tmp_path / "example.py"
+    p.write_text("a = 1\nb = 2", encoding="utf-8")  # note: no trailing newline
+    when = datetime.now()
+    msg = "a message from the test"
+    author = "the patch author"
+    got = make_patch([(str(p), "a = 1", "a = 11")], when=when, msg=msg, author=author)
+    expected = HEADER.format(when=when, msg=msg, author=author) + (
+        f"--- ./{p}\n"
+        f"+++ ./{p}\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-a = 1\n"
+        "+a = 11\n"
+        " b = 2\n"
+        "\\ No newline at end of file\n"
+    )
+    assert got == expected
+
+
+def test_make_patch_handles_missing_trailing_newline_on_changed_line(tmp_path):
+    # both sides lack a trailing newline and the differing last line forces
+    # two markers, with the `-` marker in the middle of the diff.
+    p = tmp_path / "example.py"
+    p.write_text("x = 1\nlast = old", encoding="utf-8")
+    when = datetime.now()
+    msg = "a message from the test"
+    author = "the patch author"
+    got = make_patch(
+        [(str(p), "last = old", "last = new")], when=when, msg=msg, author=author
+    )
+    expected = HEADER.format(when=when, msg=msg, author=author) + (
+        f"--- ./{p}\n"
+        f"+++ ./{p}\n"
+        "@@ -1,2 +1,2 @@\n"
+        " x = 1\n"
+        "-last = old\n"
+        "\\ No newline at end of file\n"
+        "+last = new\n"
+        "\\ No newline at end of file\n"
+    )
+    assert got == expected
+
+
 @skipif_threading
 @pytest.mark.skipif(WINDOWS, reason="backslash support is tricky")
 def test_pytest_reports_patch_file_location(pytester):


### PR DESCRIPTION
Fixes #4744.

<details><summary>Claude-written description</summary>

`make_patch()` in `hypothesis/extra/_patching.py` uses `difflib.unified_diff`, which doesn't emit the `\ No newline at end of file` marker that git requires when either side of the diff lacks a trailing newline. The pytest plugin's resulting patch is therefore rejected by `git apply` as corrupt.

Worse: when both sides' differing last lines lack newlines, the raw `unified_diff` output concatenates the `-` and `+` lines into a single mashed line (e.g. `-last = old+last = new`), so the patch isn't just missing an annotation, it's structurally broken.

The fix post-processes the diff output: for any line that doesn't end with `\n`, terminate it and append the marker. This handles all five permutations (both sides have/lack newline, equal/differing last lines).

Two new tests in `tests/patching/test_patching.py` assert exact patch text for the context-line and changed-line cases.

</details>
