### PR TITLE
Rewrite comparison filters on times() and datetimes() into bounds

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch implements filter-rewriting for :func:`~hypothesis.strategies.times`
+and :func:`~hypothesis.strategies.datetimes`: simple comparison filters such as
+``.filter(partial(operator.ge, bound))`` are rewritten into efficient bounds,
+as :func:`~hypothesis.strategies.dates` already did.  This includes strategies
+inferred from :pypi:`annotated-types` bounds like ``Annotated[datetime, Gt(...)]``,
+and contradictory filters now give an empty strategy instead of failing
+health checks.

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -21,8 +21,14 @@ from typing import TYPE_CHECKING, Annotated, overload
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.validation import check_type, check_valid_interval
 from hypothesis.strategies._internal.core import sampled_from
+from hypothesis.strategies._internal.lazy import unwrap_strategies
 from hypothesis.strategies._internal.misc import just, none, nothing
-from hypothesis.strategies._internal.strategies import SearchStrategy
+from hypothesis.strategies._internal.strategies import (
+    FilteredStrategy,
+    OneOfStrategy,
+    SampledFromStrategy,
+    SearchStrategy,
+)
 from hypothesis.strategies._internal.utils import defines_strategy
 
 if TYPE_CHECKING:
@@ -38,6 +44,67 @@ else:
 
 DATENAMES = ("year", "month", "day")
 TIMENAMES = ("hour", "minute", "second", "microsecond")
+
+_MICROSECOND = dt.timedelta(microseconds=1)
+
+
+def _comparator_bound(condition):
+    """Return ``(op, bound)`` for filter conditions like ``partial(op, bound)``,
+    with a single positional argument to one of the five comparison operators."""
+    if (
+        isinstance(condition, partial)
+        and len(condition.args) == 1
+        and not condition.keywords
+        and condition.func in (op.lt, op.le, op.eq, op.ge, op.gt)
+    ):
+        return condition.func, condition.args[0]
+    return None
+
+
+def _narrowed_bounds(func, arg, min_value, max_value, shift):
+    """Narrow [min_value, max_value] to satisfy the condition ``func(arg, x)``.
+
+    ``shift(value, steps)`` moves value by that many of the smallest representable
+    steps, raising OverflowError if the result would be unrepresentable.  Returns
+    the narrowed (min_value, max_value), or None if no values can satisfy the
+    condition.
+    """
+    if func in (op.lt, op.gt):
+        try:
+            arg = shift(arg, 1 if func is op.lt else -1)
+        except OverflowError:  # gt the maximum value, or lt the minimum
+            return None
+    lo, hi = {
+        # We're talking about op(arg, x) - the reverse of our usual intuition!
+        op.lt: (arg, max_value),  # lambda x: arg < x
+        op.le: (arg, max_value),  # lambda x: arg <= x
+        op.eq: (arg, arg),  #       lambda x: arg == x
+        op.ge: (min_value, arg),  # lambda x: arg >= x
+        op.gt: (min_value, arg),  # lambda x: arg > x
+    }[func]
+    lo = max(lo, min_value)
+    hi = min(hi, max_value)
+    if hi < lo:
+        return None
+    return lo, hi
+
+
+def _timezones_kind(strat):
+    """Classify the values a timezones= strategy can generate: "none" if only
+    None, "aware" if only tzinfo instances, or "unknown" if we can't tell."""
+    strat = unwrap_strategies(strat)
+    if isinstance(strat, SampledFromStrategy) and all(
+        name == "filter" for name, _ in strat._transformations
+    ):
+        kinds = {
+            "none" if e is None else "aware" if isinstance(e, dt.tzinfo) else "unknown"
+            for e in strat.elements
+        }
+        return kinds.pop() if len(kinds) == 1 else "unknown"
+    if isinstance(strat, OneOfStrategy):
+        kinds = {_timezones_kind(s) for s in strat.original_strategies}
+        return kinds.pop() if len(kinds) == 1 else "unknown"
+    return "unknown"
 
 
 def is_pytz_timezone(tz):
