### PR TITLE
Fix consumed bundles used with flatmap

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -203,6 +203,7 @@ their individual contributions.
 * `Will Hall <https://www.github.com/wrhall>`_ (wrsh07@gmail.com)
 * `Will Thompson <https://www.github.com/wjt>`_ (will@willthompson.co.uk)
 * `Wilfred Hughes <https://www.github.com/wilfred>`_
+* `ychampion <https://github.com/ychampion>`_
 * `Yiyang Zhan <https://www.github.com/zhanpon>`_
 * `Zac Hatfield-Dodds <https://www.github.com/Zac-HD>`_ (zac.hatfield.dodds@gmail.com)
 * `Zebulun Arendsee <https://www.github.com/arendsee>`_ (zbwrnz@gmail.com)

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes :func:`~hypothesis.stateful.consumes` so that consumed bundles
+can be used with ``.flatmap()`` in stateful rules (:issue:`4427`).
+
+Thanks to ychampion for this fix!

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -638,7 +638,7 @@ class Bundle(SearchStrategy[Ex]):
 
     def flatmap(self, expand):
         if self.draw_references:
-            return type(self)(
+            return Bundle(
                 self.name,
                 consume=self.__reference_strategy.consume,
                 draw_references=False,

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -1472,6 +1472,23 @@ def test_flatmap():
     run_state_machine_as_test(Machine)
 
 
+def test_consumed_bundle_can_be_flatmapped():
+    class Machine(RuleBasedStateMachine):
+        chars = Bundle("chars")
+
+        @initialize(target=chars)
+        def create_chars(self):
+            return "ab"
+
+        @rule(character=consumes(chars).flatmap(lambda value: st.sampled_from(value)))
+        def use_flatmap(self, character):
+            assert character in "ab"
+            assert not self.bundle("chars")
+
+    Machine.TestCase.settings = Settings(stateful_step_count=2, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
 def test_use_bundle_within_other_strategies():
     class Class:
         def __init__(self, value):


### PR DESCRIPTION
## Summary

- Fix `consumes(bundle).flatmap(...)` by preserving the consume flag without reconstructing `BundleConsumer`.
- Add a regression test for consumed bundles used through `flatmap`.

## Why

`Bundle.flatmap()` rebuilt the temporary bundle with `type(self)(..., consume=...)`. That fails for `BundleConsumer`, which is what `consumes()` returns, so the reproducer in #4427 raised `TypeError` while defining the rule.

Fixes #4427.

## Validation

- `. .venv/bin/activate && pytest hypothesis/tests/cover/test_stateful.py::test_consumed_bundle_can_be_flatmapped -q` - passed
- `. .venv/bin/activate && pytest hypothesis/tests/cover/test_stateful.py -q` - passed
- original #4427 repro script - passed

AI assistance was used; I reviewed the diff and validation.