### PR TITLE
Support timezone-aware datetime dtypes in hypothesis.extra.pandas

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,19 @@
+RELEASE_TYPE: minor
+
+This release adds support for generating timezone-aware datetimes in
+:ref:`hypothesis.extra.pandas <hypothesis-pandas>`.  You can now pass a
+:class:`~pandas.DatetimeTZDtype` - such as ``"datetime64[ns, UTC]"`` - as the
+``dtype`` of a :func:`~hypothesis.extra.pandas.series`,
+:func:`~hypothesis.extra.pandas.indexes`, or
+:func:`~hypothesis.extra.pandas.column`, and every value will share that single
+timezone (the only arrangement pandas supports outside of the ``object``
+dtype).  The datetime resolution is taken from the dtype, so you can also
+generate e.g. ``"datetime64[us, UTC]"`` columns, and for UTC and other
+fixed-offset timezones the generated values cover the full range representable
+at that resolution - which for coarser units is far wider than the
+``datetime64[ns]`` bounds of roughly 1677-2262 (:issue:`4020`).
+
+Timezone-aware generation requires pandas >= 2.1: earlier versions silently
+coerce other resolutions to nanoseconds, or crash when displaying values
+outside the nanosecond-representable range.  Generated values include ``NaT``
+unless you pass an elements strategy which excludes it.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -6,14 +6,11 @@ This release adds support for generating timezone-aware datetimes in
 ``dtype`` of a :func:`~hypothesis.extra.pandas.series`,
 :func:`~hypothesis.extra.pandas.indexes`, or
 :func:`~hypothesis.extra.pandas.column`, and every value will share that single
-timezone (the only arrangement pandas supports outside of the ``object``
-dtype).  The datetime resolution is taken from the dtype, so you can also
+timezone.  The datetime resolution is taken from the dtype, so you can also
 generate e.g. ``"datetime64[us, UTC]"`` columns, and for UTC and other
 fixed-offset timezones the generated values cover the full range representable
 at that resolution - which for coarser units is far wider than the
 ``datetime64[ns]`` bounds of roughly 1677-2262 (:issue:`4020`).
 
-Timezone-aware generation requires pandas >= 2.1: earlier versions silently
-coerce other resolutions to nanoseconds, or crash when displaying values
-outside the nanosecond-representable range.  Generated values include ``NaT``
+Timezone-aware generation requires pandas >= 2.1.  Generated values include ``NaT``
 unless you pass an elements strategy which excludes it.

--- a/hypothesis/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis/src/hypothesis/extra/pandas/impl.py
@@ -12,7 +12,7 @@ from collections import OrderedDict, abc
 from collections.abc import Sequence
 from copy import copy
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Generic, Union
 
 import numpy as np
@@ -39,6 +39,20 @@ try:
 except ImportError:
     IntegerDtype = ()
 
