### PR TITLE
Track `interesting_origin` correctly in `fuzz_one_input`

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where :ref:`fuzz_one_input <fuzz_one_input>` did not
+track the ``interesting_origin`` of failures (:issue:`4420`).  As a result, it
+only saved the single smallest failure to the database rather than the smallest
+example of each distinct failure, and the ``interesting_origin`` was missing
+from :ref:`observability <observability>` reports.

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -2328,7 +2328,11 @@ def given(
                 except UnsatisfiedAssumption:
                     status = Status.INVALID
                     return None
-                except BaseException:
+                except BaseException as e:
+                    # The engine sets data.interesting_origin in
+                    # _execute_once_for_engine, but fuzz_one_input calls
+                    # execute_once directly, so we replicate it here.
+                    data.interesting_origin = InterestingOrigin.from_exception(e)
                     known = minimal_failures.get(data.interesting_origin)
                     if settings.database is not None and (
                         known is None or sort_key(data.nodes) <= sort_key(known)

--- a/hypothesis/tests/cover/test_fuzz_one_input.py
+++ b/hypothesis/tests/cover/test_fuzz_one_input.py
@@ -130,6 +130,9 @@ def test_can_access_strategy_for_wrapped_test():
         ([b"dd", b"cc", b"bb", b"aa"], 4),  # descending -> saves all
         ([b"cc", b"dd", b"aa", b"bb"], 2),  # sawtooth -> saves cc then aa
         ([b"aa", b"bb", b"cc", b"XX"], 2),  # two distinct errors -> saves both
+        # distinct errors are tracked per interesting_origin, so the second is
+        # saved even though it's larger than the first (see #4420).
+        ([b"XX", b"yy"], 2),
     ],
 )
 def test_fuzz_one_input_does_not_add_redundant_entries_to_database(buffers, db_size):

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -370,6 +370,24 @@ def test_fuzz_one_input_status(buffer, expected_status):
     assert ls[0].how_generated == "fuzz_one_input"
 
 
+def test_fuzz_one_input_sets_interesting_origin():
+    # fuzz_one_input calls execute_once directly, bypassing the engine code
+    # which sets data.interesting_origin, so it must do so itself (see #4420).
+    @given(st.booleans())
+    def test_fails(b):
+        raise AssertionError
+
+    with capture_observations() as ls, pytest.raises(AssertionError):
+        test_fails.hypothesis.fuzz_one_input(bytes([255]))
+
+    (observation,) = ls
+    assert observation.status == "failed"
+    origin = observation.metadata.interesting_origin
+    assert origin is not None
+    assert origin.exc_type is AssertionError
+    assert observation.status_reason == str(origin)
+
+
 def _decode_choice(value):
     if isinstance(value, list):
         if value[0] == "integer":


### PR DESCRIPTION
`fuzz_one_input` calls `execute_once` directly, bypassing the engine's `_execute_once_for_engine` which is where `data.interesting_origin` is normally set. As a result, `data.interesting_origin` was always None, so distinct failures collapsed into a single database slot (only the globally-smallest example was kept) and observability reports omitted the interesting_origin.

Compute the `InterestingOrigin` in `fuzz_one_input`'s failure path so that the smallest example of each distinct origin is saved and observations report the correct origin.

Fixes https://github.com/HypothesisWorks/hypothesis/issues/4420.