### PR TITLE
Fix flatmap on consuming stateful bundles

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -130,6 +130,7 @@ their individual contributions.
 * `Marco Sirabella <https://www.github.com/mjsir911>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (marius@gedmin.as)
+* `marko1olo <https://github.com/marko1olo>`_
 * `Markus Unterwaditzer <https://github.com/untitaker>`_ (markus@unterwaditzer.net)
 * `Mateusz Sokół <https://github.com/mtsokol>`_
 * `Mathieu Paturel <https://github.com/math2001>`_ (mathieu.paturel@gmail.com)

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.stateful.consumes` so that consuming
+bundle strategies can be composed with ``.flatmap(...)`` without raising a
+``TypeError`` while constructing the strategy (:issue:`4427`).
+
+Thanks to marko1olo for this fix!

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -638,7 +638,7 @@ class Bundle(SearchStrategy[Ex]):
 
     def flatmap(self, expand):
         if self.draw_references:
-            return type(self)(
+            return Bundle(
                 self.name,
                 consume=self.__reference_strategy.consume,
                 draw_references=False,

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -1472,6 +1472,27 @@ def test_flatmap():
     run_state_machine_as_test(Machine)
 
 
+def test_flatmap_can_consume_bundle():
+    class Machine(RuleBasedStateMachine):
+        strings = Bundle("strings")
+
+        @initialize(target=strings)
+        def set_initial(self):
+            return "sample text"
+
+        @rule(
+            target=strings,
+            character=consumes(strings).flatmap(lambda text: st.sampled_from(text)),
+        )
+        def consume_flatmapped(self, character):
+            assert isinstance(character, str)
+            assert len(character) == 1
+            return character
+
+    Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
 def test_use_bundle_within_other_strategies():
     class Class:
         def __init__(self, value):


### PR DESCRIPTION
Fixes #4427.

`Bundle.flatmap()` cloned bundle strategies with `type(self)(...)`, which breaks for `BundleConsumer` from `consumes()` because its constructor accepts the source bundle instead of `name/consume/draw_references` keyword arguments.

This keeps the consume flag but clones through the base `Bundle` class for the deferred reference strategy, so `consumes(bundle).flatmap(...)` composes like other bundle strategies.

Tests run:
- `python -m pytest hypothesis/tests/cover/test_stateful.py -k "flatmap or consumes" -q`
- `python -m pytest hypothesis/tests/cover/test_stateful.py -q`
- `python -m compileall -q hypothesis/src/hypothesis/stateful.py hypothesis/tests/cover/test_stateful.py`
- `git diff --check`