+try:
+    from pandas._libs.tslibs.timezones import is_fixed_offset, is_utc
+
+    def has_fixed_offset(tz):
+        return is_utc(tz) or is_fixed_offset(tz)
+
+except ImportError:
+
+    def has_fixed_offset(tz):
+        return isinstance(tz, timezone)
+
+
+PANDAS_GE_21 = tuple(int(x) for x in pandas.__version__.split(".")[:2]) >= (2, 1)
+
 
 def dtype_for_elements_strategy(s):
     return st.shared(
@@ -51,6 +65,74 @@ def infer_dtype_if_necessary(dtype, values, elements, draw):
     if dtype is None and not values:
         return draw(dtype_for_elements_strategy(elements))
     return dtype
+
+
+def datetime_tz_dtype(dtype):
+    """Return a normalised :class:`~pandas.DatetimeTZDtype` if ``dtype`` is a
+    timezone-aware datetime dtype (e.g. ``"datetime64[ns, UTC]"``), else None.
+
+    Every value in such a column or index shares a single timezone - the only
+    arrangement pandas supports outside of the ``object`` dtype.
+    """
+    tz_dtype = None
+    if isinstance(dtype, pandas.DatetimeTZDtype):
+        tz_dtype = dtype
+    elif isinstance(dtype, str):
+        try:
+            converted = pandas.api.types.pandas_dtype(dtype)
+        except TypeError:
+            return None
+        if isinstance(converted, pandas.DatetimeTZDtype):
+            tz_dtype = converted
+    if tz_dtype is not None and not PANDAS_GE_21:  # pragma: no cover
+        # Before pandas 2.0, non-nanosecond units silently coerce to ns; on
+        # pandas 2.0.x, formatting values outside the ns-representable range
+        # raises OutOfBoundsDatetime, so failing examples could not be shown.
+        raise InvalidArgument(
+            "Generating timezone-aware datetimes requires pandas >= 2.1, but "
+            f"you have pandas {pandas.__version__}"
+        )
+    return tz_dtype
+
+
+def naive_datetime64_dtype(tz_dtype):
+    """The underlying timezone-naive ``datetime64[unit]`` dtype that backs a
+    :class:`~pandas.DatetimeTZDtype`."""
+    return np.dtype(f"datetime64[{tz_dtype.unit}]")
+
+
+def tz_default_elements(tz_dtype):
+    """Default element strategy for a :class:`~pandas.DatetimeTZDtype`: naive
+    ``datetime64[unit]`` values, interpreted as UTC instants.
+
+    With a fixed-offset timezone (including UTC) these cover the dtype's full
+    representable range.  Other timezones resolve their UTC offsets through
+    stdlib datetimes - as does pandas when displaying values - so we keep each
+    instant a day inside Python's representable range, ensuring that the
+    localized wall times stay valid too.
+    """
+    naive = naive_datetime64_dtype(tz_dtype)
+    if has_fixed_offset(tz_dtype.tz):
+        return npst.from_dtype(naive)
+    unit = tz_dtype.unit
+    lo = int(np.datetime64(datetime.min + timedelta(days=1), unit).astype(np.int64))
+    hi = int(np.datetime64(datetime.max - timedelta(days=1), unit).astype(np.int64))
+    values = st.integers(lo, hi).map(lambda v: np.datetime64(v, unit))
+    return values | st.just(np.datetime64("NaT", unit))
+
+
+def attach_timezone(obj, tz):
+    """Interpret a naive datetime64 :class:`~pandas.Series` or
+    :class:`~pandas.Index` as UTC instants and convert it to ``tz``.
+
+    We build timezone-aware columns from naive ``datetime64[unit]`` values and
+    only attach the timezone at the array level, because constructing them from
+    timezone-aware scalars silently corrupts values near the bounds of the
+    representable range.
+    """
+    if isinstance(obj, pandas.Series):
+        return obj.dt.tz_localize("UTC").dt.tz_convert(tz)
+    return obj.tz_localize("UTC").tz_convert(tz)
 
 
 @check_function
@@ -102,6 +184,16 @@ def elements_and_dtype(elements, dtype, source=None):
             f"Passed {dtype=} is a strategy, but we require a concrete dtype "
             "here.  See https://stackoverflow.com/q/74355937 for workaround patterns."
         )
+
+    tz_dtype = datetime_tz_dtype(dtype)
+    if tz_dtype is not None:
+        # With the default elements strategy we build the column from the
+        # underlying naive datetime64[unit] dtype and the caller attaches the
+        # timezone afterwards.  Custom elements are passed through and
+        # constructed with the tz dtype.
+        if elements is None:
+            return tz_default_elements(tz_dtype), naive_datetime64_dtype(tz_dtype)
+        return elements, tz_dtype
 
     _get_subclasses = getattr(IntegerDtype, "__subclasses__", list)
     dtype = {t.name: t() for t in _get_subclasses()}.get(dtype, dtype)
