### PR TITLE
fix potential `KeyError`

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a ``KeyError`` in |GitHubArtifactDatabase| when reading an
+artifact whose zip file contains no explicit directory entries, which is the
+case for zips produced by ``actions/upload-artifact``.

--- a/hypothesis/src/hypothesis/database.py
+++ b/hypothesis/src/hypothesis/database.py
@@ -966,12 +966,14 @@ class GitHubArtifactDatabase(ExampleDatabase):
                 for filename in namelist:
                     fileinfo = zf.getinfo(filename)
                     if fileinfo.is_dir():
-                        self._access_cache[PurePath(filename)] = set()
+                        self._access_cache.setdefault(PurePath(filename), set())
                     else:
                         # Get the keypath from the filename
                         keypath = PurePath(filename).parent
                         # Add the file to the keypath
-                        self._access_cache[keypath].add(PurePath(filename))
+                        self._access_cache.setdefault(keypath, set()).add(
+                            PurePath(filename)
+                        )
         except BadZipFile:
             warnings.warn(
                 "The downloaded artifact from GitHub is invalid. "

--- a/hypothesis/tests/cover/test_database_backend.py
+++ b/hypothesis/tests/cover/test_database_backend.py
@@ -40,6 +40,7 @@ from hypothesis.database import (
     MultiplexedDatabase,
     ReadOnlyDatabase,
     _db_for_path,
+    _hash,
     _pack_uleb128,
     _unpack_uleb128,
     choices_from_bytes,
@@ -299,6 +300,24 @@ def test_ga_corrupted_artifact():
         with pytest.warns(HypothesisWarning):
             assert list(database.fetch(b"")) == []
         assert database._disabled is True
+
+
+def test_ga_reads_artifact_without_directory_entries():
+    """Tests that artifacts without explicit directory entries can be read.
+
+    Real ``actions/upload-artifact`` zips only contain file entries, with no
+    separate directory entries, so the parent keypath is never seen via
+    ``is_dir()`` during cache initialization.
+    """
+    key = b"foo"
+    value = b"bar"
+    with ga_empty_artifact() as (path, zip_path):
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            # write only a file entry, without a directory entry for its parent
+            zf.writestr(f"{_hash(key)}/{_hash(value)}", value)
+
+        database = GitHubArtifactDatabase("test", "test", path=path)
+        assert list(database.fetch(key)) == [value]
 
 
 def test_ga_deletes_old_artifacts():

--- a/hypothesis/tests/cover/test_database_backend.py
+++ b/hypothesis/tests/cover/test_database_backend.py
@@ -303,12 +303,7 @@ def test_ga_corrupted_artifact():
 
 
 def test_ga_reads_artifact_without_directory_entries():
-    """Tests that artifacts without explicit directory entries can be read.
-
-    Real ``actions/upload-artifact`` zips only contain file entries, with no
-    separate directory entries, so the parent keypath is never seen via
-    ``is_dir()`` during cache initialization.
-    """
+    # see https://github.com/HypothesisWorks/hypothesis/pull/4787
     key = b"foo"
     value = b"bar"
     with ga_empty_artifact() as (path, zip_path):


### PR DESCRIPTION
## Description

During initialization in `GitHubArtifactDatabase._prepare_for_io()`, the cache was built assuming directory entries always precede their files. However, [actions/upload-artifact](https://github.com/actions/upload-artifact) zips contain no directory entries, so the `keypath` is never inserted and the subsequent `.add()` raises `KeyError`.

Instead, we use `setdefault()` so the parent `keypath` is created when needed.

This avoids the need for consumers of the official GitHub Actions to implement overrides in their test configs when registering profiles.

## Developer notes

Regression test was added first to demonstrate failure and begin test-driven development