### PR TITLE
Fix flatmap on consuming stateful bundles

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release fixes :func:`hypothesis.stateful.consumes` when it is combined
+with ``.flatmap(...)``.

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -658,6 +658,15 @@ class BundleConsumer(Bundle[Ex]):
     def __init__(self, bundle: Bundle[Ex]) -> None:
         super().__init__(bundle.name, consume=True)
 
+    def flatmap(self, expand):
+        if self.draw_references:
+            return Bundle(
+                self.name,
+                consume=True,
+                draw_references=False,
+            ).flatmap(expand)
+        return super().flatmap(expand)
+
 
 def consumes(bundle: Bundle[Ex]) -> SearchStrategy[Ex]:
     """When introducing a rule in a RuleBasedStateMachine, this function can

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -1472,6 +1472,25 @@ def test_flatmap():
     run_state_machine_as_test(Machine)
 
 
+def test_flatmap_consumes_bundle():
+    class Machine(RuleBasedStateMachine):
+        my_bundle = Bundle("my_bundle")
+
+        @initialize(target=my_bundle)
+        def set_initial(self, /) -> str:
+            return "sample text"
+
+        @rule(
+            character=consumes(my_bundle).flatmap(lambda value: st.sampled_from(value))
+        )
+        def check(self, /, *, character: str):
+            assert isinstance(character, str)
+            assert len(character) == 1
+
+    Machine.TestCase.settings = Settings(stateful_step_count=2, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
 def test_use_bundle_within_other_strategies():
     class Class:
         def __init__(self, value):


### PR DESCRIPTION
## Summary

Fixes #4427.

`Bundle.flatmap()` rebuilds the bundle with `type(self)(..., consume=..., draw_references=False)` before delegating to the normal strategy `flatmap` implementation. That works for `Bundle`, but `consumes(bundle)` returns `BundleConsumer`, whose constructor accepts a `Bundle` rather than those keyword arguments.

This gives `BundleConsumer` its own `flatmap()` implementation that keeps consuming semantics while switching to a non-reference-drawing `Bundle` for the delegated flatmap. A regression test covers `consumes(bundle).flatmap(...)` inside a state machine rule.

## Tests

- `PYTHONPATH=hypothesis/src python -m pytest hypothesis/tests/cover/test_stateful.py -q -k "flatmap"`
- `PYTHONPATH=hypothesis/src python -m pytest hypothesis/tests/cover/test_stateful.py -q`
- `PYTHONPATH=hypothesis/src python -m pytest hypothesis/tests/nocover/test_stateful.py -q`
- `python -m ruff check hypothesis/src/hypothesis/stateful.py hypothesis/tests/cover/test_stateful.py`
- `git diff --check`