### PR TITLE
Make LazySequenceCopy index bookkeeping branch-free

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,10 +30,11 @@ Run tests using the build system:
 When creating a PR that changes `hypothesis/src/`:
 1. Create `hypothesis/RELEASE.rst` with `RELEASE_TYPE: patch` (bugfixes) or `minor` (features)
 2. See `RELEASE-sample.rst` for examples
-3. **Imitate the style in `changelog.rst`** for consistency
+3. **Imitate the style in `changelog.rst`** for consistency - read a few recent entries and match their phrasing and length
 4. Follow all changelog instructions in `CONTRIBUTING.rst`
 5. Specific additional guidelines:
   * Do not over-specify built-in exceptions. For example, "fix <x>, which previously raised an error" is generally better than  "fix <x>, which previously raised ``TypeError``.
+  * The changelog explains *what* changed for users, not *how* - leave implementation details to the commit message and code comments.
 
 **Note:** A RELEASE.rst is required if and only if the PR modifies files under `hypothesis/src/`. PRs touching only tests, docs (including `hypothesis/docs/`), the website, tooling, or CI config should **not** include a RELEASE.rst.
 

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of unique collections drawing from a fixed
+pool of elements, such as :func:`~hypothesis.strategies.sets` of
+:func:`~hypothesis.strategies.sampled_from`, under symbolic-execution backends
+such as :pypi:`hypothesis-crosshair`.

--- a/hypothesis/src/hypothesis/internal/conjecture/junkdrawer.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/junkdrawer.py
@@ -31,8 +31,6 @@ from typing import (
     overload,
 )
 
-from sortedcontainers import SortedList
-
 from hypothesis.errors import HypothesisWarning
 
 T = TypeVar("T")
@@ -201,27 +199,29 @@ class LazySequenceCopy(Generic[T]):
         self.__values = values
         self.__len = len(values)
         self.__mask: dict[int, T] | None = None
-        self.__popped_indices: SortedList[int] | None = None
+        # Indices passed to pop(), in pop order, each in the coordinates that
+        # were current at the time of that pop.  See __underlying_index.
+        self.__popped_at: list[int] | None = None
 
     def __len__(self) -> int:
-        if self.__popped_indices is None:
+        if self.__popped_at is None:
             return self.__len
-        return self.__len - len(self.__popped_indices)
+        return self.__len - len(self.__popped_at)
 
     def pop(self, i: int = -1) -> T:
         if len(self) == 0:
             raise IndexError("Cannot pop from empty list")
-        i = self.__underlying_index(i)
+        i, u = self.__underlying_index(i)
 
         v = None
         if self.__mask is not None:
-            v = self.__mask.pop(i, None)
+            v = self.__mask.pop(u, None)
         if v is None:
-            v = self.__values[i]
+            v = self.__values[u]
 
-        if self.__popped_indices is None:
-            self.__popped_indices = SortedList()
-        self.__popped_indices.add(i)
+        if self.__popped_at is None:
+            self.__popped_at = []
+        self.__popped_at.append(i)
         return v
 
     def swap(self, i: int, j: int) -> None:
@@ -231,7 +231,7 @@ class LazySequenceCopy(Generic[T]):
         self[i], self[j] = self[j], self[i]
 
     def __getitem__(self, i: int) -> T:
-        i = self.__underlying_index(i)
+        _, i = self.__underlying_index(i)
 
         default = self.__values[i]
         if self.__mask is None:
@@ -240,12 +240,29 @@ class LazySequenceCopy(Generic[T]):
             return self.__mask.get(i, default)
 
     def __setitem__(self, i: int, v: T) -> None:
-        i = self.__underlying_index(i)
+        _, i = self.__underlying_index(i)
         if self.__mask is None:
             self.__mask = {}
         self.__mask[i] = v
 
