### PR TITLE
Issue #4774: Document the unsuitability of st.nothing() as a placeholder strategy

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+Document the "gotcha" that :func:`~hypothesis.strategies.nothing` is not
+suitable for use as a placeholder strategy in "explicit
+:class:`~hypothesis.example` only" setups. See :issue:`4774`.
+
+Contributed by Marco Ricci.

--- a/hypothesis/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/misc.py
@@ -83,6 +83,8 @@ def just(value: T) -> SearchStrategy[T]:
 def none() -> SearchStrategy[None]:
     """Return a strategy which only generates None.
 
+    Useful as a placeholder strategy.
+
     Examples from this strategy do not shrink (because there is only
     one).
     """
@@ -124,6 +126,14 @@ NOTHING = Nothing()
 def nothing() -> SearchStrategy["Never"]:
     """This strategy never successfully draws a value and will always reject on
     an attempt to draw.
+
+    ``nothing()`` is *not* suitable as a placeholder strategy in |@given|,
+    even when used together with |@example| and with only |Phase.explicit|
+    active, because it is too easy for a change in settings or settings profile
+    to cause the test to suddenly fail mysteriously. Prefer |st.none| as a
+    placeholder strategy for this use case. See `issue #4774
+    <https://github.com/HypothesisWorks/hypothesis/issues/4774>`__ for more
+    details.
 
     Examples from this strategy do not shrink (because there are none).
     """


### PR DESCRIPTION
Fixes #4774 (properly this time) by documenting the existing behavior of `@given(st.nothing())` as intended—even in the face of `@example` and `@settings(phases=["explicit"])`—and warning others who assume this to work (like I did) that it actually won't.

I would like to add a warning to the `Phases` documentation too, but I did not see a natural place to put this.

I am also still wondering what the actual use case for `st.nothing()` is, given that it can't be used as a runtime-unevaluated placeholder strategy.  See [my earlier comment on this](https://github.com/HypothesisWorks/hypothesis/issues/4774#issuecomment-4777887011).

(This is a documentation-only fix, so I did not bother running the test suite or somesuch; just that `build.sh documentation` works and that the output looks reasonable. I'm also rather unfamiliar with reST/Sphinx in general—I'm a Markdown/[mkdocstrings](https://mkdocstrings.github.io/) user—and my markup may be somewhat off.) 