@@ -246,11 +338,17 @@ def indexes(
     check_valid_interval(min_size, max_size, "min_size", "max_size")
     check_type(bool, unique, "unique")
 
+    tz_dtype = datetime_tz_dtype(dtype)
+    localize_tz = tz_dtype is not None and elements is None
+
     elements, dtype = elements_and_dtype(elements, dtype)
 
     if max_size is None:
         max_size = min_size + DEFAULT_MAX_SIZE
-    return ValueIndexStrategy(elements, dtype, min_size, max_size, unique, name)
+    strategy = ValueIndexStrategy(elements, dtype, min_size, max_size, unique, name)
+    if localize_tz:
+        return strategy.map(lambda ix: attach_timezone(ix, tz_dtype.tz))
+    return strategy
 
 
 @defines_strategy()
@@ -283,6 +381,15 @@ def series(
       elements strategy varies, then so will the resulting dtype of the
       series.
 
+      With pandas >= 2.1, you may also pass a timezone-aware
+      :class:`~pandas.DatetimeTZDtype` (e.g. ``"datetime64[ns, UTC]"``), in
+      which case every value in the series will share that single timezone.
+      For UTC and other fixed-offset timezones the generated values cover the
+      full range representable at the dtype's resolution - which for coarser
+      units is much wider than ``datetime64[ns]`` - while timezones with a
+      UTC offset that varies over time are limited to years 1-9999.  Values
+      include ``NaT`` unless you pass an elements strategy which excludes it.
+
     * index: If not None, a strategy for generating indexes for the
       resulting Series. This can generate either :class:`pandas.Index`
       objects or any sequence of values (which will be passed to the
@@ -309,11 +416,18 @@ def series(
     else:
         check_strategy(index, "index")
 
+    tz_dtype = datetime_tz_dtype(dtype)
+    localize_tz = tz_dtype is not None and elements is None
+
     elements, np_dtype = elements_and_dtype(elements, dtype)
     index_strategy = index
 
+    if localize_tz:
+        # Build the column with the underlying naive dtype, then attach the
+        # timezone at the array level once it has been assembled.
+        dtype = np_dtype
     # if it is converted to an object, use object for series type
-    if (
+    elif (
         np_dtype is not None
         and np_dtype.kind == "O"
         and not isinstance(dtype, IntegerDtype)
@@ -360,6 +474,8 @@ def series(
                 name=draw(name),
             )
 
+    if localize_tz:
+        return result().map(lambda s: attach_timezone(s, tz_dtype.tz))
     return result()
 
 
@@ -561,6 +677,10 @@ def data_frames(
 
     rewritten_columns = []
     column_names: set[str] = set()
+    # Maps the name of each timezone-aware datetime column to its timezone.  We
+    # build such columns with the underlying naive dtype and attach the
+    # timezone once the frame has been assembled (see attach_timezone).
+    tz_columns: dict = {}
 
     for i, c in enumerate(cols):
         check_type(column, c, f"columns[{i}]")
@@ -583,7 +703,12 @@ def data_frames(
             raise InvalidArgument(f"duplicate definition of column name {c.name!r}")
 
         column_names.add(c.name)
-        c.elements, _ = elements_and_dtype(c.elements, c.dtype, label)
+        column_tz = datetime_tz_dtype(c.dtype)
+        localize_tz = column_tz is not None and c.elements is None
+        c.elements, np_dtype = elements_and_dtype(c.elements, c.dtype, label)
+        if localize_tz:
+            c.dtype = np_dtype
+            tz_columns[c.name] = column_tz.tz
 
         if c.dtype is None and rows is not None:
             raise InvalidArgument(
@@ -668,7 +793,10 @@ def data_frames(
                         )
                     )
 
-            return pandas.DataFrame(data, index=index)
+            result = pandas.DataFrame(data, index=index)
+            for name, tz in tz_columns.items():
+                result[name] = attach_timezone(result[name], tz)
+            return result
 
         return just_draw_columns()
     else:
@@ -756,6 +884,8 @@ def data_frames(
                     break
                 else:
                     reject()
+            for name, tz in tz_columns.items():
+                result[name] = attach_timezone(result[name], tz)
             return result
 
         return assign_rows()

--- a/hypothesis/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis/src/hypothesis/extra/pandas/impl.py
@@ -39,19 +39,15 @@ try:
 except ImportError:
     IntegerDtype = ()
 
-try:
-    from pandas._libs.tslibs.timezones import is_fixed_offset, is_utc
-
-    def has_fixed_offset(tz):
-        return is_utc(tz) or is_fixed_offset(tz)
-
-except ImportError:
-
-    def has_fixed_offset(tz):
-        return isinstance(tz, timezone)
-
-
 PANDAS_GE_21 = tuple(int(x) for x in pandas.__version__.split(".")[:2]) >= (2, 1)
+
+
+def has_constant_offset(tz):
+    # datetime.timezone instances have the same UTC offset at every instant,
+    # by construction.  Zones from zoneinfo, pytz, or dateutil - even for the
+    # UTC key - resolve their offsets through stdlib datetimes instead, which
+    # limits the usable range to years 1-9999.
+    return isinstance(tz, timezone)
 
 
 def dtype_for_elements_strategy(s):
@@ -105,18 +101,20 @@ def tz_default_elements(tz_dtype):
     """Default element strategy for a :class:`~pandas.DatetimeTZDtype`: naive
     ``datetime64[unit]`` values, interpreted as UTC instants.
 
-    With a fixed-offset timezone (including UTC) these cover the dtype's full
-    representable range.  Other timezones resolve their UTC offsets through
-    stdlib datetimes - as does pandas when displaying values - so we keep each
-    instant a day inside Python's representable range, ensuring that the
-    localized wall times stay valid too.
+    With a constant-offset timezone these cover the dtype's representable
+    range, staying a day inside the int64 bounds because pandas' internal
+    conversions - e.g. when accessing an element - can otherwise overflow.
+    All other timezones resolve their UTC offsets through stdlib datetimes,
+    as does pandas when displaying values, so for those we instead keep each
+    instant a day inside Python's representable range.
     """
-    naive = naive_datetime64_dtype(tz_dtype)
-    if has_fixed_offset(tz_dtype.tz):
-        return npst.from_dtype(naive)
     unit = tz_dtype.unit
-    lo = int(np.datetime64(datetime.min + timedelta(days=1), unit).astype(np.int64))
-    hi = int(np.datetime64(datetime.max - timedelta(days=1), unit).astype(np.int64))
+    day = int(np.timedelta64(1, "D") // np.timedelta64(1, unit))
+    if has_constant_offset(tz_dtype.tz):
+        lo, hi = -(2**63) + 1 + day, 2**63 - 1 - day
+    else:
+        lo = int(np.datetime64(datetime.min + timedelta(days=1), unit).astype(np.int64))
+        hi = int(np.datetime64(datetime.max - timedelta(days=1), unit).astype(np.int64))
     values = st.integers(lo, hi).map(lambda v: np.datetime64(v, unit))
     return values | st.just(np.datetime64("NaT", unit))
 

--- a/hypothesis/tests/pandas/test_data_frame.py
+++ b/hypothesis/tests/pandas/test_data_frame.py
@@ -15,7 +15,7 @@ import pytest
 from hypothesis import HealthCheck, given, reject, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as npst, pandas as pdst
-from hypothesis.extra.pandas.impl import IntegerDtype
+from hypothesis.extra.pandas.impl import PANDAS_GE_21, IntegerDtype
 
 from tests.common.debug import (
     assert_all_examples,
@@ -29,6 +29,48 @@ from tests.pandas.helpers import supported_by_pandas
 def test_can_have_columns_of_distinct_types(df):
     assert df["a"].dtype == np.dtype(int)
     assert df["b"].dtype == np.dtype(float)
+
+
+requires_pandas21 = pytest.mark.skipif(
+    not PANDAS_GE_21, reason="timezone-aware dtypes require pandas >= 2.1"
+)
+
+
+@requires_pandas21
+def test_can_have_tz_aware_datetime_columns():
+    dtype = pd.DatetimeTZDtype(unit="us", tz="UTC")
+    assert_all_examples(
+        pdst.data_frames(
+            [pdst.column("a", dtype=dtype), pdst.column("b", dtype=dtype, unique=True)],
+            index=pdst.range_indexes(min_size=1),
+        ),
+        lambda df: df["a"].dtype == dtype
+        and df["b"].dtype == dtype
+        and df["b"].dropna().is_unique,
+    )
+
+
+@requires_pandas21
+def test_can_have_tz_aware_datetime_index():
+    dtype = pd.DatetimeTZDtype(unit="ns", tz="UTC")
+    assert_all_examples(
+        pdst.data_frames(
+            [pdst.column("a", dtype=int)], index=pdst.indexes(dtype=dtype, min_size=1)
+        ),
+        lambda df: df.index.dtype == dtype,
+    )
+
+
+@requires_pandas21
+def test_can_have_tz_aware_datetime_columns_with_rows():
+    dtype = pd.DatetimeTZDtype(unit="us", tz="UTC")
+    assert_all_examples(
+        pdst.data_frames(
+            [pdst.column("a", dtype=dtype)],
+            rows=st.tuples(st.datetimes()),
+        ),
+        lambda df: df["a"].dtype == dtype,
+    )
 
 
 @given(

--- a/hypothesis/tests/pandas/test_data_frame.py
+++ b/hypothesis/tests/pandas/test_data_frame.py
@@ -42,7 +42,6 @@ def test_can_have_tz_aware_datetime_columns():
     assert_all_examples(
         pdst.data_frames(
             [pdst.column("a", dtype=dtype), pdst.column("b", dtype=dtype, unique=True)],
-            index=pdst.range_indexes(min_size=1),
         ),
         lambda df: df["a"].dtype == dtype
         and df["b"].dtype == dtype
@@ -55,7 +54,7 @@ def test_can_have_tz_aware_datetime_index():
     dtype = pd.DatetimeTZDtype(unit="ns", tz="UTC")
     assert_all_examples(
         pdst.data_frames(
-            [pdst.column("a", dtype=int)], index=pdst.indexes(dtype=dtype, min_size=1)
+            [pdst.column("a", dtype=int)], index=pdst.indexes(dtype=dtype)
         ),
         lambda df: df.index.dtype == dtype,
     )

--- a/hypothesis/tests/pandas/test_indexes.py
+++ b/hypothesis/tests/pandas/test_indexes.py
@@ -17,8 +17,9 @@ import pytest
 from hypothesis import HealthCheck, given, reject, settings, strategies as st
 from hypothesis.errors import Unsatisfiable
 from hypothesis.extra import numpy as npst, pandas as pdst
+from hypothesis.extra.pandas.impl import PANDAS_GE_21
 
-from tests.common.debug import check_can_generate_examples
+from tests.common.debug import assert_all_examples, check_can_generate_examples
 from tests.pandas.helpers import supported_by_pandas
 
 
@@ -61,6 +62,19 @@ def test_unique_indexes_of_many_small_values(ix):
 @given(pdst.indexes(dtype="int8", name=st.just("test_name")))
 def test_name_passed_on_indexes(s):
     assert s.name == "test_name"
+
+
+@pytest.mark.skipif(
+    not PANDAS_GE_21, reason="timezone-aware dtypes require pandas >= 2.1"
+)
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+def test_tz_aware_datetime_indexes(unit):
+    dtype = pandas.DatetimeTZDtype(unit=unit, tz="UTC")
+    check_can_generate_examples(pdst.indexes(dtype=dtype, min_size=1))
+    assert_all_examples(
+        pdst.indexes(dtype=dtype, min_size=1, unique=True),
+        lambda ix: ix.dtype == dtype and ix.dropna().is_unique,
+    )
 
 
 # Sizes that fit into an int64 without overflow

--- a/hypothesis/tests/pandas/test_indexes.py
+++ b/hypothesis/tests/pandas/test_indexes.py
@@ -72,7 +72,7 @@ def test_tz_aware_datetime_indexes(unit):
     dtype = pandas.DatetimeTZDtype(unit=unit, tz="UTC")
     check_can_generate_examples(pdst.indexes(dtype=dtype, min_size=1))
     assert_all_examples(
-        pdst.indexes(dtype=dtype, min_size=1, unique=True),
+        pdst.indexes(dtype=dtype, unique=True),
         lambda ix: ix.dtype == dtype and ix.dropna().is_unique,
     )
 

--- a/hypothesis/tests/pandas/test_series.py
+++ b/hypothesis/tests/pandas/test_series.py
@@ -8,6 +8,9 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import datetime as dt
+import zoneinfo
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -15,7 +18,7 @@ import pytest
 from hypothesis import given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 from hypothesis.extra import numpy as nps, pandas as pdst
-from hypothesis.extra.pandas.impl import IntegerDtype
+from hypothesis.extra.pandas.impl import PANDAS_GE_21, IntegerDtype
 
 from tests.common.debug import (
     assert_all_examples,
@@ -121,6 +124,155 @@ def test_unique_series_are_unique(s):
 @given(pdst.series(dtype="int8", name=st.just("test_name")))
 def test_name_passed_on(s):
     assert s.name == "test_name"
+
+
+TIMEZONES = [
+    "UTC",
+    dt.timezone.utc,
+    dt.timezone(dt.timedelta(hours=5, minutes=30)),
+    dt.timezone(dt.timedelta(hours=-8)),
+]
+requires_pandas21 = pytest.mark.skipif(
+    not PANDAS_GE_21, reason="timezone-aware dtypes require pandas >= 2.1"
+)
+
+
+@pytest.mark.skipif(PANDAS_GE_21, reason="only raises on pandas < 2.1")
+def test_tz_aware_dtype_requires_pandas_21():
+    with pytest.raises(InvalidArgument, match=r"requires pandas >= 2\.1"):
+        check_can_generate_examples(pdst.series(dtype="datetime64[ns, UTC]"))
+
+
+@requires_pandas21
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+@pytest.mark.parametrize("tz", TIMEZONES)
+def test_tz_aware_series_share_one_timezone(unit, tz):
+    dtype = pd.DatetimeTZDtype(unit=unit, tz=tz)
+    assert_all_examples(
+        pdst.series(dtype=dtype, index=pdst.range_indexes(min_size=1)),
+        lambda s: s.dtype == dtype and (s.dt.tz == dtype.tz),
+    )
+
+
+@requires_pandas21
+def test_tz_aware_series_from_string_dtype():
+    assert_all_examples(
+        pdst.series(dtype="datetime64[ns, UTC]"),
+        lambda s: str(s.dtype) == "datetime64[ns, UTC]",
+    )
+
+
+@requires_pandas21
+@given(pdst.series(dtype="datetime64[s, UTC]", index=pdst.range_indexes(max_size=0)))
+def test_empty_tz_aware_series(s):
+    assert len(s) == 0
+    assert str(s.dtype) == "datetime64[s, UTC]"
+
+
+@requires_pandas21
+def test_ns_resolution_series_exercise_sub_microsecond_values():
+    find_any(
+        pdst.series(dtype="datetime64[ns, UTC]", index=pdst.range_indexes(min_size=1)),
+        lambda s: (s.dt.nanosecond != 0).any(),
+    )
+
+
+@requires_pandas21
+def test_second_resolution_covers_beyond_datetime_max():
+    # The full representable range of datetime64[s] is vastly wider than
+    # Python's datetime, which stops at the end of the year 9999.
+    epoch = dt.datetime(1970, 1, 1)
+    beyond_datetime_max = (dt.datetime.max - epoch).total_seconds() + 86400
+    find_any(
+        pdst.series(dtype="datetime64[s, UTC]", index=pdst.range_indexes(min_size=1)),
+        lambda s: _utc_seconds(s.dropna()).map(abs).gt(beyond_datetime_max).any(),
+    )
+
+
+def _utc_seconds(s):
+    return s.dt.tz_convert("UTC").dt.tz_localize(None).astype("int64")
+
+
+@requires_pandas21
+def test_tz_aware_series_accepts_custom_elements():
+    tz = dt.timezone.utc
+    elements = st.datetimes(timezones=st.just(tz)).map(lambda d: d.replace(year=2000))
+    assert_all_examples(
+        pdst.series(dtype=pd.DatetimeTZDtype("ns", tz), elements=elements),
+        lambda s: (s.dt.year == 2000).all(),
+    )
+
+
+@requires_pandas21
+def test_tz_aware_series_from_zoneinfo_timezone():
+    dtype = pd.DatetimeTZDtype(unit="us", tz=zoneinfo.ZoneInfo("America/New_York"))
+    assert_all_examples(
+        pdst.series(dtype=dtype, index=pdst.range_indexes(min_size=1)),
+        lambda s: s.dtype == dtype,
+    )
+
+
+@requires_pandas21
+def test_variable_offset_timezones_stay_within_datetime_range():
+    # Unlike fixed-offset timezones, zones whose UTC offset varies over time
+    # resolve offsets through stdlib datetimes, so generated values must stay
+    # within the years 1-9999 which those can represent.
+    dtype = pd.DatetimeTZDtype(unit="s", tz=zoneinfo.ZoneInfo("America/New_York"))
+    assert_all_examples(
+        pdst.series(dtype=dtype, index=pdst.range_indexes(min_size=1)),
+        lambda s: s.dropna().dt.year.between(1, 9999).all(),
+    )
+
+
+@requires_pandas21
+def test_tz_aware_series_from_naive_datetime_elements():
+    # Naive elements are interpreted as wall times in the dtype's timezone,
+    # with the pandas constructor's handling of DST transitions: ambiguous
+    # times resolve to the first occurrence, and imaginary times are shifted
+    # out of the gap.  We bound the elements because pandas 2.1 localizes
+    # python datetimes via nanoseconds, overflowing beyond that range.
+    dtype = pd.DatetimeTZDtype("us", zoneinfo.ZoneInfo("America/New_York"))
+    elements = st.datetimes(dt.datetime(1678, 1, 1), dt.datetime(2261, 12, 31))
+    assert_all_examples(
+        pdst.series(dtype=dtype, elements=elements),
+        lambda s: s.dtype == dtype,
+    )
+
+
+@requires_pandas21
+def test_tz_aware_series_ambiguous_times_resolve_by_fold():
+    # 01:00-01:59 on 2020-11-01 occurs twice in this timezone; the fold of
+    # each generated datetime selects which occurrence we mean, so both UTC
+    # offsets should appear in generated series.
+    tz = zoneinfo.ZoneInfo("America/New_York")
+    strategy = pdst.series(
+        dtype=pd.DatetimeTZDtype("us", tz),
+        elements=st.datetimes(
+            dt.datetime(2020, 11, 1, 1, 0),
+            dt.datetime(2020, 11, 1, 1, 59),
+            timezones=st.just(tz),
+        ),
+        index=pdst.range_indexes(min_size=1),
+    )
+    find_any(strategy, lambda s: (s.dt.strftime("%z") == "-0400").any())
+    find_any(strategy, lambda s: (s.dt.strftime("%z") == "-0500").any())
+
+
+@requires_pandas21
+def test_tz_aware_series_imaginary_times_are_normalized():
+    # 02:00-02:59 on 2020-03-08 does not exist in this timezone; such values
+    # land on a real instant on one side of the DST gap, depending on fold.
+    tz = zoneinfo.ZoneInfo("America/New_York")
+    strategy = pdst.series(
+        dtype=pd.DatetimeTZDtype("us", tz),
+        elements=st.datetimes(
+            dt.datetime(2020, 3, 8, 2, 0),
+            dt.datetime(2020, 3, 8, 2, 59),
+            timezones=st.just(tz),
+        ),
+        index=pdst.range_indexes(min_size=1),
+    )
+    assert_all_examples(strategy, lambda s: s.dt.hour.isin([1, 3]).all())
 
 
 @pytest.mark.skipif(

--- a/hypothesis/tests/pandas/test_series.py
+++ b/hypothesis/tests/pandas/test_series.py
@@ -197,6 +197,23 @@ def test_nonzero_fixed_offset_timezone_covers_beyond_datetime_max():
 
 
 @requires_pandas21
+@given(
+    pdst.series(
+        dtype=pd.DatetimeTZDtype("s", dt.timezone(dt.timedelta(hours=5, minutes=30)))
+    )
+)
+def test_fixed_offset_series_elements_can_be_accessed(s):
+    for i in range(len(s)):
+        s.iloc[i]
+
+
+@requires_pandas21
+@given(pdst.series(dtype=pd.DatetimeTZDtype("s", zoneinfo.ZoneInfo("UTC"))))
+def test_zoneinfo_series_can_be_displayed(s):
+    repr(s)
+
+
+@requires_pandas21
 def test_tz_aware_series_accepts_custom_elements():
     tz = dt.timezone.utc
     elements = st.datetimes(timezones=st.just(tz)).map(lambda d: d.replace(year=2000))

--- a/hypothesis/tests/pandas/test_series.py
+++ b/hypothesis/tests/pandas/test_series.py
@@ -188,6 +188,15 @@ def test_second_resolution_covers_beyond_datetime_max():
 
 
 @requires_pandas21
+def test_nonzero_fixed_offset_timezone_covers_beyond_datetime_max():
+    tz = dt.timezone(dt.timedelta(hours=5, minutes=30))
+    find_any(
+        pdst.series(dtype=pd.DatetimeTZDtype("s", tz)),
+        lambda s: (s.dt.year > dt.MAXYEAR).any(),
+    )
+
+
+@requires_pandas21
 def test_tz_aware_series_accepts_custom_elements():
     tz = dt.timezone.utc
     elements = st.datetimes(timezones=st.just(tz)).map(lambda d: d.replace(year=2000))

--- a/hypothesis/tests/pandas/test_series.py
+++ b/hypothesis/tests/pandas/test_series.py
@@ -149,7 +149,7 @@ def test_tz_aware_dtype_requires_pandas_21():
 def test_tz_aware_series_share_one_timezone(unit, tz):
     dtype = pd.DatetimeTZDtype(unit=unit, tz=tz)
     assert_all_examples(
-        pdst.series(dtype=dtype, index=pdst.range_indexes(min_size=1)),
+        pdst.series(dtype=dtype),
         lambda s: s.dtype == dtype and (s.dt.tz == dtype.tz),
     )
 
@@ -172,7 +172,7 @@ def test_empty_tz_aware_series(s):
 @requires_pandas21
 def test_ns_resolution_series_exercise_sub_microsecond_values():
     find_any(
-        pdst.series(dtype="datetime64[ns, UTC]", index=pdst.range_indexes(min_size=1)),
+        pdst.series(dtype="datetime64[ns, UTC]"),
         lambda s: (s.dt.nanosecond != 0).any(),
     )
 
@@ -181,16 +181,10 @@ def test_ns_resolution_series_exercise_sub_microsecond_values():
 def test_second_resolution_covers_beyond_datetime_max():
     # The full representable range of datetime64[s] is vastly wider than
     # Python's datetime, which stops at the end of the year 9999.
-    epoch = dt.datetime(1970, 1, 1)
-    beyond_datetime_max = (dt.datetime.max - epoch).total_seconds() + 86400
     find_any(
-        pdst.series(dtype="datetime64[s, UTC]", index=pdst.range_indexes(min_size=1)),
-        lambda s: _utc_seconds(s.dropna()).map(abs).gt(beyond_datetime_max).any(),
+        pdst.series(dtype="datetime64[s, UTC]"),
+        lambda s: (s.dt.year > dt.MAXYEAR).any(),
     )
-
-
-def _utc_seconds(s):
-    return s.dt.tz_convert("UTC").dt.tz_localize(None).astype("int64")
 
 
 @requires_pandas21
@@ -206,10 +200,7 @@ def test_tz_aware_series_accepts_custom_elements():
 @requires_pandas21
 def test_tz_aware_series_from_zoneinfo_timezone():
     dtype = pd.DatetimeTZDtype(unit="us", tz=zoneinfo.ZoneInfo("America/New_York"))
-    assert_all_examples(
-        pdst.series(dtype=dtype, index=pdst.range_indexes(min_size=1)),
-        lambda s: s.dtype == dtype,
-    )
+    assert_all_examples(pdst.series(dtype=dtype), lambda s: s.dtype == dtype)
 
 
 @requires_pandas21
@@ -219,8 +210,8 @@ def test_variable_offset_timezones_stay_within_datetime_range():
     # within the years 1-9999 which those can represent.
     dtype = pd.DatetimeTZDtype(unit="s", tz=zoneinfo.ZoneInfo("America/New_York"))
     assert_all_examples(
-        pdst.series(dtype=dtype, index=pdst.range_indexes(min_size=1)),
-        lambda s: s.dropna().dt.year.between(1, 9999).all(),
+        pdst.series(dtype=dtype),
+        lambda s: s.dropna().dt.year.between(dt.MINYEAR, dt.MAXYEAR).all(),
     )
 
 
@@ -252,7 +243,6 @@ def test_tz_aware_series_ambiguous_times_resolve_by_fold():
             dt.datetime(2020, 11, 1, 1, 59),
             timezones=st.just(tz),
         ),
-        index=pdst.range_indexes(min_size=1),
     )
     find_any(strategy, lambda s: (s.dt.strftime("%z") == "-0400").any())
     find_any(strategy, lambda s: (s.dt.strftime("%z") == "-0500").any())
@@ -270,7 +260,6 @@ def test_tz_aware_series_imaginary_times_are_normalized():
             dt.datetime(2020, 3, 8, 2, 59),
             timezones=st.just(tz),
         ),
-        index=pdst.range_indexes(min_size=1),
     )
     assert_all_examples(strategy, lambda s: s.dt.hour.isin([1, 3]).all())
 

--- a/hypothesis/tests/pandas/test_series.py
+++ b/hypothesis/tests/pandas/test_series.py
@@ -196,19 +196,27 @@ def test_nonzero_fixed_offset_timezone_covers_beyond_datetime_max():
     )
 
 
-@requires_pandas21
-@given(
-    pdst.series(
-        dtype=pd.DatetimeTZDtype("s", dt.timezone(dt.timedelta(hours=5, minutes=30)))
-    )
+# Constructed conditionally because the DatetimeTZDtype constructor raises
+# for non-ns units before pandas 2.0, at module import time here.
+FIXED_OFFSET_S_DTYPE = (
+    pd.DatetimeTZDtype("s", dt.timezone(dt.timedelta(hours=5, minutes=30)))
+    if PANDAS_GE_21
+    else None
 )
+ZONEINFO_S_DTYPE = (
+    pd.DatetimeTZDtype("s", zoneinfo.ZoneInfo("UTC")) if PANDAS_GE_21 else None
+)
+
+
+@requires_pandas21
+@given(pdst.series(dtype=FIXED_OFFSET_S_DTYPE))
 def test_fixed_offset_series_elements_can_be_accessed(s):
     for i in range(len(s)):
         s.iloc[i]
 
 
 @requires_pandas21
-@given(pdst.series(dtype=pd.DatetimeTZDtype("s", zoneinfo.ZoneInfo("UTC"))))
+@given(pdst.series(dtype=ZONEINFO_S_DTYPE))
 def test_zoneinfo_series_can_be_displayed(s):
     repr(s)
 


### PR DESCRIPTION
Passing a DatetimeTZDtype - e.g. "datetime64[ns, UTC]" - as the dtype of series, indexes, or column now generates columns where every value shares that single timezone, at the resolution given by the dtype's unit.

Values are generated as naive datetime64[unit] (the canonical UTC int64 storage, including NaT) and the timezone is attached at the array level with tz_localize("UTC").tz_convert(tz).  Constructing from timezone-aware scalars would silently corrupt values near the int64 bounds, and Python datetime objects cannot express the coarser-unit range at all.

For UTC and fixed-offset timezones the values cover the dtype's full representable range.  Timezones whose UTC offset varies over time resolve offsets through stdlib datetimes - as does pandas when displaying values - so those are clamped to keep localized wall times within years 1-9999.

Requires pandas >= 2.1: earlier versions silently coerce non-ns units to nanoseconds, and pandas 2.0.x raises OutOfBoundsDatetime when formatting values outside the ns-representable range.

Closes #4020.
