### PR TITLE
Stop wasting element draws when generating unique collections

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch makes generating unique collections, such as |st.sets| or
+|st.lists| with ``unique=True``, considerably more efficient (:issue:`4458`).
+Hypothesis no longer mutates test cases by copying one element of a unique
+collection over another element of the same collection, and no longer probes
+for minimal examples by drawing every element at its simplest value - both of
+which were certain to be rejected, and could waste several times as many
+draws from the element strategy as were actually returned.

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -684,6 +684,11 @@ class ConjectureData:
         self._stateful_run_times: dict[str, float] = defaultdict(float)
         self.max_depth: int = 0
         self.has_discards: bool = False
+        # While positive, we are drawing an element of a unique collection, so
+        # a "simplest" ChoiceTemplate enumerates progressively larger choices
+        # (via the shared counter) instead of repeating guaranteed-duplicates.
+        self.unique_element_depth: int = 0
+        self.simplest_index: int = 0
 
         self.provider: PrimitiveProvider = (
             provider(self, **provider_kw) if isinstance(provider, type) else provider
@@ -1080,10 +1085,19 @@ class ConjectureData:
             # node if the alternative is not "the entire data is an overrun".
             assert self.index == len(self.prefix) - 1
             if node.type == "simplest":
-                if forced is not None:
-                    choice = forced
+                index = 0
+                if forced is None and self.unique_element_depth:
+                    # imported here to break an import cycle
+                    from hypothesis.internal.conjecture.datatree import (
+                        compute_max_children,
+                    )
+
+                    index = self.simplest_index % compute_max_children(
+                        choice_type, constraints
+                    )
+                    self.simplest_index += 1
                 try:
-                    choice = choice_from_index(0, choice_type, constraints)
+                    choice = choice_from_index(index, choice_type, constraints)
                 except ChoiceTooLarge:
                     self.mark_overrun()
             else:

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -105,6 +105,9 @@ TargetObservations = dict[str, int | float]
 MisalignedAt: TypeAlias = tuple[int, ChoiceTypeT, ChoiceConstraintsT, ChoiceT | None]
 
 TOP_LABEL = calc_label_from_name("top")
+UNIQUE_COLLECTION_LABEL = calc_label_from_name(
+    "a collection with a uniqueness constraint"
+)
 MAX_DEPTH = 100
 
 threadlocal = ThreadLocal(global_test_counter=int)
@@ -419,13 +422,26 @@ class _mutator_groups(SpanProperty):
     def __init__(self, spans: "Spans") -> None:
         super().__init__(spans)
         self.groups: dict[int, set[tuple[int, int]]] = defaultdict(set)
+        self._unique_stack: list[int] = []
 
     def start_span(self, i: int, label_index: int) -> None:
         # TODO should we discard start == end cases? occurs for eg st.data()
         # which is conditionally or never drawn from. arguably swapping
         # nodes with the empty list is a useful mutation enabled by start == end?
-        key = (self.spans[i].start, self.spans[i].end)
-        self.groups[label_index].add(key)
+        #
+        # Skip spans inside a unique collection: duplicating one element of a
+        # unique collection over another is certain to fail the uniqueness
+        # filter and be discarded.  The collection's own span is still added,
+        # so duplicating a collection as a whole remains possible.
+        if not self._unique_stack:
+            key = (self.spans[i].start, self.spans[i].end)
+            self.groups[label_index].add(key)
+        if self.spans.labels[label_index] == UNIQUE_COLLECTION_LABEL:
+            self._unique_stack.append(i)
+
+    def stop_span(self, i: int, *, discarded: bool) -> None:
+        if self._unique_stack and self._unique_stack[-1] == i:
+            self._unique_stack.pop()
 
     def finish(self) -> Iterable[set[tuple[int, int]]]:
         # Discard groups with only one span, since the mutator can't

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -110,6 +110,9 @@ TargetObservations = dict[str, int | float]
 MisalignedAt: TypeAlias = tuple[int, ChoiceTypeT, ChoiceConstraintsT, ChoiceT | None]
 
 TOP_LABEL = calc_label_from_name("top")
+UNIQUE_COLLECTION_LABEL = calc_label_from_name(
+    "a collection with a uniqueness constraint"
+)
 MAX_DEPTH = 100
 
 threadlocal = ThreadLocal(global_test_counter=int)
@@ -470,13 +473,26 @@ class _mutator_groups(SpanProperty):
     def __init__(self, spans: "Spans") -> None:
         super().__init__(spans)
         self.groups: dict[int, set[tuple[int, int]]] = defaultdict(set)
+        self._unique_stack: list[int] = []
 
     def start_span(self, i: int, label_index: int) -> None:
         # TODO should we discard start == end cases? occurs for eg st.data()
         # which is conditionally or never drawn from. arguably swapping
         # nodes with the empty list is a useful mutation enabled by start == end?
-        key = (self.spans[i].start, self.spans[i].end)
-        self.groups[label_index].add(key)
+        #
+        # Skip spans inside a unique collection: duplicating one element of a
+        # unique collection over another is certain to fail the uniqueness
+        # filter and be discarded.  The collection's own span is still added,
+        # so duplicating a collection as a whole remains possible.
+        if not self._unique_stack:
+            key = (self.spans[i].start, self.spans[i].end)
+            self.groups[label_index].add(key)
+        if self.spans.labels[label_index] == UNIQUE_COLLECTION_LABEL:
+            self._unique_stack.append(i)
+
+    def stop_span(self, i: int, *, discarded: bool) -> None:
+        if self._unique_stack and self._unique_stack[-1] == i:
+            self._unique_stack.pop()
 
     def finish(self) -> Iterable[set[tuple[int, int]]]:
         # Discard groups with only one span, since the mutator can't

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -736,6 +736,11 @@ class ConjectureData:
         self._stateful_run_times: dict[str, float] = defaultdict(float)
         self.max_depth: int = 0
         self.has_discards: bool = False
+        # While positive, we are drawing an element of a unique collection, so
+        # a "simplest" ChoiceTemplate enumerates progressively larger choices
+        # (via the shared counter) instead of repeating guaranteed-duplicates.
+        self.unique_element_depth: int = 0
+        self.simplest_index: int = 0
 
         self.provider: PrimitiveProvider = (
             provider(self, **provider_kw) if isinstance(provider, type) else provider
@@ -1138,10 +1143,19 @@ class ConjectureData:
             # node if the alternative is not "the entire data is an overrun".
             assert self.index == len(self.prefix) - 1
             if node.type == "simplest":
-                if forced is not None:
-                    choice = forced
+                index = 0
+                if forced is None and self.unique_element_depth:
+                    # imported here to break an import cycle
+                    from hypothesis.internal.conjecture.datatree import (
+                        compute_max_children,
+                    )
+
+                    index = self.simplest_index % compute_max_children(
+                        choice_type, constraints
+                    )
+                    self.simplest_index += 1
                 try:
-                    choice = choice_from_index(0, choice_type, constraints)
+                    choice = choice_from_index(index, choice_type, constraints)
                 except ChoiceTooLarge:
                     self.mark_overrun()
             else:

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -357,8 +357,18 @@ class UniqueListStrategy(ListStrategy[Ex]):
             self.element_strategy, conditions=(not_yet_in_unique_list,)
         )
         data.start_span(UNIQUE_COLLECTION_LABEL)
+        if data.unique_element_depth == 0:
+            # Reset the enumeration of "simplest" template draws for each
+            # top-level unique collection, so that probes are canonical.  A
+            # collection nested inside another unique collection keeps
+            # counting, so that sibling elements remain distinct.
+            data.simplest_index = 0
         while elements.more():
-            value = filtered.do_filtered_draw(data)
+            data.unique_element_depth += 1
+            try:
+                value = filtered.do_filtered_draw(data)
+            finally:
+                data.unique_element_depth -= 1
             if value is filter_not_satisfied:
                 elements.reject(f"Aborted test because unable to satisfy {filtered!r}")
             else:

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -17,7 +17,7 @@ from hypothesis import strategies as st
 from hypothesis.control import current_build_context
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.conjecture import utils as cu
-from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.data import UNIQUE_COLLECTION_LABEL, ConjectureData
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy
 from hypothesis.internal.conjecture.utils import combine_labels
@@ -313,6 +313,7 @@ class UniqueListStrategy(ListStrategy[Ex]):
         filtered = FilteredStrategy(
             self.element_strategy, conditions=(not_yet_in_unique_list,)
         )
+        data.start_span(UNIQUE_COLLECTION_LABEL)
         while elements.more():
             value = filtered.do_filtered_draw(data)
             if value is filter_not_satisfied:
@@ -324,6 +325,7 @@ class UniqueListStrategy(ListStrategy[Ex]):
                 if self.tuple_suffixes is not None:
                     value = (value, *data.draw(self.tuple_suffixes))
                 result.append(value)
+        data.stop_span()
         assert self.max_size >= len(result) >= self.min_size
         return result
 

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -19,7 +19,7 @@ from hypothesis.errors import CannotInvert, InvalidArgument
 from hypothesis.internal.compat import add_note
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.conjecture.choice import ChoiceT
-from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.data import UNIQUE_COLLECTION_LABEL, ConjectureData
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE
 from hypothesis.internal.conjecture.junkdrawer import LazySequenceCopy, equal_values
 from hypothesis.internal.conjecture.utils import combine_labels
@@ -356,6 +356,7 @@ class UniqueListStrategy(ListStrategy[Ex]):
         filtered = FilteredStrategy(
             self.element_strategy, conditions=(not_yet_in_unique_list,)
         )
+        data.start_span(UNIQUE_COLLECTION_LABEL)
         while elements.more():
             value = filtered.do_filtered_draw(data)
             if value is filter_not_satisfied:
@@ -367,6 +368,7 @@ class UniqueListStrategy(ListStrategy[Ex]):
                 if self.tuple_suffixes is not None:
                     value = (value, *data.draw(self.tuple_suffixes))
                 result.append(value)
+        data.stop_span()
         assert self.max_size >= len(result) >= self.min_size
         return result
 

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -314,8 +314,18 @@ class UniqueListStrategy(ListStrategy[Ex]):
             self.element_strategy, conditions=(not_yet_in_unique_list,)
         )
         data.start_span(UNIQUE_COLLECTION_LABEL)
