### PR TITLE
Support `consumes(some_bundle).filter(...)` (and map) for stateful tests

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+:class:`~hypothesis.stateful.Bundle` now supports efficient |.filter|
+and |.map| methods, which compose with
+:func:`~hypothesis.stateful.consumes` in either order (:issue:`3944`).
+Previously, ``consumes(bundle).filter(fn)`` could remove rejected values from
+the bundle while retrying, and ``consumes(bundle.filter(fn))`` was a type
+error; filtered draws now select among currently-matching values and consume
+only the value which was actually drawn.
+
+Thanks to Reagan Lee for the initial implementation of this feature in
+:pull:`4084`!

--- a/hypothesis/docs/stateful.rst
+++ b/hypothesis/docs/stateful.rst
@@ -25,6 +25,8 @@ A rule can, in place of a normal strategy, take a :class:`~hypothesis.stateful.B
 
 Specifically, a rule that specifies ``target=a_bundle`` will cause its return value to be added to that bundle. A rule that specifies ``an_argument=a_bundle`` as a strategy will draw a value from that bundle.  A rule can also specify that an argument chooses a value from a bundle and removes that value by using :func:`~hypothesis.stateful.consumes` as in ``an_argument=consumes(a_bundle)``.
 
+Bundles can be filtered and mapped like any other strategy, and this composes with :func:`~hypothesis.stateful.consumes` in either order: ``consumes(a_bundle.filter(fn))`` and ``consumes(a_bundle).filter(fn)`` both draw a currently-matching value and remove only that value from the bundle.
+
 .. note::
     There is some overlap between what you can do with Bundles and what you can do with instance variables. Both represent state that rules can manipulate. If you do not need to draw values that depend on the machine's state, you can simply use instance variables. If you do need to draw values that depend on the machine's state, Bundles provide a fairly straightforward way to do this. If you need rules that draw values that depend on the machine's state in some more complicated way, you will have to abandon bundles. You can use :func:`~hypothesis.strategies.runner` and |.flatmap| to access the instance from a rule: the strategy ``runner().flatmap(lambda self: sampled_from(self.a_list))`` will draw from the instance variable ``a_list``. If you need something more complicated still, you can use |st.data| to draw data from the instance (or anywhere else) based on logic in the rule.
 

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from io import StringIO
 from time import perf_counter
-from typing import Any, ClassVar, TypeVar, overload
+from typing import Any, ClassVar, Literal, TypeVar, overload
 from unittest import TestCase
 
 from hypothesis import strategies as st
@@ -54,8 +54,10 @@ from hypothesis.strategies._internal.featureflags import FeatureFlags, FeatureSt
 from hypothesis.strategies._internal.strategies import (
     Ex,
     OneOfStrategy,
+    SampledFromStrategy,
     SearchStrategy,
     check_strategy,
+    filter_not_satisfied,
 )
 from hypothesis.utils.deprecation import note_deprecation
 from hypothesis.vendor.pretty import RepresentationPrinter
@@ -525,10 +527,22 @@ class Rule:
     def __post_init__(self):
         bundles = []
         for k, v in sorted(self.arguments.items()):
-            assert not isinstance(v, BundleReferenceStrategy)
             if isinstance(v, Bundle):
                 bundles.append(v)
-                v = BundleReferenceStrategy(v.name, consume=v.consume)
+                # We use a VarReference so that the printed reproduction refers to
+                # values by their variable names, except when a map transform is
+                # involved, in which case the value passed to the rule is not the one
+                # stored on the machine and we want to draw the transformed value
+                # directly instead of a reference.
+                draw_references = all(
+                    name == "filter" for name, _ in v._transformations
+                )
+                v = Bundle(
+                    v.name,
+                    consume=v.consume,
+                    draw_references=draw_references,
+                    transformations=v._transformations,
+                )
             self.arguments_strategies[k] = v
         self.bundles = tuple(bundles)
 
@@ -562,25 +576,34 @@ class Rule:
 self_strategy = st.runner()
 
 
-class BundleReferenceStrategy(SearchStrategy):
-    def __init__(self, name: str, *, consume: bool = False):
-        super().__init__()
-        self.name = name
-        self.consume = consume
+class _BundleSampler(SampledFromStrategy):
+    """A single draw from the current contents of a Bundle.
 
-    def do_draw(self, data):
-        machine = data.draw(self_strategy)
-        bundle = machine.bundle(self.name)
-        if not bundle:
-            data.mark_invalid(f"Cannot draw from empty bundle {self.name!r}")
-        # Shrink towards the right rather than the left. This makes it easier
-        # to delete data generated earlier, as when the error is towards the
-        # end there can be a lot of hard to remove padding.
-        position = data.draw_integer(0, len(bundle) - 1, shrink_towards=len(bundle))
-        if self.consume:
-            return bundle.pop(position)  # pragma: no cover  # coverage is flaky here
-        else:
-            return bundle[position]
+    A Bundle's elements are only known at draw time, so Bundle.do_draw
+    constructs a throwaway instance of this strategy for each draw, passing
+    (position, reference) pairs as the elements.
+
+    The throwaway instance is also what makes bundle draws thread-safe:
+    Bundle and its Rule-created copies are shared by every instance of the
+    machine class, so per-draw state must live here and never on them.
+    """
+
+    def __init__(self, machine, elements, *, force_repr, transformations):
+        super().__init__(
+            elements, force_repr=force_repr, transformations=transformations
+        )
+        self.machine = machine
+
+    def _transform(self, element):
+        # Filter and map transformations apply to the value, which we look up
+        # lazily so that untested elements cost nothing; the position and
+        # reference ride along so that Bundle.do_draw can consume the chosen
+        # element and refer to it by name.
+        position, reference = element
+        result = super()._transform(self.machine.names_to_values[reference.name])
+        if result is filter_not_satisfied:
+            return filter_not_satisfied
+        return (position, reference, result)
 
 
 class Bundle(SearchStrategy[Ex]):
@@ -603,29 +626,81 @@ class Bundle(SearchStrategy[Ex]):
 
     If the ``consume`` argument is set to True, then all values that are
     drawn from this bundle will be consumed (as above) when requested.
+
+    Bundles may be used with |.filter| and |.map| like any other
+    strategy, and this composes with :func:`~hypothesis.stateful.consumes` in
+    either order - e.g. ``consumes(b.filter(fn))`` and ``consumes(b).filter(fn)``
+    are equivalent, and only ever consume the value which was actually drawn.
     """
 
     def __init__(
-        self, name: str, *, consume: bool = False, draw_references: bool = True
+        self,
+        name: str,
+        *,
+        consume: bool = False,
+        draw_references: bool = False,
+        transformations: tuple[
+            tuple[Literal["filter", "map"], Callable[[Ex], Any]], ...
+        ] = (),
     ) -> None:
         super().__init__()
         self.name = name
-        self.__reference_strategy = BundleReferenceStrategy(name, consume=consume)
+        self.consume = consume
         self.draw_references = draw_references
-
-    @property
-    def consume(self) -> bool:
-        return self.__reference_strategy.consume
+        self._transformations = transformations
 
     def do_draw(self, data):
         machine = data.draw(self_strategy)
-        reference = data.draw(self.__reference_strategy)
-        return machine.names_to_values[reference.name]
+        bundle = machine.bundle(self.name)
+        if not bundle:
+            data.mark_invalid(f"Cannot draw from empty bundle {self.name!r}")
+        # Shrink towards the right rather than the left. This makes it easier
+        # to delete data generated earlier, as when the error is towards the
+        # end there can be a lot of hard to remove padding. do_filtered_draw
+        # shrinks the index towards zero, so we list the elements newest-first.
+        sampler = _BundleSampler(
+            machine,
+            list(enumerate(bundle))[::-1],
+            force_repr=self._base_repr(),
+            transformations=self._transformations,
+        )
+        result = sampler.do_filtered_draw(data)
+        if result is filter_not_satisfied:
+            data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")
+        position, reference, value = result
+        if self.consume:
+            bundle.pop(position)  # pragma: no cover  # coverage is flaky here
+        return reference if self.draw_references else value
+
+    # We intercept .filter and .map, rather than relying on the generic
+    # FilteredStrategy and MappedStrategy wrappers, so that transformations
+    # apply within a single draw: the generic wrappers instead retry the whole
+    # draw when a filter fails, consuming rejected values from consuming
+    # bundles, and are opaque to the reference-drawing logic in Rule.
+    def __with_transform(self, name, f):
+        return Bundle(
+            self.name,
+            consume=self.consume,
+            draw_references=self.draw_references,
+            transformations=(*self._transformations, (name, f)),
+        )
+
+    def map(self, pack):
+        return self.__with_transform("map", pack)
+
+    def filter(self, condition):
+        return self.__with_transform("filter", condition)
+
+    def _base_repr(self):
+        consume = ", consume=True" if self.consume else ""
+        return f"Bundle(name={self.name!r}{consume})"
 
     def __repr__(self):
-        if self.consume is False:
-            return f"Bundle(name={self.name!r})"
-        return f"Bundle(name={self.name!r}, consume={self.consume!r})"
+        transforms = "".join(
+            f".{name}({get_pretty_function_description(f)})"
+            for name, f in self._transformations
+        )
+        return self._base_repr() + transforms
 
     def calc_is_empty(self, recur):
         # We assume that a bundle will grow over time
@@ -637,13 +712,6 @@ class Bundle(SearchStrategy[Ex]):
         # modifying the underlying choice sequence.
         machine = data.draw(self_strategy)
         return not bool(machine.bundle(self.name))
-
-    def flatmap(self, expand):
-        if self.draw_references:
-            return Bundle(
-                self.name, consume=self.consume, draw_references=False
-            ).flatmap(expand)
-        return super().flatmap(expand)
 
     def __hash__(self):
         # Making this hashable means we hit the fast path of "everything is
@@ -669,7 +737,7 @@ def consumes(bundle: Bundle[Ex]) -> SearchStrategy[Ex]:
     """
     if not isinstance(bundle, Bundle):
         raise TypeError("Argument to be consumed must be a bundle.")
-    return Bundle(bundle.name, consume=True)
+    return Bundle(bundle.name, consume=True, transformations=bundle._transformations)
 
 
 @dataclass(slots=True, frozen=True)

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -30,6 +30,7 @@ from hypothesis.core import encode_failure
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.errors import (
     DidNotReproduce,
+    FailedHealthCheck,
     Flaky,
     FlakyStrategyDefinition,
     InvalidArgument,
@@ -48,6 +49,11 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
 )
 from hypothesis.strategies import binary, data, integers, just, lists
+from hypothesis.strategies._internal.collections import (
+    UniqueListStrategy,
+    UniqueSampledListStrategy,
+)
+from hypothesis.strategies._internal.lazy import unwrap_strategies
 
 from tests.common.utils import (
     Why,
@@ -1507,6 +1513,271 @@ def test_use_bundle_within_other_strategies():
 
     Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
     run_state_machine_as_test(Machine)
+
+
+def test_can_filter_bundle():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(10))
+
+        @rule(value=values.filter(lambda x: x % 2 == 0))
+        def use(self, value):
+            assert value % 2 == 0
+
+    Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_can_map_bundle():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(1, 2, 3)
+
+        @rule(value=values.map(lambda x: x * 10))
+        def use(self, value):
+            assert value in (10, 20, 30)
+
+    Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_can_filter_mapped_bundle():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(10))
+
+        @rule(value=values.filter(lambda x: x % 2 == 0).map(lambda x: x + 1))
+        def use(self, value):
+            assert value % 2 == 1
+
+    Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_filtering_consumed_bundle_consumes_only_the_drawn_value():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(10))
+
+        @rule(value=consumes(values).filter(lambda x: x % 2 == 0))
+        def pop_even(self, value):
+            assert value % 2 == 0
+            remaining = {
+                self.names_to_values[ref.name] for ref in self.bundle("values")
+            }
+            # rejected values are not consumed from the bundle
+            assert {1, 3, 5, 7, 9} <= remaining
+
+    Machine.TestCase.settings = Settings(stateful_step_count=5, max_examples=20)
+    run_state_machine_as_test(Machine)
+
+
+def test_can_consume_filtered_bundle():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(4))
+
+        @rule(value=consumes(values.filter(lambda x: x == 3)))
+        def pop(self, value):
+            assert value == 3
+
+    Machine.TestCase.settings = Settings(stateful_step_count=1, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_can_consume_mapped_bundle():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(1, 2, 3)
+
+        @rule(value=consumes(values).map(lambda x: x * 10))
+        def pop(self, value):
+            assert value in (10, 20, 30)
+
+    Machine.TestCase.settings = Settings(stateful_step_count=2, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_prints_variable_names_for_filtered_bundle_arguments():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(1, 2, 3)
+
+        @rule(
+            a1=values.filter(lambda x: x < 2),
+            a2=values.filter(lambda x: x > 2),
+            a3=values,
+        )
+        def fail_fast(self, a1, a2, a3):
+            raise AssertionError
+
+    Machine.TestCase.settings = NO_BLOB_SETTINGS
+    with pytest.raises(AssertionError) as err:
+        run_state_machine_as_test(Machine)
+
+    result = "\n".join(err.value.__notes__)
+    assert result == """
+Failing test case:
+state = Machine()
+values_0, values_1, values_2 = state.fill()
+state.fail_fast(a1=values_0, a2=values_2, a3=values_2)
+state.teardown()
+""".strip()
+
+
+def test_prints_variable_names_for_consumed_filtered_bundle_arguments():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(1, 2, 3)
+
+        @rule(
+            v1=consumes(values).filter(lambda x: x < 2),
+            v2=consumes(values).filter(lambda x: x > 2),
+            v3=consumes(values),
+        )
+        def fail_fast(self, v1, v2, v3):
+            raise AssertionError
+
+    Machine.TestCase.settings = NO_BLOB_SETTINGS
+    with pytest.raises(AssertionError) as err:
+        run_state_machine_as_test(Machine)
+
+    result = "\n".join(err.value.__notes__)
+    assert result == """
+Failing test case:
+state = Machine()
+values_0, values_1, values_2 = state.fill()
+state.fail_fast(v1=values_0, v2=values_2, v3=values_1)
+state.teardown()
+""".strip()
+
+
+def test_prints_mapped_bundle_values_directly():
+    # With a map transformation, the value passed to the rule is not the one
+    # stored on the machine - so we print the transformed value, not the name.
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple("ret1", "ret2")
+
+        @rule(
+            v1=values,
+            v2=values.map(lambda x: x + x),
+            v3=consumes(values).map(lambda x: x + x),
+            v4=values,
+        )
+        def fail_fast(self, v1, v2, v3, v4):
+            raise AssertionError
+
+    Machine.TestCase.settings = NO_BLOB_SETTINGS
+    with pytest.raises(AssertionError) as err:
+        run_state_machine_as_test(Machine)
+
+    result = "\n".join(err.value.__notes__)
+    assert result == """
+Failing test case:
+state = Machine()
+values_0, values_1 = state.fill()
+state.fail_fast(v1=values_1, v2='ret2ret2', v3='ret2ret2', v4=values_0)
+state.teardown()
+""".strip()
+
+
+@xfail_on_crosshair(Why.other, strict=False)  # health check may not trigger
+def test_unsatisfiable_bundle_filter_fails_health_check():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return 0
+
+        @rule(value=values.filter(lambda x: False))
+        def use(self, value):
+            raise AssertionError("should be unreachable")
+
+    Machine.TestCase.settings = Settings(stateful_step_count=2, max_examples=2)
+    with pytest.raises(FailedHealthCheck, match="filter_too_much"):
+        run_state_machine_as_test(Machine)
+
+
+def test_can_generate_unique_lists_of_bundle_values():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(5))
+
+        @rule(vs=lists(values, unique=True, min_size=2))
+        def use(self, vs):
+            assert len(set(vs)) == len(vs)
+
+    Machine.TestCase.settings = Settings(stateful_step_count=3, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_can_generate_unique_lists_of_filtered_bundle_values():
+    class Machine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(10))
+
+        @rule(vs=lists(values.filter(lambda x: x % 2 == 0), unique=True, min_size=2))
+        def use(self, vs):
+            assert len(set(vs)) == len(vs)
+            assert all(v % 2 == 0 for v in vs)
+
+    Machine.TestCase.settings = Settings(stateful_step_count=3, max_examples=10)
+    run_state_machine_as_test(Machine)
+
+
+def test_unique_lists_of_bundle_values_use_the_generic_unique_strategy():
+    # A Bundle's elements are only known at draw time, so lists(..., unique=True)
+    # must not route to UniqueSampledListStrategy, which statically inspects the
+    # elements of a SampledFromStrategy when the lists() strategy is constructed.
+    s = unwrap_strategies(lists(Bundle("b"), unique=True))
+    assert isinstance(s, UniqueListStrategy)
+    assert not isinstance(s, UniqueSampledListStrategy)
+
+
+def test_bundle_repr_includes_transformations():
+    b = Bundle("b")
+    assert repr(b) == "Bundle(name='b')"
+    assert repr(consumes(b)) == "Bundle(name='b', consume=True)"
+    assert repr(b.filter(bool)) == "Bundle(name='b').filter(bool)"
+    assert (
+        repr(consumes(b.filter(bool))) == "Bundle(name='b', consume=True).filter(bool)"
+    )
+    assert repr(consumes(b).filter(bool)) == repr(consumes(b.filter(bool)))
 
 
 def test_precondition_cannot_be_used_without_rule():

--- a/hypothesis/tests/nocover/test_threading.py
+++ b/hypothesis/tests/nocover/test_threading.py
@@ -17,7 +17,15 @@ import pytest
 from hypothesis import given, settings, strategies as st
 from hypothesis.errors import DeadlineExceeded, InvalidArgument
 from hypothesis.internal.conjecture.junkdrawer import ensure_free_stackframes
-from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    consumes,
+    initialize,
+    invariant,
+    multiple,
+    rule,
+)
 from hypothesis.strategies import SearchStrategy
 
 from tests.common.debug import check_can_generate_examples
@@ -55,6 +63,34 @@ def test_run_stateful_test_concurrently():
         @invariant()
         def my_invariant(self):
             pass
+
+    TestMyStateful = MyStateMachine.TestCase().runTest
+    run_concurrently(TestMyStateful, n=2)
+
+
+def test_run_stateful_test_with_transformed_bundles_concurrently():
+    # Bundles (and the reference-drawing copies Rule creates from them) are
+    # shared by every instance of the machine class, including across threads,
+    # so drawing from a bundle must not store per-draw state on the strategy.
+    class MyStateMachine(RuleBasedStateMachine):
+        values = Bundle("values")
+
+        @initialize(target=values)
+        def fill(self):
+            return multiple(*range(10))
+
+        @rule(target=values, n=values.filter(lambda x: x % 2 == 0))
+        def use_filtered(self, n):
+            assert n % 2 == 0
+            return n
+
+        @rule(n=values.map(lambda x: -x - 1))
+        def use_mapped(self, n):
+            assert n < 0
+
+        @rule(n=consumes(values).filter(lambda x: x % 2 == 0))
+        def pop_even(self, n):
+            assert n % 2 == 0
 
     TestMyStateful = MyStateMachine.TestCase().runTest
     run_concurrently(TestMyStateful, n=2)


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis/issues/3944 (issue) and also closes https://github.com/HypothesisWorks/hypothesis/pull/4084 (a serious PR from @reaganjlee, which foundered on a combination of complexity and limited review time from maintainers)

In short, Bundle now draws elements by constructing a SampledFromStrategy on the fly; for details see the diff.