### PR TITLE
Reject datetime bounds in dates() with InvalidArgument

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+:func:`~hypothesis.strategies.dates` now raises ``InvalidArgument`` if a
+:class:`~python:datetime.datetime` is passed as ``min_value`` or ``max_value``.
+Because ``datetime`` is a subclass of :class:`~python:datetime.date`, such
+bounds were previously accepted and then failed with a confusing ``TypeError``
+while generating examples.

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -315,6 +315,12 @@ def dates(
     """
     check_type(dt.date, min_value, "min_value")
     check_type(dt.date, max_value, "max_value")
+    # datetime is a subclass of date, so check_type() accepts it - but a datetime
+    # bound is almost certainly a mistake, and breaks our drawing logic downstream.
+    if isinstance(min_value, dt.datetime):
+        raise InvalidArgument(f"{min_value=} is a datetime, but expected a date")
+    if isinstance(max_value, dt.datetime):
+        raise InvalidArgument(f"{max_value=} is a datetime, but expected a date")
     check_valid_interval(min_value, max_value, "min_value", "max_value")
     if min_value == max_value:
         return just(min_value)

--- a/hypothesis/tests/cover/test_direct_strategies.py
+++ b/hypothesis/tests/cover/test_direct_strategies.py
@@ -64,6 +64,8 @@ def fn_ktest(*fnkwargs):
     (st.dates, {"min_value": "fish"}),
     (st.dates, {"max_value": "fish"}),
     (st.dates, {"min_value": date(2017, 8, 22), "max_value": date(2017, 8, 21)}),
+    (st.dates, {"min_value": datetime(2017, 8, 21)}),
+    (st.dates, {"max_value": datetime(2017, 8, 21)}),
     (st.datetimes, {"min_value": "fish"}),
     (st.datetimes, {"max_value": "fish"}),
     (st.datetimes, {"allow_imaginary": 0}),


### PR DESCRIPTION
A datetime passed as min_value/max_value to dates() previously slipped past check_type() (datetime subclasses date) and then failed with a bare TypeError while generating examples. Validate explicitly and raise InvalidArgument instead.