### PR TITLE
Only generate lark terminals the lexer would match entirely

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -92,6 +92,7 @@ their individual contributions.
 * `Jack Massey <https://github.com/massey101>`_
 * `Jakub Nabaglo <https://github.com/nbgl>`_ (j@nab.gl)
 * `James Lamb <https://github.com/jameslamb>`_
+* `Jayashanker Padishala <https://github.com/Jayashanker-Padishala>`_ (jayashankar.pjs@gmail.com)
 * `Jenny Rouleau <https://github.com/jennyrou>`_
 * `Jens Heinrich <https://github.com/JensHeinrich>`_
 * `Jens Tröger <https://github.com/jenstroeger>`_

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+:func:`~hypothesis.extra.lark.from_lark` could generate strings which the
+grammar's lexer tokenizes differently than the terminal they were generated
+for, and which therefore fail to parse - for example ``'"""'`` for Lark's
+built-in ``ESCAPED_STRING`` terminal (:issue:`4325`). Terminal strategies now
+only generate strings which the lexer would match in their entirety.

--- a/hypothesis/src/hypothesis/extra/lark.py
+++ b/hypothesis/src/hypothesis/extra/lark.py
@@ -20,6 +20,7 @@ from `nearley.js <https://nearley.js.org/>`_, so you may not have to write
 your own at all.
 """
 
+import re
 from inspect import signature
 
 import lark
@@ -93,7 +94,15 @@ class LarkStrategy(st.SearchStrategy):
         self.terminal_strategies: dict[str, st.SearchStrategy[str]] = {}
         for t in terminals:
             self.names_to_symbols[t.name] = Terminal(t.name)
-            s = st.from_regex(t.pattern.to_regexp(), fullmatch=True, alphabet=alphabet)
+            pattern = re.compile(t.pattern.to_regexp())
+            # Lark's lexer matches terminals unanchored, so a string which
+            # fullmatches a lazy pattern may still lex as a shorter token
+            # plus leftover characters - e.g. common.ESCAPED_STRING can
+            # fullmatch '"""', which lexes as '""' followed by an error.
+            # Only generate strings the lexer would match in their entirety.
+            s = st.from_regex(pattern, fullmatch=True, alphabet=alphabet).filter(
+                lambda s, pattern=pattern: pattern.match(s).end() == len(s)
+            )
             try:
                 s.validate()
             except IncompatibleWithAlphabet:

--- a/hypothesis/src/hypothesis/extra/lark.py
+++ b/hypothesis/src/hypothesis/extra/lark.py
@@ -95,14 +95,20 @@ class LarkStrategy(st.SearchStrategy):
         for t in terminals:
             self.names_to_symbols[t.name] = Terminal(t.name)
             pattern = re.compile(t.pattern.to_regexp())
+
+            def lexes_entirely(string: str, pattern: re.Pattern[str] = pattern) -> bool:
+                match = pattern.match(string)
+                assert match is not None  # string fullmatches the pattern
+                return match.end() == len(string)
+
             # Lark's lexer matches terminals unanchored, so a string which
             # fullmatches a lazy pattern may still lex as a shorter token
             # plus leftover characters - e.g. common.ESCAPED_STRING can
             # fullmatch '"""', which lexes as '""' followed by an error.
             # Only generate strings the lexer would match in their entirety.
-            s = st.from_regex(pattern, fullmatch=True, alphabet=alphabet).filter(
-                lambda s, pattern=pattern: pattern.match(s).end() == len(s)
-            )
+            s: st.SearchStrategy[str] = st.from_regex(
+                pattern, fullmatch=True, alphabet=alphabet
+            ).filter(lexes_entirely)
             try:
                 s.validate()
             except IncompatibleWithAlphabet:

--- a/hypothesis/tests/lark/test_grammar.py
+++ b/hypothesis/tests/lark/test_grammar.py
@@ -72,6 +72,19 @@ def test_can_specify_start_rule(data, start, type_):
     assert isinstance(value, type_)
 
 
+ESCAPED_STRING_LARK = Lark(r"""
+    %import common.ESCAPED_STRING
+    start: ESCAPED_STRING
+    """)
+
+
+@given(from_lark(ESCAPED_STRING_LARK))
+def test_generates_parseable_escaped_strings(string):
+    # ESCAPED_STRING's lazy pattern fullmatches strings like '"""' which the
+    # unanchored lexer tokenizes as a shorter match plus leftover characters.
+    ESCAPED_STRING_LARK.parse(string)
+
+
 def test_can_generate_ignored_tokens():
     list_grammar = r"""
     list : "[" [STRING ("," STRING)*] "]"


### PR DESCRIPTION
> Per the AI Policy in CONTRIBUTING.rst: this change was AI-written (Claude Code). It is a **draft** while I complete my own careful read-through; I'll mark it ready once done and I take full responsibility for the contribution.

Fixes #4325.

## The underlying cause

`from_lark` builds terminal strategies with `st.from_regex(..., fullmatch=True)`, but Lark's lexer matches terminals **unanchored**. For lazy patterns the two disagree: `common.ESCAPED_STRING` compiles to `".*?(?<!\\\\)(\\\\\\\\)*?"`, and `'"""'` *fullmatches* it (`.*?` consumes the middle quote) — yet the lexer, matching from the left, stops at `'""'` and errors on the trailing quote. So generation produced strings the grammar's own lexer tokenizes differently than intended.

Empirically: 33 of 2000 generated examples for the issue's grammar failed to parse before this change; 0 of 3000 after.

## The fix

Filter each terminal strategy so generated tokens are strings the (unanchored) terminal regex matches in their entirety:

```python
s = st.from_regex(pattern, fullmatch=True, alphabet=alphabet).filter(
    lambda s, pattern=pattern: pattern.match(s).end() == len(s)
)
```

This fixes the root cause for the reported case rather than post-filtering whole parses; a belt-and-braces parse-check with a warning (as discussed in the issue) would still be a reasonable follow-up for cross-terminal effects (e.g. priority/longest-match interactions between adjacent tokens), which this change deliberately doesn't attempt.

## Verification

- New regression test `test_generates_parseable_escaped_strings` (the issue's exact grammar; every generated string must parse).
- `pytest tests/lark/` 20/20 pass; `./build.sh format` and `./build.sh lint` clean.
- RELEASE.rst (patch) and AUTHORS.rst entry included.