### PR TITLE
Improve symbolic execution for dates, times, and datetimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,7 +253,7 @@ jobs:
       # Note that the versions below are updated by `update_pyodide_versions()` in our weekly cronjob.
       # The versions of pyodide-build and the Pyodide runtime may differ.
       PYODIDE_VERSION: 0.29.4
-      PYODIDE_BUILD_VERSION: 0.34.3
+      PYODIDE_BUILD_VERSION: 0.34.4
       # pyodide 0.29.0 (latest at time of writing) doesn't yet support 3.14
       PYTHON_VERSION: 3.13.2
     steps:

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch rewrites the internal date- and time-drawing helper to use plain
+arithmetic instead of branching on the values it draws.  The generated
+distribution is unchanged, but :func:`~hypothesis.strategies.dates`,
+:func:`~hypothesis.strategies.datetimes`, and
+:func:`~hypothesis.strategies.times` are now much more efficient under
+symbolic-execution backends such as :pypi:`crosshair-tool`, which can now
+solve for a specific date directly rather than enumerating candidates
+(:issue:`4759`).

--- a/hypothesis/pyproject.toml
+++ b/hypothesis/pyproject.toml
@@ -114,7 +114,7 @@ pandas = ["pandas>=1.1"]
 pytest = ["pytest>=4.6"]
 dpcontracts = ["dpcontracts>=0.4"]
 redis = ["redis>=3.0.0"]
-crosshair = ["hypothesis-crosshair>=0.0.28", "crosshair-tool>=0.0.104"]
+crosshair = ["hypothesis-crosshair>=0.0.28", "crosshair-tool>=0.0.106"]
 # zoneinfo is an odd one: every dependency is platform-conditional.
 zoneinfo = ["tzdata>=2026.2; sys_platform == 'win32' or sys_platform == 'emscripten'"]
 # We only support Django versions with upstream support - see
