### PR TITLE
Track explain-phase comments by span instead of node slices

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Internal refactoring of how |Phase.explain| tracks which parts of a failing
+example can vary, with no user-visible change.

--- a/hypothesis/src/hypothesis/control.py
+++ b/hypothesis/src/hypothesis/control.py
@@ -166,7 +166,7 @@ class BuildContext:
 
     @contextmanager
     def track_arg_label(self, label: str) -> Generator[ArgLabelsT, None, None]:
-        start = len(self.data.nodes)
+        span_index = self.data.next_span_index
         self._label_path.append(label)
         arg_labels: ArgLabelsT = {}
         try:
@@ -174,19 +174,15 @@ class BuildContext:
         finally:
             self._label_path.pop()
 
-            # This high up the stack, we can't see or really do much with
-            # Span / SpanRecord - not least because they're only materialized
-            # after the test case is completed.
-            #
-            # Instead, we'll stash the (start_idx, end_idx) pair on our data object
-            # for the ConjectureRunner engine to deal with, and mutate the arg_labels
-            # dict so that the pretty-printer knows where to place the
-            # which-parts-matter comments later.
-            end = len(self.data.nodes)
-            assert start <= end
-            if start != end:
-                arg_labels[label] = (start, end)
-                self.data.arg_slices.add((start, end))
+        # The draw inside this block opened a span, whose index we knew in
+        # advance even though Span objects are only materialized after the
+        # test case is completed. Stash that index on our data object for
+        # the shrinker's explain phase to vary, and mutate the arg_labels
+        # dict so that the pretty-printer knows where to place the
+        # which-parts-matter comments later. (If the draw raised instead,
+        # we skip recording, along with the rest of the test case.)
+        arg_labels[label] = span_index
+        self.data.arg_spans.add(span_index)
 
     def record_call(
         self,

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -1056,12 +1056,12 @@ class StateForActualGivenExecution:
             args = self.stuff.args
             kwargs = dict(self.stuff.kwargs)
             if example_kwargs is None:
-                kw, argslices = context.prep_args_kwargs_from_strategies(
+                kw, arglabels = context.prep_args_kwargs_from_strategies(
                     self.stuff.given_kwargs
                 )
             else:
                 kw = example_kwargs
-                argslices = {}
+                arglabels = {}
             kwargs.update(kw)
             if expected_failure is not None:
                 nonlocal text_repr
@@ -1081,10 +1081,10 @@ class StateForActualGivenExecution:
                         args,
                         kwargs,
                         force_split=True,
-                        arg_slices=argslices,
+                        arg_labels=arglabels,
                         leading_comment=(
-                            "# " + context.data.slice_comments[(0, 0)]
-                            if (0, 0) in context.data.slice_comments
+                            "# " + context.data.span_comments[None]
+                            if None in context.data.span_comments
                             else None
                         ),
                         avoid_realization=data.provider.avoid_realization,
@@ -1099,10 +1099,10 @@ class StateForActualGivenExecution:
                     args,
                     kwargs,
                     force_split=True,
-                    arg_slices=argslices,
+                    arg_labels=arglabels,
                     leading_comment=(
-                        "# " + context.data.slice_comments[(0, 0)]
-                        if (0, 0) in context.data.slice_comments
+                        "# " + context.data.span_comments[None]
+                        if None in context.data.span_comments
                         else None
                     ),
                     avoid_realization=data.provider.avoid_realization,
@@ -1509,7 +1509,7 @@ class StateForActualGivenExecution:
             ran_example = runner.new_conjecture_data(
                 falsifying_example.choices, max_choices=len(falsifying_example.choices)
             )
-            ran_example.slice_comments = falsifying_example.slice_comments
+            ran_example.span_comments = falsifying_example.span_comments
             tb = None
             origin = None
             assert falsifying_example.expected_exception is not None

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -322,6 +322,9 @@ class SpanRecord:
         self.__index_of_labels: dict[int, int] | None = {}
         self.trail = IntList()
         self.nodes: list[ChoiceNode] = []
+        # The number of spans started so far, which is also the index that the
+        # next span to start will get. Spans are indexed in start order.
+        self.span_count = 0
 
     def freeze(self) -> None:
         self.__index_of_labels = None
@@ -337,6 +340,7 @@ class SpanRecord:
             i = self.__index_of_labels.setdefault(label, len(self.labels))
             self.labels.append(label)
         self.trail.append(TrailType.CHOICE + 1 + i)
+        self.span_count += 1
 
     def stop_span(self, *, discard: bool) -> None:
         if discard:
@@ -585,8 +589,10 @@ class ConjectureResult:
     target_observations: TargetObservations
     tags: frozenset[StructuralCoverageTag]
     spans: Spans = field(repr=False, compare=False)
-    arg_slices: set[tuple[int, int]] = field(repr=False)
-    slice_comments: dict[tuple[int, int], str] = field(repr=False)
+    arg_spans: set[int] = field(repr=False)
+    # Comments for the explain phase, keyed by span index. The ``None`` key
+    # holds the whole-test comment about varying all commented parts together.
+    span_comments: dict[int | None, str] = field(repr=False)
     misaligned_at: MisalignedAt | None = field(repr=False)
     cannot_proceed_scope: CannotProceedScopeT | None = field(repr=False)
 
@@ -688,10 +694,10 @@ class ConjectureData:
         self.depth: int = -1
         self.__span_record = SpanRecord()
 
-        # Slice indices for discrete reportable parts that which-parts-matter can
+        # Span indices for discrete reportable parts that which-parts-matter can
         # try varying, to report if the minimal example always fails anyway.
-        self.arg_slices: set[tuple[int, int]] = set()
-        self.slice_comments: dict[tuple[int, int], str] = {}
+        self.arg_spans: set[int] = set()
+        self.span_comments: dict[int | None, str] = {}
         self._observability_args: dict[str, Any] = {}
         self._observability_predicates: defaultdict[str, PredicateCounts] = defaultdict(
             PredicateCounts
@@ -1146,8 +1152,8 @@ class ConjectureData:
                 has_discards=self.has_discards,
                 target_observations=self.target_observations,
                 tags=frozenset(self.tags),
-                arg_slices=self.arg_slices,
-                slice_comments=self.slice_comments,
+                arg_spans=self.arg_spans,
+                span_comments=self.span_comments,
                 misaligned_at=self.misaligned_at,
                 cannot_proceed_scope=self.cannot_proceed_scope,
             )
@@ -1233,6 +1239,12 @@ class ConjectureData:
             return v
         finally:
             self.stop_span()
+
+    @property
+    def next_span_index(self) -> int:
+        """The index that the next span to start will get. Spans are indexed
+        in start order, so this also counts the spans started so far."""
+        return self.__span_record.span_count
 
     def start_span(self, label: int) -> None:
         self.provider.span_start(label)

--- a/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
@@ -491,7 +491,7 @@ class Shrinker:
         self.explain()
 
     def explain(self) -> None:
-        if not self.should_explain or not self.shrink_target.arg_slices:
+        if not self.should_explain or not self.shrink_target.arg_spans:
             return
         with self.engine._log_phase_statistics("explain"):
             self._explain()
@@ -501,21 +501,36 @@ class Shrinker:
         shrink_target = self.shrink_target
         nodes = self.nodes
         choices = self.choices
-        chunks: dict[tuple[int, int], list[tuple[ChoiceT, ...]]] = defaultdict(list)
+        spans = self.shrink_target.spans
+        chunks: dict[int, list[tuple[ChoiceT, ...]]] = defaultdict(list)
+
+        # The node ranges of the spans we may vary. Multiple arg spans can share
+        # a range (e.g. builds() around a single strategy), in which case only
+        # the first processed gets a comment and the rest are skipped below.
+        arg_ranges = {
+            span_index: (spans[span_index].start, spans[span_index].end)
+            for span_index in self.shrink_target.arg_spans
+        }
 
         # Before we start running experiments, let's check for known inputs which would
         # make them redundant.  The shrinking process means that we've already tried many
         # variations on the minimal example, so this can save a lot of time.
         seen_passing_seq = self.engine.passing_choice_sequences(
-            prefix=self.nodes[: min(self.shrink_target.arg_slices)[0]]
+            prefix=self.nodes[: min(start for start, _ in arg_ranges.values())]
         )
 
         # Now that we've shrunk to a minimal failing example, it's time to try
         # varying each part that we've noted will go in the final report.  Consider
-        # slices in largest-first order
-        for start, end in sorted(
-            self.shrink_target.arg_slices, key=lambda x: (-(x[1] - x[0]), x)
+        # spans in largest-first order
+        for span_index, (start, end) in sorted(
+            arg_ranges.items(), key=lambda kv: (-(kv[1][1] - kv[1][0]), kv[1], kv[0])
         ):
+            # Skip spans where nothing can in fact vary: ranges that are empty
+            # (e.g. a just() draw) or consist entirely of forced choices. The
+            # "or any other generated value" comment would be false for them.
+            if all(nodes[i].was_forced for i in range(start, end)):
+                continue
+
             # Check for any previous examples that match the prefix and suffix,
             # so we can skip if we found a passing example while shrinking.
             if any(
@@ -524,14 +539,12 @@ class Shrinker:
             ):
                 continue
 
-            # Skip slices that are subsets of already-explained slices.
-            # If a larger slice can vary freely, so can its sub-slices.
-            # Note: (0, 0) is a special marker for the "together" comment that
-            # applies to the whole test, not a specific slice, so we exclude it.
+            # Skip spans whose ranges are subsets of already-explained ranges.
+            # If a larger range can vary freely, so can its sub-ranges.
             if any(
-                s <= start and end <= e
-                for s, e in self.shrink_target.slice_comments
-                if (s, e) != (0, 0)
+                spans[c].start <= start and end <= spans[c].end
+                for c in self.shrink_target.span_comments
+                if c is not None
             ):
                 continue
 
@@ -593,18 +606,18 @@ class Shrinker:
                         + result.choices[start:result_end]
                         + choices[end:]
                     )
-                    chunks[(start, end)].append(result.choices[start:result_end])
+                    chunks[span_index].append(result.choices[start:result_end])
                     result = self.engine.cached_test_function(attempt)
 
                     if result.status is Status.OVERRUN:
                         continue  # pragma: no cover  # flakily covered
                     result = cast(ConjectureResult, result)
                 else:
-                    chunks[(start, end)].append(result.choices[start:end])
+                    chunks[span_index].append(result.choices[start:end])
 
                 if shrink_target is not self.shrink_target:  # pragma: no cover
                     # If we've shrunk further without meaning to, bail out.
-                    self.shrink_target.slice_comments.clear()
+                    self.shrink_target.span_comments.clear()
                     return
                 if result.status is Status.VALID:
                     # The test passed, indicating that this param can't vary freely.
@@ -614,17 +627,19 @@ class Shrinker:
                 if self.__predicate(result):  # pragma: no branch
                     n_same_failures += 1
                     if n_same_failures >= 100:
-                        self.shrink_target.slice_comments[(start, end)] = note
+                        self.shrink_target.span_comments[span_index] = note
                         break
 
         # Finally, if we've found multiple independently-variable parts, check whether
         # they can all be varied together.
-        if len(self.shrink_target.slice_comments) <= 1:
+        if len(self.shrink_target.span_comments) <= 1:
             return
         n_same_failures_together = 0
-        # Only include slices that were actually added to slice_comments
+        # Only include spans that actually got a comment
         chunks_by_start_index = sorted(
-            (k, v) for k, v in chunks.items() if k in self.shrink_target.slice_comments
+            (arg_ranges[k], v)
+            for k, v in chunks.items()
+            if k in self.shrink_target.span_comments
         )
         for _ in range(500):  # pragma: no branch
             # no-branch here because we don't coverage-test the abort-at-500 logic.
@@ -641,14 +656,14 @@ class Shrinker:
             # This *can't* be a shrink because none of the components were.
             assert shrink_target is self.shrink_target
             if result.status == Status.VALID:
-                self.shrink_target.slice_comments[(0, 0)] = (
+                self.shrink_target.span_comments[None] = (
                     "The test sometimes passed when commented parts were varied together."
                 )
                 break  # Test passed, this param can't vary freely.
             if self.__predicate(result):  # pragma: no branch
                 n_same_failures_together += 1
                 if n_same_failures_together >= 100:
-                    self.shrink_target.slice_comments[(0, 0)] = (
+                    self.shrink_target.span_comments[None] = (
                         "The test always failed when commented parts were varied together."
                     )
                     break
@@ -665,10 +680,14 @@ class Shrinker:
         produce an irrelevant test result the outer loop discards.
         """
         nodes = self.nodes
+        spans = self.shrink_target.spans
         target_types = tuple(nodes[i].type for i in range(start, end))
         current_key = choices_key(tuple(nodes[i].value for i in range(start, end)))
         seen: set[tuple[Any, ...]] = {current_key}
-        for start2, end2 in sorted(self.shrink_target.arg_slices):
+        arg_ranges = sorted(
+            {(spans[i].start, spans[i].end) for i in self.shrink_target.arg_spans}
+        )
+        for start2, end2 in arg_ranges:
             if (start2, end2) == (start, end) or (end2 - start2) != (end - start):
                 continue
             if (

--- a/hypothesis/src/hypothesis/vendor/pretty.py
+++ b/hypothesis/src/hypothesis/vendor/pretty.py
@@ -83,7 +83,9 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 PrettyPrintFunction: TypeAlias = Callable[[Any, "RepresentationPrinter", bool], None]
-ArgLabelsT: TypeAlias = dict[str, tuple[int, int]]
+# Maps each argument label ("arg[i]" or a keyword) to the index of the span
+# created by drawing that argument.
+ArgLabelsT: TypeAlias = dict[str, int]
 
 __all__ = [
     "IDKey",
@@ -267,23 +269,25 @@ class RepresentationPrinter:
         self.type_pprinters.update(_type_pprinters)
         self.deferred_pprinters.update(_deferred_type_pprinters)
 
-        # for which-parts-matter, we track a mapping from the (start_idx, end_idx)
-        # of slices into the minimal failing example; this is per-interesting_origin
-        # but we report each separately so that's someone else's problem here.
-        # Invocations of self.repr_call() can report the slice for each argument,
-        # which will then be used to look up the relevant comment if any.
+        # for which-parts-matter, we track comments keyed by the index of the
+        # span each argument's draw created in the minimal failing example;
+        # this is per-interesting_origin but we report each separately so
+        # that's someone else's problem here. Invocations of self.repr_call()
+        # can report the span for each argument, which will then be used to
+        # look up the relevant comment if any. (The None key holds the
+        # whole-test comment, which is looked up directly, not per-argument.)
         self.known_object_printers: dict[IDKey, list[PrettyPrintFunction]]
-        self.slice_comments: dict[tuple[int, int], str]
+        self.span_comments: dict[int | None, str]
         if context is None:
             self.known_object_printers = defaultdict(list)
-            self.slice_comments = {}
+            self.span_comments = {}
         else:
             self.known_object_printers = context.known_object_printers
-            self.slice_comments = context.data.slice_comments
+            self.span_comments = context.data.span_comments
         assert all(isinstance(k, IDKey) for k in self.known_object_printers)
-        # Track which slices we've already printed comments for, to avoid
-        # duplicating comments when nested objects share the same slice range.
-        self._commented_slices: set[tuple[int, int]] = set()
+        # Track which spans we've already printed comments for, to avoid
+        # duplicating comments when nested objects share the same span.
+        self._commented_spans: set[int] = set()
 
     def pretty(self, obj: object, *, cycle: bool = False) -> None:
         """Pretty print the given object."""
@@ -519,12 +523,12 @@ class RepresentationPrinter:
         # 3. Prefer shorter expressions.
         if cycle:
             return self.text("<...>")
-        # Look up comments from slice_comments if we have arg_labels
+        # Look up comments from span_comments if we have arg_labels
         comments = {}
         if arg_labels is not None:
-            for key, sr in arg_labels.items():
-                if sr in self.slice_comments:
-                    comments[key] = self.slice_comments[sr]
+            for key, span_index in arg_labels.items():
+                if span_index in self.span_comments:
+                    comments[key] = self.span_comments[span_index]
         # If there are comments, we must use our call-style repr regardless of syntax
         if not comments:
             with suppress(Exception):
@@ -542,7 +546,7 @@ class RepresentationPrinter:
                     ast.parse(p.getvalue())
                 except Exception:
                     return _repr_pprint(obj, self, cycle)
-        return self.repr_call(name, args, kwargs, arg_slices=arg_labels)
+        return self.repr_call(name, args, kwargs, arg_labels=arg_labels)
 
     def repr_call(
         self,
@@ -551,7 +555,7 @@ class RepresentationPrinter:
         kwargs: dict[str, object],
         *,
         force_split: bool | None = None,
-        arg_slices: ArgLabelsT | None = None,
+        arg_labels: ArgLabelsT | None = None,
         leading_comment: str | None = None,
         avoid_realization: bool = False,
         known_safe_to_repr: Collection[str] = (),
@@ -561,8 +565,9 @@ class RepresentationPrinter:
         - func_name, args, and kwargs should all be pretty obvious.
         - If split_lines, we'll force one-argument-per-line; otherwise we'll place
           calls that fit on a single line (and split otherwise).
-        - arg_slices is a mapping from pos-idx or keyword to (start_idx, end_idx)
-          of the Conjecture buffer, by which we can look up comments to add.
+        - arg_labels is a mapping from pos-idx or keyword to the index of the
+          span created by drawing that argument, by which we can look up
+          comments to add.
         """
         assert isinstance(func_name, str)
         if func_name.startswith(("lambda:", "lambda ")):
@@ -571,9 +576,10 @@ class RepresentationPrinter:
             # get inlined, we can emit just the body expression with no call.
             # Skip inlining only when there are actual comments on arguments,
             # since comments need the call-style repr to attach to.
-            has_comments = arg_slices and any(
-                sr in self.slice_comments and sr not in self._commented_slices
-                for sr in arg_slices.values()
+            has_comments = arg_labels and any(
+                span_index in self.span_comments
+                and span_index not in self._commented_spans
+                for span_index in arg_labels.values()
             )
             if not has_comments:
                 inlined = _try_inline_lambda(func_name, args, kwargs, self)
@@ -582,14 +588,17 @@ class RepresentationPrinter:
             func_name = f"({func_name})"
         self.text(func_name)
         # Build list of (label, value) pairs. Labels are "arg[i]" for positional
-        # args, or the keyword name. Skip slices already commented at a higher level.
+        # args, or the keyword name. Skip spans already commented at a higher level.
         all_args = [(f"arg[{i}]", v) for i, v in enumerate(args)]
         all_args += list(kwargs.items())
-        arg_slices = arg_slices or {}
-        comments: dict[str, tuple[str, tuple[int, int]]] = {}
-        for label, sr in arg_slices.items():
-            if sr in self.slice_comments and sr not in self._commented_slices:
-                comments[label] = (self.slice_comments[sr], sr)
+        arg_labels = arg_labels or {}
+        comments: dict[str, tuple[str, int]] = {}
+        for label, span_index in arg_labels.items():
+            if (
+                span_index in self.span_comments
+                and span_index not in self._commented_spans
+            ):
+                comments[label] = (self.span_comments[span_index], span_index)
 
         if leading_comment or any(k in comments for k, _ in all_args):
             # We have to split one arg per line in order to leave comments on them.
@@ -616,10 +625,10 @@ class RepresentationPrinter:
                     self.breakable(" " if i else "")
                 if not label.startswith("arg["):
                     self.text(f"{label}=")
-                # Mark slice as commented BEFORE printing value, so nested printers skip it
+                # Mark span as commented BEFORE printing value, so nested printers skip it
                 entry = comments.get(label)
                 if entry:
-                    self._commented_slices.add(entry[1])
+                    self._commented_spans.add(entry[1])
                 if avoid_realization and label not in known_safe_to_repr:
                     self.text("<symbolic>")
                 else:
@@ -927,15 +936,16 @@ def pprint_fields(
             p.pretty(getattr(obj, field))
 
 
-def _get_slice_comment(
+def _get_span_comment(
     p: RepresentationPrinter,
     arg_labels: ArgLabelsT,
     key: Any,
-) -> tuple[str, tuple[int, int]] | None:
-    """Look up a comment for a slice, if not already printed at a higher level."""
-    if (sr := arg_labels.get(key)) and sr in p.slice_comments:
-        if sr not in p._commented_slices:
-            return (p.slice_comments[sr], sr)
+) -> tuple[str, int] | None:
+    """Look up a comment for a span, if not already printed at a higher level."""
+    span_index = arg_labels.get(key)
+    if span_index is not None and span_index in p.span_comments:
+        if span_index not in p._commented_spans:
+            return (p.span_comments[span_index], span_index)
     return None
 
 
@@ -946,7 +956,7 @@ def _tuple_pprinter(arg_labels: ArgLabelsT) -> PrettyPrintFunction:
         if cycle:
             return p.text("(...)")
 
-        get = lambda i: _get_slice_comment(p, arg_labels, f"arg[{i}]")
+        get = lambda i: _get_span_comment(p, arg_labels, f"arg[{i}]")
         has_comments = any(get(i) for i in range(len(obj)))
 
         with p.group(indent=4, open="(", close=""):
@@ -956,7 +966,7 @@ def _tuple_pprinter(arg_labels: ArgLabelsT) -> PrettyPrintFunction:
                 if has_comments or idx + 1 < len(obj) or len(obj) == 1:
                     p.text(",")
                 if entry := get(idx):
-                    p._commented_slices.add(entry[1])
+                    p._commented_spans.add(entry[1])
                     p.text(f"  # {entry[0]}")
         if has_comments and obj:
             p.break_()
@@ -972,7 +982,7 @@ def _fixeddict_pprinter(arg_labels: ArgLabelsT) -> PrettyPrintFunction:
         if cycle:
             return p.text("{...}")
 
-        get = lambda k: _get_slice_comment(p, arg_labels, k)
+        get = lambda k: _get_span_comment(p, arg_labels, k)
         # Print in the dict's actual (possibly permuted) iteration order.
         keys = list(obj)
         has_comments = any(get(k) for k in keys)
@@ -986,7 +996,7 @@ def _fixeddict_pprinter(arg_labels: ArgLabelsT) -> PrettyPrintFunction:
                 if has_comments or idx + 1 < len(keys):
                     p.text(",")
                 if entry := get(key):
-                    p._commented_slices.add(entry[1])
+                    p._commented_spans.add(entry[1])
                     p.text(f"  # {entry[0]}")
         if has_comments and obj:
             p.break_()

--- a/hypothesis/tests/conjecture/test_inquisitor.py
+++ b/hypothesis/tests/conjecture/test_inquisitor.py
@@ -82,6 +82,20 @@ def test_inquisitor_no_together_comment_if_single_argument(a, b):
     assert a
 
 
+@fails_with_output("""
+Falsifying example: test_inquisitor_skips_arguments_that_cannot_vary(
+    a='fixed',
+    b=100,
+)
+""")
+@settings(print_blob=False, derandomize=True)
+@given(st.just("fixed"), st.integers())
+def test_inquisitor_skips_arguments_that_cannot_vary(a, b):
+    # A just() draw makes no choices at all, so the explain phase must not
+    # claim its value could have been "any other generated value".
+    assert b < 100
+
+
 @st.composite
 def ints_with_forced_draw(draw):
     data = draw(st.data())

--- a/hypothesis/tests/cover/test_lambda_inlining.py
+++ b/hypothesis/tests/cover/test_lambda_inlining.py
@@ -151,13 +151,13 @@ def test_unparse_failure_returns_none(monkeypatch):
 
 def test_repr_call_skips_inlining_when_comments_present():
     p = pretty.RepresentationPrinter()
-    # Simulate explain-mode comments on slice (0, 5)
-    p.slice_comments[(0, 5)] = "or any other generated value"
+    # Simulate explain-mode comments on span 3
+    p.span_comments[3] = "or any other generated value"
     p.repr_call(
         "lambda x: f(x)",
         args=(42,),
         kwargs={},
-        arg_slices={"arg[0]": (0, 5)},
+        arg_labels={"arg[0]": 3},
     )
     result = p.getvalue()
     # Should NOT inline — must keep call style for the comment
@@ -165,13 +165,13 @@ def test_repr_call_skips_inlining_when_comments_present():
     assert "# or any other generated value" in result
 
 
-def test_repr_call_inlines_when_arg_slices_but_no_comments():
+def test_repr_call_inlines_when_arg_labels_but_no_comments():
     p = pretty.RepresentationPrinter()
-    # arg_slices present but no matching slice_comments
+    # arg_labels present but no matching span_comments
     p.repr_call(
         "lambda x: f(x)",
         args=(42,),
         kwargs={},
-        arg_slices={"arg[0]": (0, 5)},
+        arg_labels={"arg[0]": 3},
     )
     assert p.getvalue() == "f(42)"

--- a/hypothesis/tests/cover/test_pretty.py
+++ b/hypothesis/tests/cover/test_pretty.py
@@ -853,7 +853,7 @@ def test_tuple_pprinter_cycle():
     from hypothesis.vendor.pretty import _tuple_pprinter
 
     t = (1, 2, 3)
-    arg_labels = {"arg[0]": (0, 1), "arg[1]": (1, 2), "arg[2]": (2, 3)}
+    arg_labels = {"arg[0]": 1, "arg[1]": 2, "arg[2]": 3}
     pprinter = _tuple_pprinter(arg_labels)
 
     out = io.StringIO()
@@ -870,7 +870,7 @@ def test_fixeddict_pprinter_cycle():
     from hypothesis.vendor.pretty import _fixeddict_pprinter
 
     d = {"a": 1, "b": 2}
-    arg_labels = {"a": (0, 1), "b": (1, 2)}
+    arg_labels = {"a": 1, "b": 2}
     pprinter = _fixeddict_pprinter(arg_labels)
 
     out = io.StringIO()
@@ -882,17 +882,17 @@ def test_fixeddict_pprinter_cycle():
     assert out.getvalue() == "{...}"
 
 
-def test_get_slice_comment_skips_already_commented():
-    # Test that _get_slice_comment returns None for already-commented slices
-    from hypothesis.vendor.pretty import _get_slice_comment
+def test_get_span_comment_skips_already_commented():
+    # Test that _get_span_comment returns None for already-commented spans
+    from hypothesis.vendor.pretty import _get_span_comment
 
     out = io.StringIO()
     p = pretty.RepresentationPrinter(out)
-    p.slice_comments = {(0, 5): "or any other generated value"}
-    # Mark the slice as already commented
-    p._commented_slices.add((0, 5))
+    p.span_comments = {3: "or any other generated value"}
+    # Mark the span as already commented
+    p._commented_spans.add(3)
 
-    arg_labels = {"arg[0]": (0, 5)}
-    # Should return None because slice is already in _commented_slices
-    result = _get_slice_comment(p, arg_labels, "arg[0]")
+    arg_labels = {"arg[0]": 3}
+    # Should return None because the span is already in _commented_spans
+    result = _get_span_comment(p, arg_labels, "arg[0]")
     assert result is None

--- a/hypothesis/tests/scipy/test_statistics.py
+++ b/hypothesis/tests/scipy/test_statistics.py
@@ -8,6 +8,8 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import math
+
 import pytest
 import scipy
 import scipy.special
@@ -22,9 +24,15 @@ SCIPY_VERSION = tuple(int(x) for x in scipy.__version__.split("."))
 
 @given(st.integers(1, 100), st.floats(-1e150, 1e150))
 def test_stdtr_matches_scipy(df, t):
-    assert stdtr(df, t) == pytest.approx(
-        scipy.special.stdtr(df, t), rel=1e-12, abs=1e-15
-    )
+    if df == 1:
+        # scipy 1.17 regressed the accuracy of stdtr for df=1 at small |t|,
+        # with up to ~2e-9 absolute error around t=1e-8 (an upstream issue;
+        # df >= 2 still agrees with us to one ulp). df=1 has an exact closed
+        # form, so test against that stronger oracle instead of scipy.
+        expected = 0.5 + math.atan(t) / math.pi
+    else:
+        expected = scipy.special.stdtr(df, t)
+    assert stdtr(df, t) == pytest.approx(expected, rel=1e-12, abs=1e-15)
 
 
 @pytest.mark.parametrize("df", [1, 2, 3, 4, 10, 100])


### PR DESCRIPTION
IMO this is a nice cleanup in itself, but specifically worth doing because it's useful prep work for a hybrid of https://github.com/HypothesisWorks/hypothesis/pull/4713 / https://github.com/HypothesisWorks/hypothesis/pull/4743 that I'm working on.