### PR TITLE
Fix from_lark ESCAPED_STRING generation

### DIFF
--- a/hypothesis/src/hypothesis/extra/lark.py
+++ b/hypothesis/src/hypothesis/extra/lark.py
@@ -20,6 +20,7 @@ from `nearley.js <https://nearley.js.org/>`_, so you may not have to write
 your own at all.
 """
 
+import re
 from inspect import signature
 
 import lark
@@ -52,6 +53,16 @@ def get_terminal_names(
     for rule in rules:
         names |= {t.name for t in rule.expansion if isinstance(t, Terminal)}
     return names
+
+
+def _matches_entire_token(regex: str):
+    compiled = re.compile(regex)
+
+    def inner(value: str) -> bool:
+        match = compiled.match(value)
+        return match is not None and match.end() == len(value)
+
+    return inner
 
 
 class LarkStrategy(st.SearchStrategy):
@@ -93,7 +104,10 @@ class LarkStrategy(st.SearchStrategy):
         self.terminal_strategies: dict[str, st.SearchStrategy[str]] = {}
         for t in terminals:
             self.names_to_symbols[t.name] = Terminal(t.name)
-            s = st.from_regex(t.pattern.to_regexp(), fullmatch=True, alphabet=alphabet)
+            regex = t.pattern.to_regexp()
+            s = st.from_regex(regex, fullmatch=True, alphabet=alphabet).filter(
+                _matches_entire_token(regex)
+            )
             try:
                 s.validate()
             except IncompatibleWithAlphabet:

--- a/hypothesis/tests/lark/test_grammar.py
+++ b/hypothesis/tests/lark/test_grammar.py
@@ -47,6 +47,13 @@ list : "[" [NUMBER ("," NUMBER)*] "]"
 NUMBER: /[0-9]|[1-9][0-9]*/
 """
 
+ESCAPED_STRING_LARK = Lark(
+    r"""
+%import common.ESCAPED_STRING
+start: ESCAPED_STRING
+"""
+)
+
 
 @given(from_lark(Lark(EBNF_GRAMMAR, start="value")))
 def test_generates_valid_json(string):
@@ -87,6 +94,11 @@ def test_can_generate_ignored_tokens():
 
 def test_generation_without_whitespace():
     find_any(from_lark(Lark(LIST_GRAMMAR, start="list")), lambda g: " " not in g)
+
+
+@given(string=from_lark(ESCAPED_STRING_LARK))
+def test_generates_lark_escaped_strings(string):
+    ESCAPED_STRING_LARK.parse(string)
 
 
 def test_cannot_convert_EBNF_to_strategy_directly():


### PR DESCRIPTION
Fixes #4325.

## Summary
- avoid accepting partial regex matches for Lark terminals when building `from_lark()` terminal strategies
- add regression coverage for `%import common.ESCAPED_STRING`
- keep generated strings parseable by Lark for the terminal grammar

## Checks
- from `hypothesis/`: `uv run --isolated --with lark --with pytest --with pytest-xdist --with-editable . python -m pytest tests/lark/test_grammar.py -q` -> 20 passed
- from repo root: `python -m compileall -q -f hypothesis\src\hypothesis\extra\lark.py hypothesis\tests\lark\test_grammar.py`
- `git diff --check HEAD~1 HEAD`