### PR TITLE
Use stdlib tomllib instead of tomli in tooling

### DIFF
--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -35,5 +35,4 @@ watchdog # for typing
 build
 sortedcontainers-stubs # for typing
 attrs # for typing
-tomli # for update_pyproject_toml
 -r test.in

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -334,8 +334,6 @@ syrupy==5.5.3
     # via -r requirements/test.in
 tokenize-rt==6.2.0
     # via pyupgrade
-tomli==2.4.1
-    # via -r requirements/tools.in
 tomli-w==1.2.0
     # via tox
 tox==4.56.4

--- a/tooling/src/hypothesistooling/cargo.py
+++ b/tooling/src/hypothesistooling/cargo.py
@@ -10,9 +10,8 @@
 
 import re
 import subprocess
+import tomllib
 from pathlib import Path
-
-import tomli
 
 from hypothesistooling import installers as install
 from hypothesistooling.git import ROOT
@@ -25,7 +24,7 @@ RUST_BUILD_ENV = {"RUSTUP_TOOLCHAIN": ci_version_rust}
 
 
 def rust_msrv():
-    return tomli.loads(CARGO_TOML.read_text(encoding="utf-8"))["package"][
+    return tomllib.loads(CARGO_TOML.read_text(encoding="utf-8"))["package"][
         "rust-version"
     ]
 

--- a/tooling/src/hypothesistooling/release.py
+++ b/tooling/src/hypothesistooling/release.py
@@ -13,10 +13,10 @@ import os
 import re
 import subprocess
 import sys
+import tomllib
 from datetime import datetime, timezone
 
 import requests
-import tomli
 
 from hypothesistooling import cargo, installers as install
 from hypothesistooling.cargo import CARGO_TOML, RUST_BUILD_ENV, ci_version_rust
@@ -39,7 +39,9 @@ DIST = HYPOTHESIS / "dist"
 assert PYTHON_SRC.exists()
 
 
-__version__ = tomli.loads(CARGO_TOML.read_text(encoding="utf-8"))["package"]["version"]
+__version__ = tomllib.loads(CARGO_TOML.read_text(encoding="utf-8"))["package"][
+    "version"
+]
 __version_info__ = tuple(int(p) for p in __version__.split("."))
 
 
@@ -221,10 +223,10 @@ def update_changelog_and_version():
 
 def update_pyproject_toml():
     # manually write back these changes using regex instead of pulling in a
-    # toml dependency for writing. tomli doesn't support writing, and
+    # toml dependency for writing. tomllib doesn't support writing, and
     # tomli-w doesn't support writing with comments.
     toml_p = HYPOTHESIS / "pyproject.toml"
-    toml_data = tomli.loads(toml_p.read_text())
+    toml_data = tomllib.loads(toml_p.read_text())
     extras = toml_data["project"]["optional-dependencies"]
     extras.pop("all")
     readme = (ROOT / "README.md").read_text()


### PR DESCRIPTION
The release workflow's "Stamp release version into Cargo.toml" step runs write-cargo-version.py with a bare setup-python interpreter, where the third-party tomli package is not installed, so importing hypothesistooling.cargo failed. All environments that run the tooling use Python 3.13+, so we can use the stdlib tomllib module instead and drop the tomli dependency entirely.

See e.g. https://github.com/HypothesisWorks/hypothesis/actions/runs/29638893363/job/88067065423