### PR TITLE
Fix out-of-bounds `decimals()` generation

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where :func:`~hypothesis.strategies.decimals` with the
+``places`` argument could generate values outside the ``min_value`` and
+``max_value`` bounds, when those bounds had more fractional digits than
+``places`` (:issue:`4651`).

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -1840,10 +1840,13 @@ def decimals(
 
         factor = Decimal(10) ** -places
         min_num, max_num = None, None
+        # Work out the integer bounds exactly: limited-precision division can
+        # round when the bounds have more than `places` fractional digits,
+        # which would make ceil/floor over- or undershoot the true bound.
         if min_value is not None:
-            min_num = ceil(ctx(min_value).divide(min_value, factor))
+            min_num = ceil(Fraction(min_value) / Fraction(factor))
         if max_value is not None:
-            max_num = floor(ctx(max_value).divide(max_value, factor))
+            max_num = floor(Fraction(max_value) / Fraction(factor))
         if min_num is not None and max_num is not None and min_num > max_num:
             raise InvalidArgument(
                 f"There are no decimals with {places} places between "

--- a/hypothesis/tests/cover/test_numerics.py
+++ b/hypothesis/tests/cover/test_numerics.py
@@ -89,9 +89,9 @@ def test_fuzz_fractions_bounds(data):
 @given(data())
 def test_fuzz_decimals_bounds(data):
     places = data.draw(none() | integers(0, 20), label="places")
-    finite_decs = (
-        decimals(allow_nan=False, allow_infinity=False, places=places) | none()
-    )
+    # Note that the bounds are *not* restricted to `places` digits, so they may
+    # have more fractional digits than the values we generate (see issue #4651).
+    finite_decs = decimals(allow_nan=False, allow_infinity=False) | none()
     low, high = data.draw(tuples(finite_decs, finite_decs), label="low, high")
     if low is not None and high is not None and low > high:
         low, high = high, low
@@ -158,6 +158,23 @@ def test_works_with_few_values(dec):
 @given(decimals(places=3, allow_nan=False, allow_infinity=False))
 def test_issue_725_regression(x):
     pass
+
+
+@given(
+    decimals(
+        min_value=decimal.Decimal(f"0.{'0' * 63}1"),
+        max_value=decimal.Decimal(f"{'9' * 64}.{'9' * 64}"),
+        places=2,
+    )
+)
+def test_issue_4651_regression(x):
+    # Bounds with more fractional digits than `places` must not push the
+    # integer bounds out of range via rounding in the conversion.
+    assert (
+        decimal.Decimal(f"0.{'0' * 63}1")
+        <= x
+        <= decimal.Decimal(f"{'9' * 64}.{'9' * 64}")
+    )
 
 
 @given(decimals(min_value="0.1", max_value="0.3"))


### PR DESCRIPTION
Compute the integer bounds for fixed-point decimals exactly with Fraction. Previously they were derived via a limited-precision Context.divide whose precision was based only on the integer-part magnitude, so bounds with more fractional digits than `places` could round during the division and make ceil/floor over- or undershoot, yielding values outside min_value/max_value.

Fixes #4651.