### PR TITLE
Fix source distribution upload

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix not uploading source distributions to PyPI, as of :v:`6.156.0`.

--- a/hypothesis/pyproject.toml
+++ b/hypothesis/pyproject.toml
@@ -12,6 +12,9 @@ authors = [
 description = "The property-based testing library for Python"
 
 license = "MPL-2.0"
+# explicit reference the license file to work around a bug (?) in maturin where it
+# doesn't auto-include the license file for sdists
+license-files = ["LICENSE.txt"]
 requires-python = ">= 3.10"
 keywords = ["python", "testing", "fuzzing", "property-based-testing"]
 classifiers = [

--- a/hypothesis/rust/Cargo.lock
+++ b/hypothesis/rust/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hypothesis-native"
-version = "6.155.7"
+version = "6.156.1"
 dependencies = [
  "pyo3",
 ]

--- a/tooling/src/hypothesistooling/cargo.py
+++ b/tooling/src/hypothesistooling/cargo.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import re
+import subprocess
 from pathlib import Path
 
 
@@ -22,3 +23,11 @@ def write_version(cargo_toml_path: Path, new_version: str) -> None:
         flags=re.MULTILINE,
     )
     cargo_toml_path.write_text(content, encoding="utf-8")
+
+
+def update_lockfile(cargo_toml_path: Path) -> None:
+    subprocess.run(
+        ["cargo", "update", "--workspace"],
+        check=True,
+        cwd=cargo_toml_path.parent,
+    )

--- a/tooling/src/hypothesistooling/release.py
+++ b/tooling/src/hypothesistooling/release.py
@@ -183,6 +183,7 @@ def update_changelog_and_version():
         rest = "\n".join([old, len(old) * "=", "", rest])
 
     cargo.write_version(CARGO_TOML, new_version_string)
+    cargo.update_lockfile(CARGO_TOML)
 
     heading_for_new_version = f"{new_version_string} - {release_date_string()}"
     border_for_new_version = "-" * len(heading_for_new_version)


### PR DESCRIPTION
v6.156.1 released almost entirely correctly. The one failure: not uploading the sdist to pypi. Pypi rejected it because the license file was missing. https://github.com/HypothesisWorks/hypothesis/actions/runs/28646647699/job/85020649944

Status:
- v6.156.1 pypi release succeeded*, but with the sdist missing
- v6.156.1 github release manually created

sdist is the fallback installation method, for building from source, so while it's of course bad to not have uploaded the sdist here, it wasn't an emergency.