### PR TITLE
Fix flatmap on consumed stateful bundles

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ their individual contributions.
 * `follower <https://www.github.com/follower>`_
 * `Francesc Elies <https://www.github.com/FrancescElies>`_
 * `Gabe Joseph <https://github.com/gjoseph92>`_
+* `gaoflow <https://github.com/gaoflow>`_
 * `Gary Donovan <https://www.github.com/garyd203>`_
 * `Genevieve Mendoza <https://www.github.com/genevieve-me>`_
 * `George Macon <https://www.github.com/gmacon>`_

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.stateful.consumes` so it can be combined
+with ``.flatmap()`` without raising a ``TypeError`` (:issue:`4427`).
+
+Thanks to gaoflow for this fix!

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -655,8 +655,15 @@ class Bundle(SearchStrategy[Ex]):
 
 
 class BundleConsumer(Bundle[Ex]):
-    def __init__(self, bundle: Bundle[Ex]) -> None:
-        super().__init__(bundle.name, consume=True)
+    def __init__(
+        self,
+        bundle: Bundle[Ex] | str,
+        *,
+        consume: bool = True,
+        draw_references: bool = True,
+    ) -> None:
+        name = bundle.name if isinstance(bundle, Bundle) else bundle
+        super().__init__(name, consume=consume, draw_references=draw_references)
 
 
 def consumes(bundle: Bundle[Ex]) -> SearchStrategy[Ex]:

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -1472,6 +1472,27 @@ def test_flatmap():
     run_state_machine_as_test(Machine)
 
 
+def test_flatmap_consumed_bundle():
+    class Machine(RuleBasedStateMachine):
+        characters = Bundle("characters")
+
+        @initialize(target=characters)
+        def set_initial(self):
+            return "sample text"
+
+        @rule(character=consumes(characters).flatmap(st.sampled_from))
+        def check(self, character):
+            assert isinstance(character, str)
+            assert len(character) == 1
+
+    Machine.TestCase.settings = Settings(
+        stateful_step_count=5,
+        max_examples=10,
+        suppress_health_check=[HealthCheck.filter_too_much],
+    )
+    run_state_machine_as_test(Machine)
+
+
 def test_use_bundle_within_other_strategies():
     class Class:
         def __init__(self, value):


### PR DESCRIPTION
Fixes #4427.

## Summary
- make the internal `BundleConsumer` constructor compatible with the `Bundle.flatmap()` path, while preserving `consumes(bundle)` behavior
- add a regression test for `consumes(bundle).flatmap(...)`
- add the required release note and AUTHORS entry

## Tests
- `uv run --python 3.13 --with-editable hypothesis python <issue reproduction script>` -> constructed successfully
- `uv run --python 3.13 --with-editable hypothesis --with pytest pytest hypothesis/tests/cover/test_stateful.py -k 'flatmap or consuming' -q` -> 3 passed
- `uv run --python 3.13 --with-editable hypothesis --with pytest pytest hypothesis/tests/cover/test_stateful.py -q` -> 91 passed
- `uv run --python 3.13 --with ruff ruff check hypothesis/src/hypothesis/stateful.py hypothesis/tests/cover/test_stateful.py` -> passed
- `uv run --python 3.13 --with black black --check hypothesis/src/hypothesis/stateful.py hypothesis/tests/cover/test_stateful.py` -> passed
- `uv run --python 3.13 --with-editable hypothesis --with mypy --with sortedcontainers-stubs mypy hypothesis/src/hypothesis/stateful.py` -> passed
- `./build.sh check-format` -> passed
- `git diff --check` -> passed

Disclosure: this PR was prepared with AI assistance, and I reviewed the change and take responsibility for it.