### PR TITLE
Fix release wheels job on Windows

### DIFF
--- a/tooling/src/hypothesistooling/installers.py
+++ b/tooling/src/hypothesistooling/installers.py
@@ -16,7 +16,7 @@ import subprocess
 
 from hypothesistooling import scripts
 
-HOME = os.environ["HOME"]
+HOME = os.path.expanduser("~")
 INSTALLED_PYTHONS = set()
 INSTALLED_RUSTS = set()
 


### PR DESCRIPTION
hypothesistooling.installers read os.environ["HOME"] at import time, which crashes on Windows where HOME is not set. Use os.path.expanduser instead, which reads HOME on POSIX and USERPROFILE on Windows.