### PR TITLE
Teach st.functions() to create async and generator functions

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.functions` now generates functions of the same
+kind as the ``like=`` argument, so that async functions, generator functions,
+and async generator functions can be imitated as well as plain functions
+(:issue:`4149`).  ``pure=True`` is only supported for plain functions.
+
+Generated generator functions yield a list of values drawn from ``returns``,
+inferring e.g. ``returns=integers()`` from an ``Iterator[int]`` or
+``AsyncIterator[int]`` return-type annotation, and generated async functions
+follow Trio-style checkpoint semantics.

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -30,7 +30,15 @@ from contextvars import ContextVar
 from decimal import Context, Decimal, localcontext
 from fractions import Fraction
 from functools import reduce
-from inspect import Parameter, Signature, isabstract, isclass
+from inspect import (
+    Parameter,
+    Signature,
+    isabstract,
+    isasyncgenfunction,
+    isclass,
+    iscoroutinefunction,
+    isgeneratorfunction,
+)
 from re import Pattern
 from types import EllipsisType, FunctionType, GenericAlias
 from typing import (
@@ -2637,12 +2645,33 @@ def _functions(*, like, returns, pure):
             "The first argument to functions() must be a callable to imitate, "
             f"but got non-callable like={nicerepr(like)!r}"
         )
+    if pure and (
+        iscoroutinefunction(like)
+        or isgeneratorfunction(like)
+        or isasyncgenfunction(like)
+    ):
+        raise InvalidArgument(
+            f"pure=True is invalid for like={nicerepr(like)!r}, because async "
+            "functions are for non-deterministic IO and generators are consumed "
+            "by iteration, so returning a cached value makes no sense"
+        )
+    is_gen = isgeneratorfunction(like) or isasyncgenfunction(like)
     if returns in (None, ...):
-        # Passing `None` has never been *documented* as working, but it still
-        # did from May 2020 to Jan 2022 so we'll avoid breaking it without cause.
         hints = get_type_hints(like)
-        returns = from_type(hints.get("return", type(None)))
+        if is_gen:
+            # The return annotation describes the iterator, so e.g. yield
+            # integers for `-> Iterator[int]` or `-> AsyncIterator[int]`.
+            args = get_args(hints.get("return"))
+            returns = from_type(args[0]) if args else none()
+        else:
+            # Passing `None` has never been *documented* as working, but it
+            # still did from May 2020 to Jan 2022 so we'll avoid breaking it
+            # without cause.
+            returns = from_type(hints.get("return", type(None)))
     check_strategy(returns, "returns")
+    if is_gen:
+        # Generated generator functions draw a list of values to yield up front.
+        returns = lists(returns)
     return FunctionStrategy(like, returns, pure)
 
 
@@ -2693,6 +2722,20 @@ if typing.TYPE_CHECKING or ParamSpec is not None:
         strategy.  If ``returns`` is not passed, we attempt to infer a strategy
         from the return-type annotation if present, falling back to :func:`~none`.
 
+        If ``like`` is an async function, a generator function, or an async
+        generator function, the generated function will be of the same kind.
+        Awaiting a generated async function returns a value drawn from
+        ``returns``, while generated generator functions draw a list of
+        values from ``returns`` up front and then yield from it - so a
+        return-type annotation like ``Iterator[int]`` or ``AsyncIterator[int]``
+        means we infer ``returns=integers()``.  ``pure=True`` is only
+        supported when ``like`` is a plain function.
+
+        Generated async functions and async generators follow Trio-style
+        checkpoint semantics, using :pypi:`anyio` or :pypi:`sniffio` if
+        imported to find the right way to checkpoint, and falling back to
+        :mod:`asyncio` otherwise.
+
         If ``pure=True``, all arguments passed to the generated function must be
         hashable, and if passed identical arguments the original return value will
         be returned again - *not* regenerated, so beware mutable values.
@@ -2723,6 +2766,20 @@ else:  # pragma: no cover
         for the function is drawn from the ``returns`` argument, which must be a
         strategy.  If ``returns`` is not passed, we attempt to infer a strategy
         from the return-type annotation if present, falling back to :func:`~none`.
+
+        If ``like`` is an async function, a generator function, or an async
+        generator function, the generated function will be of the same kind.
+        Awaiting a generated async function returns a value drawn from
+        ``returns``, while generated generator functions draw a list of
+        values from ``returns`` up front and then yield from it - so a
+        return-type annotation like ``Iterator[int]`` or ``AsyncIterator[int]``
+        means we infer ``returns=integers()``.  ``pure=True`` is only
+        supported when ``like`` is a plain function.
+
+        Generated async functions and async generators follow Trio-style
+        checkpoint semantics, using :pypi:`anyio` or :pypi:`sniffio` if
+        imported to find the right way to checkpoint, and falling back to
+        :mod:`asyncio` otherwise.
 
         If ``pure=True``, all arguments passed to the generated function must be
         hashable, and if passed identical arguments the original return value will

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -19,10 +19,15 @@ import sys
 import typing
 import warnings
 from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
     Callable,
     Collection,
+    Generator,
     Hashable,
     Iterable,
+    Iterator,
     Mapping,
     Sequence,
 )
@@ -2661,7 +2666,23 @@ def _functions(*, like, returns, pure):
         if is_gen:
             # The return annotation describes the iterator, so e.g. yield
             # integers for `-> Iterator[int]` or `-> AsyncIterator[int]`.
-            args = get_args(hints.get("return"))
+            allowed = (
+                (AsyncIterator, AsyncIterable, AsyncGenerator)
+                if isasyncgenfunction(like)
+                else (Iterator, Iterable, Generator)
+            )
+            ret = hints.get("return")
+            # normalize eg Iterator[bool] to Iterator while keeping Iterator as Iterator.
+            kind = get_origin(ret) or ret
+            if ret is not None and kind not in allowed:
+                options = ", ".join(t.__name__ for t in allowed)
+                raise InvalidArgument(
+                    f"Cannot infer the yield type of like={nicerepr(like)!r} "
+                    f"from its return annotation {ret!r}. Expected one of "
+                    f"{options}. Alternatively, pass returns= to specify the yield type "
+                    "explicitly."
+                )
+            args = get_args(ret)
             returns = from_type(args[0]) if args else none()
         else:
             # Passing `None` has never been *documented* as working, but it

--- a/hypothesis/src/hypothesis/strategies/_internal/functions.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/functions.py
@@ -8,7 +8,14 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from inspect import Parameter, Signature
+import sys
+from inspect import (
+    Parameter,
+    Signature,
+    isasyncgenfunction,
+    iscoroutinefunction,
+    isgeneratorfunction,
+)
 from weakref import WeakKeyDictionary
 
 from hypothesis.control import note, should_note
@@ -29,6 +36,22 @@ from hypothesis.strategies._internal.strategies import (
 from hypothesis.utils.conventions import UniqueIdentifier
 
 can_vary = UniqueIdentifier("can_vary")
+
+
+async def _checkpoint():  # pragma: no cover  # depends on installed frameworks
+    # Generated async functions follow Trio-style checkpoint semantics, using
+    # anyio or sniffio to find the right way to checkpoint if the user's async
+    # framework might not be asyncio.
+    if anyio := sys.modules.get("anyio"):
+        await anyio.lowlevel.checkpoint()
+        return
+    if sniffio := sys.modules.get("sniffio"):
+        if sniffio.current_async_library() == "trio":
+            await sys.modules["trio"].lowlevel.checkpoint()
+            return
+    import asyncio  # deferred to keep `import hypothesis` fast
+
+    await asyncio.sleep(0)
 
 
 class FunctionStrategy(SearchStrategy):
@@ -76,11 +99,14 @@ class FunctionStrategy(SearchStrategy):
 
     def do_draw(self, data):
         # If we know what the function returns, we show it as a constant lambda
-        # instead of noting every call - the notes would be redundant.
-        varies = self._constant is can_vary
+        # instead of noting every call - the notes would be redundant.  A
+        # lambda is a poor description of an async function though, and
+        # generator kinds are never constant, so this is for plain functions.
+        varies = self._constant is can_vary or iscoroutinefunction(self.like)
 
-        @proxies(self.like)
-        def inner(*args, **kwargs):
+        def draw_value(args, kwargs):
+            # `pure=True` is rejected for non-plain `like`s, so only the plain
+            # `inner` below can ever take the caching branch.
             if data.frozen:
                 raise InvalidState(
                     f"This generated {nicerepr(self.like)} function can only "
@@ -103,6 +129,39 @@ class FunctionStrategy(SearchStrategy):
                     rep = repr_call(self.like, args, kwargs, reorder=False)
                     note(f"Called function: {rep} -> {val!r}")
                 return val
+
+        # Define an inner function of the same kind as `like`, so that the
+        # proxy (see `proxies`) is a coroutine, generator, or async-generator
+        # function whenever `like` is.  For generator kinds, the drawn value
+        # is a list of values to yield.
+        if iscoroutinefunction(self.like):
+
+            @proxies(self.like)
+            async def inner(*args, **kwargs):
+                value = draw_value(args, kwargs)
+                await _checkpoint()
+                return value
+
+        elif isasyncgenfunction(self.like):
+
+            @proxies(self.like)
+            async def inner(*args, **kwargs):
+                for value in draw_value(args, kwargs):
+                    await _checkpoint()
+                    yield value
+                await _checkpoint()
+
+        elif isgeneratorfunction(self.like):
+
+            @proxies(self.like)
+            def inner(*args, **kwargs):
+                yield from draw_value(args, kwargs)
+
+        else:
+
+            @proxies(self.like)
+            def inner(*args, **kwargs):
+                return draw_value(args, kwargs)
 
         if not varies:
             inner._repr_pretty_ = self._pretty_constant_function

--- a/hypothesis/tests/cover/test_functions.py
+++ b/hypothesis/tests/cover/test_functions.py
@@ -8,7 +8,13 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from inspect import signature
+from collections.abc import AsyncIterator, Generator, Iterator
+from inspect import (
+    isasyncgenfunction,
+    iscoroutinefunction,
+    isgeneratorfunction,
+    signature,
+)
 
 import pytest
 
@@ -20,6 +26,25 @@ from hypothesis.strategies import booleans, functions, integers
 
 from tests.common.debug import check_can_generate_examples
 from tests.common.utils import capture_out
+
+
+def run_coroutine(coro):
+    # Generated async functions only await checkpoints, which never block, so
+    # we can pump the coroutine to completion without an event loop.
+    while True:
+        try:
+            coro.send(None)
+        except StopIteration as e:
+            return e.value
+
+
+def collect_async_gen(agen):
+    values = []
+    while True:
+        try:
+            values.append(run_coroutine(agen.__anext__()))
+        except StopAsyncIteration:
+            return values
 
 
 def func_a():
@@ -257,6 +282,19 @@ def test_constant_functions_have_a_constant_lambda_repr(f):
     assert nicerepr(f) == "lambda x: 3"
 
 
+def test_constant_async_functions_note_their_calls_instead():
+    # A lambda would be a poor description of an async function, so we note
+    # calls as usual even when we know what awaiting them will return.
+    @given(f=functions(like=async_func, returns=st.just(3)))
+    def test(f):
+        run_coroutine(f(1))
+        raise AssertionError
+
+    output = failing_output(test)
+    assert "lambda" not in output
+    assert "Called function" in output
+
+
 raw_object = object()
 
 
@@ -289,3 +327,149 @@ def test_functions_supports_find():
     with pytest.raises(InvalidState):
         f(1, 2)
     assert f.__name__ == pure_func.__name__
+
+
+async def async_func(a: int) -> str:
+    raise NotImplementedError
+
+
+@given(functions(like=async_func))
+def test_async_functions_infer_return_type(f):
+    assert iscoroutinefunction(f)
+    assert f.__name__ == "async_func"
+    with pytest.raises(TypeError):
+        f()
+    assert isinstance(run_coroutine(f(1)), str)
+
+
+@given(functions(like=async_func, returns=integers()))
+def test_async_functions_explicit_returns(f):
+    assert isinstance(run_coroutine(f(1)), int)
+
+
+def test_async_functions_invalid_outside_given():
+    cached = None
+
+    @given(functions(like=async_func))
+    def t(f):
+        nonlocal cached
+        cached = f
+        run_coroutine(f(1))
+
+    t()
+    with pytest.raises(InvalidState):
+        run_coroutine(cached(1))
+
+
+def gen_func(a: int) -> Iterator[bool]:
+    yield True
+
+
+@given(functions(like=gen_func))
+def test_generator_functions_infer_yield_type(f):
+    assert isgeneratorfunction(f)
+    assert f.__name__ == "gen_func"
+    with pytest.raises(TypeError):
+        f()
+    for value in f(1):
+        assert isinstance(value, bool)
+
+
+@given(functions(like=gen_func, returns=integers()))
+def test_generator_functions_explicit_returns(f):
+    for value in f(1):
+        assert isinstance(value, int)
+
+
+def gen_func_with_return(a) -> Generator[bool, None, int]:
+    yield True
+    return 0
+
+
+@given(functions(like=gen_func_with_return))
+def test_generator_functions_infer_yield_type_ignoring_send_and_return(f):
+    for value in f(1):
+        assert isinstance(value, bool)
+
+
+def gen_func_no_annotation():
+    yield
+
+
+@given(functions(like=gen_func_no_annotation))
+def test_unannotated_generator_functions_yield_none(f):
+    # With no annotation to infer a yield type from, we fall back to none()
+    # just as we do for the return value of plain functions.
+    assert all(value is None for value in f())
+
+
+def test_generator_functions_invalid_outside_given():
+    cached = None
+
+    @given(functions(like=gen_func))
+    def t(f):
+        nonlocal cached
+        cached = f
+        list(f(1))
+
+    t()
+    with pytest.raises(InvalidState):
+        list(cached(1))
+
+
+def test_can_close_generated_generators_early():
+    @given(functions(like=gen_func, returns=booleans()))
+    def t(f):
+        gen = f(1)
+        next(gen, None)
+        gen.close()
+
+    t()
+
+
+async def async_gen_func(a: int) -> AsyncIterator[bool]:
+    yield True
+
+
+@given(functions(like=async_gen_func))
+def test_async_generator_functions_infer_yield_type(f):
+    assert isasyncgenfunction(f)
+    assert f.__name__ == "async_gen_func"
+    with pytest.raises(TypeError):
+        f()
+    for value in collect_async_gen(f(1)):
+        assert isinstance(value, bool)
+
+
+@given(functions(like=async_gen_func, returns=integers()))
+def test_async_generator_functions_explicit_returns(f):
+    for value in collect_async_gen(f(1)):
+        assert isinstance(value, int)
+
+
+async def async_gen_func_no_annotation():
+    yield
+
+
+@given(functions(like=async_gen_func_no_annotation))
+def test_unannotated_async_generator_functions_yield_none(f):
+    assert all(value is None for value in collect_async_gen(f()))
+
+
+def test_can_close_generated_async_generators_early():
+    @given(functions(like=async_gen_func, returns=booleans()))
+    def t(f):
+        agen = f(1)
+        try:
+            run_coroutine(agen.__anext__())
+        except StopAsyncIteration:
+            pass
+        run_coroutine(agen.aclose())
+
+    t()
+
+
+@pytest.mark.parametrize("like", [async_func, gen_func, async_gen_func])
+def test_pure_is_invalid_except_for_plain_functions(like):
+    with pytest.raises(InvalidArgument, match="pure=True is invalid"):
+        check_can_generate_examples(functions(like=like, pure=True))

--- a/hypothesis/tests/cover/test_functions.py
+++ b/hypothesis/tests/cover/test_functions.py
@@ -8,7 +8,11 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from collections.abc import AsyncIterator, Generator, Iterator
+from collections.abc import (
+    AsyncIterator,
+    Generator,
+    Iterator,
+)
 from inspect import (
     isasyncgenfunction,
     iscoroutinefunction,
@@ -24,7 +28,7 @@ from hypothesis.internal.reflection import nicerepr
 from hypothesis.reporting import with_reporter
 from hypothesis.strategies import booleans, functions, integers
 
-from tests.common.debug import check_can_generate_examples
+from tests.common.debug import assert_all_examples, check_can_generate_examples
 from tests.common.utils import capture_out
 
 
@@ -473,3 +477,70 @@ def test_can_close_generated_async_generators_early():
 def test_pure_is_invalid_except_for_plain_functions(like):
     with pytest.raises(InvalidArgument, match="pure=True is invalid"):
         check_can_generate_examples(functions(like=like, pure=True))
+
+
+def make_gen_like(annotation, *, is_async=False):
+    prefix = "async " if is_async else ""
+    # pass our globals so we can reference things like the module-level IteratorSubclass
+    # in test strings
+    namespace = dict(globals())
+    exec(
+        f"from collections.abc import *\n{prefix}def like(a) -> {annotation}:\n    yield",
+        namespace,
+    )
+    return namespace["like"]
+
+
+class IteratorSubclass(Iterator[bool]):
+    def __next__(self):
+        raise StopIteration
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    ["Iterator[bool]", "Iterable[bool]", "Generator[bool, None, None]"],
+)
+def test_generator_functions_accept_any_iterator_like_annotation(annotation):
+    assert_all_examples(
+        functions(like=make_gen_like(annotation)),
+        lambda f: all(isinstance(value, bool) for value in f(1)),
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    ["AsyncIterator[bool]", "AsyncIterable[bool]", "AsyncGenerator[bool, None]"],
+)
+def test_async_generator_functions_accept_any_async_iterator_like_annotation(
+    annotation,
+):
+    assert_all_examples(
+        functions(like=make_gen_like(annotation, is_async=True)),
+        lambda f: all(isinstance(value, bool) for value in collect_async_gen(f(1))),
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "bool",
+        "tuple[bool, str]",
+        "list[bool]",
+        "IteratorSubclass",
+        "AsyncIterator[bool]",
+    ],
+)
+def test_generator_functions_reject_other_annotations(annotation):
+    with pytest.raises(InvalidArgument, match="Cannot infer the yield type"):
+        check_can_generate_examples(functions(like=make_gen_like(annotation)))
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    ["bool", "tuple[bool, str]", "list[bool]", "Iterator[bool]"],
+)
+def test_async_generator_functions_reject_other_annotations(annotation):
+    with pytest.raises(InvalidArgument, match="Cannot infer the yield type"):
+        check_can_generate_examples(
+            functions(like=make_gen_like(annotation, is_async=True))
+        )


### PR DESCRIPTION
The functions() strategy now defines its stand-in function with the same kind as the like= argument, so imitations of async functions, generator functions, and async generator functions are themselves coroutine / generator / async-generator functions per inspect.is*.

Generated (async) generator functions draw a list of values from returns= up front and yield from it, inferring the yield type from return annotations like Iterator[int] or AsyncIterator[int].  Generated async functions and async generators follow Trio-style checkpoint semantics, using anyio or sniffio if imported to find the right way to checkpoint and falling back to asyncio otherwise.  pure=True is rejected for non-plain like= arguments, since caching makes no sense for async functions (which model IO) or generators (which are consumed by iteration).

Closes https://github.com/HypothesisWorks/hypothesis/issues/4149