@@ -124,7 +124,7 @@ zoneinfo = ["tzdata>=2026.2; sys_platform == 'win32' or sys_platform == 'emscrip
 django = ["django>=5.2"]
 watchdog = ["watchdog>=4.0.0"]
 # Avoid changing this by hand. This is automatically updated by update_changelog_and_version
-all = ["black>=20.8b0", "click>=7.0", "crosshair-tool>=0.0.104", "django>=5.2", "dpcontracts>=0.4", "hypothesis-crosshair>=0.0.28", "lark>=0.10.1", "libcst>=0.3.16", "numpy>=1.21.6", "pandas>=1.1", "pytest>=4.6", "python-dateutil>=1.4", "pytz>=2014.1", "redis>=3.0.0", "rich>=9.0.0", "tzdata>=2026.2; sys_platform == 'win32' or sys_platform == 'emscripten'", "watchdog>=4.0.0"]
+all = ["black>=20.8b0", "click>=7.0", "crosshair-tool>=0.0.106", "django>=5.2", "dpcontracts>=0.4", "hypothesis-crosshair>=0.0.28", "lark>=0.10.1", "libcst>=0.3.16", "numpy>=1.21.6", "pandas>=1.1", "pytest>=4.6", "python-dateutil>=1.4", "pytz>=2014.1", "redis>=3.0.0", "rich>=9.0.0", "tzdata>=2026.2; sys_platform == 'win32' or sys_platform == 'emscripten'", "watchdog>=4.0.0"]
 
 [tool.setuptools.dynamic]
 version = {attr = "hypothesis.version.__version__"}

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -88,13 +88,10 @@ def datetime_does_not_exist(value):
 
 
 def _num_days_in_month(year, month):
-    """Equivalent to ``monthrange(year, month)[1]`` for valid inputs.
+    """Branchless equivalent of ``monthrange(year, month)[1]`` for valid inputs.
 
-    Written using only arithmetic and (in)equality, with no branching, ``and``,
-    ``or``, or indexing on ``month``/``year``.  This keeps the result symbolic
-    under symbolic-execution backends (which would otherwise concretize the year
-    and month the moment they hit a branch or a list lookup), while remaining a
-    handful of cheap integer ops for the blackbox engine.
+    Written using only arithmetic and (in)equality, with no branching or indexing.
+    This avoids concretizing the input or adding more path constraints than necessary.
     """
     leap = (year % 4 == 0) * (1 - (year % 100 == 0) * (year % 400 != 0))
     is_feb = month == 2
@@ -108,25 +105,27 @@ def draw_capped_multipart(
     assert isinstance(min_value, (dt.date, dt.time, dt.datetime))
     assert type(min_value) == type(max_value)
     assert min_value <= max_value
+
+    # cap_{low, high} records whether every field drawn so far has equalled
+    # ``min_value``'s / ``max_value``'s, i.e. whether that bound is still "active" and
+    # constrains the next field.
+    #
+    # cap_{low, high} are conceptually booleans. We define them as integers and interpret
+    # boolean operations on them as multiplication, so that we don't concretize or
+    # branch under symbolic backends. See
+    # https://github.com/HypothesisWorks/hypothesis/issues/4759.
+    cap_low = 1
+    cap_high = 1
     result = {}
-    # ``cap_low``/``cap_high`` are 0/1 integers (not booleans) recording whether
-    # every field drawn so far has equalled ``min_value``'s / ``max_value``'s,
-    # i.e. whether that bound is still "active" and constrains the next field.
-    # We combine them into the bounds with arithmetic rather than branching, so
-    # that the *same* code stays fully symbolic under symbolic-execution
-    # backends (important for cross-backend database replay) yet compiles down
-    # to a few integer ops for the blackbox engine.  The draws themselves --
-    # their count, order, bounds, and ``shrink_towards`` -- are byte-for-byte
-    # identical to the previous branchy implementation.
-    cap_low = cap_high = 1
     for name in duration_names:
         natural_low = getattr(dt.datetime.min, name)
         if name == "day":
             natural_high = _num_days_in_month(result["year"], result["month"])
         else:
             natural_high = getattr(dt.datetime.max, name)
-        # low  = min_value.<name> if cap_low  else natural_low
-        # high = max_value.<name> if cap_high else natural_high
+        # equivalent to:
+        #   low  = min_value.<name> if cap_low  else natural_low
+        #   high = max_value.<name> if cap_high else natural_high
         low = natural_low + cap_low * (getattr(min_value, name) - natural_low)
         high = natural_high + cap_high * (getattr(max_value, name) - natural_high)
         if name == "year":

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -12,7 +12,6 @@ import datetime as dt
 import operator as op
 import warnings
 import zoneinfo
-from calendar import monthrange
 from functools import cache, partial
 from importlib import resources
 from pathlib import Path
@@ -88,6 +87,21 @@ def datetime_does_not_exist(value):
     return value != roundtrip
 
 
+def _num_days_in_month(year, month):
+    """Equivalent to ``monthrange(year, month)[1]`` for valid inputs.
+
+    Written using only arithmetic and (in)equality, with no branching, ``and``,
+    ``or``, or indexing on ``month``/``year``.  This keeps the result symbolic
+    under symbolic-execution backends (which would otherwise concretize the year
+    and month the moment they hit a branch or a list lookup), while remaining a
+    handful of cheap integer ops for the blackbox engine.
+    """
+    leap = (year % 4 == 0) * (1 - (year % 100 == 0) * (year % 400 != 0))
+    is_feb = month == 2
+    is_30_day = 1 - (month != 4) * (month != 6) * (month != 9) * (month != 11)
+    return 31 - is_30_day - is_feb * (3 - leap)
+
+
 def draw_capped_multipart(
     data, min_value, max_value, duration_names=DATENAMES + TIMENAMES
 ):
@@ -95,19 +109,33 @@ def draw_capped_multipart(
     assert type(min_value) == type(max_value)
     assert min_value <= max_value
     result = {}
-    cap_low, cap_high = True, True
+    # ``cap_low``/``cap_high`` are 0/1 integers (not booleans) recording whether
+    # every field drawn so far has equalled ``min_value``'s / ``max_value``'s,
+    # i.e. whether that bound is still "active" and constrains the next field.
+    # We combine them into the bounds with arithmetic rather than branching, so
+    # that the *same* code stays fully symbolic under symbolic-execution
+    # backends (important for cross-backend database replay) yet compiles down
+    # to a few integer ops for the blackbox engine.  The draws themselves --
+    # their count, order, bounds, and ``shrink_towards`` -- are byte-for-byte
+    # identical to the previous branchy implementation.
+    cap_low = cap_high = 1
     for name in duration_names:
-        low = getattr(min_value if cap_low else dt.datetime.min, name)
-        high = getattr(max_value if cap_high else dt.datetime.max, name)
-        if name == "day" and not cap_high:
-            _, high = monthrange(**result)
+        natural_low = getattr(dt.datetime.min, name)
+        if name == "day":
+            natural_high = _num_days_in_month(result["year"], result["month"])
+        else:
+            natural_high = getattr(dt.datetime.max, name)
+        # low  = min_value.<name> if cap_low  else natural_low
+        # high = max_value.<name> if cap_high else natural_high
+        low = natural_low + cap_low * (getattr(min_value, name) - natural_low)
+        high = natural_high + cap_high * (getattr(max_value, name) - natural_high)
         if name == "year":
             val = data.draw_integer(low, high, shrink_towards=2000)
         else:
             val = data.draw_integer(low, high)
         result[name] = val
-        cap_low = cap_low and val == low
-        cap_high = cap_high and val == high
+        cap_low = cap_low * (val == low)
+        cap_high = cap_high * (val == high)
     if hasattr(min_value, "fold"):
         # The `fold` attribute is ignored in comparison of naive datetimes.
         # In tz-aware datetimes it would require *very* invasive changes to

--- a/hypothesis/tests/cover/test_datetimes.py
+++ b/hypothesis/tests/cover/test_datetimes.py
@@ -13,17 +13,20 @@ from calendar import monthrange
 
 import pytest
 
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, example, given, settings
+from hypothesis import strategies as st
 from hypothesis.strategies import dates, datetimes, timedeltas, times
 from hypothesis.strategies._internal.datetime import _num_days_in_month
 
 from tests.common.debug import assert_simple_property, find_any, minimal
 
 
-@pytest.mark.parametrize("year", [1, 1900, 2000, 2004, 2023, 2024, 2100, 9999])
+@example(1900)
+@example(2000)
+@example(2004)
+@example(2100)
+@given(st.integers(dt.MINYEAR, dt.MAXYEAR))
 def test_num_days_in_month_matches_monthrange(year):
-    # The branchless _num_days_in_month must agree with the stdlib for every
-    # month, including the century/400-year leap rules around February.
     for month in range(1, 13):
         assert _num_days_in_month(year, month) == monthrange(year, month)[1]
 

--- a/hypothesis/tests/cover/test_datetimes.py
+++ b/hypothesis/tests/cover/test_datetimes.py
@@ -13,8 +13,7 @@ from calendar import monthrange
 
 import pytest
 
-from hypothesis import HealthCheck, example, given, settings
-from hypothesis import strategies as st
+from hypothesis import HealthCheck, example, given, settings, strategies as st
 from hypothesis.strategies import dates, datetimes, timedeltas, times
 from hypothesis.strategies._internal.datetime import _num_days_in_month
 

--- a/hypothesis/tests/cover/test_datetimes.py
+++ b/hypothesis/tests/cover/test_datetimes.py
@@ -9,13 +9,23 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime as dt
+from calendar import monthrange
 
 import pytest
 
 from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import dates, datetimes, timedeltas, times
+from hypothesis.strategies._internal.datetime import _num_days_in_month
 
 from tests.common.debug import assert_simple_property, find_any, minimal
+
+
+@pytest.mark.parametrize("year", [1, 1900, 2000, 2004, 2023, 2024, 2100, 9999])
+def test_num_days_in_month_matches_monthrange(year):
+    # The branchless _num_days_in_month must agree with the stdlib for every
+    # month, including the century/400-year leap rules around February.
+    for month in range(1, 13):
+        assert _num_days_in_month(year, month) == monthrange(year, month)[1]
 
 
 def test_can_find_positive_delta():

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -84,7 +84,6 @@ def do_it_all(l, a, x, data):
     1 / ((x or 1) % 7)
 
 
-@xfail_on_crosshair(Why.other, strict=False)  # flakey BackendCannotProceed ??
 @skipif_threading  # captures observations from other threads
 def test_observability():
     with capture_observations() as ls:
@@ -202,10 +201,7 @@ def test_normal_representation_includes_draws():
         tc for tc in observations if tc.type == "test_case" and tc.status == "passed"
     ]
     assert test_cases
-    # TODO crosshair has a soundness bug with assume. remove branch when fixed
-    # https://github.com/pschanely/hypothesis-crosshair/issues/34
-    if not crosshair:
-        assert {tc.representation for tc in test_cases} == {expected}
+    assert {tc.representation for tc in test_cases} == {expected}
 
 
 @xfail_on_crosshair(Why.other)

--- a/hypothesis/tests/crosshair/test_crosshair.py
+++ b/hypothesis/tests/crosshair/test_crosshair.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import datetime as dt
+
 import crosshair
 import pytest
 from hypothesis_crosshair_provider.crosshair_provider import CrossHairPrimitiveProvider
@@ -224,3 +226,14 @@ def test_realizes_event():
 def test_event_with_realization(value):
     event(value)
     float(value)
+
+
+def test_crosshair_can_hit_a_specific_date():
+    # See https://github.com/HypothesisWorks/hypothesis/issues/4759.
+    @given(st.dates())
+    @settings(backend="crosshair", database=None)
+    def f(d):
+        assert d != dt.date(2030, 2, 14)
+
+    with pytest.raises(AssertionError):
+        f()

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -6,19 +6,19 @@
 #
 annotated-types==0.7.0
     # via -r requirements/coverage.in
-black==26.5.0
+black==26.5.1
     # via -r requirements/coverage.in
-click==8.3.3
+click==8.4.1
     # via
     #   -r requirements/coverage.in
     #   black
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
 dpcontracts==0.6.0
     # via -r requirements/coverage.in
 execnet==2.1.2
     # via pytest-xdist
-fakeredis==2.35.1
+fakeredis==2.36.0
     # via -r requirements/coverage.in
 iniconfig==2.3.0
     # via pytest
@@ -28,7 +28,7 @@ libcst==1.8.6
     # via -r requirements/coverage.in
 mypy-extensions==1.1.0
     # via black
-numpy==2.4.5
+numpy==2.4.6
     # via
     #   -r requirements/coverage.in
     #   pandas
@@ -42,7 +42,7 @@ pathspec==1.1.1
     # via black
 pexpect==4.9.0
     # via -r requirements/test.in
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via black
 pluggy==1.6.0
     # via
@@ -74,7 +74,7 @@ pytz==2026.2
     # via -r requirements/coverage.in
 pyyaml==6.0.3
     # via libcst
-redis==7.4.0
+redis==8.0.0
     # via fakeredis
 six==1.17.0
     # via python-dateutil
@@ -82,7 +82,7 @@ sortedcontainers==2.4.0
     # via
     #   fakeredis
     #   hypothesis (hypothesis/pyproject.toml)
-syrupy==5.2.0
+syrupy==5.3.1
     # via -r requirements/test.in
 typing-extensions==4.15.0
     # via -r requirements/coverage.in

--- a/requirements/crosshair.txt
+++ b/requirements/crosshair.txt
@@ -13,13 +13,13 @@ cattrs==26.1.0
     # via
     #   lsprotocol
     #   pygls
-crosshair-tool==0.0.104
+crosshair-tool==0.0.106
     # via
     #   -r requirements/crosshair.in
     #   hypothesis-crosshair
 execnet==2.1.2
     # via pytest-xdist
-hypothesis==6.152.7
+hypothesis==6.155.1
     # via hypothesis-crosshair
 hypothesis-crosshair==0.0.28
     # via -r requirements/crosshair.in
@@ -58,9 +58,9 @@ sortedcontainers==2.4.0
     # via
     #   hypothesis
     #   hypothesis (hypothesis/pyproject.toml)
-syrupy==5.2.0
+syrupy==5.3.1
     # via -r requirements/test.in
-typeshed-client==2.11.0
+typeshed-client==2.12.0
     # via crosshair-tool
 typing-extensions==4.15.0
     # via
@@ -72,5 +72,5 @@ typing-inspect==0.9.0
     # via crosshair-tool
 z3-solver==4.16.0.0
     # via crosshair-tool
-zipp==3.23.1
+zipp==4.1.0
     # via importlib-metadata

--- a/requirements/fuzzing.txt
+++ b/requirements/fuzzing.txt
@@ -12,17 +12,17 @@ attrs==26.1.0
     # via
     #   outcome
     #   trio
-black==26.5.0
+black==26.5.1
     # via
     #   -r requirements/coverage.in
     #   hypofuzz
     #   hypothesis
-click==8.3.3
+click==8.4.1
     # via
     #   -r requirements/coverage.in
     #   black
     #   hypothesis
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via
     #   hypofuzz
     #   pytest-cov
@@ -30,7 +30,7 @@ dpcontracts==0.6.0
     # via -r requirements/coverage.in
 execnet==2.1.2
     # via pytest-xdist
-fakeredis==2.35.1
+fakeredis==2.36.0
     # via -r requirements/coverage.in
 h11==0.16.0
     # via
@@ -46,9 +46,9 @@ hyperframe==6.1.0
     # via h2
 hypofuzz==25.11.1
     # via -r requirements/fuzzing.in
-hypothesis[cli,watchdog]==6.152.7
+hypothesis[cli,watchdog]==6.155.1
     # via hypofuzz
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   trio
@@ -66,7 +66,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mypy-extensions==1.1.0
     # via black
-numpy==2.4.5
+numpy==2.4.6
     # via
     #   -r requirements/coverage.in
     #   pandas
@@ -82,7 +82,7 @@ pathspec==1.1.1
     # via black
 pexpect==4.9.0
     # via -r requirements/test.in
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via black
 pluggy==1.6.0
     # via
@@ -121,7 +121,7 @@ pytz==2026.2
     # via -r requirements/coverage.in
 pyyaml==6.0.3
     # via libcst
-redis==7.4.0
+redis==8.0.0
     # via fakeredis
 rich==15.0.0
     # via hypothesis
@@ -135,9 +135,9 @@ sortedcontainers==2.4.0
     #   hypothesis
     #   hypothesis (hypothesis/pyproject.toml)
     #   trio
-starlette==1.0.0
+starlette==1.2.1
     # via hypofuzz
-syrupy==5.2.0
+syrupy==5.3.1
     # via -r requirements/test.in
 trio==0.33.0
     # via hypofuzz

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,5 +27,5 @@ pytest-xdist==3.8.0
     # via -r requirements/test.in
 sortedcontainers==2.4.0
     # via hypothesis (hypothesis/pyproject.toml)
-syrupy==5.2.0
+syrupy==5.3.1
     # via -r requirements/test.in

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -14,7 +14,7 @@ anyio==4.13.0
     #   watchfiles
 asgiref==3.11.1
     # via django
-ast-serialize==0.4.0
+ast-serialize==0.5.0
     # via mypy
 asttokens==3.0.1
     # via stack-data
@@ -28,7 +28,7 @@ beautifulsoup4==4.14.3
     # via
     #   furo
     #   sphinx-codeautolink
-black==26.5.0
+black==26.5.1
     # via shed
 blinker==1.9.0
     # via pelican
@@ -36,15 +36,15 @@ build==1.5.0
     # via
     #   -r requirements/tools.in
     #   pip-tools
-cachetools==7.1.2
+cachetools==7.1.4
     # via tox
-certifi==2026.4.22
+certifi==2026.5.20
     # via requests
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-click==8.3.3
+click==8.4.1
     # via
     #   black
     #   pip-tools
@@ -57,16 +57,16 @@ colorama==0.4.6
     #   tox
 com2ann==0.3.0
     # via shed
-coverage==7.14.0
+coverage==7.14.1
     # via -r requirements/tools.in
 cryptography==48.0.0
     # via
     #   secretstorage
     #   types-pyopenssl
     #   types-redis
-decorator==5.2.1
+decorator==5.3.1
     # via ipython
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 django==6.0.5
     # via -r requirements/tools.in
@@ -96,7 +96,7 @@ h11==0.16.0
     # via uvicorn
 id==1.6.1
     # via twine
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   requests
@@ -104,7 +104,7 @@ imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via -r requirements/tools.in
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -148,7 +148,7 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==11.0.2
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -162,7 +162,7 @@ nh3==0.3.5
     # via readme-renderer
 nodeenv==1.10.0
     # via pyright
-numpy==2.4.5
+numpy==2.4.6
     # via -r requirements/tools.in
 ordered-set==4.1.0
     # via pelican
@@ -190,7 +190,7 @@ pexpect==4.9.0
     #   ipython
 pip-tools==7.5.3
     # via -r requirements/tools.in
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   black
     #   python-discovery
@@ -223,13 +223,13 @@ pygments==2.19.2
     #   readme-renderer
     #   rich
     #   sphinx
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via tox
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyright==1.1.409
+pyright==1.1.410
     # via -r requirements/tools.in
 pytest==9.0.3
     # via
@@ -242,7 +242,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/tools.in
     #   pelican
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via
     #   tox
     #   virtualenv
@@ -275,7 +275,7 @@ rich==15.0.0
     #   twine
 roman-numerals==4.1.0
     # via sphinx
-ruff==0.15.13
+ruff==0.15.15
     # via -r requirements/tools.in
 secretstorage==3.5.0
     # via keyring
@@ -283,7 +283,7 @@ shed==2024.1.1
     # via -r requirements/tools.in
 six==1.17.0
     # via python-dateutil
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
 sortedcontainers==2.4.0
     # via
@@ -291,7 +291,7 @@ sortedcontainers==2.4.0
     #   sortedcontainers-stubs
 sortedcontainers-stubs==2.4.3
     # via -r requirements/tools.in
-soupsieve==2.8.3
+soupsieve==2.8.4
     # via beautifulsoup4
 sphinx==9.1.0
     # via
@@ -326,9 +326,9 @@ sqlparse==0.5.5
     # via django
 stack-data==0.6.3
     # via ipython
-starlette==1.0.0
+starlette==1.2.1
     # via sphinx-autobuild
-syrupy==5.2.0
+syrupy==5.3.1
     # via -r requirements/test.in
 tokenize-rt==6.2.0
     # via pyupgrade
@@ -336,7 +336,7 @@ tomli==2.4.1
     # via -r requirements/tools.in
 tomli-w==1.2.0
     # via tox
-tox==4.54.0
+tox==4.55.0
     # via -r requirements/tools.in
 traitlets==5.15.0
     # via
@@ -344,17 +344,17 @@ traitlets==5.15.0
     #   matplotlib-inline
 twine==6.2.0
     # via -r requirements/tools.in
-types-cffi==2.0.0.20260508
+types-cffi==2.0.0.20260518
     # via types-pyopenssl
 types-click==7.1.8
     # via -r requirements/tools.in
 types-pyopenssl==24.1.0.20240722
     # via types-redis
-types-pytz==2026.2.0.20260506
+types-pytz==2026.2.0.20260518
     # via -r requirements/tools.in
 types-redis==4.6.0.20241004
     # via -r requirements/tools.in
-types-setuptools==82.0.0.20260508
+types-setuptools==82.0.0.20260518
     # via types-cffi
 typing-extensions==4.15.0
     # via
@@ -370,13 +370,13 @@ urllib3==2.7.0
     #   id
     #   requests
     #   twine
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via sphinx-autobuild
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via tox
 watchdog==6.0.0
     # via -r requirements/tools.in
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via
     #   pelican
     #   sphinx-autobuild
@@ -388,7 +388,7 @@ wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.1
+pip==26.1.2
     # via pip-tools
 setuptools==82.0.1
     # via pip-tools

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -484,7 +484,7 @@ def update_pyodide_versions():
         key=version_tuple,
     )
 
-    cross_build_environments_url = "https://raw.githubusercontent.com/pyodide/pyodide/refs/heads/main/pyodide-cross-build-environments.json"
+    cross_build_environments_url = "https://raw.githubusercontent.com/pyodide/pyodide/refs/heads/main/metadata/pyodide-cross-build-environments-v2.json"
     cross_build_environments_data = requests.get(cross_build_environments_url).json()
 
     # Find the latest stable release for the Pyodide runtime/xbuildenv that is compatible


### PR DESCRIPTION
Rewrite `draw_capped_multipart` to use branchless arithmetic instead of branching on drawn values, and add a branchless `_num_days_in_month` helper in place of `calendar.monthrange` (which works directly in Crosshair but not via hypothesis-crosshair; I'm unsure why).  The generated distribution is unchanged, but symbolic-execution backends such as crosshair can now solve for a specific date directly instead of concretely enumerating candidates.

Closes https://github.com/HypothesisWorks/hypothesis/issues/4759.

Also bumps our dependencies, because the weekly cronjob was broken (pyodide metadata changed url), and I wanted to depend on the latest crosshair.