@@ -177,6 +244,10 @@ def draw_capped_multipart(
     return result
 
 
+def _shift_datetime(value, steps):
+    return value + steps * _MICROSECOND
+
+
 class DatetimeStrategy(SearchStrategy):
     def __init__(self, min_value, max_value, timezones_strat, allow_imaginary):
         super().__init__()
@@ -293,6 +364,85 @@ class DatetimeStrategy(SearchStrategy):
                 f"Failed to draw a datetime between {self.min_value!r} and "
                 f"{self.max_value!r} with timezone from {self.tz_strat!r}."
             )
+
+    def filter(self, condition):
+        if (parsed := _comparator_bound(condition)) is not None and isinstance(
+            arg := parsed[1], dt.datetime
+        ):
+            func = parsed[0]
+            try:
+                bound_aware = arg.utcoffset() is not None
+            except Exception:
+                # A tzinfo whose utcoffset() raises; comparing against this
+                # bound will raise the same error at draw time.
+                return super().filter(condition)
+            if not bound_aware:
+                # The bound compares as naive (either no tzinfo, or a tzinfo
+                # without a UTC offset), so we can only rewrite it into the
+                # naive wall-clock bounds if it really is naive and every
+                # generated value is too.
+                if (
+                    arg.tzinfo is None
+                    and not self.aware
+                    and _timezones_kind(self.tz_strat) == "none"
+                ):
+                    bounds = _narrowed_bounds(
+                        func, arg, self.min_value, self.max_value, _shift_datetime
+                    )
+                    if bounds is None:
+                        return nothing()
+                    if bounds == (self.min_value, self.max_value):
+                        return self
+                    return datetimes(
+                        *bounds,
+                        timezones=self.tz_strat,
+                        allow_imaginary=self.allow_imaginary,
+                    )
+            else:
+                # An aware bound constrains the instant of generated values,
+                # so we narrow our aware bounds to the closed interval of
+                # satisfying instants - retaining strict predicates below,
+                # which then reject at most the boundary instant per timezone.
+                # We compare bounds by their _instant() key, since comparison
+                # of datetimes which share a tzinfo would fall back to
+                # wall-clock order, ignoring the fold.
+                if self.aware:
+                    min_value, max_value = self.min_value, self.max_value
+                elif (self.min_value, self.max_value) == (
+                    dt.datetime.min,
+                    dt.datetime.max,
+                ) and _timezones_kind(self.tz_strat) != "none":
+                    # An unbounded naive-mode strategy whose values are all
+                    # aware: promote to aware mode, bounded by the filter.
+                    min_value = max_value = None
+                else:
+                    return super().filter(condition)
+                key = _instant(arg)
+                if func in (op.lt, op.le, op.eq) and (
+                    min_value is None or _instant(min_value) < key
+                ):
+                    min_value = arg
+                if func in (op.gt, op.ge, op.eq) and (
+                    max_value is None or key < _instant(max_value)
+                ):
+                    max_value = arg
+                if min_value is not None and max_value is not None:
+                    lo, hi = _instant(min_value), _instant(max_value)
+                    if hi < lo or (func in (op.lt, op.gt) and lo == hi == key):
+                        # Only aware-mode strategies can reach this, and they
+                        # generate only aware values (or raise for a bad
+                        # timezones strategy), so this is provably empty.
+                        return nothing()
+                if min_value is self.min_value and max_value is self.max_value:
+                    result = self
+                else:
+                    result = DatetimeStrategy(
+                        min_value, max_value, self.tz_strat, self.allow_imaginary
+                    )
+                if func in (op.lt, op.gt):
+                    return FilteredStrategy(result, (condition,))
+                return result
+        return super().filter(condition)
 
 
 @overload
