### PR TITLE
Deploy live website previews for PRs via Cloudflare Pages

### DIFF
--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,0 +1,106 @@
+name: Deploy website preview
+
+# Deploys the website built from a pull request to Cloudflare Pages, and posts
+# (or updates) a comment on the PR with the preview URL.  This runs via
+# workflow_run so that it has access to secrets even for PRs from forks; it
+# must therefore never execute code from the PR - we only upload the static
+# site which the unprivileged build workflow produced.
+#
+# Requires a Cloudflare Pages project named `hypothesis-website`, and the
+# CLOUDFLARE_API_TOKEN (with Cloudflare Pages:Edit) and CLOUDFLARE_ACCOUNT_ID
+# repository secrets.
+
+on:
+  # Safe here because we never check out or execute anything from the PR;
+  # we only deploy the static artifact built by the unprivileged workflow.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
+    workflows: ["Build website & deploy to GitHub Pages"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: website-preview-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      # The build workflow only uploads this artifact for PRs which touch the
+      # website, so a failed download just means there's nothing to preview.
+      - name: Download PR number
+        id: download-pr
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read PR number
+        id: pr
+        if: steps.download-pr.outcome == 'success'
+        # The artifact was produced from untrusted PR code, so validate it.
+        run: |
+          number="$(cat pr-number.txt)"
+          if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: $number" >&2
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+      - name: Download website build
+        if: steps.pr.outputs.number
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: website
+          path: site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        if: steps.pr.outputs.number
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >
+            pages deploy site
+            --project-name=hypothesis-website
+            --branch=pr-${{ steps.pr.outputs.number }}
+            --commit-hash=${{ github.event.workflow_run.head_sha }}
+      - name: Comment preview URL on PR
+        if: steps.pr.outputs.number
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # The stable per-PR alias, e.g. https://pr-123.hypothesis-website.pages.dev
+          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+        with:
+          script: |
+            const marker = "<!-- website-preview -->";
+            const issue_number = parseInt(process.env.PR_NUMBER, 10);
+            const body =
+              `${marker}\nWebsite preview for ${process.env.HEAD_SHA}: ` +
+              process.env.PREVIEW_URL;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy website preview
 
-# Deploys the website built from a pull request to Cloudflare Pages, and posts
-# (or updates) a comment on the PR with the preview URL.  This runs via
+# Deploys the website built from a pull request to Cloudflare Pages, and
+# posts (or updates) a comment on the PR with the preview URL.  This runs via
 # workflow_run so that it has access to secrets even for PRs from forks; it
 # must therefore never execute code from the PR - we only upload the static
 # site which the unprivileged build workflow produced.
@@ -11,8 +11,7 @@ name: Deploy website preview
 # repository secrets.
 
 on:
-  # Safe here because we never check out or execute anything from the PR;
-  # we only deploy the static artifact built by the unprivileged workflow.
+  # Safe here because we never check out or execute anything from the PR.
   workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Build website & deploy to GitHub Pages"]
     types: [completed]
@@ -29,31 +28,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      contents: read
       pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      # The build workflow only uploads this artifact for PRs which touch the
-      # website, so a failed download just means there's nothing to preview.
-      - name: Download PR number
-        id: download-pr
-        continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: pr-number
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Read PR number
+      # workflow_run events don't reliably include the PR number (in
+      # particular for PRs from forks), so look it up from the head commit.
+      - name: Find PR number
         id: pr
-        if: steps.download-pr.outcome == 'success'
-        # The artifact was produced from untrusted PR code, so validate it.
         run: |
-          number="$(cat pr-number.txt)"
-          if ! [[ "$number" =~ ^[0-9]+$ ]]; then
-            echo "Invalid PR number: $number" >&2
-            exit 1
-          fi
-          echo "number=$number" >> "$GITHUB_OUTPUT"
+          gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" \
+            --jq '"number=\(.[0].number)"' >> "$GITHUB_OUTPUT"
       - name: Download website build
-        if: steps.pr.outputs.number
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: website
@@ -62,7 +50,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to Cloudflare Pages
         id: deploy
-        if: steps.pr.outputs.number
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -73,34 +60,11 @@ jobs:
             --branch=pr-${{ steps.pr.outputs.number }}
             --commit-hash=${{ github.event.workflow_run.head_sha }}
       - name: Comment preview URL on PR
-        if: steps.pr.outputs.number
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           # The stable per-PR alias, e.g. https://pr-123.hypothesis-website.pages.dev
-          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-        with:
-          script: |
-            const marker = "<!-- website-preview -->";
-            const issue_number = parseInt(process.env.PR_NUMBER, 10);
-            const body =
-              `${marker}\nWebsite preview for ${process.env.HEAD_SHA}: ` +
-              process.env.PREVIEW_URL;
-            const { owner, repo } = context.repo;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-            });
-            const existing = comments.find((c) => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --edit-last --create-if-none \
+            --body "Website preview for $HEAD_SHA: $URL"

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -8,7 +8,8 @@ name: Deploy website preview
 #
 # Requires a Cloudflare Pages project named `hypothesis-website`, and the
 # CLOUDFLARE_API_TOKEN (with Cloudflare Pages:Edit) and CLOUDFLARE_ACCOUNT_ID
-# repository secrets.
+# secrets in the `website-preview` environment, which should have a deployment
+# branch policy allowing only master so that no other workflow can read them.
 
 on:
   # Safe here because we never check out or execute anything from the PR.
@@ -26,6 +27,7 @@ jobs:
   deploy-preview:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    environment: website-preview
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,8 +5,10 @@ on:
   push:
     branches: ["master"]
 
-  # On pull requests we build the website but don't deploy it, so that broken
-  # changes are caught in review rather than after merging.
+  # On pull requests we build the website but don't deploy it to Pages, so
+  # that broken changes are caught in review rather than after merging.  If
+  # the PR touches the website we also upload artifacts which the
+  # website-preview workflow deploys to Cloudflare Pages as a live preview.
   pull_request:
     branches: ["master"]
 
@@ -32,16 +34,40 @@ jobs:
         with:
           lfs: true
           persist-credentials: false
+          # Deep enough to diff the PR merge commit against its base parent.
+          fetch-depth: 2
+      - name: Check whether the PR touches the website
+        id: changes
+        if: github.event_name == 'pull_request'
+        run: |
+          if git diff --name-only HEAD^1 HEAD | grep -qE '^(website/|\.github/workflows/website)'; then
+            echo "website=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "website=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build website
         run: ./build.sh website
       # Serve this with e.g. `python -m http.server` instead of opening the
       # files directly, because the site uses root-relative links.
       - name: Upload preview artifact
+        if: github.event_name != 'pull_request' || steps.changes.outputs.website == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: website
           path: 'website/output/'
           retention-days: 14
+      # Uploaded only when the PR touches the website, so that the preview
+      # workflow deploys (and comments on) only website PRs.
+      - name: Save PR number for the preview deployment
+        if: github.event_name == 'pull_request' && steps.changes.outputs.website == 'true'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      - name: Upload PR number artifact
+        if: github.event_name == 'pull_request' && steps.changes.outputs.website == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-number
+          path: pr-number.txt
+          retention-days: 1
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,12 +5,16 @@ on:
   push:
     branches: ["master"]
 
-  # On pull requests we build the website but don't deploy it to Pages, so
-  # that broken changes are caught in review rather than after merging.  If
-  # the PR touches the website we also upload artifacts which the
-  # website-preview workflow deploys to Cloudflare Pages as a live preview.
+  # On pull requests which touch the website we build it but don't deploy to
+  # Pages, so that broken changes are caught in review rather than after
+  # merging; the website-preview workflow then deploys the uploaded artifact
+  # to Cloudflare Pages as a live preview.
   pull_request:
     branches: ["master"]
+    paths:
+      - "website/**"
+      - "brand/**"
+      - ".github/workflows/website*.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -34,40 +38,16 @@ jobs:
         with:
           lfs: true
           persist-credentials: false
-          # Deep enough to diff the PR merge commit against its base parent.
-          fetch-depth: 2
-      - name: Check whether the PR touches the website
-        id: changes
-        if: github.event_name == 'pull_request'
-        run: |
-          if git diff --name-only HEAD^1 HEAD | grep -qE '^(website/|\.github/workflows/website)'; then
-            echo "website=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "website=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: Build website
         run: ./build.sh website
       # Serve this with e.g. `python -m http.server` instead of opening the
       # files directly, because the site uses root-relative links.
       - name: Upload preview artifact
-        if: github.event_name != 'pull_request' || steps.changes.outputs.website == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: website
           path: 'website/output/'
           retention-days: 14
-      # Uploaded only when the PR touches the website, so that the preview
-      # workflow deploys (and comments on) only website PRs.
-      - name: Save PR number for the preview deployment
-        if: github.event_name == 'pull_request' && steps.changes.outputs.website == 'true'
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-      - name: Upload PR number artifact
-        if: github.event_name == 'pull_request' && steps.changes.outputs.website == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pr-number
-          path: pr-number.txt
-          retention-days: 1
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
See https://github.com/HypothesisWorks/hypothesis/issues/4495.  Config by Fable; we'll see it working (I expect) in a follow-up PR which actually makes a small website edit too - but we can't really preview because it'll only run off master.