### PR TITLE
Fix flaky recursion in recursive forward-reference resolution

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,6 +41,7 @@ When creating a PR that changes `hypothesis/src/`:
    - **Concise** - remove unnecessary verbosity
    - **Idiomatic** - follows Python and Hypothesis conventions
    - **Minimally commented** - code should be self-documenting; only add comments where truly needed
+   - **Module-scope imports** - put imports at the top of the module wherever possible; only use function-local imports when needed to break a real import cycle or to lazy-load an optional dependency
 2. **Run `./build.sh format; ./build.sh lint`** immediately before committing to auto-format and lint code
 3. **Do not reference issues or PRs in commit messages** (e.g., avoid `Fixes #1234` or `See #5678`) - this clutters the issue timeline with unnecessary links
 

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where resolving recursive forward references in
+|st.from_type| (such as ``A = list[Union["A", str]]``, added in :v:`6.152.11`)
+could recurse until it hit the interpreter's recursion limit before falling
+back to a deferred strategy.  Because this depended on the ambient stack depth,
+it occasionally surfaced as a spurious ``RecursionError`` or other flaky
+failure.  We now break the cycle eagerly by deferring, so resolution uses a
+small and constant amount of stack regardless of how deeply nested the
+reference is.

--- a/hypothesis/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/types.py
@@ -30,6 +30,7 @@ import uuid
 import warnings
 import zoneinfo
 from collections.abc import Iterator
+from contextvars import ContextVar
 from functools import partial
 from pathlib import PurePath
 from types import FunctionType
@@ -218,6 +219,13 @@ def type_sorting_key(t):
     t = get_origin(t) or t
     is_container = int(try_issubclass(t, collections.abc.Container))
     return (is_container, repr(t))
+
+
+# Types whose forward references we are currently resolving, used to break the
+# recursion in self- or mutually-referential forward references such as
+# ``A = list[Union["A", str]]``.  Without this we would recurse until hitting a
+# RecursionError, which makes resolution depend on the ambient stack depth.
+_forward_ref_resolution: ContextVar[list] = ContextVar("forward_ref_resolution")
 
 
 def _resolve_forward_ref_in_caller(forward_arg: str) -> typing.Any:
@@ -679,7 +687,20 @@ def from_typing_type(thing):
         if resolved is None:  # pragma: no branch
             resolved = _resolve_forward_ref_in_caller(thing.__forward_arg__)
         if resolved is not None and is_a_type(resolved):
-            return st.from_type(resolved)
+            try:
+                in_progress = _forward_ref_resolution.get()
+            except LookupError:
+                _forward_ref_resolution.set(in_progress := [])
+            if resolved in in_progress:
+                # We're already resolving this type higher up the stack, so this
+                # is a recursive reference; defer to break the cycle and rely on
+                # st.from_type's cache to tie the recursive knot.
+                return st.deferred(lambda r=resolved: st.from_type(r))
+            in_progress.append(resolved)
+            try:
+                return st.from_type(resolved)
+            finally:
+                in_progress.pop()
 
     def is_maximal(t):
         # For each k in the mapping, we use it if it's the most general type

--- a/hypothesis/tests/nocover/test_type_lookup_forward_ref.py
+++ b/hypothesis/tests/nocover/test_type_lookup_forward_ref.py
@@ -14,6 +14,7 @@ import pytest
 
 from hypothesis import given, settings, strategies as st
 from hypothesis.errors import ResolutionFailed
+from hypothesis.strategies._internal import core, types
 
 from tests.common.debug import find_any
 from tests.common.utils import skipif_threading
@@ -47,6 +48,33 @@ def test_self_referential_forward_ref_nested():
     Tree = dict[str, Union["Tree", int]]
     result = find_any(st.from_type(Tree))
     assert isinstance(result, dict)
+
+
+def test_recursive_forward_ref_resolution_is_bounded(monkeypatch):
+    # Resolving a recursive forward reference must break the cycle by deferring,
+    # rather than recursing once per available stack frame until it hits the
+    # interpreter's recursion limit. The latter made resolution depend on the
+    # ambient stack depth, which was flaky. Here we assert that from_typing_type
+    # only recurses a small, bounded number of times (we measured 66 without the
+    # deferral, versus 2 with it).
+    real = types.from_typing_type
+    state = {"depth": 0, "max_depth": 0}
+
+    def counting(thing):
+        state["depth"] += 1
+        state["max_depth"] = max(state["max_depth"], state["depth"])
+        try:
+            return real(thing)
+        finally:
+            state["depth"] -= 1
+
+    monkeypatch.setattr(types, "from_typing_type", counting)
+    core.from_type.__clear_cache()
+
+    A = list[Union["A", str]]
+    st.from_type(A).validate()
+
+    assert 0 < state["max_depth"] <= 10
 
 
 @skipif_threading  # weird errors around b_strategy scope?


### PR DESCRIPTION
Resolving recursive forward references such as `A = list[Union["A", str]]` recursed once per available stack frame until hitting a RecursionError, then fell back to a deferred strategy. Termination therefore depended on the ambient stack depth, which made resolution flaky (spurious RecursionError and other intermittent failures). Break the cycle eagerly by deferring when we re-enter resolution of a type whose forward reference we are already resolving, so resolution uses a small and constant amount of stack.