### PR TITLE
Split explain-phase statistics out of shrink phase

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+The ``--hypothesis-show-statistics`` report now accounts for the
+|Phase.explain| phase separately, rather than including its runtime and test
+cases in the |Phase.shrink| phase (:issue:`4179`).

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -401,8 +401,9 @@ class ConjectureRunner:
             elapsed = time.perf_counter() - start_time
             # A phase can be entered more than once (the explain phase runs once
             # per shrinking target), so accumulate into any existing bucket.
-            stats = self.statistics.setdefault(  # type: ignore
-                phase + "-phase", {"duration-seconds": 0.0, "test-cases": []}
+            stats = self.statistics.setdefault(
+                phase + "-phase",  # type: ignore
+                {"duration-seconds": 0.0, "test-cases": []},
             )
             stats["duration-seconds"] += elapsed - self._nested_phase_seconds
             stats["test-cases"] += self.stats_per_test_case

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -226,6 +226,7 @@ StatisticsDict = TypedDict(
         "generate-phase": NotRequired[PhaseStatistics],
         "reuse-phase": NotRequired[PhaseStatistics],
         "shrink-phase": NotRequired[PhaseStatistics],
+        "explain-phase": NotRequired[PhaseStatistics],
         "stopped-because": NotRequired[str],
         "targets": NotRequired[dict[str, float]],
         "nodeid": NotRequired[str],
@@ -308,6 +309,8 @@ class ConjectureRunner:
         self._current_phase: str = "(not a phase)"
         self.statistics: StatisticsDict = {}
         self.stats_per_test_case: list[CallStats] = []
+        # Time spent in any nested phase, so the enclosing phase can exclude it.
+        self._nested_phase_seconds: float = 0.0
 
         self.interesting_examples: dict[InterestingOrigin, ConjectureResult] = {}
         # We use call_count because there may be few possible valid_examples.
@@ -379,20 +382,42 @@ class ConjectureRunner:
 
     @contextmanager
     def _log_phase_statistics(
-        self, phase: Literal["reuse", "generate", "shrink"]
+        self, phase: Literal["reuse", "generate", "shrink", "explain"]
     ) -> Generator[None, None, None]:
-        self.stats_per_test_case.clear()
+        # Phases may nest - the explain phase runs inside the shrink phase - so
+        # we save and restore the per-call stats and current phase, exclude the
+        # duration of any nested phase, and accumulate when a phase is entered
+        # more than once (the explain phase runs once per shrinking target).
+        saved_stats = self.stats_per_test_case
+        saved_phase = self._current_phase
+        saved_nested_seconds = self._nested_phase_seconds
+        self.stats_per_test_case = []
+        self._current_phase = phase
+        self._nested_phase_seconds = 0.0
         start_time = time.perf_counter()
         try:
-            self._current_phase = phase
             yield
         finally:
-            self.statistics[phase + "-phase"] = {  # type: ignore
-                "duration-seconds": time.perf_counter() - start_time,
-                "test-cases": list(self.stats_per_test_case),
-                "distinct-failures": len(self.interesting_examples),
-                "shrinks-successful": self.shrinks,
-            }
+            elapsed = time.perf_counter() - start_time
+            duration = elapsed - self._nested_phase_seconds
+            stats = cast(
+                "PhaseStatistics | None", self.statistics.get(phase + "-phase")
+            )
+            if stats is None:
+                self.statistics[phase + "-phase"] = {  # type: ignore
+                    "duration-seconds": duration,
+                    "test-cases": self.stats_per_test_case,
+                    "distinct-failures": len(self.interesting_examples),
+                    "shrinks-successful": self.shrinks,
+                }
+            else:
+                stats["duration-seconds"] += duration
+                stats["test-cases"] += self.stats_per_test_case
+                stats["distinct-failures"] = len(self.interesting_examples)
+                stats["shrinks-successful"] = self.shrinks
+            self.stats_per_test_case = saved_stats
+            self._current_phase = saved_phase
+            self._nested_phase_seconds = saved_nested_seconds + elapsed
 
     @property
     def should_optimise(self) -> bool:

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -399,22 +399,15 @@ class ConjectureRunner:
             yield
         finally:
             elapsed = time.perf_counter() - start_time
-            duration = elapsed - self._nested_phase_seconds
-            stats = cast(
-                "PhaseStatistics | None", self.statistics.get(phase + "-phase")
+            # A phase can be entered more than once (the explain phase runs once
+            # per shrinking target), so accumulate into any existing bucket.
+            stats = self.statistics.setdefault(  # type: ignore
+                phase + "-phase", {"duration-seconds": 0.0, "test-cases": []}
             )
-            if stats is None:
-                self.statistics[phase + "-phase"] = {  # type: ignore
-                    "duration-seconds": duration,
-                    "test-cases": self.stats_per_test_case,
-                    "distinct-failures": len(self.interesting_examples),
-                    "shrinks-successful": self.shrinks,
-                }
-            else:
-                stats["duration-seconds"] += duration
-                stats["test-cases"] += self.stats_per_test_case
-                stats["distinct-failures"] = len(self.interesting_examples)
-                stats["shrinks-successful"] = self.shrinks
+            stats["duration-seconds"] += elapsed - self._nested_phase_seconds
+            stats["test-cases"] += self.stats_per_test_case
+            stats["distinct-failures"] = len(self.interesting_examples)
+            stats["shrinks-successful"] = self.shrinks
             self.stats_per_test_case = saved_stats
             self._current_phase = saved_phase
             self._nested_phase_seconds = saved_nested_seconds + elapsed

--- a/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
@@ -491,10 +491,12 @@ class Shrinker:
         self.explain()
 
     def explain(self) -> None:
-
         if not self.should_explain or not self.shrink_target.arg_slices:
             return
+        with self.engine._log_phase_statistics("explain"):
+            self._explain()
 
+    def _explain(self) -> None:
         self.max_stall = 2**100
         shrink_target = self.shrink_target
         nodes = self.nodes

--- a/hypothesis/tests/cover/test_statistical_events.py
+++ b/hypothesis/tests/cover/test_statistical_events.py
@@ -16,6 +16,7 @@ import pytest
 
 from hypothesis import (
     HealthCheck,
+    Phase,
     assume,
     event,
     example,
@@ -183,6 +184,21 @@ def test_has_lambdas_in_output():
 
     stats = call_for_statistics(test)
     assert any("lambda x: x % 2 == 0" in e for e in unique_events(stats))
+
+
+def test_explain_phase_is_separate_from_shrink_phase():
+    @settings(phases=[Phase.generate, Phase.shrink, Phase.explain], derandomize=True)
+    @given(st.integers(min_value=0), st.integers(min_value=0))
+    def test(a, b):
+        assert a < 100
+
+    stats = call_for_statistics(test)
+    # The explain phase varies the freely-changeable ``b`` argument, so its
+    # test cases land in their own bucket rather than inflating the shrink phase.
+    assert stats["explain-phase"]["test-cases"]
+    described = describe_statistics(stats)
+    assert "during shrink phase" in described
+    assert "during explain phase" in described
 
 
 def test_stops_after_x_shrinks(monkeypatch):


### PR DESCRIPTION
Previously the explain phase ran inside the shrink phase's statistics context, so its runtime and test cases were folded into the shrink phase and a slow explain phase looked like slow shrinking. Make phase logging nestable so explain gets its own bucket, with the shrink phase excluding nested explain time.

Closes https://github.com/HypothesisWorks/hypothesis/issues/4179.