### PR TITLE
Track `note()` in observability outputs

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -7,6 +7,9 @@ notes were only shown in the terminal for the minimal failing example (or
 for every example under |Verbosity.verbose|), and never appeared in
 observations at all.
 
+The :class:`~hypothesis.errors.Unsatisfiable` error message now explains
+when Hypothesis has tried every possible input, so that the assumptions of
+the test are impossible to satisfy and running more examples cannot help.
 Also removes an outdated reference to test timeouts from the
 :class:`~hypothesis.errors.Unsatisfiable` docstring; the timeout setting
 was removed in :v:`4.0.0`.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+Values recorded with :func:`~hypothesis.note` are now included in
+:ref:`observability <observability>` reports, as an ordered list of strings
+under the ``metadata.notes`` key of each test-case observation.  Previously,
+notes were only shown in the terminal for the minimal failing example (or
+for every example under |Verbosity.verbose|), and never appeared in
+observations at all.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -6,10 +6,3 @@ under the ``metadata.notes`` key of each test-case observation.  Previously,
 notes were only shown in the terminal for the minimal failing example (or
 for every example under |Verbosity.verbose|), and never appeared in
 observations at all.
-
-The :class:`~hypothesis.errors.Unsatisfiable` error message now explains
-when Hypothesis has tried every possible input, so that the assumptions of
-the test are impossible to satisfy and running more examples cannot help.
-Also removes an outdated reference to test timeouts from the
-:class:`~hypothesis.errors.Unsatisfiable` docstring; the timeout setting
-was removed in :v:`4.0.0`.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -6,3 +6,7 @@ under the ``metadata.notes`` key of each test-case observation.  Previously,
 notes were only shown in the terminal for the minimal failing example (or
 for every example under |Verbosity.verbose|), and never appeared in
 observations at all.
+
+Also removes an outdated reference to test timeouts from the
+:class:`~hypothesis.errors.Unsatisfiable` docstring; the timeout setting
+was removed in :v:`4.0.0`.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -3,6 +3,6 @@ RELEASE_TYPE: minor
 Values recorded with :func:`~hypothesis.note` are now included in
 :ref:`observability <observability>` reports, as an ordered list of strings
 under the ``metadata.notes`` key of each test-case observation.  Previously,
-notes were only shown in the terminal for the minimal failing example (or
-for every example under |Verbosity.verbose|), and never appeared in
+notes were only shown in the terminal for the |minimal failing test case|
+(or for every test case under |Verbosity.verbose|), and never appeared in
 observations at all.

--- a/hypothesis/docs/reference/integrations.rst
+++ b/hypothesis/docs/reference/integrations.rst
@@ -142,6 +142,10 @@ float observation associated with it.  All events are collected and summarized i
 recording them in observations, Hypothesis will try to maximize the targeted value.
 Knowing that, you can use this to guide the search for failing inputs.
 
+:func:`~hypothesis.note` values are also recorded, in order, under the
+``metadata.notes`` key of each test-case observation - whether or not they
+were printed to the terminal.
+
 
 Data Format
 ~~~~~~~~~~~

--- a/hypothesis/docs/reference/schema_metadata.json
+++ b/hypothesis/docs/reference/schema_metadata.json
@@ -9,6 +9,11 @@
             "type": ["string", "null"],
             "description": "The ``@reproduce_failure`` decorator string for failing tests, if and only if ``status == \"failed\"``."
         },
+        "notes": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "The values recorded by calls to |note|, in order."
+        },
         "predicates": {
             "type": "object",
             "description": "The number of times each |assume| and |@precondition| predicate was satisfied (``True``) and not satisfied (``False``).",
@@ -61,6 +66,6 @@
             "description": "The internal ``InterestingOrigin`` object for failing tests, if and only if ``status == \"failed\"``. The ``traceback`` string value is derived from this object."
         }
     },
-    "required": ["traceback", "reproduction_decorator", "predicates", "backend", "sys.argv", "os.getpid()", "imported_at", "data_status", "interesting_origin"],
+    "required": ["traceback", "reproduction_decorator", "notes", "predicates", "backend", "sys.argv", "os.getpid()", "imported_at", "data_status", "interesting_origin"],
     "additionalProperties": false
 }

