### PR TITLE
Support timezone-aware bounds in datetimes()

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.datetimes` now accepts timezone-aware
+``min_value`` and ``max_value`` bounds, which are treated as moments in time.
+In this case ``timezones`` defaults to :func:`~hypothesis.strategies.timezones`,
+and each generated datetime lies between the two moments.
+Passing one aware and one naive bound is an error.
+
+If :pypi:`annotated-types` has been imported, the overloaded type hints
+for this strategy now distinguish naive from aware datetimes using
+``Timezone`` metadata.

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -10,11 +10,13 @@
 
 import datetime as dt
 import operator as op
+import sys
 import warnings
 import zoneinfo
 from functools import cache, partial
 from importlib import resources
 from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, overload
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.validation import check_type, check_valid_interval
@@ -22,6 +24,17 @@ from hypothesis.strategies._internal.core import sampled_from
 from hypothesis.strategies._internal.misc import just, none, nothing
 from hypothesis.strategies._internal.strategies import SearchStrategy
 from hypothesis.strategies._internal.utils import defines_strategy
+
+if TYPE_CHECKING:
+    from annotated_types import Timezone
+
+    NaiveDatetime = Annotated[dt.datetime, Timezone(None)]
+    AwareDatetime = Annotated[dt.datetime, Timezone(...)]
+elif at := sys.modules.get("annotated_types"):
+    NaiveDatetime = Annotated[dt.datetime, at.Timezone(None)]
+    AwareDatetime = Annotated[dt.datetime, at.Timezone(...)]
+else:
+    NaiveDatetime = AwareDatetime = dt.datetime
 
 DATENAMES = ("year", "month", "day")
 TIMENAMES = ("hour", "minute", "second", "microsecond")
@@ -51,6 +64,25 @@ def replace_tzinfo(value, timezone):
         #       documenting the problem and recommending use of `dateutil` instead.
         return timezone.localize(value, is_dst=not value.fold)
     return value.replace(tzinfo=timezone)
+
+
+def _instant(value):
+    """A sort key ordering aware datetimes by the moment they refer to.
+
+    Unlike comparison of datetimes which share a tzinfo - which falls back to
+    ignoring both the timezone and the fold attribute - this respects the fold,
+    and unlike .astimezone() it cannot overflow near datetime.min/max.
+    """
+    return value.replace(tzinfo=None) - dt.datetime.min - value.utcoffset()
+
+
+def _ambiguous(value, tz):
+    # Whether the naive value is inside a DST fold, i.e. is a wall time which
+    # occurs twice in tz, so that its utcoffset depends on the fold attribute.
+    return (
+        replace_tzinfo(value.replace(fold=0), tz).utcoffset()
+        != replace_tzinfo(value.replace(fold=1), tz).utcoffset()
+    )
 
 
 def datetime_does_not_exist(value):
@@ -148,13 +180,33 @@ def draw_capped_multipart(
 class DatetimeStrategy(SearchStrategy):
     def __init__(self, min_value, max_value, timezones_strat, allow_imaginary):
         super().__init__()
-        assert isinstance(min_value, dt.datetime)
-        assert isinstance(max_value, dt.datetime)
-        assert min_value.tzinfo is None
-        assert max_value.tzinfo is None
-        assert min_value <= max_value
         assert isinstance(timezones_strat, SearchStrategy)
         assert isinstance(allow_imaginary, bool)
+        self.aware = (min_value is not None and min_value.tzinfo is not None) or (
+            max_value is not None and max_value.tzinfo is not None
+        )
+        if self.aware:
+            for value in (min_value, max_value):
+                assert value is None or (
+                    isinstance(value, dt.datetime) and value.tzinfo is not None
+                )
+            # The instants bounding this strategy, as _instant() sort keys.
+            # UTC offsets are less than a day, so a None bound is replaced by
+            # a key which lies outside the representable range.
+            self.min_instant = (
+                dt.timedelta(days=-2) if min_value is None else _instant(min_value)
+            )
+            self.max_instant = (
+                dt.datetime.max - dt.datetime.min + dt.timedelta(days=2)
+                if max_value is None
+                else _instant(max_value)
+            )
+            assert self.min_instant <= self.max_instant
+        else:
+            for value in (min_value, max_value):
+                assert isinstance(value, dt.datetime)
+                assert value.tzinfo is None
+            assert min_value <= max_value
         self.min_value = min_value
         self.max_value = max_value
         self.tz_strat = timezones_strat
@@ -163,7 +215,16 @@ class DatetimeStrategy(SearchStrategy):
     def do_draw(self, data):
         # We start by drawing a timezone, and an initial datetime.
         tz = data.draw(self.tz_strat)
-        result = self.draw_naive_datetime_and_combine(data, tz)
+        if self.aware:
+            if not isinstance(tz, dt.tzinfo):
+                raise InvalidArgument(
+                    f"Drew {tz!r} from the timezones strategy {self.tz_strat!r}, "
+                    "but with aware min_value/max_value bounds the timezones "
+                    "strategy must only generate tzinfo objects (not None)"
+                )
+            result = self.draw_aware_datetime(data, tz)
+        else:
+            result = self.draw_naive_datetime_and_combine(data, tz)
 
         # TODO: with some probability, systematically search for one of
         #   - an imaginary time (if allowed),
@@ -176,6 +237,53 @@ class DatetimeStrategy(SearchStrategy):
             data.mark_invalid(f"{result} does not exist (usually a DST transition)")
         return result
 
+    def in_bounds(self, value):
+        return self.min_instant <= _instant(value) <= self.max_instant
+
+    def draw_aware_datetime(self, data, tz):
+        def wall_clock(bound, extreme):
+            if bound is None:
+                return extreme
+            try:
+                return bound.astimezone(tz).replace(tzinfo=None)
+            except OverflowError:
+                # UTC offsets are less than a day, so an overflowing bound
+                # must be within a day of datetime.min/max, converting to a
+                # moment beyond them.  If every wall time representable in tz
+                # is on the in-bounds side, the bound is simply vacuous here;
+                # otherwise nothing in tz is in bounds.
+                near_min = bound.replace(tzinfo=None) - dt.datetime.min < dt.timedelta(
+                    days=2
+                )
+                if near_min == (extreme is dt.datetime.min):
+                    return extreme
+                data.mark_invalid(f"{bound!r} is not representable in {tz!r}")
+
+        min_local = wall_clock(self.min_value, dt.datetime.min)
+        max_local = wall_clock(self.max_value, dt.datetime.max)
+        if min_local > max_local or (
+            max_local - min_local <= dt.timedelta(days=1)
+            and (_ambiguous(min_local, tz) or _ambiguous(max_local, tz))
+        ):
+            # A large fraction of the wall times between bounds inside or close
+            # to a DST fold would risk rejection below - and bounds inside the
+            # same fold may even be in inverted wall-clock order, like
+            # 01:59 EDT < 01:01 EST - so we recurse to draw in UTC, where wall
+            # times are unambiguous and ordered, and convert.  This is the
+            # standard draw with the standard shrink order, except that
+            # simplicity is judged on the UTC wall time rather than the local.
+            value = self.draw_aware_datetime(data, dt.timezone.utc)
+            try:
+                return value.astimezone(tz)
+            except OverflowError:
+                data.mark_invalid(f"{value!r} is not representable in {tz!r}")
+        result = draw_capped_multipart(data, min_local, max_local)
+        value = replace_tzinfo(dt.datetime(**result), timezone=tz)
+        if not self.in_bounds(value):
+            # An ambiguous wall time next to a bound, with the out-of-bounds fold.
+            data.mark_invalid(f"{value!r} is outside the bounds")
+        return value
+
     def draw_naive_datetime_and_combine(self, data, tz):
         result = draw_capped_multipart(data, self.min_value, self.max_value)
         try:
@@ -187,20 +295,61 @@ class DatetimeStrategy(SearchStrategy):
             )
 
 
+@overload
+def datetimes(
+    min_value: NaiveDatetime | None = None,
+    max_value: NaiveDatetime | None = None,
+    *,
+    timezones: SearchStrategy[None] | None = None,
+) -> SearchStrategy[NaiveDatetime]:  # pragma: no cover
+    ...
+
+
+@overload
+def datetimes(
+    min_value: dt.datetime | None = None,
+    max_value: dt.datetime | None = None,
+    *,
+    timezones: SearchStrategy[dt.tzinfo],
+    allow_imaginary: bool = True,
+) -> SearchStrategy[AwareDatetime]:  # pragma: no cover
+    ...
+
+
+@overload
+def datetimes(
+    min_value: None = None,
+    max_value: None = None,
+    *,
+    timezones: SearchStrategy[dt.tzinfo | None],
+    allow_imaginary: bool = True,
+) -> SearchStrategy[dt.datetime]:  # pragma: no cover
+    ...
+
+
 @defines_strategy(force_reusable_values=True)
 def datetimes(
-    min_value: dt.datetime = dt.datetime.min,
-    max_value: dt.datetime = dt.datetime.max,
+    min_value: dt.datetime | None = None,
+    max_value: dt.datetime | None = None,
     *,
-    timezones: SearchStrategy[dt.tzinfo | None] = none(),
+    timezones: SearchStrategy[dt.tzinfo | None] | None = None,
     allow_imaginary: bool = True,
 ) -> SearchStrategy[dt.datetime]:
-    """datetimes(min_value=datetime.datetime.min, max_value=datetime.datetime.max, *, timezones=none(), allow_imaginary=True)
+    """datetimes(min_value=None, max_value=None, *, timezones=None, allow_imaginary=True)
 
     A strategy for generating datetimes, which may be timezone-aware.
 
-    This strategy works by drawing a naive datetime between ``min_value``
-    and ``max_value``, which must both be naive (have no timezone).
+    If ``min_value`` and ``max_value`` are naive datetimes, or omitted, this
+    strategy works by drawing a naive datetime between them - defaulting to
+    ``datetime.min`` and ``datetime.max`` respectively - and then attaching
+    a timezone drawn from ``timezones``, which defaults to
+    :func:`~hypothesis.strategies.none`.
+
+    If instead both bounds are timezone-aware, they are treated as moments in
+    time, and ``timezones`` defaults to :func:`~hypothesis.strategies.timezones`.
+    Each generated datetime is aware, in a timezone drawn from ``timezones`` -
+    which must not generate ``None`` - and lies between the two moments.
+    Passing one aware and one naive bound is an error.
 
     ``timezones`` must be a strategy that generates either ``None``, for naive
     datetimes, or :class:`~python:datetime.tzinfo` objects for 'aware' datetimes.
@@ -217,31 +366,57 @@ def datetimes(
     timezone and calendar adjustments, etc.  Imaginary datetimes are allowed
     by default, because malformed timestamps are a common source of bugs.
 
+    .. note::
+
+        Arithmetic and comparisons on timezone-aware datetimes can be very
+        surprising around daylight-savings changes.  See `this CPython issue
+        <https://github.com/python/cpython/issues/116035>`__ for details
+        and discussion.
+
     Examples from this strategy shrink towards midnight on January 1st 2000,
     local time.
     """
-    # Why must bounds be naive?  In principle, we could also write a strategy
-    # that took aware bounds, but the API and validation is much harder.
-    # If you want to generate datetimes between two particular moments in
-    # time I suggest (a) just filtering out-of-bounds values; (b) if bounds
-    # are very close, draw a value and subtract its UTC offset, handling
-    # overflows and nonexistent times; or (c) do something customised to
-    # handle datetimes in e.g. a four-microsecond span which is not
-    # representable in UTC.  Handling (d), all of the above, leads to a much
-    # more complex API for all users and a useful feature for very few.
     check_type(bool, allow_imaginary, "allow_imaginary")
-    check_type(dt.datetime, min_value, "min_value")
-    check_type(dt.datetime, max_value, "max_value")
-    if min_value.tzinfo is not None:
-        raise InvalidArgument(f"{min_value=} must not have tzinfo")
-    if max_value.tzinfo is not None:
-        raise InvalidArgument(f"{max_value=} must not have tzinfo")
-    check_valid_interval(min_value, max_value, "min_value", "max_value")
-    if not isinstance(timezones, SearchStrategy):
+    if min_value is not None:
+        check_type(dt.datetime, min_value, "min_value")
+    if max_value is not None:
+        check_type(dt.datetime, max_value, "max_value")
+    if timezones is not None and not isinstance(timezones, SearchStrategy):
         raise InvalidArgument(
             f"{timezones=} must be a SearchStrategy that can "
             "provide tzinfo for datetimes (either None or dt.tzinfo objects)"
         )
+    if (min_value is None or min_value.tzinfo is None) and (
+        max_value is None or max_value.tzinfo is None
+    ):
+        min_value = dt.datetime.min if min_value is None else min_value
+        max_value = dt.datetime.max if max_value is None else max_value
+        if timezones is None:
+            timezones = none()
+        check_valid_interval(min_value, max_value, "min_value", "max_value")
+    else:
+        # Aware bounds describe moments in time; we check both are aware here,
+        # and then at draw time convert them to the drawn timezone and proceed
+        # as in the naive case.
+        for name, value in [("min_value", min_value), ("max_value", max_value)]:
+            if value is not None and value.tzinfo is None:
+                raise InvalidArgument(
+                    f"{name}={value!r} is naive, but the other bound is "
+                    "timezone-aware; the bounds must be both naive or both aware"
+                )
+        if timezones is None:
+            timezones = _timezones()
+        # Compare explicitly as moments in time: comparison of datetimes which
+        # share a tzinfo falls back to wall-clock order, ignoring the fold.
+        if (
+            min_value is not None
+            and max_value is not None
+            and _instant(max_value) < _instant(min_value)
+        ):
+            raise InvalidArgument(
+                f"Cannot have {max_value=} < {min_value=}, comparing as "
+                "moments in time"
+            )
     return DatetimeStrategy(min_value, max_value, timezones, allow_imaginary)
 
 
@@ -504,3 +679,8 @@ def timezones(*, no_cache: bool = False) -> SearchStrategy["zoneinfo.ZoneInfo"]:
     return timezone_keys().map(
         zoneinfo.ZoneInfo.no_cache if no_cache else zoneinfo.ZoneInfo
     )
+
+
+# In datetimes() above, the ``timezones`` argument shadows this module's
+# timezones() strategy, so we refer to it by this alias instead.
+_timezones = timezones

--- a/hypothesis/tests/cover/test_datetimes.py
+++ b/hypothesis/tests/cover/test_datetimes.py
@@ -14,10 +14,17 @@ from calendar import monthrange
 import pytest
 
 from hypothesis import HealthCheck, example, given, settings, strategies as st
+from hypothesis.errors import InvalidArgument, Unsatisfiable
 from hypothesis.strategies import dates, datetimes, timedeltas, times
-from hypothesis.strategies._internal.datetime import _num_days_in_month
+from hypothesis.strategies._internal.datetime import _instant, _num_days_in_month
 
-from tests.common.debug import assert_simple_property, find_any, minimal
+from tests.common.debug import (
+    assert_all_examples,
+    assert_simple_property,
+    check_can_generate_examples,
+    find_any,
+    minimal,
+)
 
 
 @example(1900)
@@ -157,3 +164,158 @@ def test_can_generate_time_with_fold_1():
 @given(datetimes(allow_imaginary=False))
 def test_allow_imaginary_is_not_an_error_for_naive_datetimes(d):
     pass
+
+
+UTC = dt.timezone.utc
+fixed_offsets = st.builds(
+    dt.timezone, st.timedeltas(dt.timedelta(hours=-23), dt.timedelta(hours=23))
+)
+
+
+@pytest.mark.parametrize("aware_arg", ["min_value", "max_value"])
+def test_mixing_aware_and_naive_bounds_is_invalid(aware_arg):
+    kwargs = {
+        "min_value": dt.datetime(2000, 1, 1),
+        "max_value": dt.datetime(2001, 1, 1),
+    }
+    kwargs[aware_arg] = kwargs[aware_arg].replace(tzinfo=UTC)
+    with pytest.raises(InvalidArgument):
+        datetimes(**kwargs).validate()
+
+
+def test_aware_bounds_are_compared_as_moments_in_time():
+    lo = dt.datetime(2000, 1, 1, 12, tzinfo=UTC)
+    hi = lo.astimezone(dt.timezone(dt.timedelta(hours=-5)))  # the same moment
+    assert lo.replace(tzinfo=None) > hi.replace(tzinfo=None)
+    assert_simple_property(datetimes(lo, hi, timezones=st.just(UTC)), lambda d: d == lo)
+    with pytest.raises(InvalidArgument):
+        datetimes(hi + dt.timedelta(seconds=1), lo, timezones=st.just(UTC)).validate()
+
+
+def test_aware_bounds_with_none_from_timezones_strategy_is_invalid():
+    lo = dt.datetime(2000, 1, 1, tzinfo=UTC)
+    with pytest.raises(InvalidArgument):
+        check_can_generate_examples(datetimes(min_value=lo, timezones=st.none()))
+
+
+@given(
+    st.data(),
+    datetimes(timezones=st.just(UTC)),
+    datetimes(timezones=st.just(UTC)),
+)
+def test_datetimes_stay_within_aware_bounds(data, lo, hi):
+    if lo > hi:
+        lo, hi = hi, lo
+    out = data.draw(datetimes(lo, hi, timezones=fixed_offsets))
+    assert isinstance(out.tzinfo, dt.timezone)
+    assert _instant(lo) <= _instant(out) <= _instant(hi)
+
+
+@given(datetimes(min_value=dt.datetime(2000, 1, 1, tzinfo=UTC), timezones=st.just(UTC)))
+def test_single_aware_bound_min(d):
+    assert d >= dt.datetime(2000, 1, 1, tzinfo=UTC)
+
+
+@given(datetimes(max_value=dt.datetime(2000, 1, 1, tzinfo=UTC), timezones=st.just(UTC)))
+def test_single_aware_bound_max(d):
+    assert d <= dt.datetime(2000, 1, 1, tzinfo=UTC)
+
+
+def test_shrinks_to_aware_min_bound():
+    lo = dt.datetime(2024, 3, 4, 5, 6, tzinfo=UTC)
+    assert minimal(datetimes(min_value=lo, timezones=st.just(UTC))) == lo
+
+
+def test_bounds_unrepresentable_in_timezone_are_rejected():
+    lo = dt.datetime.max.replace(tzinfo=UTC) - dt.timedelta(hours=1)
+    tz = dt.timezone(dt.timedelta(hours=5))
+    with pytest.raises(Unsatisfiable):
+        check_can_generate_examples(datetimes(min_value=lo, timezones=st.just(tz)))
+
+
+@given(
+    datetimes(
+        dt.datetime.min.replace(tzinfo=UTC),
+        dt.datetime.max.replace(tzinfo=UTC),
+        timezones=st.sampled_from(
+            [dt.timezone(dt.timedelta(hours=h)) for h in (-10, 10)]
+        ),
+    )
+)
+def test_extreme_aware_bounds_are_clamped_per_timezone(d):
+    # Each of these timezones can represent only some moments between the
+    # bounds; the rest of each bound's range is clamped away harmlessly.
+    pass
+
+
+class EternalFold(dt.tzinfo):
+    """A pathological timezone in which every wall time is ambiguous, with a
+    utcoffset of +2h at fold=0 and +1h at fold=1."""
+
+    def utcoffset(self, value):
+        return dt.timedelta(hours=2 - value.fold)
+
+    def tzname(self, value):
+        return "Weird"
+
+    def dst(self, value):
+        return dt.timedelta(0)
+
+
+def test_pathological_timezone_may_leave_no_valid_fold():
+    # With an interval of more than a day we draw local wall times; every wall
+    # time in EternalFold is ambiguous, so draws adjacent to a bound whose fold
+    # would fall out of bounds are rejected.
+    tz = EternalFold()
+    lo = dt.datetime(2000, 1, 1, 1, 10, fold=1, tzinfo=tz)
+    hi = dt.datetime(2000, 1, 3, 2, 20, tzinfo=tz)
+    assert_all_examples(
+        datetimes(lo, hi, timezones=st.just(tz)),
+        lambda d: _instant(lo) <= _instant(d) <= _instant(hi),
+        settings=settings(max_examples=300),
+    )
+
+
+def test_pathological_timezone_inverted_bounds_draw_via_utc():
+    tz = EternalFold()
+    lo = dt.datetime(2000, 1, 1, 2, 0, tzinfo=tz)
+    hi = dt.datetime(2000, 1, 1, 1, 30, fold=1, tzinfo=tz)
+    # ...so lo is an earlier moment than hi, but a later wall-clock time!
+    assert _instant(lo) < _instant(hi)
+    assert lo.replace(tzinfo=None) > hi.replace(tzinfo=None)
+    assert_all_examples(
+        datetimes(lo, hi, timezones=st.just(tz)),
+        lambda d: _instant(lo) <= _instant(d) <= _instant(hi),
+    )
+
+
+def test_pathological_timezone_bounds_unrepresentable_in_utc():
+    # Wall-clock-inverted bounds near datetime.min, whose moments precede it.
+    tz = EternalFold()
+    lo = dt.datetime.min.replace(minute=30, tzinfo=tz)
+    hi = dt.datetime.min.replace(minute=15, fold=1, tzinfo=tz)
+    assert _instant(lo) < _instant(hi)
+    with pytest.raises(Unsatisfiable):
+        check_can_generate_examples(datetimes(lo, hi, timezones=st.just(tz)))
+
+
+def test_pathological_timezone_unrepresentable_moments_are_rejected():
+    # Near datetime.max, some of the moments between these bounds have no
+    # EternalFold wall time at all; drawing one is rejected, and the rest
+    # generate as usual.
+    tz = EternalFold()
+    lo = dt.datetime.max.replace(hour=23, minute=30, tzinfo=tz)
+    hi = dt.datetime.max.replace(hour=23, minute=59, fold=1, tzinfo=tz)
+    assert_all_examples(
+        datetimes(lo, hi, timezones=st.just(tz)),
+        lambda d: _instant(lo) <= _instant(d) <= _instant(hi),
+    )
+
+
+def test_pathological_timezone_single_bound_near_extreme():
+    tz = EternalFold()
+    hi = (dt.datetime.min + dt.timedelta(minutes=90)).replace(fold=1, tzinfo=tz)
+    assert_all_examples(
+        datetimes(max_value=hi, timezones=st.just(tz)),
+        lambda d: _instant(d) <= _instant(hi),
+    )

--- a/hypothesis/tests/datetime/test_dateutil_timezones.py
+++ b/hypothesis/tests/datetime/test_dateutil_timezones.py
@@ -17,7 +17,7 @@ import pytest
 from hypothesis import assume, given
 from hypothesis.errors import FailedHealthCheck, InvalidArgument
 from hypothesis.strategies import data, datetimes, just, sampled_from, times
-from hypothesis.strategies._internal.datetime import datetime_does_not_exist
+from hypothesis.strategies._internal.datetime import _instant, datetime_does_not_exist
 
 from tests.common.debug import assert_all_examples, find_any, minimal
 from tests.common.utils import Why, fails_with, xfail_on_crosshair
@@ -51,9 +51,18 @@ def test_timezone_aware_datetimes_are_timezone_aware(dt):
 
 
 @given(sampled_from(["min_value", "max_value"]), datetimes(timezones=timezones()))
-def test_datetime_bounds_must_be_naive(name, val):
+def test_mixed_naive_aware_datetime_bounds_are_invalid(name, val):
+    kwargs = {"min_value": dt.datetime.min, "max_value": dt.datetime.max, name: val}
     with pytest.raises(InvalidArgument):
-        datetimes(**{name: val}).validate()
+        datetimes(**kwargs).validate()
+
+
+@given(data(), datetimes(timezones=timezones()), datetimes(timezones=timezones()))
+def test_datetimes_stay_within_aware_bounds(data, lo, hi):
+    if _instant(lo) > _instant(hi):
+        lo, hi = hi, lo
+    out = data.draw(datetimes(lo, hi, timezones=timezones()))
+    assert _instant(lo) <= _instant(out) <= _instant(hi)
 
 
 def test_timezones_arg_to_datetimes_must_be_search_strategy():

--- a/hypothesis/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis/tests/datetime/test_pytz_timezones.py
@@ -17,7 +17,7 @@ import pytest
 from hypothesis import assume, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument, StopTest
 from hypothesis.strategies import data, datetimes, just, sampled_from, times
-from hypothesis.strategies._internal.datetime import datetime_does_not_exist
+from hypothesis.strategies._internal.datetime import _instant, datetime_does_not_exist
 
 from tests.common.debug import assert_all_examples, find_any, minimal
 from tests.common.utils import Why, xfail_on_crosshair
@@ -53,9 +53,38 @@ def test_timezone_aware_datetimes_are_timezone_aware(dt):
 
 
 @given(sampled_from(["min_value", "max_value"]), datetimes(timezones=timezones()))
-def test_datetime_bounds_must_be_naive(name, val):
+def test_mixed_naive_aware_datetime_bounds_are_invalid(name, val):
+    kwargs = {"min_value": dt.datetime.min, "max_value": dt.datetime.max, name: val}
     with pytest.raises(InvalidArgument):
-        datetimes(**{name: val}).validate()
+        datetimes(**kwargs).validate()
+
+
+@given(data(), datetimes(timezones=timezones()), datetimes(timezones=timezones()))
+def test_datetimes_stay_within_aware_bounds(data, lo, hi):
+    if _instant(lo) > _instant(hi):
+        lo, hi = hi, lo
+    out = data.draw(datetimes(lo, hi, timezones=timezones()))
+    assert _instant(lo) <= _instant(out) <= _instant(hi)
+
+
+@pytest.mark.parametrize("hour, minute, inverted", [(1, 15, True), (3, 0, False)])
+def test_aware_bounds_at_dublin_fall_back(hour, minute, inverted):
+    # Europe/Dublin has a negative DST offset, so mapping fold to pytz's
+    # is_dst inverts the candidate moments for an ambiguous wall time; the
+    # bounds logic must not rely on their order.  Dublin fell back from
+    # 02:00 UTC+1 to 01:00 GMT at 2020-10-25 01:00 UTC.
+    tz = pytz.timezone("Europe/Dublin")
+    lo = dt.datetime(2020, 10, 25, 0, 30, tzinfo=dt.timezone.utc)
+    hi = dt.datetime(2020, 10, 25, hour, minute, tzinfo=dt.timezone.utc)
+
+    def local(value):
+        return value.astimezone(tz).replace(tzinfo=None)
+
+    assert (local(lo) > local(hi)) == inverted
+    assert_all_examples(
+        datetimes(lo, hi, timezones=just(tz)),
+        lambda d: _instant(lo) <= _instant(d) <= _instant(hi),
+    )
 
 
 def test_underflow_in_simplify():

--- a/hypothesis/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis/tests/datetime/test_zoneinfo_timezones.py
@@ -126,6 +126,27 @@ def test_bounds_inside_a_fold(key, day):
     find_any(strategy, lambda d: d.fold == 1)
 
 
+@pytest.mark.parametrize("key, day", FALL_BACK_DAYS)
+def test_fold_inverted_bounds_are_invalid(key, day):
+    # fold=1 is the later moment, so these bounds are ordered by wall clock time, but not
+    # by UTC (_instant) time. This ordering should be rejected.
+    lo = at(day, 1, 45, key=key, fold=1)
+    hi = at(day, 1, 50, key=key, fold=0)
+    assert lo.replace(tzinfo=None) < hi.replace(tzinfo=None)
+    assert _instant(hi) < _instant(lo)
+    with pytest.raises(InvalidArgument):
+        st.datetimes(lo, hi, timezones=st.just(lo.tzinfo)).validate()
+
+
+@pytest.mark.parametrize("key, day", FALL_BACK_DAYS)
+def test_equal_bounds_at_ambiguous_moment_preserves_fold(key, day):
+    dt = at(day, 1, 30, key=key, fold=1)
+    assert_all_examples(
+        st.datetimes(dt, dt, timezones=st.just(dt.tzinfo)),
+        lambda d: _instant(d) == _instant(dt) and d.fold == 1,
+    )
+
+
 @pytest.mark.parametrize("kwargs", [{"no_cache": 1}])
 def test_timezones_argument_validation(kwargs):
     with pytest.raises(InvalidArgument):

--- a/hypothesis/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis/tests/datetime/test_zoneinfo_timezones.py
@@ -8,15 +8,22 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import datetime as dt
 import platform
 import zoneinfo
 
 import pytest
 
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
+from hypothesis.strategies._internal.datetime import _instant
 
-from tests.common.debug import assert_no_examples, find_any, minimal
+from tests.common.debug import (
+    assert_all_examples,
+    assert_no_examples,
+    find_any,
+    minimal,
+)
 
 
 def test_utc_is_minimal():
@@ -35,6 +42,88 @@ def test_datetimes_stay_within_naive_bounds(data, lo, hi):
         lo, hi = hi, lo
     out = data.draw(st.datetimes(lo, hi, timezones=st.timezones()))
     assert lo <= out.replace(tzinfo=None) <= hi
+
+
+@given(
+    st.data(),
+    st.datetimes(timezones=st.timezones()),
+    st.datetimes(timezones=st.timezones()),
+)
+def test_datetimes_stay_within_aware_bounds(data, lo, hi):
+    if _instant(lo) > _instant(hi):
+        lo, hi = hi, lo
+    # timezones defaults to st.timezones() when the bounds are aware
+    out = data.draw(st.datetimes(lo, hi))
+    assert isinstance(out.tzinfo, zoneinfo.ZoneInfo)
+    assert _instant(lo) <= _instant(out) <= _instant(hi)
+
+
+@given(
+    st.datetimes(
+        min_value=dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc), allow_imaginary=False
+    )
+)
+def test_allow_imaginary_is_not_an_error_for_aware_bounds(d):
+    pass
+
+
+# America/New_York fell back from 02:00 EDT to 01:00 EST on 2020-11-01, and
+# Europe/Dublin - which has a negative DST offset - from 02:00 UTC+1 to 01:00 GMT
+# on 2020-10-25; in both, wall times between 01:00 and 02:00 are ambiguous.
+FALL_BACK_DAYS = [
+    ("America/New_York", dt.date(2020, 11, 1)),
+    ("Europe/Dublin", dt.date(2020, 10, 25)),
+]
+
+
+def at(day, hour, minute=0, *, key, fold=0):
+    tzinfo = zoneinfo.ZoneInfo(key)
+    return dt.datetime.combine(day, dt.time(hour, minute, fold=fold), tzinfo=tzinfo)
+
+
+@pytest.mark.parametrize("key, day", FALL_BACK_DAYS)
+def test_bounds_at_either_side_of_a_fold(key, day):
+    lo = at(day, 1, 30, key=key, fold=1)
+    hi = at(day, 3, key=key)
+    # Wall times up to an hour after lo are ambiguous: with fold=0 they would
+    # be moments before it, so the strategy must constrain the fold to 1.
+    assert_all_examples(
+        st.datetimes(lo, hi, timezones=st.just(lo.tzinfo)),
+        lambda d: _instant(lo) <= _instant(d) <= _instant(hi),
+    )
+    lo2 = at(day, 0, key=key)
+    hi2 = at(day, 1, 45, key=key, fold=0)
+    assert_all_examples(
+        st.datetimes(lo2, hi2, timezones=st.just(lo.tzinfo)),
+        lambda d: _instant(lo2) <= _instant(d) <= _instant(hi2),
+    )
+
+
+@pytest.mark.parametrize("key, day", FALL_BACK_DAYS)
+def test_fold_bound_with_long_interval(key, day):
+    # Intervals of more than a day are drawn as local wall times, rejecting
+    # the rare draw of an ambiguous time beside a bound with the out-of-bounds
+    # fold - rather than the draw-in-UTC approach for shorter intervals.
+    lo = at(day, 1, 30, key=key, fold=1)
+    hi = at(day + dt.timedelta(days=3), 3, key=key)
+    assert_all_examples(
+        st.datetimes(lo, hi, timezones=st.just(lo.tzinfo)),
+        lambda d: _instant(lo) <= _instant(d) <= _instant(hi),
+        settings=settings(max_examples=300),
+    )
+
+
+@pytest.mark.parametrize("key, day", FALL_BACK_DAYS)
+def test_bounds_inside_a_fold(key, day):
+    lo = at(day, 1, 55, key=key, fold=0)
+    hi = at(day, 1, 5, key=key, fold=1)
+    # ...so lo is an earlier moment than hi, but a later wall-clock time!
+    assert _instant(lo) < _instant(hi)
+    assert lo.replace(tzinfo=None) > hi.replace(tzinfo=None)
+    strategy = st.datetimes(lo, hi, timezones=st.just(lo.tzinfo))
+    assert_all_examples(strategy, lambda d: _instant(lo) <= _instant(d) <= _instant(hi))
+    find_any(strategy, lambda d: d.fold == 0)
+    find_any(strategy, lambda d: d.fold == 1)
 
 
 @pytest.mark.parametrize("kwargs", [{"no_cache": 1}])

--- a/hypothesis/tests/test_annotated_types.py
+++ b/hypothesis/tests/test_annotated_types.py
@@ -10,6 +10,7 @@
 
 import datetime as dt
 import re
+import subprocess
 import sys
 import zoneinfo
 from typing import Annotated, TypeVar
@@ -215,3 +216,15 @@ else:
         assert value["x"] >= 0
         assert value.get("y", 0) >= 0
         assert value.get("z", 0) >= 0
+
+
+def test_datetimes_annotations_use_timezone_metadata():
+    # The aliases annotating st.datetimes() overloads pick up annotated-types
+    # metadata only if it was already imported, so check in a fresh process.
+    code = """
+import annotated_types, typing
+from hypothesis.strategies._internal import datetime as d
+assert typing.get_args(d.NaiveDatetime)[1] == annotated_types.Timezone(None)
+assert typing.get_args(d.AwareDatetime)[1] == annotated_types.Timezone(...)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
min_value and max_value now default to None, and may both be timezone-aware datetimes, which are treated as moments in time; in that case timezones defaults to st.timezones() and must not generate None. Mixing one aware and one naive bound is an error.

This change is both nice in itself - meeting a fairly common use-case, more efficiently than our previous suggestion of filtering - and unlocks a filter-rewriting followup which should help some data-scientists.