### PR TITLE
claude: enforce ruff UP031 and UP037 lint rules

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch replaces some internal ``%``-style string formatting with
+f-strings, and enables the ``UP031`` and ``UP037`` ruff lint rules to keep
+it that way.  There is no user-visible change.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,5 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch replaces some internal ``%``-style string formatting with
-f-strings, and enables the ``UP031`` and ``UP037`` ruff lint rules to keep
-it that way.  There is no user-visible change.
+This patch replaces some internal ``%``-style string formatting with f-strings. There is no user-visible change.

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -717,10 +717,9 @@ class ConjectureData:
         self.start_span(TOP_LABEL)
 
     def __repr__(self) -> str:
-        return "ConjectureData(%s, %d choices%s)" % (
-            self.status.name,
-            len(self.nodes),
-            ", frozen" if self.frozen else "",
+        return (
+            f"ConjectureData({self.status.name}, {len(self.nodes)} "
+            f"choices{', frozen' if self.frozen else ''})"
         )
 
     @property

--- a/hypothesis/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -381,10 +381,10 @@ class ensure_free_stackframes:
             # is happening and it's hard to imagine an
             # intentionally-deeply-recursive use of this code.
             assert cur_depth <= 1000, (
-                "Hypothesis would usually add %d to the stack depth of %d here, "
-                "but we are already much deeper than expected.  Aborting now, to "
-                "avoid extending the stack limit in an infinite loop..."
-                % (self.new_limit - self.old_limit, self.old_limit)
+                f"Hypothesis would usually add {self.new_limit - self.old_limit} to "
+                f"the stack depth of {self.old_limit} here, but we are already much "
+                "deeper than expected.  Aborting now, to avoid extending the stack "
+                "limit in an infinite loop..."
             )
             try:
                 _stackframe_limiter.enter_context(

--- a/hypothesis/src/hypothesis/provisional.py
+++ b/hypothesis/src/hypothesis/provisional.py
@@ -106,8 +106,10 @@ class DomainNameStrategy(st.SearchStrategy[str]):
             label_regex = r"[a-zA-Z][a-zA-Z0-9]?"
         else:
             maximum_center_character_pattern_repetitions = self.max_element_length - 2
-            label_regex = r"[a-zA-Z]([a-zA-Z0-9\-]{0,%d}[a-zA-Z0-9])?" % (
-                maximum_center_character_pattern_repetitions,
+            label_regex = (
+                r"[a-zA-Z]([a-zA-Z0-9\-]{0,"
+                f"{maximum_center_character_pattern_repetitions}"
+                r"}[a-zA-Z0-9])?"
             )
 
         # Construct reusable strategies here to avoid a performance hit by doing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ ignore = [
     "SIM300",
     "SIM905",
     "UP031",
-    "UP037",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ ignore = [
     "SIM114",
     "SIM300",
     "SIM905",
-    "UP031",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION

<details>
This removes ``UP031`` (printf-string-formatting) and ``UP037``
(quoted-annotation) from the ruff ignore list, and applies the
corresponding fixes.

``UP037`` needed no code changes on master. ``UP031`` flagged three
``%``-style format strings, which ruff cannot autofix, so they were
rewritten to f-strings by hand. Each rewrite was checked to produce
byte-identical output to the original. There is no user-visible change.
</details>