### PR TITLE
Accept covariant value types in `fixed_dictionaries()`

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch improves the type annotations of |st.fixed_dictionaries|, which now
+accepts a :class:`~collections.abc.Mapping` rather than requiring an invariant
+``dict``.  Because the value type is covariant, type-checkers can now infer the
+generated type even when the strategies are heterogeneous, e.g. a ``mapping``
+annotated as ``dict[str, SearchStrategy[int] | SearchStrategy[str]]`` (:issue:`4665`).
+
+The ``mapping`` and ``optional`` arguments may now also have different key and
+value types, which are unioned in the inferred result.

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -10,7 +10,7 @@
 
 import copy
 import math
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any, TypeGuard, overload
 
 from hypothesis import strategies as st
@@ -370,30 +370,30 @@ class UniqueSampledListStrategy(UniqueListStrategy):
         return result
 
 
-class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
-    """A strategy which produces dicts with a fixed set of keys, given a
+class FixedDictStrategy(SearchStrategy[Mapping[Any, Any]]):
+    """A strategy which produces mappings with a fixed set of keys, given a
     strategy for each of their equivalent values.
 
-    e.g. {'foo' : some_int_strategy} would generate dicts with the single
+    e.g. {'foo' : some_int_strategy} would generate mappings with the single
     key 'foo' mapping to some integer.
     """
 
     def __init__(
         self,
-        mapping: dict[Any, SearchStrategy[Any]],
+        mapping: Mapping[Any, SearchStrategy[Any]],
         *,
-        optional: dict[Any, SearchStrategy[Any]] | None,
+        optional: Mapping[Any, SearchStrategy[Any]] | None,
     ):
         super().__init__()
         dict_type = type(mapping)
         self.mapping = mapping
         keys = tuple(mapping.keys())
         self.fixed = st.tuples(*[mapping[k] for k in keys]).map(
-            lambda value: dict_type(zip(keys, value, strict=True))
+            lambda value: dict_type(zip(keys, value, strict=True))  # type: ignore
         )
         self.optional = optional
 
-    def do_draw(self, data: ConjectureData) -> dict[Any, Any]:
+    def do_draw(self, data: ConjectureData) -> Mapping[Any, Any]:
         context = current_build_context()
         arg_labels: ArgLabelsT = {}
         pairs: list[tuple[Any, Any]] = []
@@ -422,11 +422,11 @@ class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
         # Vary the dict's iteration order (#3906).  We shuffle after choosing
         # the optional keys, so only order varies, not the set of keys.
         cu.fisher_yates_shuffle(data, pairs)
-        value = type(self.mapping)(pairs)
+        value = type(self.mapping)(pairs)  # type: ignore
 
         if arg_labels:
             context.known_object_printers[IDKey(value)].append(
-                _fixeddict_pprinter(arg_labels, self.mapping)
+                _fixeddict_pprinter(arg_labels)
             )
         return value
 

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -499,43 +499,59 @@ def iterables(
     ).map(PrettyIter)
 
 
-# this type definition is imprecise, in multiple ways:
-# * mapping and optional can be of different types:
-#      s: dict[str | int, int] = st.fixed_dictionaries(
-#         {"a": st.integers()}, optional={1: st.integers()}
-#     )
-# * the values in either mapping or optional need not all be of the same type:
-#      s: dict[str, int | bool] = st.fixed_dictionaries(
-#         {"a": st.integers(), "b": st.booleans()}
-#     )
-# * the arguments may be of any dict-compatible type, in which case the return
-#   value will be of that type instead of dict
+# fixed_dictionaries accepts Mapping rather than the invariant dict so that
+# type-checkers can infer the value type even when the per-key strategies are
+# heterogeneous: Mapping is covariant in its value type and SearchStrategy is
+# covariant in its own, so e.g. `SearchStrategy[int] | SearchStrategy[str]` is
+# accepted as `SearchStrategy[int | str]`.  The overloads let mapping and
+# optional contribute independent key and value types, which are unioned in the
+# result.  See revealed_types.py for the resulting types.
 #
-# Overloads may help here, but I doubt we'll be able to satisfy all these
-# constraints.
+# We use fresh typevars rather than the module-level Ex because Ex has a default
+# (PEP 696), and a defaulted typevar may not precede a bare one in a signature.
 #
-# Here's some platonic ideal test cases for revealed_types.py, with the understanding
-# that some may not be achievable:
-#
-#   ("fixed_dictionaries({'a': booleans()})", "dict[str, bool]"),
-#   ("fixed_dictionaries({'a': booleans(), 'b': integers()})", "dict[str, bool | int]"),
-#   ("fixed_dictionaries({}, optional={'a': booleans()})", "dict[str, bool]"),
-#   (
-#       "fixed_dictionaries({'a': booleans()}, optional={1: booleans()})",
-#       "dict[str | int, bool]",
-#   ),
-#   (
-#       "fixed_dictionaries({'a': booleans()}, optional={1: integers()})",
-#       "dict[str | int, bool | int]",
-#   ),
+# The remaining imprecision is that we always report a plain dict, even though
+# at runtime the result preserves the concrete (dict-subclass) type of mapping.
+K = TypeVar("K")
+V = TypeVar("V")
+K2 = TypeVar("K2")
+V2 = TypeVar("V2")
+
+
+@overload
+def fixed_dictionaries(
+    mapping: Mapping[K, SearchStrategy[V]],
+) -> SearchStrategy[dict[K, V]]:  # pragma: no cover
+    ...
+
+
+@overload
+def fixed_dictionaries(
+    # Matching an empty mapping against NoReturn lets the result come solely
+    # from optional, rather than picking up a spurious `Any` from the empty
+    # mapping (whose key and value types are otherwise uninferable).
+    mapping: Mapping[NoReturn, NoReturn],
+    *,
+    optional: Mapping[K2, SearchStrategy[V2]],
+) -> SearchStrategy[dict[K2, V2]]:  # pragma: no cover
+    ...
+
+
+@overload
+def fixed_dictionaries(
+    mapping: Mapping[K, SearchStrategy[V]],
+    *,
+    optional: Mapping[K2, SearchStrategy[V2]],
+) -> SearchStrategy[dict[K | K2, V | V2]]:  # pragma: no cover
+    ...
 
 
 @defines_strategy()
 def fixed_dictionaries(
-    mapping: dict[T, SearchStrategy[Ex]],
+    mapping: Mapping[Any, SearchStrategy[Any]],
     *,
-    optional: dict[T, SearchStrategy[Ex]] | None = None,
-) -> SearchStrategy[dict[T, Ex]]:
+    optional: Mapping[Any, SearchStrategy[Any]] | None = None,
+) -> SearchStrategy[dict[Any, Any]]:
     """Generates a dictionary of the same type as mapping with a fixed set of
     keys mapping to strategies. ``mapping`` must be a dict subclass.
 
