### PR TITLE
Cut a new release

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch fixes our build pipeline from :v:`6.156.0`, to actually publish wheels.
+This patch fixes our build pipeline from :v:`6.156.0`, so that wheels are actually published.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes our build pipeline from :v:`6.156.0`, to actually publish wheels.

--- a/hypothesis/src/hypothesis/extra/django/_impl.py
+++ b/hypothesis/src/hypothesis/extra/django/_impl.py
@@ -159,10 +159,10 @@ def from_form(
     ``...`` (:obj:`python:Ellipsis`) as a keyword argument to infer a strategy for
     a field which has a default value instead of using the default.
     """
-    # currently unsupported:
-    # ComboField
-    # FilePathField
-    # ImageField
+    # Currently unsupported:
+    # * ComboField
+    # * FilePathField
+    # * ImageField
     form_kwargs = form_kwargs or {}
     if not issubclass(form, df.BaseForm):
         raise InvalidArgument(f"{form=} must be a subtype of Form")


### PR DESCRIPTION
This cuts a new release to trigger the release process, because the failed CI job is not retryable in the way we want. I asked @DRMacIver to fix https://github.com/HypothesisWorks/hypothesis/pull/4783#issuecomment-4859618314, so that should work now. 

Current status:
- The `v6.156.0` changelog, etc exists as a commit on master
- The `v6.156.0` tag and release exist on github, because I manually created it: https://github.com/HypothesisWorks/hypothesis/releases/tag/v6.156.0
- The `v6.156.0` release does not exist on PyPI

I didn't view reverting the `v6.156.0` commit as a real option, so I felt manually creating the github release (low effort/risk) but not the PyPI release (high effort/risk) was best.

The `v6.156.1` release should proceed as normal/expected when this PR is merged.