### PR TITLE
Ship 32bit wheels for windows and linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,14 +92,31 @@ jobs:
               manylinux: '',
               interpreter: 'python3.10 python3.11 python3.12 python3.13 python3.14 python3.14t pypy3.11'
             }
+          - {
+              os: ubuntu-latest,
+              target: i686,
+              libc: manylinux,
+              manylinux: auto,
+              abi3-only: true
+            }
+          - {
+              os: windows-latest,
+              target: x86,
+              python-architecture: x86,
+              libc: '',
+              manylinux: '',
+              abi3-only: true
+            }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'
+        architecture: ${{ matrix.python-architecture }}
     - name: Stamp release version into Cargo.toml
       run: python tooling/scripts/write-cargo-version.py "${{ needs.prepare-release.outputs.new_version }}"
     - name: Build wheels
+      if: ${{ !matrix.abi3-only }}
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+We now publish abi3 wheels for 32-bit linux and 32-bit windows.


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/4789.

This only ships abi3 wheels. Shipping the full version matrix would improve performance only, which is not worth doing for such a small platform/arch by usage.