### PR TITLE
fix: draw 65 bits in BytestringProvider.draw_float to support negativ…

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes :class:`~hypothesis.internal.conjecture.providers.BytestringProvider`
+so that :meth:`draw_float` can generate negative floats. Previously, only 64 bits
+were drawn for a 65-bit float index format, so the sign bit was always zero and
+negative floats could never be produced.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch fixes :class:`~hypothesis.internal.conjecture.providers.BytestringProvider`
-so that :meth:`draw_float` can generate negative floats. Previously, only 64 bits
-were drawn for a 65-bit float index format, so the sign bit was always zero and
-negative floats could never be produced.
+This patch fixes ``BytestringProvider.draw_float`` so that it can generate
+negative floats. Previously, only 64 bits were drawn for a 65-bit float index
+format, so the sign bit was always zero and negative floats could never be
+produced.

--- a/hypothesis/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/providers.py
@@ -1193,7 +1193,7 @@ class BytestringProvider(PrimitiveProvider):
         allow_nan: bool = True,
         smallest_nonzero_magnitude: float,
     ) -> float:
-        n = self._draw_bits(64)
+        n = self._draw_bits(65)
         sign = -1 if n >> 64 else 1
         f = sign * lex_to_float(n & ((1 << 64) - 1))
         clamper = make_float_clamper(


### PR DESCRIPTION
## Fix: `BytestringProvider.draw_float` cannot generate negative floats

### Summary

`BytestringProvider.draw_float` only draws 64 bits even though the float index format uses 65 bits. This causes the sign bit to always be `0`, preventing negative floats from being generated.

### Fix

Draw 65 bits instead of 64 so bit 64 can correctly represent the sign:

```python
# Before
n = self._draw_bits(64)

# After
n = self._draw_bits(65)
```

This matches the 65-bit format already used by `choice_from_index` and `choice_to_index`.

### Impact

`BytestringProvider` is used by `fuzz_one_input`, so this bug prevents fuzz targets from exercising negative float inputs.

### Testing

* Existing provider contract tests pass.
* Verified generated floats continue to satisfy `choice_permitted`.
