### PR TITLE
Fix assume condition in `adapting-strategies.rst`

### DIFF
--- a/hypothesis/docs/tutorial/adapting-strategies.rst
+++ b/hypothesis/docs/tutorial/adapting-strategies.rst
@@ -56,7 +56,7 @@ Assuming away test cases
 
 |.filter| lets you filter test inputs from a single strategy. Hypothesis also provides an |assume| function for when you need to filter an entire test case, based on an arbitrary condition.
 
-The |assume| function skips test cases where some condition evaluates to ``True``. You can use it anywhere in your test. We could have expressed our |.filter| example above using |assume| as well:
+The |assume| function skips test cases where some condition evaluates to ``False``. You can use it anywhere in your test. We could have expressed our |.filter| example above using |assume| as well:
 
 .. code-block:: python
 


### PR DESCRIPTION
The [adapting-strategies.rst](https://github.com/HypothesisWorks/hypothesis/blob/4afeada246751658ceadf7389ad946a4fcf64175/hypothesis/docs/tutorial/adapting-strategies.rst?plain=1#L59) doc states that the `assume(condition)` function skips test cases where `condition` is `True`, but this appears to be the opposite of the actual behavior. See for example `hypothesis/src/hypothesis.control.py` [lines 80-81](https://github.com/HypothesisWorks/hypothesis/blob/4afeada246751658ceadf7389ad946a4fcf64175/hypothesis/src/hypothesis/control.py#L80-L81) where `if not condition` raises an exception. Additionally the code example in `adapting-strategies.rst` states that "b will be nonzero here" after calling `assume(b != 0)`, which suggests the test case will be skipped where condition is `False`. This PR fixes the error by replacing `True` with `False`.

This change is also supported by [line 114 in quickstart.rst](https://github.com/HypothesisWorks/hypothesis/blob/4afeada246751658ceadf7389ad946a4fcf64175/hypothesis/docs/quickstart.rst?plain=1#L114) where it states that "For more complicated conditions, you can use `|assume|`, which tells Hypothesis to discard any test case with a false-y argument".