@@ -420,6 +570,18 @@ def datetimes(
     return DatetimeStrategy(min_value, max_value, timezones, allow_imaginary)
 
 
+_ARBITRARY_DATE = dt.date(2000, 1, 1)
+
+
+def _shift_time(value, steps):
+    # dt.time supports no arithmetic, so we go via a datetime on a fixed day
+    # and treat crossing midnight as overflowing the representable range.
+    shifted = dt.datetime.combine(_ARBITRARY_DATE, value) + steps * _MICROSECOND
+    if shifted.date() != _ARBITRARY_DATE:
+        raise OverflowError
+    return shifted.time()
+
+
 class TimeStrategy(SearchStrategy):
     def __init__(self, min_value, max_value, timezones_strat):
         super().__init__()
@@ -431,6 +593,27 @@ class TimeStrategy(SearchStrategy):
         result = draw_capped_multipart(data, self.min_value, self.max_value, TIMENAMES)
         tz = data.draw(self.tz_strat)
         return dt.time(**result, tzinfo=tz)
+
+    def filter(self, condition):
+        # We only rewrite naive times: ordering aware times works in terms of
+        # utcoffset(), which is None for e.g. ZoneInfo tzinfos on a time - so
+        # such values compare as naive anyway, and rewriting fixed-offset aware
+        # times isn't worth the extra complexity.
+        if (
+            (parsed := _comparator_bound(condition)) is not None
+            and isinstance(arg := parsed[1], dt.time)
+            and arg.tzinfo is None
+            and _timezones_kind(self.tz_strat) == "none"
+        ):
+            bounds = _narrowed_bounds(
+                parsed[0], arg, self.min_value, self.max_value, _shift_time
+            )
+            if bounds is None:
+                return nothing()
+            if bounds == (self.min_value, self.max_value):
+                return self
+            return times(*bounds, timezones=self.tz_strat)
+        return super().filter(condition)
 
 
 @defines_strategy(force_reusable_values=True)
@@ -459,6 +642,10 @@ def times(
     return TimeStrategy(min_value, max_value, timezones)
 
 
+def _shift_date(value, steps):
+    return value + steps * dt.timedelta(days=1)
+
+
 class DateStrategy(SearchStrategy):
     def __init__(self, min_value, max_value):
         super().__init__()
@@ -475,31 +662,19 @@ class DateStrategy(SearchStrategy):
 
     def filter(self, condition):
         if (
-            isinstance(condition, partial)
-            and len(args := condition.args) == 1
-            and not condition.keywords
-            and isinstance(arg := args[0], dt.date)
-            and condition.func in (op.lt, op.le, op.eq, op.ge, op.gt)
+            (parsed := _comparator_bound(condition)) is not None
+            # datetime is a date subclass, but not comparable with dates
+            and isinstance(arg := parsed[1], dt.date)
+            and not isinstance(arg, dt.datetime)
         ):
-            try:
-                arg += dt.timedelta(days={op.lt: 1, op.gt: -1}.get(condition.func, 0))
-            except OverflowError:  # gt date.max, or lt date.min
+            bounds = _narrowed_bounds(
+                parsed[0], arg, self.min_value, self.max_value, _shift_date
+            )
+            if bounds is None:
                 return nothing()
-            lo, hi = {
-                # We're talking about op(arg, x) - the reverse of our usual intuition!
-                op.lt: (arg, self.max_value),  # lambda x: arg < x
-                op.le: (arg, self.max_value),  # lambda x: arg <= x
-                op.eq: (arg, arg),  #            lambda x: arg == x
-                op.ge: (self.min_value, arg),  # lambda x: arg >= x
-                op.gt: (self.min_value, arg),  # lambda x: arg > x
-            }[condition.func]
-            lo = max(lo, self.min_value)
-            hi = min(hi, self.max_value)
-            if hi < lo:
-                return nothing()
-            if lo <= self.min_value and self.max_value <= hi:
+            if bounds == (self.min_value, self.max_value):
                 return self
-            return dates(lo, hi)
+            return dates(*bounds)
 
         return super().filter(condition)
 

--- a/hypothesis/tests/cover/test_filter_rewriting.py
+++ b/hypothesis/tests/cover/test_filter_rewriting.py
@@ -27,6 +27,11 @@ from hypothesis.internal.filtering import max_len, min_len
 from hypothesis.internal.floats import next_down, next_up
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.strategies._internal.core import data
+from hypothesis.strategies._internal.datetime import (
+    DatetimeStrategy,
+    TimeStrategy,
+    _timezones_kind,
+)
 from hypothesis.strategies._internal.lazy import LazyStrategy, unwrap_strategies
 from hypothesis.strategies._internal.numbers import FloatStrategy, IntegersStrategy
 from hypothesis.strategies._internal.strategies import FilteredStrategy, MappedStrategy
@@ -644,6 +649,305 @@ def test_dates_filter_rewriting():
     new = bare.filter(partial(operator.le, today))
     assert not new.is_empty
     assert new is not bare
+
+    # datetime is a date subclass, but not comparable with dates - don't rewrite
+    assert isinstance(
+        bare.filter(partial(operator.ge, dt.datetime(2003, 1, 1))), FilteredStrategy
+    )
+
+
+def test_times_filter_rewriting():
+    noon = dt.time(12)
+
+    assert st.times().filter(partial(operator.lt, dt.time.max)).is_empty
+    assert st.times().filter(partial(operator.gt, dt.time.min)).is_empty
+    assert st.times(min_value=noon).filter(partial(operator.gt, noon)).is_empty
+    assert st.times(max_value=noon).filter(partial(operator.lt, noon)).is_empty
+
+    bare = unwrap_strategies(st.times())
+    assert bare.filter(partial(operator.ge, dt.time.max)) is bare
+    assert bare.filter(partial(operator.le, dt.time.min)) is bare
+
+    new = unwrap_strategies(bare.filter(partial(operator.le, noon)))
+    assert isinstance(new, TimeStrategy)
+    assert (new.min_value, new.max_value) == (noon, dt.time.max)
+
+    # We don't rewrite times which might be aware, or bounds which are,
+    # or bounds which are not times at all
+    aware = unwrap_strategies(st.times(timezones=st.just(dt.timezone.utc)))
+    assert isinstance(aware.filter(partial(operator.ge, noon)), FilteredStrategy)
+    aware_noon = dt.time(12, tzinfo=dt.timezone.utc)
+    assert isinstance(bare.filter(partial(operator.ge, aware_noon)), FilteredStrategy)
+    assert isinstance(bare.filter(partial(operator.ge, 3)), FilteredStrategy)
+
+
+UTC_2000 = dt.datetime(2000, 1, 1, tzinfo=dt.timezone.utc)
+
+
+class NoneOffsetTimezone(dt.tzinfo):
+    # Datetimes with this tzinfo compare as naive.
+    def utcoffset(self, value):
+        return None
+
+    def tzname(self, value):
+        return "?"
+
+    def dst(self, value):
+        return None
+
+
+class RaisingOffsetTimezone(NoneOffsetTimezone):
+    def utcoffset(self, value):
+        raise ValueError("this tzinfo has no idea what the offset is")
+
+
+def test_datetimes_filter_rewriting():
+    x = dt.datetime(2003, 1, 1)
+
+    assert st.datetimes().filter(partial(operator.lt, dt.datetime.max)).is_empty
+    assert st.datetimes().filter(partial(operator.gt, dt.datetime.min)).is_empty
+    assert st.datetimes(min_value=x).filter(partial(operator.gt, x)).is_empty
+    assert st.datetimes(max_value=x).filter(partial(operator.lt, x)).is_empty
+
+    bare = unwrap_strategies(st.datetimes())
+    assert bare.filter(partial(operator.ge, dt.datetime.max)) is bare
+    assert bare.filter(partial(operator.le, dt.datetime.min)) is bare
+
+    # Mixed naive/aware comparisons raise TypeError at draw time, so we don't
+    # rewrite a naive bound unless the values are always naive, and vice-versa.
+    aware_vals = unwrap_strategies(st.datetimes(timezones=st.just(dt.timezone.utc)))
+    for strat, bound in [(aware_vals, x), (bare, x.replace(tzinfo=dt.timezone.utc))]:
+        out = strat.filter(partial(operator.ge, bound))
+        assert isinstance(out, FilteredStrategy)
+        assert out.filtered_strategy is strat
+
+    # Nor do we rewrite when a naive-mode strategy has its own wall-clock
+    # bounds, which an aware-bounds strategy could not also enforce,
+    walled = unwrap_strategies(
+        st.datetimes(max_value=x, timezones=st.just(dt.timezone.utc))
+    )
+    assert isinstance(walled.filter(partial(operator.ge, UTC_2000)), FilteredStrategy)
+    # or when the values are aware but the bound compares as naive,
+    pseudo_naive = dt.datetime(2000, 1, 1, tzinfo=NoneOffsetTimezone())
+    assert isinstance(bare.filter(partial(operator.ge, pseudo_naive)), FilteredStrategy)
+    # or the bound's utcoffset() raises,
+    raising = dt.datetime(2000, 1, 1, tzinfo=RaisingOffsetTimezone())
+    assert isinstance(bare.filter(partial(operator.ge, raising)), FilteredStrategy)
+    # or the bound isn't a datetime at all.
+    assert isinstance(bare.filter(partial(operator.ge, "2003")), FilteredStrategy)
+
+
+@pytest.mark.parametrize(
+    "strategy, predicate, min_value, max_value",
+    [
+        (
+            st.times(),
+            partial(operator.lt, dt.time(12)),
+            dt.time(12, 0, 0, 1),
+            dt.time.max,
+        ),
+        (st.times(), partial(operator.le, dt.time(12)), dt.time(12), dt.time.max),
+        (st.times(), partial(operator.eq, dt.time(12)), dt.time(12), dt.time(12)),
+        (st.times(), partial(operator.ge, dt.time(12)), dt.time.min, dt.time(12)),
+        (
+            st.times(),
+            partial(operator.gt, dt.time(12)),
+            dt.time.min,
+            dt.time(11, 59, 59, 999999),
+        ),
+        (
+            st.datetimes(),
+            partial(operator.lt, dt.datetime(2003, 1, 1)),
+            dt.datetime(2003, 1, 1, 0, 0, 0, 1),
+            dt.datetime.max,
+        ),
+        (
+            st.datetimes(),
+            partial(operator.le, dt.datetime(2003, 1, 1)),
+            dt.datetime(2003, 1, 1),
+            dt.datetime.max,
+        ),
+        (
+            st.datetimes(),
+            partial(operator.eq, dt.datetime(2003, 1, 1)),
+            dt.datetime(2003, 1, 1),
+            dt.datetime(2003, 1, 1),
+        ),
+        (
+            st.datetimes(),
+            partial(operator.ge, dt.datetime(2003, 1, 1)),
+            dt.datetime.min,
+            dt.datetime(2003, 1, 1),
+        ),
+        (
+            st.datetimes(),
+            partial(operator.gt, dt.datetime(2003, 1, 1)),
+            dt.datetime.min,
+            dt.datetime(2002, 12, 31, 23, 59, 59, 999999),
+        ),
+    ],
+    ids=get_pretty_function_description,
+)
+@settings(max_examples=A_FEW)
+@given(data=st.data())
+def test_time_and_datetime_filter_rewriting(
+    data, strategy, predicate, min_value, max_value
+):
+    s = unwrap_strategies(strategy.filter(predicate))
+    assert isinstance(s, (TimeStrategy, DatetimeStrategy))
+    assert (s.min_value, s.max_value) == (min_value, max_value)
+    value = data.draw(s)
+    assert predicate(value)
+
+
+def test_aware_datetimes_filter_rewriting_narrows_bounds():
+    s = unwrap_strategies(st.datetimes(timezones=st.just(dt.timezone.utc)))
+    out = s.filter(partial(operator.le, UTC_2000))
+    # An aware comparison filter is rewritten into aware bounds, which the
+    # strategy enforces exactly.
+    assert isinstance(out, DatetimeStrategy)
+    assert (out.min_value, out.max_value) == (UTC_2000, None)
+    # A filter which does not tighten those bounds is a no-op,
+    assert out.filter(partial(operator.le, UTC_2000 - dt.timedelta(days=1))) is out
+    # while a tighter filter narrows them.
+    tighter = out.filter(partial(operator.le, UTC_2000 + dt.timedelta(days=1)))
+    assert tighter.min_value == UTC_2000 + dt.timedelta(days=1)
+    upper = s.filter(partial(operator.ge, UTC_2000)).filter(
+        partial(operator.ge, UTC_2000 - dt.timedelta(days=1))
+    )
+    assert upper.max_value == UTC_2000 - dt.timedelta(days=1)
+    pinned = s.filter(partial(operator.eq, UTC_2000))
+    assert (pinned.min_value, pinned.max_value) == (UTC_2000, UTC_2000)
+
+
+def test_aware_datetimes_strict_filters_narrow_and_retain_the_predicate():
+    s = unwrap_strategies(st.datetimes(timezones=st.just(dt.timezone.utc)))
+    # A strict filter narrows to the closed interval of satisfying instants
+    # and keeps the predicate, which then rejects at most the boundary
+    # instant in each timezone.  This works even at instants whose
+    # neighbours are unrepresentable in the bound's own (or any) timezone:
+    max_utc = dt.datetime.max.replace(tzinfo=dt.timezone.utc)
+    out = s.filter(partial(operator.lt, max_utc))
+    assert isinstance(out, FilteredStrategy)
+    assert out.filtered_strategy.min_value == max_utc
+    assert out.flat_conditions[0].args[0] == max_utc
+    # including when the strict bound does not tighten the closed interval.
+    at_min = s.filter(partial(operator.ge, UTC_2000))
+    strict = at_min.filter(partial(operator.gt, UTC_2000))
+    assert isinstance(strict, FilteredStrategy)
+    assert strict.filtered_strategy is at_min
+
+
+def test_aware_datetimes_filter_rewriting_contradictions_are_empty():
+    s = st.datetimes(timezones=st.just(dt.timezone.utc))
+    assert (
+        s.filter(partial(operator.lt, UTC_2000))
+        .filter(partial(operator.gt, UTC_2000))
+        .is_empty
+    )
+    early = st.datetimes(max_value=dt.datetime(1990, 1, 1, tzinfo=dt.timezone.utc))
+    assert early.filter(partial(operator.le, UTC_2000)).is_empty
+    late = st.datetimes(min_value=dt.datetime(2010, 1, 1, tzinfo=dt.timezone.utc))
+    assert late.filter(partial(operator.ge, UTC_2000)).is_empty
+    # A strict filter at the single remaining instant is also provably empty.
+    pinned = st.datetimes(min_value=UTC_2000, max_value=UTC_2000)
+    assert pinned.filter(partial(operator.lt, UTC_2000)).is_empty
+    assert pinned.filter(partial(operator.gt, UTC_2000)).is_empty
+
+
+@settings(max_examples=A_FEW)
+@given(
+    st.datetimes(timezones=st.just(dt.timezone(dt.timedelta(hours=-5))))
+    .filter(partial(operator.le, UTC_2000))
+    .filter(partial(operator.le, UTC_2000 - dt.timedelta(days=1)))
+    .filter(partial(operator.lt, UTC_2000))
+    .filter(partial(operator.ge, UTC_2000 + dt.timedelta(hours=1)))
+    .filter(partial(operator.ge, UTC_2000 + dt.timedelta(days=1)))
+    .filter(partial(operator.gt, UTC_2000 + dt.timedelta(hours=1)))
+)
+def test_aware_datetimes_filter_rewriting_is_exact_for_fixed_offsets(value):
+    # A one-hour window in twenty millennia would fail the filter_too_much
+    # health check without rewriting.  The looser filters have no further
+    # effect, and the strict ones exclude the endpoints.
+    assert UTC_2000 < value < UTC_2000 + dt.timedelta(hours=1)
+
+
+@settings(max_examples=A_FEW)
+@given(
+    st.datetimes(timezones=st.just(dt.timezone.utc)).filter(
+        partial(operator.ge, UTC_2000)
+    )
+)
+def test_aware_datetimes_filter_rewriting_upper_bound_only(value):
+    assert value <= UTC_2000
+
+
+def test_timezones_strategy_classification():
+    utc = dt.timezone.utc
+    assert _timezones_kind(st.none()) == "none"
+    assert _timezones_kind(st.none() | st.none()) == "none"
+    assert _timezones_kind(st.none().filter(lambda x: True)) == "none"
+    assert _timezones_kind(st.just(utc)) == "aware"
+    assert _timezones_kind(st.sampled_from([utc, dt.timezone.min])) == "aware"
+    assert _timezones_kind(st.sampled_from([None, utc])) == "unknown"
+    assert _timezones_kind(st.none() | st.just(utc)) == "unknown"
+    assert _timezones_kind(st.none().map(lambda x: x)) == "unknown"
+    assert _timezones_kind(st.just("not a tzinfo")) == "unknown"
+
+
+@fails_with(ValueError)
+@given(
+    st.datetimes(timezones=st.just(NoneOffsetTimezone())).filter(
+        partial(operator.ge, UTC_2000)
+    )
+)
+def test_rewritten_aware_bound_with_offsetless_timezone_errors_at_draw_time(value):
+    # The bound is aware and the timezones strategy generates tzinfo instances,
+    # so we rewrite - and then converting the bound into this offset-less
+    # timezone fails loudly at draw time.
+    pass
+
+
+@fails_with(ValueError)
+@given(
+    st.datetimes(timezones=st.just(RaisingOffsetTimezone())).filter(
+        partial(operator.ge, UTC_2000)
+    )
+)
+def test_rewritten_aware_bound_with_raising_timezone_errors_at_draw_time(value):
+    pass
+
+
+@fails_with(TypeError)
+@given(st.dates().filter(partial(operator.ge, dt.datetime(2003, 1, 1))))
+def test_dates_filter_with_datetime_bound_errors_at_draw_time(value):
+    pass
+
+
+@fails_with(TypeError)
+@given(st.datetimes().filter(partial(operator.ge, UTC_2000)))
+def test_naive_datetimes_with_aware_bound_error_at_draw_time(value):
+    pass
+
+
+@fails_with(TypeError)
+@given(
+    st.datetimes(timezones=st.just(dt.timezone.utc)).filter(
+        partial(operator.ge, dt.datetime(2000, 1, 1))
+    )
+)
+def test_aware_datetimes_with_naive_bound_error_at_draw_time(value):
+    pass
+
+
+@fails_with(TypeError)
+@given(
+    st.datetimes(min_value=UTC_2000, timezones=st.just(dt.timezone.utc)).filter(
+        partial(operator.ge, dt.datetime(2000, 6, 1))
+    )
+)
+def test_aware_mode_datetimes_with_naive_bound_error_at_draw_time(value):
+    pass
 
 
 @pytest.mark.skipif(

--- a/hypothesis/tests/datetime/test_zoneinfo_timezones.py
+++ b/hypothesis/tests/datetime/test_zoneinfo_timezones.py
@@ -9,14 +9,17 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime as dt
+import operator
 import platform
 import zoneinfo
+from functools import partial
 
 import pytest
 
 from hypothesis import given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
-from hypothesis.strategies._internal.datetime import _instant
+from hypothesis.strategies._internal.datetime import DatetimeStrategy, _instant
+from hypothesis.strategies._internal.lazy import unwrap_strategies
 
 from tests.common.debug import (
     assert_all_examples,
@@ -28,6 +31,35 @@ from tests.common.debug import (
 
 def test_utc_is_minimal():
     assert minimal(st.timezones()) is zoneinfo.ZoneInfo("UTC")
+
+
+@settings(max_examples=25)
+@given(
+    st.datetimes(timezones=st.timezones())
+    .filter(partial(operator.le, dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)))
+    .filter(partial(operator.ge, dt.datetime(2020, 4, 1, tzinfo=dt.timezone.utc)))
+)
+def test_aware_datetimes_filter_rewriting_narrows_arbitrary_timezones(value):
+    # A three-month window in a twenty-thousand-year range would fail the
+    # filter_too_much health check without rewriting.
+    assert dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc) <= value
+    assert value <= dt.datetime(2020, 4, 1, tzinfo=dt.timezone.utc)
+
+
+def test_aware_datetimes_filter_rewriting_uses_instant_semantics():
+    # A predicate comparing values which share the bound's tzinfo object uses
+    # fold-ignoring wall-clock order, while the rewritten bounds order values
+    # by the moment they refer to, matching the strategy's semantics for aware
+    # bounds.  These differ only for ambiguous wall times inside a DST fold:
+    tz = zoneinfo.ZoneInfo("America/New_York")
+    bound = dt.datetime(2020, 11, 1, 1, 30, tzinfo=tz)  # EDT; 1-2am repeats
+    inside = dt.datetime(2020, 11, 1, 1, 0, fold=1, tzinfo=tz)  # EST, so a
+    # later instant than the bound, despite the earlier wall-clock reading
+    predicate = partial(operator.le, bound)
+    assert not predicate(inside)
+    s = unwrap_strategies(st.datetimes(timezones=st.just(tz))).filter(predicate)
+    assert isinstance(s, DatetimeStrategy)
+    assert s.in_bounds(inside)
 
 
 def test_can_generate_non_utc():

--- a/hypothesis/tests/test_annotated_types.py
+++ b/hypothesis/tests/test_annotated_types.py
@@ -19,6 +19,7 @@ import pytest
 
 from hypothesis import given, strategies as st
 from hypothesis.errors import HypothesisWarning, InvalidArgument, ResolutionFailed
+from hypothesis.strategies._internal.datetime import DatetimeStrategy
 from hypothesis.strategies._internal.lazy import unwrap_strategies
 from hypothesis.strategies._internal.strategies import FilteredStrategy
 from hypothesis.strategies._internal.types import _get_constraints
@@ -135,6 +136,18 @@ def test_unknown_generic_alias_in_metadata_error():
         check_can_generate_examples(st.from_type(Annotated[int, Positive]))
     assert "Did you mean `Annotated[int, Gt(gt=0)]`?" in str(excinfo.value)
     assert "subscripted with the type" in str(excinfo.value)
+
+
+def test_annotated_datetime_bounds_are_rewritten():
+    lo, hi = dt.datetime(2000, 1, 1), dt.datetime(2000, 1, 2)
+    strategy = unwrap_strategies(
+        st.from_type(Annotated[dt.datetime, at.Gt(lo), at.Lt(hi)])
+    )
+    assert isinstance(strategy, DatetimeStrategy)
+    assert strategy.min_value == lo + dt.timedelta(microseconds=1)
+    assert strategy.max_value == hi - dt.timedelta(microseconds=1)
+    # and contradictory constraints give a visibly-empty strategy
+    assert st.from_type(Annotated[dt.datetime, at.Gt(hi), at.Lt(lo)]).is_empty
 
 
 def test_predicate_constraint():


### PR DESCRIPTION
Filter-rewriting is a great trick - you might think that it just enables ill-advised uses of Hypothesis, but I'll actually argue that there are many valuable cases (e.g. annotated-types constraints) where _someone_ is going to have to convert between predicates and constructive bounds, and if we do that internally it unlocks a bunch of neat ecosystem integrations.

And since https://github.com/HypothesisWorks/hypothesis/pull/4805, we can practically do it for datetimes too, so we do.  See also https://github.com/HypothesisWorks/hypothesis/pull/4801.