### PR TITLE
More CI fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,7 +250,6 @@ jobs:
       # The versions of pyodide-build and the Pyodide runtime may differ.
       PYODIDE_VERSION: 314.0.0
       PYODIDE_BUILD_VERSION: 0.35.1
-      # pyodide 0.29.0 (latest at time of writing) doesn't yet support 3.14
       PYTHON_VERSION: 3.14.2
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
               interpreter: 'python3.10 python3.11 python3.12 python3.13 python3.14 python3.14t'
             }
           - {
-              os: macos-13,
+              os: macos-latest,
               target: x86_64,
               libc: '',
               manylinux: '',
@@ -138,9 +138,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # automatically updated by update_pyodide_versions()
-      PYODIDE_VERSION: 0.29.4
-      PYODIDE_BUILD_VERSION: 0.34.4
-      PYTHON_VERSION: 3.13.2
+      PYODIDE_VERSION: 314.0.0
+      PYODIDE_BUILD_VERSION: 0.35.1
+      PYTHON_VERSION: 3.14.2
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -562,15 +562,21 @@ def update_pyodide_versions():
     pyodide_version = pyodide_release["version"]
     python_version = pyodide_release["python_version"]
 
-    ci_file = ROOT / ".github/workflows/main.yml"
-    config = ci_file.read_text(encoding="utf-8")
-    for name, var in [
-        ("PYODIDE", pyodide_version),
-        ("PYODIDE_BUILD", pyodide_build_version),
-        ("PYTHON", python_version),
-    ]:
-        config = re.sub(f"{name}_VERSION: {vers_re}", f"{name}_VERSION: {var}", config)
-    ci_file.write_text(config, encoding="utf-8")
+    ci_files = [
+        ROOT / ".github/workflows/main.yml",
+        ROOT / ".github/workflows/release.yml",
+    ]
+    for ci_file in ci_files:
+        config = ci_file.read_text(encoding="utf-8")
+        for name, var in [
+            ("PYODIDE", pyodide_version),
+            ("PYODIDE_BUILD", pyodide_build_version),
+            ("PYTHON", python_version),
+        ]:
+            config = re.sub(
+                f"{name}_VERSION: {vers_re}", f"{name}_VERSION: {var}", config
+            )
+        ci_file.write_text(config, encoding="utf-8")
 
 
 def update_vendored_files():


### PR DESCRIPTION
See failures in https://github.com/HypothesisWorks/hypothesis/actions/runs/28531727396

- github no longer has macos-13 runners. Cross-compile from newer macs instead
- pyodide versions were outdated and weren't getting updated automatically

getting closer!