### PR TITLE
Teach `@proxies` to preserve the kind of the decorated function

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch improves our internal ``@proxies`` decorator, which now preserves
+the kind of the decorated function: proxies for async functions, generator
+functions, and async generator functions are themselves functions of the same
+kind.  This prepares for upcoming :func:`~hypothesis.strategies.functions`
+support (:issue:`4149`).

--- a/hypothesis/src/hypothesis/internal/reflection.py
+++ b/hypothesis/src/hypothesis/internal/reflection.py
@@ -354,11 +354,13 @@ def source_exec_as_module(source: str) -> ModuleType:
 
 
 COPY_SIGNATURE_SCRIPT = """
+from contextlib import aclosing, closing
+
 from hypothesis.utils.conventions import not_set
 
 def accept({funcname}):
-    def {name}{signature}:
-        return {funcname}({invocation})
+    {def_prefix}def {name}{signature}:
+        {body}
     return {name}
 """.lstrip()
 
@@ -420,17 +422,38 @@ def define_function_signature(name, docstring, signature):
         if varkw:
             invocation_parts.append("**" + varkw.name)
 
-        candidate_names = ["f"] + [f"f_{i}" for i in range(1, len(used_names) + 2)]
+        candidate_names = ["f"] + [f"f_{i}" for i in range(1, len(used_names) + 4)]
+        free_names = [n for n in candidate_names if n not in used_names]
+        funcname, gen, val = free_names[:3]
 
-        for funcname in candidate_names:  # pragma: no branch
-            if funcname not in used_names:
-                break
+        invocation = f"{funcname}({', '.join(invocation_parts)})"
+        # Preserve the kind of the wrapped function, so that e.g. proxies for
+        # async or generator functions are themselves async or generators -
+        # closing the proxy also closes the underlying (async) generator.
+        if inspect.iscoroutinefunction(f):
+            def_prefix, body = "async ", f"return await {invocation}"
+        elif inspect.isasyncgenfunction(f):
+            def_prefix = "async "
+            body = (
+                f"async with aclosing({invocation}) as {gen}:\n"
+                f"            async for {val} in {gen}:\n"
+                f"                yield {val}"
+            )
+        elif inspect.isgeneratorfunction(f):
+            def_prefix = ""
+            body = (
+                f"with closing({invocation}) as {gen}:\n"
+                f"            return (yield from {gen})"
+            )
+        else:
+            def_prefix, body = "", f"return {invocation}"
 
         source = COPY_SIGNATURE_SCRIPT.format(
             name=name,
             funcname=funcname,
             signature=str(newsig),
-            invocation=", ".join(invocation_parts),
+            def_prefix=def_prefix,
+            body=body,
         )
         result = source_exec_as_module(source).accept(f)
         result.__doc__ = docstring

--- a/hypothesis/tests/cover/test_reflection.py
+++ b/hypothesis/tests/cover/test_reflection.py
@@ -12,7 +12,14 @@ import sys
 from copy import deepcopy
 from datetime import time
 from functools import partial, wraps
-from inspect import Parameter, Signature, signature
+from inspect import (
+    Parameter,
+    Signature,
+    isasyncgenfunction,
+    iscoroutinefunction,
+    isgeneratorfunction,
+    signature,
+)
 from textwrap import dedent
 from unittest.mock import MagicMock, Mock, NonCallableMagicMock, NonCallableMock
 
@@ -453,6 +460,97 @@ def test_can_proxy_lambdas(func, args, expected):
 
     assert wrapped.__name__ == "<lambda>"
     assert wrapped(*args) == expected
+
+
+def test_can_proxy_async_functions():
+    async def foo(a):
+        return a
+
+    @proxies(foo)
+    async def bar(*args, **kwargs):
+        return await foo(*args, **kwargs)
+
+    assert iscoroutinefunction(bar)
+    coro = bar(1)
+    with pytest.raises(StopIteration) as stop:
+        coro.send(None)
+    assert stop.value.value == 1
+
+
+def test_can_proxy_generator_functions():
+    def foo(a):
+        yield a
+        return a + 1
+
+    @proxies(foo)
+    def bar(*args, **kwargs):
+        return (yield from foo(*args, **kwargs))
+
+    assert isgeneratorfunction(bar)
+    gen = bar(1)
+    assert next(gen) == 1
+    with pytest.raises(StopIteration) as stop:
+        next(gen)
+    assert stop.value.value == 2
+
+
+def test_can_proxy_async_generator_functions():
+    async def foo(a):
+        yield a
+
+    @proxies(foo)
+    async def bar(*args, **kwargs):
+        async for value in foo(*args, **kwargs):
+            yield value
+
+    assert isasyncgenfunction(bar)
+    agen = bar(1)
+    with pytest.raises(StopIteration) as stop:
+        agen.__anext__().send(None)
+    assert stop.value.value == 1
+    with pytest.raises(StopAsyncIteration):
+        agen.__anext__().send(None)
+
+
+def test_closing_proxied_generator_closes_the_inner_generator():
+    closed = []
+
+    def foo(a):
+        yield a
+
+    @proxies(foo)
+    def bar(a):
+        try:
+            yield a
+        finally:
+            closed.append(a)
+
+    gen = bar(1)
+    assert next(gen) == 1
+    gen.close()
+    assert closed == [1]
+
+
+def test_closing_proxied_async_generator_closes_the_inner_generator():
+    closed = []
+
+    async def foo(a):
+        yield a
+
+    @proxies(foo)
+    async def bar(a):
+        try:
+            yield a
+        finally:
+            closed.append(a)
+
+    agen = bar(1)
+    with pytest.raises(StopIteration) as stop:
+        agen.__anext__().send(None)
+    assert stop.value.value == 1
+    with pytest.raises(StopIteration):
+        agen.aclose().send(None)
+    assert closed == [1]
 
 
 class Snowman:


### PR DESCRIPTION
_I've separated out some preparation for #4149, to make the future diff easier to review._

Wrappers produced by `define_function_signature` (and hence `@proxies`) are now coroutine, generator, or async-generator functions whenever the function they decorate is, delegating with await / yield from / async for as appropriate.  Generator and async-generator wrappers use closing()/aclosing() so that closing the proxy also closes the underlying (async) generator.