+        if data.unique_element_depth == 0:
+            # Reset the enumeration of "simplest" template draws for each
+            # top-level unique collection, so that probes are canonical.  A
+            # collection nested inside another unique collection keeps
+            # counting, so that sibling elements remain distinct.
+            data.simplest_index = 0
         while elements.more():
-            value = filtered.do_filtered_draw(data)
+            data.unique_element_depth += 1
+            try:
+                value = filtered.do_filtered_draw(data)
+            finally:
+                data.unique_element_depth -= 1
             if value is filter_not_satisfied:
                 elements.reject(f"Aborted test because unable to satisfy {filtered!r}")
             else:

--- a/hypothesis/tests/conjecture/test_mutations.py
+++ b/hypothesis/tests/conjecture/test_mutations.py
@@ -8,7 +8,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
-from hypothesis import strategies as st
+from hypothesis import given, seed, settings, strategies as st
 
 from tests.common.debug import find_any
 
@@ -45,4 +45,40 @@ def test_can_find_duplicated_subtree():
             and v[0] == v[2][0]
             and v[1] == v[2][1]
         ),
+    )
+
+
+def test_mutations_avoid_duplicating_within_unique_collections():
+    # Duplicating one element of a unique collection onto another element of
+    # the same collection is certain to be rejected, wasting (potentially
+    # expensive) element draws.
+    executions = 0
+    delivered = 0
+
+    @st.composite
+    def counted_integers(draw):
+        nonlocal executions
+        executions += 1
+        return draw(st.integers())
+
+    @seed(0)
+    @settings(max_examples=100, database=None)
+    @given(st.sets(counted_integers(), min_size=3, max_size=3))
+    def t(x):
+        nonlocal delivered
+        delivered += len(x)
+
+    t()
+    # around 6x before we taught the mutator about uniqueness; now ~1.06x
+    assert executions <= 1.5 * delivered
+
+
+def test_can_duplicate_between_unique_collections():
+    # While the mutator avoids duplicating elements within a single unique
+    # collection, duplicating between two different collections is still
+    # possible (and useful).
+    unique_lists = st.lists(st.integers(), unique=True, min_size=1, max_size=5)
+    find_any(
+        st.tuples(unique_lists, unique_lists),
+        lambda t: bool({x for x in t[0] if abs(x) > 2**40} & set(t[1])),
     )

