### PR TITLE
fix: strip headers auth on redirects

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,7 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch fixes |GitHubArtifactDatabase| to drop the ``Authorization`` header
-when GitHub redirects an artifact download to a presigned storage URL on a
-different host.  The bearer token is only required for ``api.github.com``, and
-forwarding it across the redirect caused the presigned URL to reject the
-download with a ``401``.
+This patch fixes |GitHubArtifactDatabase| failing to download artifacts due to a colliding ``Authorization`` header.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch fixes |GitHubArtifactDatabase| to drop the ``Authorization`` header
+when GitHub redirects an artifact download to a presigned storage URL on a
+different host.  The bearer token is only required for ``api.github.com``, and
+forwarding it across the redirect caused the presigned URL to reject the
+download with a ``401``.

--- a/hypothesis/src/hypothesis/database.py
+++ b/hypothesis/src/hypothesis/database.py
@@ -34,8 +34,7 @@ from typing import (
     cast,
 )
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlsplit
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.request import Request, urlopen
 from zipfile import BadZipFile, ZipFile
 
 from hypothesis.configuration import StorageDirectory, storage_directory
@@ -814,19 +813,6 @@ class MultiplexedDatabase(ExampleDatabase):
             db.remove_listener(self._broadcast_change)
 
 
-class _AuthStrippingRedirectHandler(HTTPRedirectHandler):
-    """Drop the ``Authorization`` header when _following a cross-host redirect_."""
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        new = super().redirect_request(req, fp, code, msg, headers, newurl)
-        if (
-            new is not None
-            and urlsplit(newurl).hostname != urlsplit(req.full_url).hostname
-        ):
-            new.remove_header("Authorization")
-        return new
-
-
 class GitHubArtifactDatabase(ExampleDatabase):
     """
     A file-based database loaded from a `GitHub Actions <https://docs.github.com/en/actions>`_ artifact.
@@ -1064,17 +1050,14 @@ class GitHubArtifactDatabase(ExampleDatabase):
             headers={
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2022-11-28 ",
-                "Authorization": f"Bearer {self.token}",
             },
         )
+        # see https://github.com/HypothesisWorks/hypothesis/pull/4791
+        request.add_unredirected_header("Authorization", f"Bearer {self.token}")
         warning_message = None
         response_bytes: bytes | None = None
-        # GitHub redirects artifact downloads to a presigned Blob Storage URL; use
-        # an opener that strips our bearer token on that cross-host redirect, which
-        # the presigned URL would otherwise reject with a 401.
-        opener = build_opener(_AuthStrippingRedirectHandler)
         try:
-            with opener.open(request) as response:
+            with urlopen(request) as response:
                 response_bytes = response.read()
         except HTTPError as e:
             if e.code == 401:

--- a/hypothesis/src/hypothesis/database.py
+++ b/hypothesis/src/hypothesis/database.py
@@ -817,7 +817,7 @@ class MultiplexedDatabase(ExampleDatabase):
 class _AuthStrippingRedirectHandler(HTTPRedirectHandler):
     """Drop the ``Authorization`` header when _following a cross-host redirect_."""
 
-    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
         new = super().redirect_request(req, fp, code, msg, headers, newurl)
         if (
             new is not None

--- a/hypothesis/src/hypothesis/database.py
+++ b/hypothesis/src/hypothesis/database.py
@@ -34,7 +34,8 @@ from typing import (
     cast,
 )
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 from zipfile import BadZipFile, ZipFile
 
 from hypothesis.configuration import StorageDirectory, storage_directory
@@ -813,6 +814,19 @@ class MultiplexedDatabase(ExampleDatabase):
             db.remove_listener(self._broadcast_change)
 
 
+class _AuthStrippingRedirectHandler(HTTPRedirectHandler):
+    """Drop the ``Authorization`` header when _following a cross-host redirect_."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if (
+            new is not None
+            and urlsplit(newurl).hostname != urlsplit(req.full_url).hostname
+        ):
+            new.remove_header("Authorization")
+        return new
+
+
 class GitHubArtifactDatabase(ExampleDatabase):
     """
     A file-based database loaded from a `GitHub Actions <https://docs.github.com/en/actions>`_ artifact.
@@ -1055,8 +1069,12 @@ class GitHubArtifactDatabase(ExampleDatabase):
         )
         warning_message = None
         response_bytes: bytes | None = None
+        # GitHub redirects artifact downloads to a presigned Blob Storage URL; use
+        # an opener that strips our bearer token on that cross-host redirect, which
+        # the presigned URL would otherwise reject with a 401.
+        opener = build_opener(_AuthStrippingRedirectHandler)
         try:
-            with urlopen(request) as response:
+            with opener.open(request) as response:
                 response_bytes = response.read()
         except HTTPError as e:
             if e.code == 401:

--- a/hypothesis/tests/cover/test_database_backend.py
+++ b/hypothesis/tests/cover/test_database_backend.py
@@ -8,7 +8,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-import email.message
 import os
 import re
 import shutil
@@ -21,7 +20,6 @@ from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from shutil import make_archive, rmtree
-from urllib.request import Request
 
 import pytest
 
@@ -41,7 +39,6 @@ from hypothesis.database import (
     InMemoryExampleDatabase,
     MultiplexedDatabase,
     ReadOnlyDatabase,
-    _AuthStrippingRedirectHandler,
     _db_for_path,
     _hash,
     _pack_uleb128,
@@ -316,42 +313,6 @@ def test_ga_reads_artifact_without_directory_entries():
 
         database = GitHubArtifactDatabase("test", "test", path=path)
         assert list(database.fetch(key)) == [value]
-
-
-def _redirect(handler, from_url, to_url, headers):
-    return handler.redirect_request(
-        Request(from_url, headers=headers),
-        fp=None,
-        code=302,
-        msg="Found",
-        headers=email.message.Message(),
-        newurl=to_url,
-    )
-
-
-def test_auth_stripping_redirect_handler_drops_authorization_cross_host():
-    """Tests that cross-host redirects _do not_ leak the GitHub bearer token."""
-    new = _redirect(
-        _AuthStrippingRedirectHandler(),
-        "https://api.github.com/repos/o/r/actions/artifacts/1/zip",
-        "https://productionresultssa.blob.core.windows.net/x?sig=abc",
-        {"Authorization": "Bearer secret", "Accept": "application/json"},
-    )
-    assert new is not None
-    assert new.get_header("Authorization") is None
-    assert new.get_header("Accept") == "application/json"
-
-
-def test_auth_stripping_redirect_handler_keeps_authorization_same_host():
-    """Tests that same-host redirects _do_ retain the Authorization header."""
-    new = _redirect(
-        _AuthStrippingRedirectHandler(),
-        "https://api.github.com/a",
-        "https://api.github.com/b",
-        {"Authorization": "Bearer secret"},
-    )
-    assert new is not None
-    assert new.get_header("Authorization") == "Bearer secret"
 
 
 def test_ga_deletes_old_artifacts():

--- a/hypothesis/tests/cover/test_database_backend.py
+++ b/hypothesis/tests/cover/test_database_backend.py
@@ -8,6 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import email.message
 import os
 import re
 import shutil
@@ -20,6 +21,7 @@ from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from shutil import make_archive, rmtree
+from urllib.request import Request
 
 import pytest
 
@@ -39,6 +41,7 @@ from hypothesis.database import (
     InMemoryExampleDatabase,
     MultiplexedDatabase,
     ReadOnlyDatabase,
+    _AuthStrippingRedirectHandler,
     _db_for_path,
     _hash,
     _pack_uleb128,
@@ -313,6 +316,42 @@ def test_ga_reads_artifact_without_directory_entries():
 
         database = GitHubArtifactDatabase("test", "test", path=path)
         assert list(database.fetch(key)) == [value]
+
+
+def _redirect(handler, from_url, to_url, headers):
+    return handler.redirect_request(
+        Request(from_url, headers=headers),
+        fp=None,
+        code=302,
+        msg="Found",
+        headers=email.message.Message(),
+        newurl=to_url,
+    )
+
+
+def test_auth_stripping_redirect_handler_drops_authorization_cross_host():
+    """Tests that cross-host redirects _do not_ leak the GitHub bearer token."""
+    new = _redirect(
+        _AuthStrippingRedirectHandler(),
+        "https://api.github.com/repos/o/r/actions/artifacts/1/zip",
+        "https://productionresultssa.blob.core.windows.net/x?sig=abc",
+        {"Authorization": "Bearer secret", "Accept": "application/json"},
+    )
+    assert new is not None
+    assert new.get_header("Authorization") is None
+    assert new.get_header("Accept") == "application/json"
+
+
+def test_auth_stripping_redirect_handler_keeps_authorization_same_host():
+    """Tests that same-host redirects _do_ retain the Authorization header."""
+    new = _redirect(
+        _AuthStrippingRedirectHandler(),
+        "https://api.github.com/a",
+        "https://api.github.com/b",
+        {"Authorization": "Bearer secret"},
+    )
+    assert new is not None
+    assert new.get_header("Authorization") == "Bearer secret"
 
 
 def test_ga_deletes_old_artifacts():


### PR DESCRIPTION
# Claude-generated 

## Description

When `GitHubArtifactDatabase` downloads an artifact, GitHub's REST endpoint
(`api.github.com`) responds with a redirect to a presigned Blob Storage URL on a
different host (e.g. `*.blob.core.windows.net`). That URL is already authenticated
by its signature, and rejects the request with a `401` if it *also* receives our
`Authorization: Bearer <token>` header.

Python's `urllib` re-sends all original headers across redirects with no host check,
so the token leaked to the storage host and the download failed. This patch adds a
small `HTTPRedirectHandler` subclass that drops the `Authorization` header when — and
only when — the redirect target's host differs from the original request's host,
matching the behaviour of `curl -L` and `requests`.

## Developer notes

- **Security angle:** beyond fixing the `401`, this stops the `GITHUB_TOKEN` bearer
  from being forwarded to a third-party host — a credential leak, not just a
  functional bug.
- **Why a custom handler:** unlike `requests`, stdlib `urlopen` does not strip
  auth on cross-host redirects, so we subclass `HTTPRedirectHandler` and wire it in
  via `build_opener(...)` in `_get_bytes`. Same-host redirects keep the token, and
  unrelated headers (e.g. `Accept`) are preserved.
- **Testing:** the network path (`_fetch_artifact` / `_get_bytes`) needs a live
  GitHub artifact and presigned redirect, so it remains `# pragma: no cover`. The
  redirect decision, however, is isolated in `_AuthStrippingRedirectHandler`, whose
  `redirect_request` is a pure function — covered by two unit tests with no network:
  one asserting the token is dropped cross-host (while `Accept` survives), and one
  asserting it's retained same-host.