@@ -549,12 +565,12 @@ def fixed_dictionaries(
     Examples from this strategy shrink by shrinking each individual value in
     the generated dictionary, and omitting optional key-value pairs.
     """
-    check_type(dict, mapping, "mapping")
+    check_type(Mapping, mapping, "mapping")
     for k, v in mapping.items():
         check_strategy(v, f"mapping[{k!r}]")
 
     if optional is not None:
-        check_type(dict, optional, "optional")
+        check_type(Mapping, optional, "optional")
         for k, v in optional.items():
             check_strategy(v, f"optional[{k!r}]")
         if type(mapping) != type(optional):
@@ -569,7 +585,13 @@ def fixed_dictionaries(
                 f"which is invalid: {set(mapping) & set(optional)!r}"
             )
 
-    return FixedDictStrategy(mapping, optional=optional)
+    # FixedDictStrategy honestly types itself as SearchStrategy[Mapping], since
+    # type(mapping)(pairs) may return any Mapping subclass.  We narrow to dict
+    # here because that's what callers almost always get and find convenient.
+    return cast(
+        "SearchStrategy[dict[Any, Any]]",
+        FixedDictStrategy(mapping, optional=optional),
+    )
 
 
 _get_first_item = operator.itemgetter(0)

--- a/hypothesis/src/hypothesis/vendor/pretty.py
+++ b/hypothesis/src/hypothesis/vendor/pretty.py
@@ -964,10 +964,7 @@ def _tuple_pprinter(arg_labels: ArgLabelsT) -> PrettyPrintFunction:
     return inner
 
 
-def _fixeddict_pprinter(
-    arg_labels: ArgLabelsT,
-    mapping: dict[Any, Any],
-) -> PrettyPrintFunction:
+def _fixeddict_pprinter(arg_labels: ArgLabelsT) -> PrettyPrintFunction:
     """Pretty printer for fixed_dictionaries that shows sub-argument comments."""
 
     def inner(obj: dict, p: RepresentationPrinter, cycle: bool) -> None:

--- a/hypothesis/tests/cover/test_pretty.py
+++ b/hypothesis/tests/cover/test_pretty.py
@@ -870,9 +870,8 @@ def test_fixeddict_pprinter_cycle():
     from hypothesis.vendor.pretty import _fixeddict_pprinter
 
     d = {"a": 1, "b": 2}
-    mapping = {"a": None, "b": None}  # dummy mapping for key ordering
     arg_labels = {"a": (0, 1), "b": (1, 2)}
-    pprinter = _fixeddict_pprinter(arg_labels, mapping)
+    pprinter = _fixeddict_pprinter(arg_labels)
 
     out = io.StringIO()
     p = pretty.RepresentationPrinter(out)

--- a/whole_repo_tests/types/revealed_types.py
+++ b/whole_repo_tests/types/revealed_types.py
@@ -63,6 +63,17 @@ REVEALED_TYPES = [
         "Any",
     ),
     ("from_regex(r'.', alphabet=None)", "str"),
+    ("fixed_dictionaries({'a': booleans()})", "dict[str, bool]"),
+    ("fixed_dictionaries({'a': booleans(), 'b': integers()})", "dict[str, int]"),
+    ("fixed_dictionaries({}, optional={'a': booleans()})", "dict[str, bool]"),
+    (
+        "fixed_dictionaries({'a': booleans()}, optional={1: booleans()})",
+        "dict[str | int, bool]",
+    ),
+    (
+        "fixed_dictionaries({'a': booleans()}, optional={1: integers()})",
+        "dict[str | int, bool | int]",
+    ),
 ]
 
 
@@ -101,6 +112,12 @@ DIFF_REVEALED_TYPES = [
         "dictionaries(integers(), datetimes())",
         "dict[int, datetime.datetime]",
         "dict[int, datetime]",
+    ),
+    # mypy joins heterogeneous values to their common base, pyright keeps the union
+    DifferingRevealedTypes(
+        "fixed_dictionaries({'a': text(), 'b': integers()})",
+        "dict[str, object]",
+        "dict[str, int | str]",
     ),
 ]
 

--- a/whole_repo_tests/types/test_mypy.py
+++ b/whole_repo_tests/types/test_mypy.py
@@ -563,6 +563,23 @@ def test_pos_only_args(tmp_path):
     )
 
 
+def test_mypy_issue_4665(tmp_path):
+    f = tmp_path / "check_mypy_on_fixed_dictionaries_union_values.py"
+    f.write_text(
+        textwrap.dedent("""
+            from hypothesis.strategies import SearchStrategy, fixed_dictionaries, integers, text
+
+            mapping: dict[str, SearchStrategy[str] | SearchStrategy[int]] = {
+                "ant": text(),
+                "bat": integers(),
+            }
+            fixed_dictionaries(mapping)
+            """),
+        encoding="utf-8",
+    )
+    assert_mypy_errors(f, [])
+
+
 @pytest.mark.parametrize("python_version", PYTHON_VERSIONS)
 def test_mypy_passes_on_basic_test(tmp_path, python_version):
     f = tmp_path / "check_mypy_on_basic_tests.py"

--- a/whole_repo_tests/types/test_pyright.py
+++ b/whole_repo_tests/types/test_pyright.py
@@ -154,6 +154,24 @@ def test_pyright_issue_3348(tmp_path: Path):
     assert _get_pyright_errors(file) == []
 
 
+def test_pyright_issue_4665(tmp_path: Path):
+    file = tmp_path / "test.py"
+    file.write_text(
+        textwrap.dedent("""
+            from hypothesis.strategies import SearchStrategy, fixed_dictionaries, integers, text
+
+            mapping: dict[str, SearchStrategy[str] | SearchStrategy[int]] = {
+                "ant": text(),
+                "bat": integers(),
+            }
+            fixed_dictionaries(mapping)
+            """),
+        encoding="utf-8",
+    )
+    _write_config(tmp_path, {"typeCheckingMode": "strict"})
+    assert _get_pyright_errors(file) == []
+
+
 def test_numpy_arrays_strategy(tmp_path: Path):
     file = tmp_path / "test.py"
     file.write_text(


### PR DESCRIPTION
Annotate the mapping and optional arguments as Mapping rather than the invariant dict, so type-checkers can infer the generated value type even when the per-key strategies are heterogeneous (e.g. a mapping annotated as `dict[str, SearchStrategy[int] | SearchStrategy[str]]`).

Fixes https://github.com/HypothesisWorks/hypothesis/issues/4665.