--- a/hypothesis/tests/conjecture/test_test_data.py
+++ b/hypothesis/tests/conjecture/test_test_data.py
@@ -14,6 +14,7 @@ import pytest
 
 from hypothesis import strategies as st
 from hypothesis.errors import Frozen
+from hypothesis.internal.conjecture.choice import ChoiceTemplate
 from hypothesis.internal.conjecture.data import (
     MAX_DEPTH,
     ConjectureData,
@@ -400,3 +401,40 @@ def test_overruns_at_exactly_max_length():
         except StopTest:
             pass
         assert data.status is Status.OVERRUN
+
+
+def test_simplest_template_enumerates_unique_collection_elements():
+    # an all-simplest draw would duplicate elements and never satisfy the
+    # uniqueness constraint, so the template enumerates instead.
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    result = data.draw(st.lists(st.integers(), unique=True, min_size=3, max_size=3))
+    assert len(set(result)) == 3
+
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    assert data.draw(st.lists(st.booleans(), unique=True, min_size=2)) == [False, True]
+
+
+def test_simplest_template_unique_collections_are_canonical():
+    # the enumeration restarts for each top-level unique collection, so probes
+    # do not depend on what was drawn earlier in the test case...
+    strategy = st.lists(st.integers(), unique=True, min_size=3, max_size=3)
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    assert data.draw(strategy) == data.draw(strategy)
+
+    # ...but nested unique collections keep counting, so that the sibling
+    # elements of their parent collection remain distinct.
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    result = data.draw(
+        st.lists(
+            st.lists(st.integers(), min_size=2, max_size=2),
+            unique_by=tuple,
+            min_size=2,
+            max_size=2,
+        )
+    )
+    assert len({tuple(inner) for inner in result}) == 2
+
+
+def test_simplest_template_still_simplest_without_uniqueness():
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    assert data.draw(st.lists(st.integers(), min_size=3, max_size=3)) == [0, 0, 0]

--- a/hypothesis/tests/conjecture/test_test_data.py
+++ b/hypothesis/tests/conjecture/test_test_data.py
@@ -16,7 +16,7 @@ import pytest
 from hypothesis import strategies as st
 from hypothesis.control import BuildContext
 from hypothesis.errors import Frozen
-from hypothesis.internal.conjecture.choice import ValueHole
+from hypothesis.internal.conjecture.choice import ChoiceTemplate, ValueHole
 from hypothesis.internal.conjecture.data import (
     MAX_DEPTH,
     ConjectureData,
@@ -546,3 +546,40 @@ def test_value_hole_overruns_when_the_simplest_choice_is_too_large():
     with pytest.raises(StopTest):
         d.draw_bytes(10_000, 10_000)
     assert d.status is Status.OVERRUN
+
+
+def test_simplest_template_enumerates_unique_collection_elements():
+    # an all-simplest draw would duplicate elements and never satisfy the
+    # uniqueness constraint, so the template enumerates instead.
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    result = data.draw(st.lists(st.integers(), unique=True, min_size=3, max_size=3))
+    assert len(set(result)) == 3
+
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    assert data.draw(st.lists(st.booleans(), unique=True, min_size=2)) == [False, True]
+
+
+def test_simplest_template_unique_collections_are_canonical():
+    # the enumeration restarts for each top-level unique collection, so probes
+    # do not depend on what was drawn earlier in the test case...
+    strategy = st.lists(st.integers(), unique=True, min_size=3, max_size=3)
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    assert data.draw(strategy) == data.draw(strategy)
+
+    # ...but nested unique collections keep counting, so that the sibling
+    # elements of their parent collection remain distinct.
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    result = data.draw(
+        st.lists(
+            st.lists(st.integers(), min_size=2, max_size=2),
+            unique_by=tuple,
+            min_size=2,
+            max_size=2,
+        )
+    )
+    assert len({tuple(inner) for inner in result}) == 2
+
+
+def test_simplest_template_still_simplest_without_uniqueness():
+    data = ConjectureData(prefix=[ChoiceTemplate("simplest", count=None)], random=None)
+    assert data.draw(st.lists(st.integers(), min_size=3, max_size=3)) == [0, 0, 0]


### PR DESCRIPTION
(1) the mutator no longer duplicates spans between elements of the same unique collection, and (2) ChoiceTemplate("simplest") enumerates distinct elements inside unique collections (canonically per top-level collection), so zero-extend probes now succeed instead of aborting. Closes #4458.

```
Benchmark (100 examples, seed 0, element-strategy executions per unique element):
  sets(integers(), 3..3):         5.88 -> 1.33
  sets(integers(), 6..6):         6.28 -> 1.17
  sets(text(max_size=3), 5..5):   4.36 -> 1.39
```
