### PR TITLE
Align Pyodide wheel builds with Rust ABI expectations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,18 +267,35 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
     - name: Install pyodide-build and Pyodide cross-build environment
       run: |
-        pip install pyodide-build==${{ env.PYODIDE_BUILD_VERSION }}
-        pyodide xbuildenv install ${{ env.PYODIDE_VERSION }}
+        pip install pyodide-build==${PYODIDE_BUILD_VERSION}
+        pyodide xbuildenv install ${PYODIDE_VERSION}
+    - name: Get Pyodide build configuration
+      id: pyodide-config
+      run: |
+        echo "rust-toolchain=$(pyodide config get rust_toolchain)" >> "$GITHUB_OUTPUT"
+        echo "rustflags=$(pyodide config get rustflags)" >> "$GITHUB_OUTPUT"
+        echo "python-minor=$(echo "$PYTHON_VERSION" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+    - name: Install Emscripten SDK
+      run: |
+        pyodide xbuildenv install-emscripten
+        pyodide config get emscripten_dir >> "$GITHUB_PATH"
+    - name: Build pyemscripten wheel
+      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+      env:
+        CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUSTFLAGS: ${{ steps.pyodide-config.outputs.rustflags }}
+      with:
+        target: wasm32-unknown-emscripten
+        args: --release --out dist --interpreter ${{ steps.pyodide-config.outputs.python-minor }}
+        working-directory: hypothesis
+        rust-toolchain: ${{ steps.pyodide-config.outputs.rust-toolchain }}
     - name: Set up Pyodide venv and install dependencies
       run: |
-        rustup target add wasm32-unknown-emscripten
         pip install --upgrade setuptools pip wheel
-        pyodide build hypothesis --outdir dist/
-        pip download --dest=dist/ pytest tzdata syrupy  # fetch all the wheels
-        rm dist/packaging-*.whl  # fails with `invalid metadata entry 'name'`
+        pip download --dest=hypothesis/dist/ pytest tzdata syrupy  # fetch all the wheels
+        rm hypothesis/dist/packaging-*.whl  # fails with `invalid metadata entry 'name'`
         pyodide venv .venv-pyodide
         source .venv-pyodide/bin/activate
-        pip install dist/*.whl
+        pip install hypothesis/dist/*.whl
     - name: Run tests
       run: |
         source .venv-pyodide/bin/activate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,14 +155,31 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install pyodide-build and Pyodide cross-build environment
       run: |
-        pip install pyodide-build==${{ env.PYODIDE_BUILD_VERSION }}
-        pyodide xbuildenv install ${{ env.PYODIDE_VERSION }}
-    - name: Install Rust wasm32-unknown-emscripten target
-      run: rustup target add wasm32-unknown-emscripten
+        pip install pyodide-build==${PYODIDE_BUILD_VERSION}
+        pyodide xbuildenv install ${PYODIDE_VERSION}
+    - name: Get Pyodide build configuration
+      id: pyodide-config
+      run: |
+        echo "rust-toolchain=$(pyodide config get rust_toolchain)" >> "$GITHUB_OUTPUT"
+        echo "rustflags=$(pyodide config get rustflags)" >> "$GITHUB_OUTPUT"
+        echo "python-minor=$(echo "$PYTHON_VERSION" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+    - name: Install Emscripten SDK
+      run: |
+        pyodide xbuildenv install-emscripten
+        pyodide config get emscripten_dir >> "$GITHUB_PATH"
     - name: Stamp release version into Cargo.toml
-      run: python tooling/scripts/write-cargo-version.py "${{ needs.prepare-release.outputs.new_version }}"
+      run: python tooling/scripts/write-cargo-version.py "${NEEDS_PREPARE_RELEASE_OUTPUTS_NEW_VERSION}"
+      env:
+        NEEDS_PREPARE_RELEASE_OUTPUTS_NEW_VERSION: ${{ needs.prepare-release.outputs.new_version }}
     - name: Build Pyodide wheel
-      run: pyodide build hypothesis --outdir hypothesis/dist/
+      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+      env:
+        CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUSTFLAGS: ${{ steps.pyodide-config.outputs.rustflags }}
+      with:
+        target: wasm32-unknown-emscripten
+        args: --release --out dist --interpreter ${{ steps.pyodide-config.outputs.python-minor }}
+        working-directory: hypothesis
+        rust-toolchain: ${{ steps.pyodide-config.outputs.rust-toolchain }}
     - uses: actions/upload-artifact@v4
       with:
         name: dist-pyodide


### PR DESCRIPTION
Hi! Since Hypothesis has a Rust core now, here are some fixes that I recommend to better align with our Rust-to-WASM support. We have some docs here: https://pyodide-build.readthedocs.io/en/latest/tutorials/rust.html, and as part of our latest 314.0 release, the Pydantic team wrote an article to talk about it as well: https://pydantic.dev/articles/emscripten-wheels-pydantic.

The changes here are as follows:
- Instead of using a GitHub Action to set up the Emscripten toolchain, the `pyodide xbuildenv install-emscripten` command is now used. It automatically pins and installs a patched version of Emscripten based on what is used in Pyodide. Some of those patches were relevant for compiling Rust projects in the past, and they don't alter the ABI.
- The Rust toolchain and the Rust compiler flags are surfaced from the `pyodide config` CLI. More details are available in the documentation pages for the [PyEmscripten platform](https://pyodide.org/en/stable/development/abi.html).
- Maturin (via its corresponding action) is used, instead of `pyodide-build` (though `pyodide-build` more or less works, too), and it consumes the Rust flags from the config.

P.S. I noticed that y'all don't pin your actions and some of them are on pretty old versions – I'd recommend updating them via `uvx gha-update`, and using [Zizmor](https://zizmor.sh/) as a GitHub Action or pre-commit hook. Apologies if this has been brought up elsewhere before!

Thank you!