### PR TITLE
claude: fix link preview dark styling in furo auto theme mode

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,7 +33,7 @@ When creating a PR that changes `hypothesis/src/`:
 3. **Imitate the style in `changelog.rst`** for consistency
 4. Follow all changelog instructions in `CONTRIBUTING.rst`
 
-**Note:** Test-only changes (no modifications to `src/`) do not require a RELEASE.rst file.
+**Note:** A RELEASE.rst is required if and only if the PR modifies files under `hypothesis/src/`. PRs touching only tests, docs (including `hypothesis/docs/`), the website, tooling, or CI config should **not** include a RELEASE.rst.
 
 ## Before Committing
 

--- a/hypothesis/docs/_static/dark-fix.css
+++ b/hypothesis/docs/_static/dark-fix.css
@@ -11,3 +11,18 @@ body[data-theme="dark"] .tooltip .tooltip-content {
 body[data-theme="dark"] .tooltip .arrow {
     background: var(--color-background-primary);
 }
+
+/*
+Furo also renders dark when the theme is "auto" (the default) and the OS
+prefers dark, via this same media query. Cover that case too; see
+https://github.com/HypothesisWorks/hypothesis/issues/4734.
+*/
+@media (prefers-color-scheme: dark) {
+    body:not([data-theme="light"]) .tooltip .tooltip-content {
+        background-color: var(--color-background-primary);
+    }
+
+    body:not([data-theme="light"]) .tooltip .arrow {
+        background: var(--color-background-primary);
+    }
+}


### PR DESCRIPTION
Speculative but I'm pretty confident this is right. Closes (the root cause of) https://github.com/HypothesisWorks/hypothesis/issues/4734.

<details><summary>Claude-written description</summary>

Fixes the dark-mode styling of ReadTheDocs link previews when furo's theme is "auto" (the default for first-time visitors) and the OS prefers dark.

Furo applies its dark palette via two distinct selectors: `body[data-theme=dark]` (explicit toggle) and `@media (prefers-color-scheme: dark) { body:not([data-theme=light]) }` (auto mode). Our existing `dark-fix.css` only covered the first, so in auto+OS-dark the page rendered dark but the link-preview tooltip kept the readthedocs-addons defaults: white background with `#8d8d8d` text. The theme-toggle icon in the issue screenshot confirms the reporter was in auto mode, and the mismatch was verified against the live docs site (auto mode → tooltip background `rgb(255, 255, 255)`; explicit dark → `rgb(19, 20, 22)`). This adds the same auto-mode media-query pattern furo itself uses.

Also rewords the RELEASE.rst note in `.claude/CLAUDE.md`: the previous phrasing ("test-only changes do not require a RELEASE.rst") invited the wrong inference that other non-`src/` changes (like this one) need a release file. CI requires a RELEASE.rst exactly when `hypothesis/src/` is modified (`has_source_changes()` in `tooling/`), so no release file is included in this PR.

The low-contrast `#8d8d8d` tooltip text is hardcoded upstream in readthedocs/addons and remains out of scope here.

</details>
