### PR TITLE
Ship abi3 wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
           - check-py311-pandas15
           - check-py310-pandas14
           - check-py310-pandas13
+          - check-abi3
           ## FIXME: actions update means Python builds without eg _bz2, which was required
           # - check-py310-pandas12
           # - check-py310-pandas11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,13 @@ jobs:
         manylinux: ${{ matrix.manylinux }}
         args: --release --out dist --interpreter ${{ matrix.interpreter }}
         working-directory: hypothesis
+    - name: Build abi3 wheel
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ matrix.target }}
+        manylinux: ${{ matrix.manylinux }}
+        args: --release --out dist --features abi3
+        working-directory: hypothesis
     - uses: actions/upload-artifact@v4
       with:
         name: dist-wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.libc }}

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+In addition to our version-specific wheels, we now also publish ``abi3`` wheels, built against the 3.10 stable ABI.

--- a/hypothesis/rust/Cargo.toml
+++ b/hypothesis/rust/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.29", features = ["extension-module"] }
 
+[features]
+abi3 = ["pyo3/abi3-py310"]
+
 [profile.release]
 # we may want to revisit these settings as we move more of hypothesis
 # into rust and see what our actual compile and run times look like.

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -5,6 +5,7 @@ dpcontracts
 ipython
 lark
 libcst
+maturin
 mypy
 numpy
 pelican[markdown]

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -146,6 +146,8 @@ markupsafe==3.0.3
     # via jinja2
 matplotlib-inline==0.2.2
     # via ipython
+maturin==1.14.1
+    # via -r requirements/tools.in
 mdurl==0.1.2
     # via markdown-it-py
 more-itertools==11.1.0

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -14,6 +14,7 @@ import pathlib
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import date
 from pathlib import Path
 from textwrap import indent
@@ -720,6 +721,7 @@ python_tests = task(
     if_changed=(
         PYTHON_SRC,
         PYTHON_TESTS,
+        HYPOTHESIS / "rust",
         HYPOTHESIS / "pyproject.toml",
         ROOT / "tooling",
         HYPOTHESIS / "scripts",
@@ -813,6 +815,18 @@ standard_tox_task("snapshots")
 @task()
 def check_quality(*args):
     run_tox("quality", PYTHONS[ci_version], *args)
+
+
+@python_tests
+def check_abi3(*args):
+    with tempfile.TemporaryDirectory() as dist:
+        pip_tool(
+            "maturin", "build", "--features", "abi3", "--out", dist, cwd=HYPOTHESIS
+        )
+        (wheel,) = Path(dist).glob("*.whl")
+        assert "abi3" in wheel.name, wheel.name
+        slug = ci_version.replace(".", "")
+        run_tox(f"py{slug}-cover", PYTHONS[ci_version], f"--installpkg={wheel}", *args)
 
 
 @task()

--- a/whole_repo_tests/whole_repo/test_ci_config.py
+++ b/whole_repo_tests/whole_repo/test_ci_config.py
@@ -31,6 +31,16 @@ def test_python_versions_are_tested_in_ci(version):
     assert f"- check-py{slug}" in ci_checks, f"Add {version} to main.yml and tox.ini"
 
 
+def test_abi3_floor_is_minimum_supported_python():
+    cargo_toml = Path("hypothesis/rust/Cargo.toml").read_text(encoding="utf-8")
+    floor = re.search(r"pyo3/abi3-py3(\d+)", cargo_toml).group(1)
+    requires = re.search(
+        r'requires-python = ">= ?3\.(\d+)"',
+        Path("hypothesis/pyproject.toml").read_text(encoding="utf-8"),
+    ).group(1)
+    assert floor == requires
+
+
 def test_python_versions_are_in_trove_classifiers():
     got_classifiers = {
         line.strip(' ",\n')


### PR DESCRIPTION
This ships cp310-abi3 wheels in addition to our version-specific wheels. This lets us provide a forward-compatible fallback for versions where we don't ship a specific wheel.

I (got fable to) check pip's resolution behavior, and it prefers version-specific wheels where possible.

Closes https://github.com/HypothesisWorks/hypothesis/issues/4789.