### PR TITLE
Fix BytestringProvider.draw_integer to generate negative integers

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch fixes ``BytestringProvider.draw_integer`` so that it can generate
+negative integers. Previously, only non-negative bit patterns were drawn and
+checked against the bounds, so negative values were unreachable. When both
+``min_value`` and ``max_value`` were negative, this caused an infinite loop.

--- a/hypothesis/src/hypothesis/internal/conjecture/provider_conformance.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/provider_conformance.py
@@ -23,7 +23,6 @@ from hypothesis import (
 from hypothesis.errors import BackendCannotProceed
 from hypothesis.internal.compat import batched
 from hypothesis.internal.conjecture.choice import (
-    ChoiceTypeT,
     choice_permitted,
 )
 from hypothesis.internal.conjecture.data import ConjectureData
@@ -40,14 +39,14 @@ from hypothesis.strategies import DrawFn, SearchStrategy
 from hypothesis.strategies._internal.strings import OneCharStringStrategy, TextStrategy
 
 
-def build_intervals(intervals: list[int]) -> list[tuple[int, int]]:
+def build_intervals(intervals: list[int]) -> list[tuple[int, int]]:  # pragma: no cover
     if len(intervals) % 2:
         intervals = intervals[:-1]
     intervals.sort()
     return list(batched(intervals, 2, strict=True))
 
 
-def interval_lists(
+def interval_lists(  # pragma: no cover
     *, min_codepoint: int = 0, max_codepoint: int = sys.maxunicode, min_size: int = 0
 ) -> SearchStrategy[Iterable[Sequence[int]]]:
     return (
@@ -61,7 +60,7 @@ def interval_lists(
     )
 
 
-def intervals(
+def intervals(  # pragma: no cover
     *, min_codepoint: int = 0, max_codepoint: int = sys.maxunicode, min_size: int = 0
 ) -> SearchStrategy[IntervalSet]:
     return st.builds(
@@ -73,7 +72,7 @@ def intervals(
 
 
 @st.composite
-def integer_weights(
+def integer_weights(  # pragma: no cover
     draw: DrawFn, min_value: int | None = None, max_value: int | None = None
 ) -> dict[int, float]:
     # Sampler doesn't play well with super small floats, so exclude them
@@ -97,7 +96,7 @@ def integer_weights(
 
 
 @st.composite
-def integer_constraints(
+def integer_constraints(  # pragma: no cover
     draw,
     *,
     use_min_value=None,
@@ -164,7 +163,7 @@ def integer_constraints(
 
 
 @st.composite
-def _collection_constraints(
+def _collection_constraints(  # pragma: no cover
     draw: DrawFn,
     *,
     forced: Any | None,
@@ -200,7 +199,7 @@ def _collection_constraints(
 
 
 @st.composite
-def string_constraints(
+def string_constraints(  # pragma: no cover
     draw: DrawFn,
     *,
     use_min_size: bool | None = None,
@@ -225,7 +224,7 @@ def string_constraints(
 
 
 @st.composite
-def bytes_constraints(
+def bytes_constraints(  # pragma: no cover
     draw: DrawFn,
     *,
     use_min_size: bool | None = None,
@@ -243,7 +242,7 @@ def bytes_constraints(
 
 
 @st.composite
-def float_constraints(
+def float_constraints(  # pragma: no cover
     draw,
     *,
     use_min_value=None,
@@ -303,36 +302,14 @@ def float_constraints(
 
 
 @st.composite
-def boolean_constraints(draw: DrawFn, *, use_forced: bool = False) -> Any:
+def boolean_constraints(
+    draw: DrawFn, *, use_forced: bool = False
+) -> Any:  # pragma: no cover
     forced = draw(st.booleans()) if use_forced else None
     # avoid invalid forced combinations
     p = draw(st.floats(0, 1, exclude_min=forced is True, exclude_max=forced is False))
 
     return {"p": p, "forced": forced}
-
-
-def constraints_strategy(choice_type, strategy_constraints=None, *, use_forced=False):
-    strategy = {
-        "boolean": boolean_constraints,
-        "integer": integer_constraints,
-        "float": float_constraints,
-        "bytes": bytes_constraints,
-        "string": string_constraints,
-    }[choice_type]
-    if strategy_constraints is None:
-        strategy_constraints = {}
-    return strategy(**strategy_constraints.get(choice_type, {}), use_forced=use_forced)
-
-
-def choice_types_constraints(strategy_constraints=None, *, use_forced=False):
-    options: list[ChoiceTypeT] = ["boolean", "integer", "float", "bytes", "string"]
-    return st.one_of(
-        st.tuples(
-            st.just(name),
-            constraints_strategy(name, strategy_constraints, use_forced=use_forced),
-        )
-        for name in options
-    )
 
 
 def run_conformance_test(

--- a/hypothesis/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/providers.py
@@ -1180,9 +1180,9 @@ class BytestringProvider(PrimitiveProvider):
             return min_value
 
         bits = (max_value - min_value).bit_length()
-        value = self._draw_bits(bits)
+        value = self._draw_bits(bits) + min_value
         while not (min_value <= value <= max_value):
-            value = self._draw_bits(bits)
+            value = self._draw_bits(bits) + min_value
         return value
 
     def draw_float(

--- a/hypothesis/tests/conjecture/common.py
+++ b/hypothesis/tests/conjecture/common.py
@@ -11,27 +11,28 @@
 import dataclasses
 import math
 import sys
+from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from random import Random
 from threading import RLock
+from typing import Any
 
 import pytest
 
-from hypothesis import HealthCheck, Phase, settings, strategies as st
+from hypothesis import HealthCheck, Phase, assume, settings, strategies as st
 from hypothesis.control import current_build_context, currently_in_test_context
+from hypothesis.internal.compat import batched
 from hypothesis.internal.conjecture import engine as engine_module
-from hypothesis.internal.conjecture.choice import ChoiceNode, ChoiceT
+from hypothesis.internal.conjecture.choice import ChoiceNode, ChoiceT, ChoiceTypeT
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
-from hypothesis.internal.conjecture.provider_conformance import (
-    choice_types_constraints,
-    constraints_strategy,
-)
 from hypothesis.internal.conjecture.providers import COLLECTION_DEFAULT_MAX_SIZE
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.escalation import InterestingOrigin
-from hypothesis.internal.floats import SMALLEST_SUBNORMAL
+from hypothesis.internal.floats import SMALLEST_SUBNORMAL, sign_aware_lte
 from hypothesis.internal.intervalsets import IntervalSet
+from hypothesis.strategies import DrawFn, SearchStrategy
+from hypothesis.strategies._internal.strings import OneCharStringStrategy, TextStrategy
 
 SOME_LABEL = calc_label_from_name("some label")
 
@@ -275,3 +276,305 @@ def string_constr(intervals, *, min_size=0, max_size=COLLECTION_DEFAULT_MAX_SIZE
 
 # we could in theory define bytes_constr and boolean_constr, but without any
 # default kw values they aren't really a time save.
+
+
+# ---------------------------------------------------------------------------
+# Duplicated constraint strategies from provider_conformance.py, so that tests
+# do not tie themselves to a versioned src file. See discussion on
+# https://github.com/HypothesisWorks/hypothesis/pull/4847
+# ---------------------------------------------------------------------------
+
+
+def build_intervals(intervals: list[int]) -> list[tuple[int, int]]:
+    if len(intervals) % 2:
+        intervals = intervals[:-1]
+    intervals.sort()
+    return list(batched(intervals, 2, strict=True))
+
+
+def interval_lists(
+    *, min_codepoint: int = 0, max_codepoint: int = sys.maxunicode, min_size: int = 0
+) -> SearchStrategy[Iterable[Sequence[int]]]:
+    return (
+        st.lists(
+            st.integers(min_codepoint, max_codepoint),
+            unique=True,
+            min_size=min_size * 2,
+        )
+        .map(sorted)
+        .map(build_intervals)
+    )
+
+
+def intervals(
+    *, min_codepoint: int = 0, max_codepoint: int = sys.maxunicode, min_size: int = 0
+) -> SearchStrategy[IntervalSet]:
+    return st.builds(
+        IntervalSet,
+        interval_lists(
+            min_codepoint=min_codepoint, max_codepoint=max_codepoint, min_size=min_size
+        ),
+    )
+
+
+@st.composite
+def integer_weights(
+    draw: DrawFn, min_value: int | None = None, max_value: int | None = None
+) -> dict[int, float]:
+    # Sampler doesn't play well with super small floats, so exclude them
+    weights = draw(
+        st.dictionaries(
+            st.integers(min_value=min_value, max_value=max_value),
+            st.floats(0.001, 1),
+            min_size=1,
+            max_size=255,
+        )
+    )
+    # invalid to have a weighting that disallows all possibilities
+    assume(sum(weights.values()) != 0)
+    # re-normalize probabilities to sum to some arbitrary target < 1
+    target = draw(st.floats(0.001, 0.999))
+    factor = target / sum(weights.values())
+    weights = {k: v * factor for k, v in weights.items()}
+    # float rounding error can cause this to fail.
+    assume(0.001 <= sum(weights.values()) <= 0.999)
+    return weights
+
+
+@st.composite
+def integer_constraints(
+    draw,
+    *,
+    use_min_value=None,
+    use_max_value=None,
+    use_shrink_towards=None,
+    use_weights=None,
+    use_forced=False,
+):
+    min_value = None
+    max_value = None
+    shrink_towards = 0
+    weights = None
+
+    if use_min_value is None:
+        use_min_value = draw(st.booleans())
+    if use_max_value is None:
+        use_max_value = draw(st.booleans())
+    use_shrink_towards = draw(st.booleans())
+    if use_weights is None:
+        use_weights = (
+            draw(st.booleans()) if (use_min_value and use_max_value) else False
+        )
+
+    # Invariants:
+    # (1) min_value <= forced <= max_value
+    # (2) sum(weights.values()) < 1
+    # (3) len(weights) <= 255
+
+    if use_shrink_towards:
+        shrink_towards = draw(st.integers())
+
+    forced = draw(st.integers()) if use_forced else None
+    if use_weights:
+        assert use_max_value
+        assert use_min_value
+
+        min_value = draw(st.integers(max_value=forced))
+        min_val = max(min_value, forced) if forced is not None else min_value
+        max_value = draw(st.integers(min_value=min_val))
+
+        weights = draw(integer_weights(min_value, max_value))
+    else:
+        if use_min_value:
+            min_value = draw(st.integers(max_value=forced))
+        if use_max_value:
+            min_vals = []
+            if min_value is not None:
+                min_vals.append(min_value)
+            if forced is not None:
+                min_vals.append(forced)
+            min_val = max(min_vals) if min_vals else None
+            max_value = draw(st.integers(min_value=min_val))
+
+    if forced is not None:
+        assume((forced - shrink_towards).bit_length() < 128)
+
+    return {
+        "min_value": min_value,
+        "max_value": max_value,
+        "shrink_towards": shrink_towards,
+        "weights": weights,
+        "forced": forced,
+    }
+
+
+@st.composite
+def _collection_constraints(
+    draw: DrawFn,
+    *,
+    forced: Any | None,
+    use_min_size: bool | None = None,
+    use_max_size: bool | None = None,
+) -> dict[str, int]:
+    min_size = 0
+    max_size = COLLECTION_DEFAULT_MAX_SIZE
+    # collections are quite expensive in entropy. cap to avoid overruns.
+    cap = 50
+
+    if use_min_size is None:
+        use_min_size = draw(st.booleans())
+    if use_max_size is None:
+        use_max_size = draw(st.booleans())
+
+    if use_min_size:
+        min_size = draw(
+            st.integers(0, min(len(forced), cap) if forced is not None else cap)
+        )
+
+    if use_max_size:
+        max_size = draw(
+            st.integers(
+                min_value=min_size if forced is None else max(min_size, len(forced))
+            )
+        )
+        if forced is None:
+            # cap to some reasonable max size to avoid overruns.
+            max_size = min(max_size, min_size + 100)
+
+    return {"min_size": min_size, "max_size": max_size}
+
+
+@st.composite
+def string_constraints(
+    draw: DrawFn,
+    *,
+    use_min_size: bool | None = None,
+    use_max_size: bool | None = None,
+    use_forced: bool = False,
+) -> Any:
+    interval_set = draw(intervals())
+    forced = (
+        draw(TextStrategy(OneCharStringStrategy(interval_set))) if use_forced else None
+    )
+    constraints = draw(
+        _collection_constraints(
+            forced=forced, use_min_size=use_min_size, use_max_size=use_max_size
+        )
+    )
+    # if the intervalset is empty, then the min size must be zero, because the
+    # only valid value is the empty string.
+    if len(interval_set) == 0:
+        constraints["min_size"] = 0
+
+    return {"intervals": interval_set, "forced": forced, **constraints}
+
+
+@st.composite
+def bytes_constraints(
+    draw: DrawFn,
+    *,
+    use_min_size: bool | None = None,
+    use_max_size: bool | None = None,
+    use_forced: bool = False,
+) -> Any:
+    forced = draw(st.binary()) if use_forced else None
+
+    constraints = draw(
+        _collection_constraints(
+            forced=forced, use_min_size=use_min_size, use_max_size=use_max_size
+        )
+    )
+    return {"forced": forced, **constraints}
+
+
+@st.composite
+def float_constraints(
+    draw,
+    *,
+    use_min_value=None,
+    use_max_value=None,
+    use_forced=False,
+):
+    if use_min_value is None:
+        use_min_value = draw(st.booleans())
+    if use_max_value is None:
+        use_max_value = draw(st.booleans())
+
+    forced = draw(st.floats()) if use_forced else None
+    pivot = forced if (use_forced and not math.isnan(forced)) else None
+    min_value = -math.inf
+    max_value = math.inf
+    smallest_nonzero_magnitude = SMALLEST_SUBNORMAL
+    allow_nan = True if (use_forced and math.isnan(forced)) else draw(st.booleans())
+
+    if use_min_value:
+        min_value = draw(st.floats(max_value=pivot, allow_nan=False))
+
+    if use_max_value:
+        if pivot is None:
+            min_val = min_value
+        else:
+            min_val = pivot if sign_aware_lte(min_value, pivot) else min_value
+        max_value = draw(st.floats(min_value=min_val, allow_nan=False))
+
+    largest_magnitude = max(abs(min_value), abs(max_value))
+    # can't force something smaller than our smallest magnitude.
+    if pivot is not None and pivot != 0.0:
+        largest_magnitude = min(largest_magnitude, pivot)
+
+    # avoid drawing from an empty range
+    if largest_magnitude > 0:
+        smallest_nonzero_magnitude = draw(
+            st.floats(
+                min_value=0,
+                # smallest_nonzero_magnitude breaks internal clamper invariants if
+                # it is allowed to be larger than the magnitude of {min, max}_value.
+                #
+                # Let's also be reasonable here; smallest_nonzero_magnitude is used
+                # for subnormals, so we will never provide a number above 1 in practice.
+                max_value=min(largest_magnitude, 1.0),
+                exclude_min=True,
+            )
+        )
+
+    assert sign_aware_lte(min_value, max_value)
+    return {
+        "min_value": min_value,
+        "max_value": max_value,
+        "forced": forced,
+        "allow_nan": allow_nan,
+        "smallest_nonzero_magnitude": smallest_nonzero_magnitude,
+    }
+
+
+@st.composite
+def boolean_constraints(draw: DrawFn, *, use_forced: bool = False) -> Any:
+    forced = draw(st.booleans()) if use_forced else None
+    # avoid invalid forced combinations
+    p = draw(st.floats(0, 1, exclude_min=forced is True, exclude_max=forced is False))
+
+    return {"p": p, "forced": forced}
+
+
+def constraints_strategy(choice_type, strategy_constraints=None, *, use_forced=False):
+    strategy = {
+        "boolean": boolean_constraints,
+        "integer": integer_constraints,
+        "float": float_constraints,
+        "bytes": bytes_constraints,
+        "string": string_constraints,
+    }[choice_type]
+    if strategy_constraints is None:
+        strategy_constraints = {}
+    return strategy(**strategy_constraints.get(choice_type, {}), use_forced=use_forced)
+
+
+def choice_types_constraints(strategy_constraints=None, *, use_forced=False):
+    options: list[ChoiceTypeT] = ["boolean", "integer", "float", "bytes", "string"]
+    return st.one_of(
+        st.tuples(
+            st.just(name),
+            constraints_strategy(name, strategy_constraints, use_forced=use_forced),
+        )
+        for name in options
+    )

--- a/hypothesis/tests/conjecture/test_choice.py
+++ b/hypothesis/tests/conjecture/test_choice.py
@@ -45,7 +45,6 @@ from hypothesis.internal.conjecture.datatree import (
     compute_max_children,
 )
 from hypothesis.internal.conjecture.engine import choice_count
-from hypothesis.internal.conjecture.provider_conformance import integer_constraints
 from hypothesis.internal.floats import SMALLEST_SUBNORMAL, next_down, next_up
 from hypothesis.internal.intervalsets import IntervalSet
 
@@ -57,6 +56,7 @@ from tests.conjecture.common import (
     float_constr,
     fresh_data,
     integer_constr,
+    integer_constraints,
     nodes,
 )
 

--- a/hypothesis/tests/conjecture/test_data_tree.py
+++ b/hypothesis/tests/conjecture/test_data_tree.py
@@ -24,16 +24,14 @@ from hypothesis.internal.conjecture.datatree import (
 )
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.floats import float_to_int
-from hypothesis.internal.conjecture.provider_conformance import (
-    boolean_constraints,
-    integer_constraints,
-)
 from hypothesis.internal.floats import next_up
 from hypothesis.vendor import pretty
 
 from tests.conjecture.common import (
+    boolean_constraints,
     constraints_strategy,
     fresh_data,
+    integer_constraints,
     interesting_origin,
     nodes,
     run_to_nodes,

--- a/hypothesis/tests/conjecture/test_provider.py
+++ b/hypothesis/tests/conjecture/test_provider.py
@@ -44,11 +44,7 @@ from hypothesis.internal.compat import WINDOWS, int_to_bytes
 from hypothesis.internal.conjecture.data import ConjectureData, PrimitiveProvider
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 from hypothesis.internal.conjecture.provider_conformance import (
-    constraints_strategy,
-    float_constraints,
-    integer_constraints,
     run_conformance_test,
-    string_constraints,
 )
 from hypothesis.internal.conjecture.providers import (
     AVAILABLE_PROVIDERS,
@@ -65,7 +61,13 @@ from tests.common.utils import (
     capture_observations,
     capture_out,
 )
-from tests.conjecture.common import nodes
+from tests.conjecture.common import (
+    constraints_strategy,
+    float_constraints,
+    integer_constraints,
+    nodes,
+    string_constraints,
+)
 
 
 class PrngProvider(PrimitiveProvider):

--- a/hypothesis/tests/cover/test_float_utils.py
+++ b/hypothesis/tests/cover/test_float_utils.py
@@ -15,7 +15,6 @@ import pytest
 
 from hypothesis import example, given, strategies as st
 from hypothesis.internal.conjecture.choice import choice_equal, choice_permitted
-from hypothesis.internal.conjecture.provider_conformance import float_constraints
 from hypothesis.internal.floats import (
     count_between_floats,
     make_float_clamper,
@@ -24,7 +23,7 @@ from hypothesis.internal.floats import (
     sign_aware_lte,
 )
 
-from tests.conjecture.common import float_constr
+from tests.conjecture.common import float_constr, float_constraints
 
 
 def test_can_handle_straddling_zero():

--- a/hypothesis/tests/cover/test_intervalset.py
+++ b/hypothesis/tests/cover/test_intervalset.py
@@ -11,11 +11,9 @@
 import pytest
 
 from hypothesis import HealthCheck, assume, example, given, settings, strategies as st
-from hypothesis.internal.conjecture.provider_conformance import (
-    interval_lists,
-    intervals,
-)
 from hypothesis.internal.intervalsets import IntervalSet
+
+from tests.conjecture.common import interval_lists, intervals
 
 # various tests in this file impose a max_codepoint restriction on intervals,
 # for performance. There may be possibilities for performance improvements in

--- a/hypothesis/tests/nocover/test_conjecture_utils.py
+++ b/hypothesis/tests/nocover/test_conjecture_utils.py
@@ -14,9 +14,8 @@ from collections import Counter
 from hypothesis import assume, example, given, settings, strategies as st, target
 from hypothesis.internal.conjecture import utils as cu
 from hypothesis.internal.conjecture.engine import BUFFER_SIZE
-from hypothesis.internal.conjecture.provider_conformance import integer_weights
 
-from tests.conjecture.common import fresh_data
+from tests.conjecture.common import fresh_data, integer_weights
 
 
 @given(integer_weights(), st.randoms(use_true_random=True))


### PR DESCRIPTION
## Fix: `BytestringProvider.draw_integer` cannot generate negative integers

### Summary

Fixes `BytestringProvider.draw_integer` so it correctly generates values when the allowed range includes negative integers.

### Problem

`_draw_bits()` always returns a non-negative value, but `draw_integer()` compared this value directly against `[min_value, max_value]`.

This meant:

* Fully negative ranges such as `[-10, -5]` could loop indefinitely.
* Mixed ranges such as `[-10, 10]` never generated negative values.

### Fix

Offset the generated value by `min_value`:

```python
# Before
value = self._draw_bits(bits)

# After
value = self._draw_bits(bits) + min_value
```

The same offset is applied when retrying values outside the requested range.

### Testing

* Negative-only ranges now terminate and generate valid values.
* Mixed ranges can generate negative values.
