### PR TITLE
Don't swallow user errors raised after the data is frozen

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes a bug where an exception raised by a test after its data had
+already been frozen - for example in a teardown step, or after an explicit
+freeze - was silently swallowed instead of propagating to the user
+(:issue:`4132`).

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -876,15 +876,8 @@ def _suppressed_a_stoptest(e: BaseException) -> bool:
     # True if e was raised while one of our StopTests was propagating. This
     # happens when a user error in a finally block (or stateful teardown) around
     # data.draw suppresses the StopTest we raise during generation, which then
-    # shows up in e's __context__ chain.
-    seen = set()
-    context = e.__context__
-    while context is not None and id(context) not in seen:
-        if isinstance(context, StopTest):
-            return True
-        seen.add(id(context))
-        context = context.__context__
-    return False
+    # shows up as e's __context__.
+    return isinstance(e.__context__, StopTest)
 
 
 @contextlib.contextmanager

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -864,6 +864,29 @@ def _flatten_group(excgroup: BaseExceptionGroup[T]) -> list[T]:
     return found_exceptions
 
 
+def _only_internal_markers(e: BaseException) -> bool:
+    # True if e is only our own Frozen/StopTest markers (possibly inside an
+    # exception group), with no real user error mixed in.
+    if isinstance(e, BaseExceptionGroup):
+        return all(_only_internal_markers(child) for child in e.exceptions)
+    return isinstance(e, (Frozen, StopTest))
+
+
+def _suppressed_a_stoptest(e: BaseException) -> bool:
+    # True if e was raised while one of our StopTests was propagating. This
+    # happens when a user error in a finally block (or stateful teardown) around
+    # data.draw suppresses the StopTest we raise during generation, which then
+    # shows up in e's __context__ chain.
+    seen = set()
+    context = e.__context__
+    while context is not None and id(context) not in seen:
+        if isinstance(context, StopTest):
+            return True
+        seen.add(id(context))
+        context = context.__context__
+    return False
+
+
 @contextlib.contextmanager
 def unwrap_markers_from_group() -> Generator[None, None, None]:
     try:
@@ -1288,11 +1311,16 @@ class StateForActualGivenExecution:
             ):
                 raise
 
-            if data.frozen:
-                # This can happen if an error occurred in a finally
-                # block somewhere, suppressing our original StopTest.
-                # We raise a new one here to resume normal operation.
+            if data.frozen and (_only_internal_markers(e) or _suppressed_a_stoptest(e)):
+                # No real user error here: it's either just our Frozen/StopTest
+                # markers, or a finally/teardown error that masked the StopTest we
+                # raise during generation (we'll see the real failure when
+                # shrinking). Re-raise StopTest so the engine carries on.
                 raise StopTest(data.testcounter) from e
+            elif data.frozen:
+                # The user raised a real error after the data was frozen (e.g. in
+                # teardown). Let it through instead of dropping it. See #4132.
+                raise
             else:
                 # The test failed by raising an exception, so we inform the
                 # engine that this test run was interesting. This is the normal

--- a/hypothesis/tests/cover/test_error_in_draw.py
+++ b/hypothesis/tests/cover/test_error_in_draw.py
@@ -31,6 +31,18 @@ def test_error_is_in_finally():
     assert "[0, 1, -1]" in "\n".join(err.value.__notes__)
 
 
+def test_error_raised_after_freeze_is_not_swallowed():
+    # Regression test for #4132: an error raised after the data is frozen should
+    # reach the user, not be silently swallowed.
+    @given(st.data())
+    def test(d):
+        d.conjecture_data.freeze()
+        raise TypeError("oops")
+
+    with pytest.raises(TypeError, match="oops"):
+        test()
+
+
 @given(st.data())
 def test_warns_on_bool_strategy(data):
     with pytest.warns(


### PR DESCRIPTION
closes #4132

Ran into this when an error raised after the `ConjectureData` was already frozen (in a teardown, or after an explicit `freeze()`) just vanished and the test passed. The engine catches the exception, assumes its own `StopTest` got suppressed somewhere along the way, raises a fresh `StopTest`, and drops the user's error on the floor.

Small repro:

```python
@given(st.data())
def foo(data):
    data.conjecture_data.freeze()
    raise TypeError("oops")

foo()  # passes silently before this change; raises TypeError after
```

So now we only re-raise `StopTest` when the thing we caught isn't a real user error — either it's just our own markers (`Frozen`/`StopTest`), or it suppressed a `StopTest` that was mid-flight during generation (checked by walking the `__context__` chain). Anything else is a genuine user error and propagates as normal.

Added a regression test for it, and the existing discard tests (`test_discard_frozen`, `test_error_is_in_finally`, and the stateful teardown paths) still pass.