--- a/hypothesis/src/hypothesis/control.py
+++ b/hypothesis/src/hypothesis/control.py
@@ -285,7 +285,7 @@ def note(value: object) -> None:
             value = pretty(value)
         context = _current_build_context.value
         assert context is not None
-        if observability_enabled() and not context.data.frozen:
+        if observability_enabled():
             context.data.note(value)
         if should_report:
             report(value)

--- a/hypothesis/src/hypothesis/control.py
+++ b/hypothesis/src/hypothesis/control.py
@@ -274,12 +274,21 @@ def note(value: object) -> None:
     to a string.
 
     This value is reported for the |minimal failing test case|, and on |Verbosity.verbose|
-    or lower.
+    or higher.
+
+    Notes are also recorded in the ``metadata.notes`` key of each test case
+    observation, if :ref:`observability <observability>` is enabled.
     """
-    if should_note():
+    should_report = should_note()
+    if should_report or observability_enabled():
         if not isinstance(value, str):
             value = pretty(value)
-        report(value)
+        context = _current_build_context.value
+        assert context is not None
+        if observability_enabled() and not context.data.frozen:
+            context.data.note(value)
+        if should_report:
+            report(value)
 
 
 def event(value: str, payload: Any = "") -> None:

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -1451,7 +1451,7 @@ class StateForActualGivenExecution:
                     explanations.append(
                         "Hypothesis tried every possible input, so the "
                         "assumptions of this test are impossible to satisfy - "
-                        "not merely unlikely - and running more examples "
+                        "not merely unlikely - and running more test cases "
                         "cannot help."
                     )
                 # use a somewhat arbitrary cutoff to avoid recommending spurious

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -81,7 +81,11 @@ from hypothesis.internal.compat import (
 )
 from hypothesis.internal.conjecture.choice import ChoiceT
 from hypothesis.internal.conjecture.data import ConjectureData, Status
-from hypothesis.internal.conjecture.engine import BUFFER_SIZE, ConjectureRunner
+from hypothesis.internal.conjecture.engine import (
+    BUFFER_SIZE,
+    ConjectureRunner,
+    ExitReason,
+)
 from hypothesis.internal.conjecture.junkdrawer import (
     ensure_free_stackframes,
     gc_cumulative_time,
@@ -1443,6 +1447,13 @@ class StateForActualGivenExecution:
         else:
             if runner.valid_examples == 0:
                 explanations = []
+                if runner.exit_reason is ExitReason.finished:
+                    explanations.append(
+                        "Hypothesis tried every possible input, so the "
+                        "assumptions of this test are impossible to satisfy - "
+                        "not merely unlikely - and running more examples "
+                        "cannot help."
+                    )
                 # use a somewhat arbitrary cutoff to avoid recommending spurious
                 # fixes.
                 # eg, a few invalid examples from internal filters when the

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -1365,6 +1365,11 @@ class StateForActualGivenExecution:
                 except BackendCannotProceed:
                     self._string_repr = "<backend failed to realize symbolic arguments>"
 
+                try:
+                    data.notes = data.provider.realize(data.notes)
+                except BackendCannotProceed:
+                    data.notes = []
+
                 data.freeze()
                 tc = make_testcase(
                     run_start=self._start_timestamp,

--- a/hypothesis/src/hypothesis/errors.py
+++ b/hypothesis/src/hypothesis/errors.py
@@ -50,15 +50,13 @@ class NoSuchExample(HypothesisException):
 
 
 class Unsatisfiable(_Trimmable):
-    """We ran out of time or test cases before we could find enough test cases
-    which satisfy the assumptions of this hypothesis.
+    """We ran out of test cases before we could find enough which satisfy the
+    assumptions of this hypothesis.
 
-    This could be because the function is too slow. If so, try upping
-    the timeout. It could also be because the function is using assume
-    in a way that is too hard to satisfy. If so, try writing a custom
-    strategy or using a better starting point (e.g if you are requiring
-    a list has unique values you could instead filter out all duplicate
-    values from the list)
+    This could be because the function is using |assume| in a way that is
+    too hard to satisfy. If so, try writing a custom strategy or using a
+    better starting point (e.g if you are requiring a list has unique
+    values you could instead filter out all duplicate values from the list)
     """
 
 

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -1164,10 +1164,8 @@ class ConjectureData:
         if self.frozen:
             raise Frozen(f"Cannot call {name} on frozen ConjectureData")
 