-    def __underlying_index(self, i: int) -> int:
+    def __underlying_index(self, i: int) -> tuple[int, int]:
+        # given an index i in the popped representation of the list, compute
+        # its corresponding index u in the underlying list. given
+        #   l = [1, 4, 2, 10, 188]
+        #   l.pop(3)
+        #   l.pop(1)
+        #   assert l == [1, 2, 188]
+        #
+        # we want l[i] == self.__values[u], and return both the normalized
+        # (non-negative, bounds-checked) i and u.
+        #
+        # A pop at index p maps each later index x in the popped coordinates
+        # to x + (p <= x) in the coordinates current at the time of that pop,
+        # so applying this from the most recent pop back to the oldest turns i
+        # into an index into the underlying sequence.  We add the comparison
+        # as an integer rather than branching on it so that, under
+        # symbolic-execution backends, symbolic indices pass through here
+        # without forcing any solver queries.
         n = len(self)
         if i < -n or i >= n:
             raise IndexError(f"Index {i} out of range [0, {n})")
@@ -253,22 +270,12 @@ class LazySequenceCopy(Generic[T]):
             i += n
         assert 0 <= i < n
 
-        if self.__popped_indices is not None:
-            # given an index i in the popped representation of the list, compute
-            # its corresponding index in the underlying list. given
-            #   l = [1, 4, 2, 10, 188]
-            #   l.pop(3)
-            #   l.pop(1)
-            #   assert l == [1, 2, 188]
-            #
-            # we want l[i] == self.__values[f(i)], where f is this function.
-            assert len(self.__popped_indices) <= len(self.__values)
-
-            for idx in self.__popped_indices:
-                if idx > i:
-                    break
-                i += 1
-        return i
+        u = i
+        if self.__popped_at is not None:
+            assert len(self.__popped_at) <= len(self.__values)
+            for p in reversed(self.__popped_at):
+                u += p <= u
+        return i, u
 
     # even though we have len + getitem, mypyc requires iter.
     def __iter__(self) -> Iterable[T]:

--- a/hypothesis/tests/cover/test_sampled_from.py
+++ b/hypothesis/tests/cover/test_sampled_from.py
@@ -34,7 +34,7 @@ from tests.common.debug import (
     assert_simple_property,
     check_can_generate_examples,
 )
-from tests.common.utils import fails_with
+from tests.common.utils import Why, fails_with, xfail_on_crosshair
 
 an_enum = enum.Enum("A", "a b c")
 a_flag = enum.Flag("A", "a b c")
@@ -175,6 +175,11 @@ def test_max_size_is_respected_with_unique_sampled_from(ls):
     assert len(ls) <= 3
 
 
+# crosshair-tool 0.0.108 encodes `==` between a promoted symbolic int and a
+# symbolic float as SMT structural equality, under which +0.0 != -0.0; this
+# makes the uniqueness check take an infeasible branch and realization then
+# raises CrossHairInternal.  Remove once a fixed crosshair-tool is pinned.
+@xfail_on_crosshair(Why.other)
 @given(st.lists(st.sampled_from([0, 0.0]), unique=True, min_size=1))
 def test_issue_2247_regression(ls):
     assert len(ls) == 1


### PR DESCRIPTION
Replace the sorted-popped-indices representation with an append-only list of pop positions (each in the coordinates current at the time of that pop), applied in reverse to translate an index to the underlying sequence.  The index-to-value mapping is unchanged, but the translation is now arithmetic on the index rather than branching on it, so under symbolic-execution backends such as hypothesis-crosshair a symbolic index passes through without forcing any solver queries, and unique collections drawing from a fixed pool of elements speed up severalfold without realizing any symbolic values.

Performance in the non-crosshair case is also (slightly) faster for most workloads.

----------

Also xfail test_issue_2247_regression under crosshair until https://github.com/pschanely/CrossHair/pull/470 is released.  This PR is part of a set with https://github.com/pschanely/CrossHair/pull/482, and maybe more perf improvements to come?