-    def note(self, value: Any) -> None:
+    def note(self, value: str) -> None:
         self.__assert_not_frozen("note")
-        if not isinstance(value, str):
-            value = repr(value)
         self.notes.append(value)
 
     def draw(

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -582,7 +582,7 @@ class ConjectureResult:
     interesting_origin: InterestingOrigin | None
     nodes: tuple[ChoiceNode, ...] = field(repr=False, compare=False)
     length: int
-    output: str
+    notes: list[str]
     expected_exception: BaseException | None
     expected_traceback: str | None
     has_discards: bool
@@ -655,7 +655,7 @@ class ConjectureData:
 
         self.length: int = 0
         self.index: int = 0
-        self.output: str = ""
+        self.notes: list[str] = []
         self.status: Status = Status.VALID
         self.frozen: bool = False
         self.testcounter: int = threadlocal.global_test_counter
@@ -1146,7 +1146,7 @@ class ConjectureData:
                 spans=self.spans,
                 nodes=self.nodes,
                 length=self.length,
-                output=self.output,
+                notes=self.notes,
                 expected_traceback=self.expected_traceback,
                 expected_exception=self.expected_exception,
                 has_discards=self.has_discards,
@@ -1168,7 +1168,7 @@ class ConjectureData:
         self.__assert_not_frozen("note")
         if not isinstance(value, str):
             value = repr(value)
-        self.output += value
+        self.notes.append(value)
 
     def draw(
         self,

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -962,11 +962,7 @@ class ConjectureRunner:
             assert isinstance(data, ConjectureData)  # mypy is silly
             status = f"{status} ({data.events.get('invalid because', '?')})"
 
-        newline_tab = "\n\t"
-        self.debug(
-            f"{len(data.choices)} choices -> {status}\n\t{data.choices}"
-            f"{newline_tab + newline_tab.join(data.notes) if data.notes else ''}"
-        )
+        self.debug(f"{len(data.choices)} choices -> {status}\n\t{data.choices}")
 
     def observe_for_provider(self) -> AbstractContextManager:
         def on_observation(observation: Observation) -> None:

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -965,7 +965,7 @@ class ConjectureRunner:
         newline_tab = "\n\t"
         self.debug(
             f"{len(data.choices)} choices -> {status}\n\t{data.choices}"
-            f"{newline_tab + data.output if data.output else ''}"
+            f"{newline_tab + newline_tab.join(data.notes) if data.notes else ''}"
         )
 
     def observe_for_provider(self) -> AbstractContextManager:

--- a/hypothesis/src/hypothesis/internal/observability.py
+++ b/hypothesis/src/hypothesis/internal/observability.py
@@ -173,6 +173,7 @@ def nodes_to_json(nodes: tuple[ChoiceNode, ...]) -> list[dict[str, Any]]:
 class ObservationMetadata:
     traceback: str | None
     reproduction_decorator: str | None
+    notes: list[str]
     predicates: dict[str, PredicateCounts]
     backend: dict[str, Any]
     sys_argv: list[str]
@@ -188,6 +189,7 @@ class ObservationMetadata:
         data = {
             "traceback": self.traceback,
             "reproduction_decorator": self.reproduction_decorator,
+            "notes": self.notes,
             "predicates": self.predicates,
             "backend": self.backend,
             "sys.argv": self.sys_argv,
@@ -461,6 +463,7 @@ def make_testcase(
                 "reproduction_decorator": (
                     reproduction_decorator(data.choices) if status == "failed" else None
                 ),
+                "notes": list(data.notes),
                 "predicates": dict(data._observability_predicates),
                 "backend": backend_metadata or {},
                 "data_status": data.status,

--- a/hypothesis/tests/conjecture/test_test_data.py
+++ b/hypothesis/tests/conjecture/test_test_data.py
@@ -59,7 +59,7 @@ def test_draw_past_end_sets_overflow():
 def test_notes_repr():
     d = ConjectureData.for_choices([])
     d.note(b"hi")
-    assert repr(b"hi") in d.output
+    assert repr(b"hi") in d.notes
 
 
 def test_can_mark_interesting():
@@ -290,13 +290,13 @@ def test_can_note_non_str():
     d = ConjectureData.for_choices([])
     x = object()
     d.note(x)
-    assert repr(x) in d.output
+    assert repr(x) in d.notes
 
 
 def test_can_note_str_as_non_repr():
     d = ConjectureData.for_choices([])
     d.note("foo")
-    assert d.output == "foo"
+    assert d.notes == ["foo"]
 
 
 def test_result_is_overrun():

--- a/hypothesis/tests/conjecture/test_test_data.py
+++ b/hypothesis/tests/conjecture/test_test_data.py
@@ -56,12 +56,6 @@ def test_draw_past_end_sets_overflow():
     assert d.status == Status.OVERRUN
 
 
-def test_notes_repr():
-    d = ConjectureData.for_choices([])
-    d.note(b"hi")
-    assert repr(b"hi") in d.notes
-
-
 def test_can_mark_interesting():
     d = ConjectureData.for_choices([])
     with pytest.raises(StopTest):
@@ -286,14 +280,7 @@ def test_empty_strategy_is_invalid():
     assert d.status == Status.INVALID
 
 
-def test_can_note_non_str():
-    d = ConjectureData.for_choices([])
-    x = object()
-    d.note(x)
-    assert repr(x) in d.notes
-
-
-def test_can_note_str_as_non_repr():
+def test_can_note():
     d = ConjectureData.for_choices([])
     d.note("foo")
     assert d.notes == ["foo"]

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -59,10 +59,12 @@ from hypothesis.stateful import (
 from hypothesis.strategies._internal.utils import to_jsonable
 
 from tests.common.utils import (
+    Why,
     capture_observations,
     checks_deprecated_behaviour,
     run_concurrently,
     skipif_threading,
+    xfail_on_crosshair,
 )
 from tests.conjecture.common import choices, integer_constr, nodes
 
@@ -192,6 +194,9 @@ def test_notes_recorded_for_every_observation():
         assert tc.metadata.notes == [f"noted {x}", f"[{x}]"]
 
 
+# the f-string here formats a symbolic integer, which distracts crosshair
+# from exploring the x >= 10 branch of the assertion
+@xfail_on_crosshair(Why.undiscovered)
 def test_notes_recorded_for_minimal_failing_example():
     @given(st.integers())
     @settings(database=None)

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -175,6 +175,38 @@ def test_failure_includes_notes():
     assert test_cases[-1].representation == expected
 
 
+def test_notes_recorded_for_every_observation():
+    @given(st.integers(0, 100))
+    @settings(database=None)
+    def f(x):
+        note(f"noted {x}")
+        note([x])
+
+    with capture_observations() as observations:
+        f()
+
+    test_cases = [tc for tc in observations if tc.type == "test_case"]
+    assert test_cases
+    for tc in test_cases:
+        x = tc.arguments["x"]
+        assert tc.metadata.notes == [f"noted {x}", f"[{x}]"]
+
+
+def test_notes_recorded_for_minimal_failing_example():
+    @given(st.integers())
+    @settings(database=None)
+    def f(x):
+        note(f"noted {x}")
+        assert x < 10
+
+    with capture_observations() as observations, pytest.raises(AssertionError):
+        f()
+
+    final = [tc for tc in observations if tc.type == "test_case"][-1]
+    assert final.how_generated == "minimal failing test case"
+    assert final.metadata.notes == ["noted 10"]
+
+
 def test_normal_representation_includes_draws():
     @given(st.data())
     def f(data):
@@ -548,6 +580,7 @@ def test_metadata_to_json():
         ) == {
             "traceback",
             "reproduction_decorator",
+            "notes",
             "predicates",
             "backend",
             "sys.argv",

--- a/hypothesis/tests/cover/test_randoms.py
+++ b/hypothesis/tests/cover/test_randoms.py
@@ -27,6 +27,7 @@ from hypothesis.strategies._internal.random import (
 )
 
 from tests.common.debug import assert_all_examples, find_any
+from tests.common.utils import Why, xfail_on_crosshair
 
 
 def test_implements_all_random_methods():
@@ -123,7 +124,20 @@ def any_call(draw):
     return (method, *draw(any_call_of_method(method)))
 
 
-@pytest.mark.parametrize("method", RANDOM_METHODS)
+@pytest.mark.parametrize(
+    "method",
+    [
+        pytest.param(
+            method,
+            marks=(
+                xfail_on_crosshair(Why.other, strict=False, as_marks=True)
+                if method == "triangular"
+                else ()
+            ),
+        )
+        for method in RANDOM_METHODS
+    ],
+)
 @given(any_random, st.data())
 def test_call_all_methods(method, rnd, data):
     args, kwargs = data.draw(any_call_of_method(method))

--- a/hypothesis/tests/cover/test_testdecorators.py
+++ b/hypothesis/tests/cover/test_testdecorators.py
@@ -514,6 +514,21 @@ def test_notes_high_filter_rates_in_unsatisfiable_error():
         f()
 
 
+def test_notes_exhausted_search_space_in_unsatisfiable_error():
+    @given(booleans())
+    def f(v):
+        assume(False)
+
+    with pytest.raises(
+        Unsatisfiable,
+        match=(
+            r"Unable to satisfy assumptions of f\. Hypothesis tried every "
+            r"possible input"
+        ),
+    ):
+        f()
+
+
 # crosshair generates one valid input before verifying the test function,
 # so the Unsatisfiable check never occurs.
 # (not strict due to slowness causing crosshair to bail out on the first input,

--- a/hypothesis/tests/cover/test_verbosity.py
+++ b/hypothesis/tests/cover/test_verbosity.py
@@ -10,13 +10,13 @@
 
 from contextlib import contextmanager
 
-from hypothesis import example, find, given
+from hypothesis import example, find, given, note
 from hypothesis._settings import Verbosity, settings
 from hypothesis.reporting import default as default_reporter, with_reporter
 from hypothesis.strategies import booleans, integers, lists
 
 from tests.common.debug import minimal
-from tests.common.utils import capture_out, fails
+from tests.common.utils import capture_observations, capture_out, fails
 
 
 @contextmanager
@@ -35,6 +35,19 @@ def test_prints_intermediate_in_success():
 
         test_works()
     assert "Test case:" in o.getvalue()
+
+
+def test_notes_are_not_printed_twice_in_debug_mode():
+    # the engine's debug output must not repeat notes which were already
+    # printed, even when observability has recorded them on the data
+    @settings(verbosity=Verbosity.debug, max_examples=1, database=None)
+    @given(booleans())
+    def test_works(x):
+        note("this is a note")
+
+    with capture_verbosity() as o, capture_observations():
+        test_works()
+    assert o.getvalue().count("this is a note") == 1
 
 
 def test_does_not_log_in_quiet_mode():

--- a/hypothesis/tests/quality/test_poisoned_lists.py
+++ b/hypothesis/tests/quality/test_poisoned_lists.py
@@ -75,7 +75,6 @@ def test_minimal_poisoned_containers(seed, size, p, strategy_class):
 
     def test_function(data):
         v = data.draw(strategy)
-        data.note(v)
         if POISON in v:
             data.mark_interesting(interesting_origin())
 

--- a/hypothesis/tests/quality/test_poisoned_lists.py
+++ b/hypothesis/tests/quality/test_poisoned_lists.py
@@ -75,7 +75,7 @@ def test_minimal_poisoned_containers(seed, size, p, strategy_class):
 
     def test_function(data):
         v = data.draw(strategy)
-        data.output = repr(v)
+        data.note(v)
         if POISON in v:
             data.mark_interesting(interesting_origin())
 


### PR DESCRIPTION
Previously, note() only wrote to the terminal reporter, and only for the minimal failing example or under Verbosity.verbose - so notes never appeared in observability output at all, despite the tutorial saying they did.

note() now records its (stringified) value on the current ConjectureData whenever observability is enabled, regardless of verbosity, and make_testcase() includes those values as an ordered list under the new metadata.notes key of every test-case observation.

Motivation for `note()`: https://github.com/HypothesisWorks/hypothesis/pull/4631#discussion_r3628662014.  Also I mentioned https://github.com/HypothesisWorks/hypothesis/pull/4631#discussion_r3621864345 and folded it in here.