### PR TITLE
Rename remaining internal example terminology to test case

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release continues the terminology change in :ref:`version 6.159.0 <v6.159.0>`, updating more internal wording and names from "example" to "test case".

--- a/hypothesis/docs/reference/schema_observations.json
+++ b/hypothesis/docs/reference/schema_observations.json
@@ -20,7 +20,7 @@
                 },
                 "representation": {
                     "type": "string",
-                    "description": "The string representation of the input. In Hypothesis, this includes the property name and arguments (like ``test_a(a=1)``), any interactive draws from |st.data|, and additionally some comments from |Phase.explain| for failing examples."
+                    "description": "The string representation of the input. In Hypothesis, this includes the property name and arguments (like ``test_a(a=1)``), any interactive draws from |st.data|, and additionally some comments from |Phase.explain| for failing test cases."
                 },
                 "arguments": {
                     "type": "object",
@@ -28,7 +28,7 @@
                 },
                 "how_generated": {
                     "type": ["string", "null"],
-                    "description": "How the input was generated, if known.  In Hypothesis this might be an explicit example, generated during a particular phase with some backend, or by replaying the minimal failing example."
+                    "description": "How the input was generated, if known.  In Hypothesis this might be an explicit example, generated during a particular phase with some backend, or by replaying the minimal failing test case."
                 },
                 "features": {
                     "type": "object",

--- a/hypothesis/docs/tutorial/adapting-strategies.rst
+++ b/hypothesis/docs/tutorial/adapting-strategies.rst
@@ -75,7 +75,7 @@ Where possible, you should use |.filter|. Hypothesis can often rewrite simple fi
 
 For more complex relationships that can't be expressed with |.filter|, use |assume|.
 
-Here's an example of a test where we want to filter out two different types of examples:
+Here's an example of a test where we want to filter out two different types of inputs:
 
 .. code-block:: python
 

--- a/hypothesis/docs/tutorial/replaying-failures.rst
+++ b/hypothesis/docs/tutorial/replaying-failures.rst
@@ -76,8 +76,8 @@ Prefer |@example| over the database for correctness
 
 While the database is useful for quick local iteration, Hypothesis may invalidate it when upgrading (because e.g. the internal format may have changed). Changes to the source code of a test function may also change its database key, invalidating its stored entries. We therefore recommend against relying on the database for the correctness of your tests. If you want to ensure an input is run every time, use |@example|.
 
-Replaying examples with |@reproduce_failure|
---------------------------------------------
+Replaying test cases with |@reproduce_failure|
+----------------------------------------------
 
 If |settings.print_blob| is set to ``True`` (the default in the ``ci`` settings profile), and a test fails, Hypothesis will print an |@reproduce_failure| decorator containing an opaque blob as part of the error message:
 

--- a/hypothesis/src/hypothesis/_settings.py
+++ b/hypothesis/src/hypothesis/_settings.py
@@ -974,7 +974,8 @@ class settings(metaclass=settingsMeta):
         Because Hypothesis runs the test many times, it can sometimes find multiple
         bugs in a single run.  Reporting all of them at once is usually very useful,
         but replacing the exceptions can occasionally clash with debuggers.
-        If disabled, only the exception with the smallest minimal example is raised.
+        If disabled, only the exception with the smallest
+        |minimal failing test case| is raised.
 
         The default value is ``True``.
         """

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -2324,8 +2324,8 @@ def given(
                 thread_overlap=thread_overlap,
             )
             database_key = function_digest(test) + b".secondary"
-            # We track the minimal-so-far example for each distinct origin, so
-            # that we track log-n instead of n examples for long runs.  In particular
+            # We track the minimal-so-far test case for each distinct origin, so
+            # that we track log-n instead of n test cases for long runs.  In particular
             # it means that we saturate for common errors in long runs instead of
             # storing huge volumes of low-value data.
             minimal_failures: dict = {}

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -594,7 +594,7 @@ def execute_explicit_examples(state, wrapped_test, arguments, kwargs, original_s
                     state.execute_once,
                     empty_data,
                     is_final=True,
-                    print_example=True,
+                    print_test_case=True,
                     example_kwargs=example_kwargs,
                 )
                 with with_reporter(fragments_reported.append):
@@ -947,7 +947,7 @@ class StateForActualGivenExecution:
         }
 
         self.last_exception = None
-        self.falsifying_examples = ()
+        self.falsifying_test_cases = ()
         self.ever_executed = False
         self.xfail_example_reprs: set[str] = set()
         self.failed_normally = False
@@ -985,7 +985,7 @@ class StateForActualGivenExecution:
         self,
         data,
         *,
-        print_example=False,
+        print_test_case=False,
         is_final=False,
         expected_failure=None,
         example_kwargs=None,
@@ -1071,9 +1071,9 @@ class StateForActualGivenExecution:
                 nonlocal text_repr
                 text_repr = repr_call(test, args, kwargs)
 
-            if print_example or current_verbosity() >= Verbosity.verbose:
+            if print_test_case or current_verbosity() >= Verbosity.verbose:
                 printer = RepresentationPrinter(context=context)
-                if print_example:
+                if print_test_case:
                     printer.text("Failing test case:")
                 else:
                     printer.text("Test case:")
@@ -1194,16 +1194,16 @@ class StateForActualGivenExecution:
         self, err: FlakyReplay, context: BaseException
     ) -> FlakyFailure:
         assert self._runner is not None
-        # Note that in the mark_interesting case, _context_ itself
-        # is part of err._interesting_examples - but it's not in
-        # _runner.interesting_examples - this is fine, as the context
+        # Note that in the mark_interesting case, _context_
+        # is part of err._interesting_origins - but it's not in
+        # _runner.interesting_test_cases - this is fine, as the context
         # (i.e., immediate exception) is appended.
-        interesting_examples = [
-            self._runner.interesting_examples[origin]
+        interesting_test_cases = [
+            self._runner.interesting_test_cases[origin]
             for origin in err._interesting_origins
-            if origin in self._runner.interesting_examples
+            if origin in self._runner.interesting_test_cases
         ]
-        exceptions = [result.expected_exception for result in interesting_examples]
+        exceptions = [result.expected_exception for result in interesting_test_cases]
         exceptions.append(context)  # the immediate exception
         return FlakyFailure(err.reason, exceptions)
 
@@ -1438,14 +1438,14 @@ class StateForActualGivenExecution:
 
         if runner.call_count == 0:
             return
-        if runner.interesting_examples:
-            self.falsifying_examples = sorted(
-                runner.interesting_examples.values(),
+        if runner.interesting_test_cases:
+            self.falsifying_test_cases = sorted(
+                runner.interesting_test_cases.values(),
                 key=lambda d: sort_key(d.nodes),
                 reverse=True,
             )
         else:
-            if runner.valid_examples == 0:
+            if runner.valid_test_cases == 0:
                 explanations = []
                 if runner.exit_reason is ExitReason.finished:
                     explanations.append(
@@ -1456,23 +1456,23 @@ class StateForActualGivenExecution:
                     )
                 # use a somewhat arbitrary cutoff to avoid recommending spurious
                 # fixes.
-                # eg, a few invalid examples from internal filters when the
+                # eg, a few invalid test cases from internal filters when the
                 # problem is the user generating large inputs, or a
                 # few overruns during internal mutation when the problem is
                 # impossible user filters/assumes.
-                if runner.invalid_examples > min(20, runner.call_count // 5):
+                if runner.invalid_test_cases > min(20, runner.call_count // 5):
                     explanations.append(
-                        f"{runner.invalid_examples} of {runner.call_count} "
-                        "examples failed a .filter() or assume() condition. Try "
+                        f"{runner.invalid_test_cases} of {runner.call_count} "
+                        "test cases failed a .filter() or assume() condition. Try "
                         "making your filters or assumes less strict, or rewrite "
                         "using strategy parameters: "
                         "st.integers().filter(lambda x: x > 0) fails less often "
                         "(that is, never) when rewritten as st.integers(min_value=1)."
                     )
-                if runner.overrun_examples > min(20, runner.call_count // 5):
+                if runner.overrun_test_cases > min(20, runner.call_count // 5):
                     explanations.append(
-                        f"{runner.overrun_examples} of {runner.call_count} "
-                        "examples were too large to finish generating; try "
+                        f"{runner.overrun_test_cases} of {runner.call_count} "
+                        "test cases were too large to finish generating; try "
                         "reducing the typical size of your inputs?"
                     )
                 rep = get_pretty_function_description(self.test)
@@ -1497,11 +1497,11 @@ class StateForActualGivenExecution:
                 stacklevel=3,
             )
 
-        if not self.falsifying_examples:
+        if not self.falsifying_test_cases:
             return
         elif not (self.settings.report_multiple_bugs and pytest_shows_exceptiongroups):
             # Pretend that we only found one failure, by discarding the others.
-            del self.falsifying_examples[:-1]
+            del self.falsifying_test_cases[:-1]
 
         # The engine found one or more failures, so we need to reproduce and
         # report them.
@@ -1513,26 +1513,27 @@ class StateForActualGivenExecution:
             report_lines.append("")
 
         explanations = explanatory_lines(self.explain_traces, self.settings)
-        for falsifying_example in self.falsifying_examples:
+        for falsifying_test_case in self.falsifying_test_cases:
             fragments = []
 
-            ran_example = runner.new_conjecture_data(
-                falsifying_example.choices, max_choices=len(falsifying_example.choices)
+            ran_test_case = runner.new_conjecture_data(
+                falsifying_test_case.choices,
+                max_choices=len(falsifying_test_case.choices),
             )
-            ran_example.span_comments = falsifying_example.span_comments
+            ran_test_case.span_comments = falsifying_test_case.span_comments
             tb = None
             origin = None
-            assert falsifying_example.expected_exception is not None
-            assert falsifying_example.expected_traceback is not None
+            assert falsifying_test_case.expected_exception is not None
+            assert falsifying_test_case.expected_traceback is not None
             try:
                 with with_reporter(fragments.append):
                     self.execute_once(
-                        ran_example,
-                        print_example=True,
+                        ran_test_case,
+                        print_test_case=True,
                         is_final=True,
                         expected_failure=(
-                            falsifying_example.expected_exception,
-                            falsifying_example.expected_traceback,
+                            falsifying_test_case.expected_exception,
+                            falsifying_test_case.expected_traceback,
                         ),
                     )
             except StopTest as e:
@@ -1540,28 +1541,28 @@ class StateForActualGivenExecution:
                 # how to access the current exception, if it failed
                 # differently on this run. In fact, in the only known
                 # reproducer, the StopTest is caused by OVERRUN before the
-                # test is even executed. Possibly because all initial examples
+                # test is even executed. Possibly because all initial test cases
                 # failed until the final non-traced replay, and something was
                 # exhausted? Possibly a FIXME, but sufficiently weird to
                 # ignore for now.
                 err = FlakyFailure(
-                    "Inconsistent results: An example failed on the "
+                    "Inconsistent results: A test case failed on the "
                     "first run but now succeeds (or fails with another "
                     "error, or is for some reason not runnable).",
                     # (note: e is a BaseException)
-                    [falsifying_example.expected_exception or e],
+                    [falsifying_test_case.expected_exception or e],
                 )
                 errors_to_report.append(ReportableError(fragments, err))
             except UnsatisfiedAssumption as e:  # pragma: no cover  # ironically flaky
                 err = FlakyFailure(
-                    "Unreliable assumption: An example which satisfied "
+                    "Unreliable assumption: A test case which satisfied "
                     "assumptions on the first run now fails it.",
                     [e],
                 )
                 errors_to_report.append(ReportableError(fragments, err))
             except BaseException as e:
                 # If we have anything for explain-mode, this is the time to report.
-                fragments.extend(explanations[falsifying_example.interesting_origin])
+                fragments.extend(explanations[falsifying_test_case.interesting_origin])
                 error_with_tb = e.with_traceback(get_trimmed_traceback())
                 errors_to_report.append(ReportableError(fragments, error_with_tb))
                 tb = format_exception(e, get_trimmed_traceback(e))
@@ -1570,16 +1571,16 @@ class StateForActualGivenExecution:
                 # execute_once() will always raise either the expected error, or Flaky.
                 raise NotImplementedError("This should be unreachable")
             finally:
-                ran_example.freeze()
+                ran_test_case.freeze()
                 if observability_enabled():
                     # log our observability line for the final failing test case
                     tc = make_testcase(
                         run_start=self._start_timestamp,
                         property=self.test_identifier,
-                        data=ran_example,
+                        data=ran_test_case,
                         how_generated="minimal failing test case",
                         representation=self._string_repr,
-                        arguments=ran_example._observability_args,
+                        arguments=ran_test_case._observability_args,
                         timing=self._timing_features,
                         coverage=None,  # Not recorded when we're replaying the MFE
                         status="passed" if sys.exc_info()[0] else "failed",
@@ -1593,7 +1594,7 @@ class StateForActualGivenExecution:
                 if self.settings.print_blob:
                     fragments.append(
                         "\nYou can reproduce this test case by temporarily adding "
-                        f"{reproduction_decorator(falsifying_example.choices)} "
+                        f"{reproduction_decorator(falsifying_test_case.choices)} "
                         "as a decorator on your test function"
                     )
 
@@ -2104,7 +2105,7 @@ def given(
                         f"{type(runner).__qualname__}, but this "
                         "class does not inherit from the supported versions in "
                         "`hypothesis.extra.django`.  Use the Hypothesis variants "
-                        "to ensure that each example is run in a separate "
+                        "to ensure that each test case is run in a separate "
                         "database transaction."
                     )
 
@@ -2163,7 +2164,7 @@ def given(
                     try:
                         state.execute_once(
                             ConjectureData.for_choices(decode_failure(failure)),
-                            print_example=True,
+                            print_test_case=True,
                             is_final=True,
                         )
                         raise DidNotReproduce(
@@ -2213,14 +2214,14 @@ def given(
                     Phase.explicit in state.settings.phases
                     and getattr(wrapped_test, "hypothesis_explicit_examples", ())
                 )
-                SKIP_BECAUSE_NO_EXAMPLES = unittest.SkipTest(
+                SKIP_BECAUSE_NO_TEST_CASES = unittest.SkipTest(
                     "Hypothesis has been told to run no test cases for this test."
                 )
                 if not (
                     Phase.reuse in settings.phases or Phase.generate in settings.phases
                 ):
                     if not ran_explicit_examples:
-                        raise SKIP_BECAUSE_NO_EXAMPLES
+                        raise SKIP_BECAUSE_NO_TEST_CASES
                     return
 
                 try:
@@ -2287,7 +2288,7 @@ def given(
                         raise the_error_hypothesis_found
 
                 if not (ran_explicit_examples or state.ever_executed):
-                    raise SKIP_BECAUSE_NO_EXAMPLES
+                    raise SKIP_BECAUSE_NO_TEST_CASES
             finally:
                 with thread_overlap_lock:
                     del thread_overlap[threadid]
@@ -2423,7 +2424,7 @@ def find(
     random: Random | None = None,
     database_key: bytes | None = None,
 ) -> Ex:
-    """Returns the minimal example from the given strategy ``specifier`` that
+    """Returns the minimal value from the given strategy ``specifier`` that
     matches the predicate function ``condition``."""
     if settings is None:
         settings = Settings(max_examples=2000)
@@ -2433,7 +2434,7 @@ def find(
 
     if database_key is None and settings.database is not None:
         # Note: The database key is not guaranteed to be unique. If not, replaying
-        # of database examples may fail to reproduce due to being replayed on the
+        # of database test cases may fail to reproduce due to being replayed on the
         # wrong condition.
         database_key = function_digest(condition)
 

--- a/hypothesis/src/hypothesis/extra/ghostwriter.py
+++ b/hypothesis/src/hypothesis/extra/ghostwriter.py
@@ -1812,7 +1812,7 @@ def _make_binop_body(
             _write_call(func, "b", "a", assign="right"),
         )
     if identity is not None:
-        # Guess that the identity element is the minimal example from our operands
+        # Guess that the identity element is the minimal value from our operands
         # strategy.  This is correct often enough to be worthwhile, and close enough
         # that it's a good starting point to edit much of the rest.
         if identity is ...:

--- a/hypothesis/src/hypothesis/extra/pandas/impl.py
+++ b/hypothesis/src/hypothesis/extra/pandas/impl.py
@@ -83,7 +83,7 @@ def datetime_tz_dtype(dtype):
     if tz_dtype is not None and not PANDAS_GE_21:  # pragma: no cover
         # Before pandas 2.0, non-nanosecond units silently coerce to ns; on
         # pandas 2.0.x, formatting values outside the ns-representable range
-        # raises OutOfBoundsDatetime, so failing examples could not be shown.
+        # raises OutOfBoundsDatetime, so failing test cases could not be shown.
         raise InvalidArgument(
             "Generating timezone-aware datetimes requires pandas >= 2.1, but "
             f"you have pandas {pandas.__version__}"

--- a/hypothesis/src/hypothesis/internal/conjecture/choice.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/choice.py
@@ -118,7 +118,7 @@ class ChoiceNode:
         if self.was_forced:
             assert with_value is None, "modifying a forced node doesn't make sense"
         # explicitly not copying index. node indices are only assigned via
-        # ExampleRecord. This prevents footguns with relying on stale indices
+        # SpanRecord. This prevents footguns with relying on stale indices
         # after copying.
         return ChoiceNode(
             type=self.type,

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -729,7 +729,7 @@ class ConjectureData:
         self.__result: ConjectureResult | None = None
 
         # Observations used for targeted search.  They'll be aggregated in
-        # ConjectureRunner.generate_new_examples and fed to TargetSelector.
+        # ConjectureRunner.generate_new_test_cases and fed to TargetSelector.
         self.target_observations: TargetObservations = {}
 
         # Tags which indicate something about which part of the search space
@@ -747,7 +747,7 @@ class ConjectureData:
         self.__span_record = SpanRecord()
 
         # Span indices for discrete reportable parts that which-parts-matter can
-        # try varying, to report if the minimal example always fails anyway.
+        # try varying, to report if the minimal test case always fails anyway.
         self.arg_spans: set[int] = set()
         self.span_comments: dict[int | None, str] = {}
         self._observability_args: dict[str, Any] = {}

--- a/hypothesis/src/hypothesis/internal/conjecture/datatree.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/datatree.py
@@ -136,7 +136,7 @@ class Conclusion:
 # by using this. We just may think the node is exhausted when in fact it has more
 # possible children to be explored. This has the potential to finish generation
 # early due to exhausting the entire tree, but that is quite unlikely: (1) the
-# number of examples would have to be quite high, and (2) the tree would have to
+# number of test cases would have to be quite high, and (2) the tree would have to
 # contain only one or two nodes, or generate_novel_prefix would simply switch to
 # exploring another non-exhausted node.
 #
@@ -146,7 +146,7 @@ class Conclusion:
 # unconditionally is cheaper than estimating against this value.
 #
 # The one case where this may be detrimental is fuzzing, where the throughput of
-# examples is so high that it really may saturate important nodes. We'll cross
+# test cases is so high that it really may saturate important nodes. We'll cross
 # that bridge when we come to it.
 MAX_CHILDREN_EFFECTIVELY_INFINITE: Final[int] = 10_000_000
 

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -116,9 +116,9 @@ def shortlex(s):
 
 @dataclass(slots=True, frozen=False)
 class HealthCheckState:
-    valid_examples: int = field(default=0)
-    invalid_examples: int = field(default=0)
-    overrun_examples: int = field(default=0)
+    valid_test_cases: int = field(default=0)
+    invalid_test_cases: int = field(default=0)
+    overrun_test_cases: int = field(default=0)
     draw_times: defaultdict[str, list[float]] = field(
         default_factory=lambda: defaultdict(list)
     )
@@ -302,9 +302,9 @@ class ConjectureRunner:
         self.finish_shrinking_deadline: float | None = None
         self.call_count: int = 0
         self.misaligned_count: int = 0
-        self.valid_examples: int = 0
-        self.invalid_examples: int = 0
-        self.overrun_examples: int = 0
+        self.valid_test_cases: int = 0
+        self.invalid_test_cases: int = 0
+        self.overrun_test_cases: int = 0
         self.random: Random = random or Random(_random.getrandbits(128))
         self.database_key: bytes | None = database_key
         self.ignore_limits: bool = ignore_limits
@@ -318,13 +318,13 @@ class ConjectureRunner:
         # Time spent in any nested phase, so the enclosing phase can exclude it.
         self._nested_phase_seconds: float = 0.0
 
-        self.interesting_examples: dict[InterestingOrigin, ConjectureResult] = {}
-        # We use call_count because there may be few possible valid_examples.
+        self.interesting_test_cases: dict[InterestingOrigin, ConjectureResult] = {}
+        # We use call_count because there may be few possible valid_test_cases.
         self.first_bug_found_at: int | None = None
         self.last_bug_found_at: int | None = None
         self.first_bug_found_time: float = math.inf
 
-        self.shrunk_examples: set[InterestingOrigin] = set()
+        self.shrunk_test_cases: set[InterestingOrigin] = set()
         self.health_check_state: HealthCheckState | None = None
         self.tree: DataTree = DataTree()
         self.provider: PrimitiveProvider | type[PrimitiveProvider] = _get_provider(
@@ -334,7 +334,7 @@ class ConjectureRunner:
         self.best_observed_targets: defaultdict[str, float] = defaultdict(
             lambda: NO_SCORE
         )
-        self.best_examples_of_observed_targets: dict[str, ConjectureResult] = {}
+        self.best_test_cases_of_observed_targets: dict[str, ConjectureResult] = {}
 
         # We keep the pareto front in the example database if we have one. This
         # is only marginally useful at present, but speeds up local development
@@ -413,7 +413,7 @@ class ConjectureRunner:
             )
             stats["duration-seconds"] += elapsed - self._nested_phase_seconds
             stats["test-cases"] += self.stats_per_test_case
-            stats["distinct-failures"] = len(self.interesting_examples)
+            stats["distinct-failures"] = len(self.interesting_test_cases)
             stats["shrinks-successful"] = self.shrinks
             self.stats_per_test_case = saved_stats
             self._current_phase = saved_phase
@@ -576,10 +576,10 @@ class ConjectureRunner:
                     self._switch_to_hypothesis_provider = True
 
             # treat all BackendCannotProceed exceptions as invalid. This isn't
-            # great; "verified" should really be counted as self.valid_examples += 1.
-            # But we check self.valid_examples == 0 to determine whether to raise
+            # great; "verified" should really be counted as self.valid_test_cases += 1.
+            # But we check self.valid_test_cases == 0 to determine whether to raise
             # Unsatisfiable, and that would throw this check off.
-            self.invalid_examples += 1
+            self.invalid_test_cases += 1
             data.cannot_proceed_scope = exc.scope
 
         # this fiddly bit of control flow is to work around `return` being
@@ -669,31 +669,31 @@ class ConjectureRunner:
             for k, v in data.target_observations.items():
                 self.best_observed_targets[k] = max(self.best_observed_targets[k], v)
 
-                if k not in self.best_examples_of_observed_targets:
+                if k not in self.best_test_cases_of_observed_targets:
                     data_as_result = data.as_result()
                     assert not isinstance(data_as_result, _Overrun)
-                    self.best_examples_of_observed_targets[k] = data_as_result
+                    self.best_test_cases_of_observed_targets[k] = data_as_result
                     continue
 
-                existing_example = self.best_examples_of_observed_targets[k]
-                existing_score = existing_example.target_observations[k]
+                existing_test_case = self.best_test_cases_of_observed_targets[k]
+                existing_score = existing_test_case.target_observations[k]
 
                 if v < existing_score:
                     continue
 
                 if v > existing_score or sort_key(data.nodes) < sort_key(
-                    existing_example.nodes
+                    existing_test_case.nodes
                 ):
                     data_as_result = data.as_result()
                     assert not isinstance(data_as_result, _Overrun)
-                    self.best_examples_of_observed_targets[k] = data_as_result
+                    self.best_test_cases_of_observed_targets[k] = data_as_result
 
         if data.status is Status.VALID:
-            self.valid_examples += 1
+            self.valid_test_cases += 1
         if data.status is Status.INVALID:
-            self.invalid_examples += 1
+            self.invalid_test_cases += 1
         if data.status is Status.OVERRUN:
-            self.overrun_examples += 1
+            self.overrun_test_cases += 1
 
         if data.status == Status.INTERESTING:
             if not self.using_hypothesis_backend:
@@ -731,7 +731,7 @@ class ConjectureRunner:
             key = data.interesting_origin
             changed = False
             try:
-                existing = self.interesting_examples[key]
+                existing = self.interesting_test_cases[key]
             except KeyError:
                 changed = True
                 self.last_bug_found_at = self.call_count
@@ -747,11 +747,11 @@ class ConjectureRunner:
 
             if changed:
                 self.save_choices(data.choices)
-                self.interesting_examples[key] = data.as_result()  # type: ignore
+                self.interesting_test_cases[key] = data.as_result()  # type: ignore
                 if not self.using_hypothesis_backend:
                     self._backend_found_failure = True
                 self.__data_cache.pin(self._cache_key(data.choices), data.as_result())
-                self.shrunk_examples.discard(key)
+                self.shrunk_test_cases.discard(key)
 
             if self.shrinks >= MAX_SHRINKS:
                 self.exit_with(ExitReason.max_shrinks)
@@ -772,15 +772,15 @@ class ConjectureRunner:
             )
             self.exit_with(ExitReason.very_slow_shrinking)
 
-        if not self.interesting_examples:
+        if not self.interesting_test_cases:
             # Note that this logic is reproduced to end the generation phase when
-            # we have interesting examples.  Update that too if you change this!
+            # we have interesting test cases.  Update that too if you change this!
             # (The doubled implementation is because here we exit the engine entirely,
             #  while in the other case below we just want to move on to shrinking.)
-            if self.valid_examples >= self.settings.max_examples:
+            if self.valid_test_cases >= self.settings.max_examples:
                 self.exit_with(ExitReason.max_examples)
-            if (self.invalid_examples + self.overrun_examples) > (
-                INVALID_THRESHOLD_BASE + INVALID_PER_VALID * self.valid_examples
+            if (self.invalid_test_cases + self.overrun_test_cases) > (
+                INVALID_THRESHOLD_BASE + INVALID_PER_VALID * self.valid_test_cases
             ):
                 self.exit_with(ExitReason.max_iterations)
 
@@ -817,29 +817,29 @@ class ConjectureRunner:
             state.draw_times[k].append(v)
 
         if data.status == Status.VALID:
-            state.valid_examples += 1
+            state.valid_test_cases += 1
         elif data.status == Status.INVALID:
-            state.invalid_examples += 1
+            state.invalid_test_cases += 1
         else:
             assert data.status == Status.OVERRUN
-            state.overrun_examples += 1
+            state.overrun_test_cases += 1
 
         max_valid_draws = 10
         max_invalid_draws = 50
         max_overrun_draws = 20
 
-        assert state.valid_examples <= max_valid_draws
+        assert state.valid_test_cases <= max_valid_draws
 
-        if state.valid_examples == max_valid_draws:
+        if state.valid_test_cases == max_valid_draws:
             self.health_check_state = None
             return
 
-        if state.overrun_examples == max_overrun_draws:
+        if state.overrun_test_cases == max_overrun_draws:
             fail_health_check(
                 self.settings,
                 "Generated inputs routinely consumed more than the maximum "
-                f"allowed entropy: {state.valid_examples} inputs were generated "
-                f"successfully, while {state.overrun_examples} inputs exceeded the "
+                f"allowed entropy: {state.valid_test_cases} inputs were generated "
+                f"successfully, while {state.overrun_test_cases} inputs exceeded the "
                 f"maximum allowed entropy during generation."
                 "\n\n"
                 f"Testing with inputs this large tends to be slow, and to produce "
@@ -856,12 +856,12 @@ class ConjectureRunner:
                 "for details.",
                 HealthCheck.data_too_large,
             )
-        if state.invalid_examples == max_invalid_draws:
+        if state.invalid_test_cases == max_invalid_draws:
             fail_health_check(
                 self.settings,
                 "It looks like this test is filtering out a lot of inputs. "
-                f"{state.valid_examples} inputs were generated successfully, "
-                f"while {state.invalid_examples} inputs were filtered out. "
+                f"{state.valid_test_cases} inputs were generated successfully, "
+                f"while {state.invalid_test_cases} inputs were filtered out. "
                 "\n\n"
                 "An input might be filtered out by calls to assume(), "
                 "strategy.filter(...), or occasionally by Hypothesis internals."
@@ -891,11 +891,11 @@ class ConjectureRunner:
             and not self.thread_overlap.get(threading.get_ident(), False)
         ):
             extra_str = []
-            if state.invalid_examples:
-                extra_str.append(f"{state.invalid_examples} invalid inputs")
-            if state.overrun_examples:
+            if state.invalid_test_cases:
+                extra_str.append(f"{state.invalid_test_cases} invalid inputs")
+            if state.overrun_test_cases:
                 extra_str.append(
-                    f"{state.overrun_examples} inputs which exceeded the "
+                    f"{state.overrun_test_cases} inputs which exceeded the "
                     "maximum allowed entropy"
                 )
             extra_str = ", and ".join(extra_str)
@@ -904,7 +904,7 @@ class ConjectureRunner:
             fail_health_check(
                 self.settings,
                 "Input generation is slow: Hypothesis only generated "
-                f"{state.valid_examples} valid inputs after {draw_time:.2f} "
+                f"{state.valid_test_cases} valid inputs after {draw_time:.2f} "
                 f"seconds{extra_str}."
                 "\n" + state.timing_report() + "\n\n"
                 "This could be for a few reasons:"
@@ -1006,11 +1006,11 @@ class ConjectureRunner:
                 self._run()
             except RunIsComplete:
                 pass
-            for v in self.interesting_examples.values():
+            for v in self.interesting_test_cases.values():
                 self.debug_data(v)
             self.debug(
-                f"Run complete after {self.call_count} examples "
-                f"({self.valid_examples} valid) and {self.shrinks} shrinks"
+                f"Run complete after {self.call_count} test cases "
+                f"({self.valid_test_cases} valid) and {self.shrinks} shrinks"
             )
 
     @property
@@ -1019,32 +1019,32 @@ class ConjectureRunner:
             return None
         return self.settings.database
 
-    def has_existing_examples(self) -> bool:
+    def has_existing_test_cases(self) -> bool:
         return self.database is not None and Phase.reuse in self.settings.phases
 
-    def reuse_existing_examples(self) -> None:
+    def reuse_existing_test_cases(self) -> None:
         """If appropriate (we have a database and have been told to use it),
-        try to reload existing examples from the database.
+        try to reload existing test cases from the database.
 
         If there are a lot we don't try all of them. We always try the
-        smallest example in the database (which is guaranteed to be the
-        last failure) and the largest (which is usually the seed example
+        smallest test case in the database (which is guaranteed to be the
+        last failure) and the largest (which is usually the seed test case
         which the last failure came from but we don't enforce that). We
         then take a random sampling of the remainder and try those. Any
-        examples that are no longer interesting are cleared out.
+        test cases that are no longer interesting are cleared out.
         """
-        if self.has_existing_examples():
+        if self.has_existing_test_cases():
             self.debug("Reusing test cases from database")
             # We have to do some careful juggling here. We have two database
             # corpora: The primary and secondary. The primary corpus is a
-            # small set of minimized examples each of which has at one point
+            # small set of minimized test cases each of which has at one point
             # demonstrated a distinct bug. We want to retry all of these.
 
-            # We also have a secondary corpus of examples that have at some
+            # We also have a secondary corpus of test cases that have at some
             # point demonstrated interestingness (currently only ones that
-            # were previously non-minimal examples of a bug, but this will
+            # were previously non-minimal test cases for a bug, but this will
             # likely expand in future). These are a good source of potentially
-            # interesting examples, but there are a lot of them, so we down
+            # interesting test cases, but there are a lot of them, so we down
             # sample the secondary corpus to a more manageable size.
 
             corpus = sorted(
@@ -1095,14 +1095,14 @@ class ConjectureRunner:
                 if all_interesting_in_primary_were_exact:
                     self.reused_previously_shrunk_test_case = True
 
-            # Because self.database is not None (because self.has_existing_examples())
+            # Because self.database is not None (because self.has_existing_test_cases())
             # and self.database_key is not None (because we fetched using it above),
             # we can guarantee self.pareto_front is not None
             assert self.pareto_front is not None
 
-            # If we've not found any interesting examples so far we try some of
+            # If we've not found any interesting test cases so far we try some of
             # the pareto front from the last run.
-            if len(corpus) < desired_size and not self.interesting_examples:
+            if len(corpus) < desired_size and not self.interesting_test_cases:
                 desired_extra = desired_size - len(corpus)
                 pareto_corpus = list(self.settings.database.fetch(self.pareto_key))
                 if len(pareto_corpus) > desired_extra:
@@ -1137,18 +1137,18 @@ class ConjectureRunner:
         # the shrinking phase having found one or more bugs, while the other
         # will exit having found zero bugs.
         invalid_threshold = (
-            INVALID_THRESHOLD_BASE + INVALID_PER_VALID * self.valid_examples
+            INVALID_THRESHOLD_BASE + INVALID_PER_VALID * self.valid_test_cases
         )
         if (
-            self.valid_examples >= self.settings.max_examples
-            or (self.invalid_examples + self.overrun_examples) > invalid_threshold
+            self.valid_test_cases >= self.settings.max_examples
+            or (self.invalid_test_cases + self.overrun_test_cases) > invalid_threshold
         ):
             return False
 
         # If we haven't found a bug, keep looking - if we hit any limits on
         # the number of tests to run that will raise an exception and stop
         # the run.
-        if not self.interesting_examples:
+        if not self.interesting_test_cases:
             return True
         # Users who disable shrinking probably want to exit as fast as possible.
         # If we've found a bug and won't report more than one, stop looking.
@@ -1170,10 +1170,10 @@ class ConjectureRunner:
             self.first_bug_found_at + 1000, self.last_bug_found_at * 2
         )
 
-    def generate_new_examples(self) -> None:
+    def generate_new_test_cases(self) -> None:
         if Phase.generate not in self.settings.phases:
             return
-        if self.interesting_examples:
+        if self.interesting_test_cases:
             # The example database has failing test cases from a previous run,
             # so we'd rather report that they're still failing ASAP than take
             # the time to look for additional failures.
@@ -1243,13 +1243,13 @@ class ConjectureRunner:
         # it has failed too many times in a row.
         consecutive_zero_extend_is_invalid = 0
 
-        # We control growth during initial example generation, for two
+        # We control growth during initial test case generation, for two
         # reasons:
         #
-        # * It gives us an opportunity to find small examples early, which
+        # * It gives us an opportunity to find small test cases early, which
         #   gives us a fast path for easy to find bugs.
         # * It avoids low probability events where we might end up
-        #   generating very large examples during health checks, which
+        #   generating very large test cases during health checks, which
         #   on slower machines can trigger HealthCheck.too_slow.
         #
         # The heuristic we use is that we attempt to estimate the smallest
@@ -1257,18 +1257,18 @@ class ConjectureRunner:
         # an order of magnitude larger than that. If we fail to estimate
         # the size accurately, we skip over this prefix and try again.
         #
-        # We need to tune the example size based on the initial prefix,
+        # We need to tune the test case size based on the initial prefix,
         # because any fixed size might be too small, and any size based
         # on the strategy in general can fall afoul of strategies that
         # have very different sizes for different prefixes.
         #
-        # We previously set a minimum value of 10 on small_example_cap, with the
+        # We previously set a minimum value of 10 on small_test_case_cap, with the
         # reasoning of avoiding flaky health checks. However, some users set a
         # low max_examples for performance. A hard lower bound in this case biases
-        # the distribution towards small (and less powerful) examples. Flaky
+        # the distribution towards small (and less powerful) test cases. Flaky
         # and loud health checks are better than silent performance degradation.
-        small_example_cap = min(self.settings.max_examples // 10, 50)
-        optimise_at = max(self.settings.max_examples // 2, small_example_cap + 1, 10)
+        small_test_case_cap = min(self.settings.max_examples // 10, 50)
+        optimise_at = max(self.settings.max_examples // 2, small_test_case_cap + 1, 10)
         ran_optimisations = False
         self._switch_to_hypothesis_provider = False
 
@@ -1283,24 +1283,24 @@ class ConjectureRunner:
             self._current_phase = "generate"
             prefix = self.generate_novel_prefix()
             if (
-                self.valid_examples <= small_example_cap
-                and self.call_count <= 5 * small_example_cap
-                and not self.interesting_examples
+                self.valid_test_cases <= small_test_case_cap
+                and self.call_count <= 5 * small_test_case_cap
+                and not self.interesting_test_cases
                 and consecutive_zero_extend_is_invalid < 5
             ):
-                minimal_example = self.cached_test_function(
+                minimal_test_case = self.cached_test_function(
                     prefix + (ChoiceTemplate("simplest", count=None),)
                 )
 
-                if minimal_example.status < Status.VALID:
+                if minimal_test_case.status < Status.VALID:
                     consecutive_zero_extend_is_invalid += 1
                     continue
                 # Because the Status code is greater than Status.VALID, it cannot be
-                # Status.OVERRUN, which guarantees that the minimal_example is a
+                # Status.OVERRUN, which guarantees that the minimal_test_case is a
                 # ConjectureResult object.
-                assert isinstance(minimal_example, ConjectureResult)
+                assert isinstance(minimal_test_case, ConjectureResult)
                 consecutive_zero_extend_is_invalid = 0
-                minimal_extension = len(minimal_example.choices) - len(prefix)
+                minimal_extension = len(minimal_test_case.choices) - len(prefix)
                 max_length = len(prefix) + minimal_extension * 5
 
                 # We could end up in a situation where even though the prefix was
@@ -1324,8 +1324,8 @@ class ConjectureRunner:
                 if trial_data.observer.killed:
                     continue
 
-                # We might have hit the cap on number of examples we should
-                # run when calculating the minimal example.
+                # We might have hit the cap on number of test cases we should
+                # run when calculating the minimal test case.
                 if not self.should_generate_more():
                     break
 
@@ -1342,19 +1342,19 @@ class ConjectureRunner:
                 and "invalid because" not in data.events
             ):
                 data.events["invalid because"] = (
-                    "reduced max size for early examples (avoids flaky health checks)"
+                    "reduced max size for early test cases (avoids flaky health checks)"
                 )
 
             self.generate_mutations_from(data)
 
             # Although the optimisations are logically a distinct phase, we
-            # actually normally run them as part of example generation. The
+            # actually normally run them as part of test case generation. The
             # reason for this is that we cannot guarantee that optimisation
             # actually exhausts our budget: It might finish running and we
             # discover that actually we still could run a bunch more test cases
             # if we want.
             if (
-                self.valid_examples >= max(small_example_cap, optimise_at)
+                self.valid_test_cases >= max(small_test_case_cap, optimise_at)
                 and not ran_optimisations
             ):
                 ran_optimisations = True
@@ -1473,9 +1473,9 @@ class ConjectureRunner:
                 else:
                     start, end = self.random.choice([(start1, end1), (start2, end2)])
                     replacement = data.choices[start:end]
-                    # We attempt to replace both the examples with
+                    # We attempt to replace both the spans with
                     # whichever choice we made. Note that this might end
-                    # up messing up and getting the example boundaries
+                    # up messing up and getting the span boundaries
                     # wrong - labels matching are only a best guess as to
                     # whether the two are equivalent - but it doesn't
                     # really matter. It may not achieve the desired result,
@@ -1528,7 +1528,7 @@ class ConjectureRunner:
 
         # We want to avoid running the optimiser for too long in case we hit
         # an unbounded target score. We start this off fairly conservatively
-        # in case interesting examples are easy to find and then ramp it up
+        # in case interesting test cases are easy to find and then ramp it up
         # on an exponential schedule so we don't hamper the optimiser too much
         # if it needs a long time to find good enough improvements.
         max_improvements = 10
@@ -1537,7 +1537,7 @@ class ConjectureRunner:
 
             any_improvements = False
 
-            for target, data in list(self.best_examples_of_observed_targets.items()):
+            for target, data in list(self.best_test_cases_of_observed_targets.items()):
                 optimiser = Optimiser(
                     self, data, target, max_improvements=max_improvements
                 )
@@ -1545,7 +1545,7 @@ class ConjectureRunner:
                 if optimiser.improvements > 0:
                     any_improvements = True
 
-            if self.interesting_examples:
+            if self.interesting_test_cases:
                 break
 
             max_improvements *= 2
@@ -1567,16 +1567,16 @@ class ConjectureRunner:
         # have to use the primitive provider to interpret database bits...
         self._switch_to_hypothesis_provider = True
         with self._log_phase_statistics("reuse"):
-            self.reuse_existing_examples()
+            self.reuse_existing_test_cases()
         # Fast path for development: If the database gave us interesting
-        # examples from the previously stored primary key, don't try
+        # test cases from the previously stored primary key, don't try
         # shrinking it again as it's unlikely to work.
         if self.reused_previously_shrunk_test_case:
             self.exit_with(ExitReason.finished)
         # ...but we should use the supplied provider when generating...
         self._switch_to_hypothesis_provider = False
         with self._log_phase_statistics("generate"):
-            self.generate_new_examples()
+            self.generate_new_test_cases()
             # We normally run the targeting phase mixed in with the generate phase,
             # but if we've been asked to run it but not generation then we have to
             # run it explicitly on its own here.
@@ -1586,7 +1586,7 @@ class ConjectureRunner:
         # ...and back to the primitive provider when shrinking.
         self._switch_to_hypothesis_provider = True
         with self._log_phase_statistics("shrink"):
-            self.shrink_interesting_examples()
+            self.shrink_interesting_test_cases()
         self.exit_with(ExitReason.finished)
 
     def new_conjecture_data(
@@ -1611,21 +1611,21 @@ class ConjectureRunner:
             random=self.random,
         )
 
-    def shrink_interesting_examples(self) -> None:
-        """If we've found interesting examples, try to replace each of them
-        with a minimal interesting example with the same interesting_origin.
+    def shrink_interesting_test_cases(self) -> None:
+        """If we've found interesting test cases, try to replace each of them
+        with a minimal interesting test case with the same interesting_origin.
 
-        We may find one or more examples with a new interesting_origin
+        We may find one or more test cases with a new interesting_origin
         during the shrink process. If so we shrink these too.
         """
-        if Phase.shrink not in self.settings.phases or not self.interesting_examples:
+        if Phase.shrink not in self.settings.phases or not self.interesting_test_cases:
             return
 
         self.debug("Shrinking failing test cases")
         self.finish_shrinking_deadline = time.perf_counter() + MAX_SHRINKING_SECONDS
 
         for prev_data in sorted(
-            self.interesting_examples.values(), key=lambda d: sort_key(d.nodes)
+            self.interesting_test_cases.values(), key=lambda d: sort_key(d.nodes)
         ):
             assert prev_data.status == Status.INTERESTING
             data = self.new_conjecture_data(prev_data.choices)
@@ -1635,21 +1635,21 @@ class ConjectureRunner:
 
         self.clear_secondary_key()
 
-        while len(self.shrunk_examples) < len(self.interesting_examples):
-            target, example = min(
+        while len(self.shrunk_test_cases) < len(self.interesting_test_cases):
+            target, result = min(
                 (
                     (k, v)
-                    for k, v in self.interesting_examples.items()
-                    if k not in self.shrunk_examples
+                    for k, v in self.interesting_test_cases.items()
+                    if k not in self.shrunk_test_cases
                 ),
                 key=lambda kv: (sort_key(kv[1].nodes), shortlex(repr(kv[0]))),
             )
-            self.debug(f"Shrinking {target!r}: {example.choices}")
+            self.debug(f"Shrinking {target!r}: {result.choices}")
 
             if not self.settings.report_multiple_bugs:
                 # If multi-bug reporting is disabled, we shrink our currently-minimal
-                # failure, allowing 'slips' to any bug with a smaller minimal example.
-                self.shrink(example, lambda d: d.status == Status.INTERESTING)
+                # failure, allowing 'slips' to any bug with a smaller minimal test case.
+                self.shrink(result, lambda d: d.status == Status.INTERESTING)
                 return
 
             def predicate(d: ConjectureResult | _Overrun) -> bool:
@@ -1658,13 +1658,13 @@ class ConjectureRunner:
                 d = cast(ConjectureResult, d)
                 return d.interesting_origin == target
 
-            self.shrink(example, predicate)
+            self.shrink(result, predicate)
 
-            self.shrunk_examples.add(target)
+            self.shrunk_test_cases.add(target)
 
     def clear_secondary_key(self) -> None:
-        if self.has_existing_examples():
-            # If we have any smaller examples in the secondary corpus, now is
+        if self.has_existing_test_cases():
+            # If we have any smaller test cases in the secondary corpus, now is
             # a good time to try them to see if they work as shrinks. They
             # probably won't, but it's worth a shot and gives us a good
             # opportunity to clear out the database.
@@ -1681,32 +1681,32 @@ class ConjectureRunner:
                     continue
                 primary = {
                     choices_to_bytes(v.choices)
-                    for v in self.interesting_examples.values()
+                    for v in self.interesting_test_cases.values()
                 }
                 if shortlex(c) > max(map(shortlex, primary)):
                     break
 
                 self.cached_test_function(choices)
                 # We unconditionally remove c from the secondary key as it
-                # is either now primary or worse than our primary example
-                # of this reason for interestingness.
+                # is either now primary or worse than our primary test case
+                # for this reason for interestingness.
                 self.settings.database.delete(self.secondary_key, c)
 
     def shrink(
         self,
-        example: ConjectureData | ConjectureResult,
+        initial: ConjectureData | ConjectureResult,
         predicate: ShrinkPredicateT | None = None,
         allow_transition: (
             Callable[[ConjectureData | ConjectureResult, ConjectureData], bool] | None
         ) = None,
     ) -> ConjectureData | ConjectureResult:
-        s = self.new_shrinker(example, predicate, allow_transition)
+        s = self.new_shrinker(initial, predicate, allow_transition)
         s.shrink()
         return s.shrink_target
 
     def new_shrinker(
         self,
-        example: ConjectureData | ConjectureResult,
+        initial: ConjectureData | ConjectureResult,
         predicate: ShrinkPredicateT | None = None,
         allow_transition: (
             Callable[[ConjectureData | ConjectureResult, ConjectureData], bool] | None
@@ -1714,7 +1714,7 @@ class ConjectureRunner:
     ) -> Shrinker:
         return Shrinker(
             self,
-            example,
+            initial,
             predicate,
             allow_transition=allow_transition,
             explain=Phase.explain in self.settings.phases,

--- a/hypothesis/src/hypothesis/internal/conjecture/optimiser.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/optimiser.py
@@ -83,9 +83,7 @@ class Optimiser:
 
     def hill_climb(self) -> None:
         """The main hill climbing loop where we actually do the work: Take
-        data, and attempt to improve its score for target. select_example takes
-        a data object and returns an index to an example where we should focus
-        our efforts."""
+        data, and attempt to improve its score for target."""
 
         nodes_examined = set()
 

--- a/hypothesis/src/hypothesis/internal/conjecture/pareto.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/pareto.py
@@ -48,7 +48,7 @@ def dominance(left: ConjectureResult, right: ConjectureResult) -> DominanceRelat
         * Something that is smaller in shrinking order is better.
         * Something that has higher status is better.
         * Each ``interesting_origin`` is treated as its own score, so if two
-          interesting examples have different origins then neither dominates
+          interesting test cases have different origins then neither dominates
           the other.
         * For each target observation, a higher score is better.
 
@@ -114,7 +114,7 @@ class ParetoFront:
 
     Note that the pareto front is potentially quite large, and currently this
     will store the entire front in memory. This is bounded by the number of
-    valid examples we run, which is max_examples in normal execution, and
+    valid test cases we run, which is max_examples in normal execution, and
     currently we do not support workflows with large max_examples which have
     large values of max_examples very well anyway, so this isn't a major issue.
     In future we may weish to implement some sort of paging out to disk so that
@@ -307,19 +307,19 @@ class ParetoOptimiser:
         seen = set()
 
         # We iterate backwards through the pareto front, using the shrinker to
-        # (hopefully) replace each example with a smaller one. Note that it's
+        # (hopefully) replace each test case with a smaller one. Note that it's
         # important that we start from the end for two reasons: Firstly, by
         # doing it this way we ensure that any new front members we discover
         # during optimisation will also get optimised (because they will be
         # inserted into the part of the front that we haven't visited yet),
         # and secondly we generally expect that we will not finish this process
         # in a single run, because it's relatively expensive in terms of our
-        # example budget, and by starting from the end we ensure that each time
+        # test case budget, and by starting from the end we ensure that each time
         # we run the tests we improve the pareto front because we work on the
         # bits that we haven't covered yet.
         i = len(self.front) - 1
         prev = None
-        while i >= 0 and not self.__engine.interesting_examples:
+        while i >= 0 and not self.__engine.interesting_test_cases:
             assert self.front
             i = min(i, len(self.front) - 1)
             target = self.front[i]
@@ -335,7 +335,7 @@ class ParetoOptimiser:
                 shrinker.
 
                 Note that during shrinking we may discover other smaller
-                examples that this function will reject and will get added to
+                test cases that this function will reject and will get added to
                 the front. This is fine, because they will be processed on
                 later iterations of this loop."""
                 if dominance(destination, source) == DominanceRelation.LEFT_DOMINATES:

--- a/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
@@ -311,8 +311,8 @@ class Shrinker:
         in_target_phase: bool = False,
     ):
         """Create a shrinker for a particular engine, with a given starting
-        point and predicate. When shrink() is called it will attempt to find an
-        example for which predicate is True and which is strictly smaller than
+        point and predicate. When shrink() is called it will attempt to find a
+        test case for which predicate is True and which is strictly smaller than
         initial.
 
         Note that initial is a ConjectureData object, and predicate
@@ -325,7 +325,7 @@ class Shrinker:
         self.__derived_values: dict = {}
 
         self.initial_size = len(initial.choices)
-        # We keep track of the current best example on the shrink_target
+        # We keep track of the current best test case on the shrink_target
         # attribute.
         self.shrink_target = initial
         self.clear_change_tracking()
@@ -535,7 +535,7 @@ class Shrinker:
                 continue
 
             # Check for any previous test cases that match the prefix and suffix,
-            # so we can skip if we found a passing example while shrinking.
+            # so we can skip if we found a passing test case while shrinking.
             if any(
                 startswith(seen, nodes[:start]) and endswith(seen, nodes[end:])
                 for seen in seen_passing_seq
@@ -565,7 +565,7 @@ class Shrinker:
                 # no-branch here because we don't coverage-test the abort-at-500 logic.
 
                 if n_attempt - 10 - len(candidates) > n_same_failures * 5:
-                    # stop early if we're seeing mostly invalid examples
+                    # stop early if we're seeing mostly invalid test cases
                     break  # pragma: no cover
 
                 if n_attempt < len(candidates):
@@ -1338,7 +1338,7 @@ class Shrinker:
 
             # This can happen if we have discards but they are all of
             # zero length. This shouldn't happen very often so it's
-            # faster to check for it here than at the point of example
+            # faster to check for it here than at the point of span
             # generation.
             if not discarded:
                 break

--- a/hypothesis/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/utils.py
@@ -109,11 +109,11 @@ def check_sample(
             f"Cannot sample from {values!r} because it is not an ordered collection. "
             f"Hypothesis goes to some length to ensure that the {strategy_name} "
             "strategy has stable results between runs. To replay a saved "
-            "example, the sampled values must have the same iteration order "
+            "test case, the sampled values must have the same iteration order "
             "on every run - ruling out sets, dicts, etc due to hash "
             "randomization. Most cases can simply use `sorted(values)`, but "
             "mixed types or special values such as math.nan require careful "
-            "handling - and note that when simplifying an example, "
+            "handling - and note that when shrinking a test case, "
             "Hypothesis treats earlier values as simpler."
         )
     if isinstance(values, range):

--- a/hypothesis/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/utils.py
@@ -261,7 +261,7 @@ class Sampler:
 
 class many:
     """Utility class for collections. Bundles up the logic we use for "should I
-    keep drawing more values?" and handles starting and stopping examples in
+    keep drawing more values?" and handles starting and stopping spans in
     the right place.
 
     Intended usage is something like:
@@ -343,7 +343,7 @@ class many:
             return False
 
     def reject(self, why: str | None = None) -> None:
-        """Reject the last example (i.e. don't count it towards our budget of
+        """Reject the last element (i.e. don't count it towards our budget of
         elements because it's not going to go in the final collection)."""
         assert self.count > 0
         self.count -= 1

--- a/hypothesis/src/hypothesis/internal/observability.py
+++ b/hypothesis/src/hypothesis/internal/observability.py
@@ -424,7 +424,7 @@ def make_testcase(
     elif data.interesting_origin:
         status_reason = str(data.interesting_origin)
     elif phase == "shrink" and data.status == Status.OVERRUN:
-        status_reason = "exceeded size of current best example"
+        status_reason = "exceeded size of current best test case"
     else:
         status_reason = str(data.events.pop("invalid because", ""))
 

--- a/hypothesis/src/hypothesis/strategies/_internal/attrs.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/attrs.py
@@ -96,7 +96,7 @@ def from_attrs_attribute(
     """Infer a strategy from the metadata on an attr.Attribute object."""
     # Try inferring from the default argument.  Note that this will only help if
     # the user passed `...` to builds() for this attribute, but in that case
-    # we use it as the minimal example.
+    # we use it as the minimal value.
     default: SearchStrategy = st.nothing()
     # attr/__init__.pyi uses overloads to declare Factory as a function, not a
     # class. This is a fib - at runtime and always, it is a class.

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -193,7 +193,7 @@ class ListStrategy(SearchStrategy[list[Ex]]):
         self.element_strategy = elements
         if min_size > BUFFER_SIZE:
             raise InvalidArgument(
-                f"{self!r} can never generate an example, because min_size is larger "
+                f"{self!r} can never generate a value, because min_size is larger "
                 "than Hypothesis supports.  Including it is at best slowing down your "
                 "tests for no benefit; at worst making them fail (maybe flakily) with "
                 "a HealthCheck error."

--- a/hypothesis/src/hypothesis/strategies/_internal/shared.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/shared.py
@@ -47,7 +47,7 @@ class SharedStrategy(SearchStrategy[Ex]):
             if self.label != other.label:
                 warnings.warn(
                     f"Different strategies are shared under {key=}. This"
-                    " risks drawing values that are not valid examples for the strategy,"
+                    " risks drawing values that are not valid for the strategy,"
                     " or that have a narrower range than expected."
                     f" Conflicting strategies: ({self!r}, {other!r}).",
                     HypothesisWarning,

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -328,7 +328,7 @@ class SearchStrategy(Generic[Ex]):
                 "The `.example()` method is good for exploring strategies, but should "
                 "only be used interactively.  We recommend using `@given` for tests - "
                 "it performs better, saves and replays failures to avoid flakiness, "
-                f"and reports minimal examples. (strategy: {self!r})",
+                f"and reports minimal failing test cases. (strategy: {self!r})",
                 NonInteractiveExampleWarning,
                 stacklevel=2,
             )
@@ -350,7 +350,7 @@ class SearchStrategy(Generic[Ex]):
                 raise HypothesisException(
                     "Using example() inside a test function is a bad "
                     "idea. Instead consider using hypothesis.strategies.data() "
-                    "to draw more examples during testing. See "
+                    "to draw more values during testing. See "
                     "https://hypothesis.readthedocs.io/en/latest/reference/"
                     "strategies.html#hypothesis.strategies.data for more details."
                 )

--- a/hypothesis/tests/conjecture/common.py
+++ b/hypothesis/tests/conjecture/common.py
@@ -61,8 +61,8 @@ def run_to_data(f):
         random=Random(0),
     )
     runner.run()
-    assert runner.interesting_examples
-    (last_data,) = runner.interesting_examples.values()
+    assert runner.interesting_test_cases
+    (last_data,) = runner.interesting_test_cases.values()
     return last_data
 
 
@@ -99,9 +99,9 @@ def shrinking_from(start):
             random=Random(0),
         )
         runner.cached_test_function(start)
-        assert runner.interesting_examples
+        assert runner.interesting_test_cases
 
-        (last_data,) = runner.interesting_examples.values()
+        (last_data,) = runner.interesting_test_cases.values()
         return runner.new_shrinker(last_data, lambda d: d.status == Status.INTERESTING)
 
     return accept

--- a/hypothesis/tests/conjecture/test_engine.py
+++ b/hypothesis/tests/conjecture/test_engine.py
@@ -100,7 +100,7 @@ def test_can_load_data_from_a_corpus():
 
     runner = ConjectureRunner(f, settings=settings(database=db), database_key=key)
     runner.run()
-    (last_data,) = runner.interesting_examples.values()
+    (last_data,) = runner.interesting_test_cases.values()
     assert last_data.choices == (value,)
     assert len(list(db.fetch(key))) == 1
 
@@ -119,11 +119,11 @@ def slow_shrinker():
 def test_terminates_shrinks(n, monkeypatch):
     db = InMemoryExampleDatabase()
 
-    def generate_new_examples(self):
+    def generate_new_test_cases(self):
         self.cached_test_function((255,) * 1000)
 
     monkeypatch.setattr(
-        ConjectureRunner, "generate_new_examples", generate_new_examples
+        ConjectureRunner, "generate_new_test_cases", generate_new_test_cases
     )
     monkeypatch.setattr(engine_module, "MAX_SHRINKS", n)
 
@@ -134,7 +134,7 @@ def test_terminates_shrinks(n, monkeypatch):
         database_key=b"key",
     )
     runner.run()
-    (last_data,) = runner.interesting_examples.values()
+    (last_data,) = runner.interesting_test_cases.values()
     assert last_data.status == Status.INTERESTING
     assert runner.exit_reason == ExitReason.max_shrinks
     assert runner.shrinks == n
@@ -223,7 +223,7 @@ def test_can_navigate_to_a_valid_example():
     runner = ConjectureRunner(f, settings=settings(max_examples=5000, database=None))
     with buffer_size_limit(4):
         runner.run()
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
 
 
 def test_stops_after_max_examples_when_reading():
@@ -298,12 +298,12 @@ def test_interleaving_engines():
         runner = ConjectureRunner(g, random=rnd)
         children.append(runner)
         runner.run()
-        if runner.interesting_examples:
+        if runner.interesting_test_cases:
             data.mark_interesting(interesting_origin())
 
     assert tuple(n.value for n in nodes) == (b"\0",)
     for c in children:
-        assert not c.interesting_examples
+        assert not c.interesting_test_cases
 
 
 def test_phases_can_disable_shrinking():
@@ -437,7 +437,7 @@ def fails_health_check(label, **kwargs):
         with pytest.raises(FailedHealthCheck) as e:
             runner.run()
         assert str(label) in str(e.value)
-        assert not runner.interesting_examples
+        assert not runner.interesting_test_cases
 
     return accept
 
@@ -641,7 +641,7 @@ def test_uniqueness_is_preserved_when_writing_at_beginning():
 
     runner = ConjectureRunner(f, settings=settings(max_examples=50))
     runner.run()
-    assert runner.valid_examples == len(seen)
+    assert runner.valid_test_cases == len(seen)
 
 
 @pytest.mark.parametrize("skip_target", [False, True])
@@ -649,11 +649,11 @@ def test_uniqueness_is_preserved_when_writing_at_beginning():
 def test_clears_out_its_database_on_shrinking(
     initial_attempt, skip_target, monkeypatch
 ):
-    def generate_new_examples(self):
+    def generate_new_test_cases(self):
         self.cached_test_function(initial_attempt)
 
     monkeypatch.setattr(
-        ConjectureRunner, "generate_new_examples", generate_new_examples
+        ConjectureRunner, "generate_new_test_cases", generate_new_test_cases
     )
 
     key = b"key"
@@ -674,18 +674,18 @@ def test_clears_out_its_database_on_shrinking(
         if n != 127 or not skip_target:
             db.save(runner.secondary_key, choices_to_bytes([n]))
     runner.run()
-    assert len(runner.interesting_examples) == 1
+    assert len(runner.interesting_test_cases) == 1
     for b in db.fetch(runner.secondary_key):
         assert choices_from_bytes(b)[0] >= 127
     assert len(list(db.fetch(runner.database_key))) == 1
 
 
 def test_shrinks_both_interesting_examples(monkeypatch):
-    def generate_new_examples(self):
+    def generate_new_test_cases(self):
         self.cached_test_function((1,))
 
     monkeypatch.setattr(
-        ConjectureRunner, "generate_new_examples", generate_new_examples
+        ConjectureRunner, "generate_new_test_cases", generate_new_test_cases
     )
 
     def f(data):
@@ -694,15 +694,15 @@ def test_shrinks_both_interesting_examples(monkeypatch):
 
     runner = ConjectureRunner(f)
     runner.run()
-    assert runner.interesting_examples[interesting_origin(0)].choices == (0,)
-    assert runner.interesting_examples[interesting_origin(1)].choices == (1,)
+    assert runner.interesting_test_cases[interesting_origin(0)].choices == (0,)
+    assert runner.interesting_test_cases[interesting_origin(1)].choices == (1,)
 
 
 def test_discarding(monkeypatch):
     monkeypatch.setattr(Shrinker, "shrink", Shrinker.remove_discarded)
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda runner: runner.cached_test_function((False, True) * 10),
     )
 
@@ -777,7 +777,7 @@ def test_discarding_can_fail():
 def test_shrinking_from_mostly_zero(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda self: self.cached_test_function((0,) * 5 + (2,)),
     )
 
@@ -794,7 +794,7 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
     monkeypatch.setattr(Shrinker, "shrink", Shrinker.remove_discarded)
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda runner: runner.cached_test_function((False, False, True, True)),
     )
 
@@ -835,7 +835,7 @@ def test_database_clears_secondary_key():
         database.save(runner.secondary_key, choices_to_bytes([i]))
 
     runner.cached_test_function((10,))
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
 
     assert len(set(database.fetch(key))) == 1
     assert len(set(database.fetch(runner.secondary_key))) == 10
@@ -867,7 +867,7 @@ def test_database_uses_values_from_secondary_key():
         database.save(runner.secondary_key, choices_to_bytes([i]))
 
     runner.cached_test_function((10,))
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
     assert len(set(database.fetch(key))) == 1
     assert len(set(database.fetch(runner.secondary_key))) == 10
 
@@ -878,7 +878,7 @@ def test_database_uses_values_from_secondary_key():
         choices_from_bytes(b)[0] for b in database.fetch(runner.secondary_key)
     } == set(range(6, 11))
 
-    (v,) = runner.interesting_examples.values()
+    (v,) = runner.interesting_test_cases.values()
     assert v.choices == (5,)
 
 
@@ -1129,7 +1129,7 @@ def test_exhaust_space():
     )
     runner.run()
     assert runner.tree.is_exhausted
-    assert runner.valid_examples == 2
+    assert runner.valid_test_cases == 2
 
 
 SMALL_COUNT_SETTINGS = settings(runner_settings, max_examples=500)
@@ -1179,7 +1179,7 @@ def test_prefix_cannot_exceed_buffer_size(monkeypatch):
 
         runner = ConjectureRunner(test, settings=SMALL_COUNT_SETTINGS, random=Random(0))
         runner.run()
-        assert runner.valid_examples == buffer_size
+        assert runner.valid_test_cases == buffer_size
 
 
 def test_does_not_shrink_multiple_bugs_when_told_not_to():
@@ -1198,9 +1198,9 @@ def test_does_not_shrink_multiple_bugs_when_told_not_to():
         random=Random(0),
     )
     runner.cached_test_function((255, 255))
-    runner.shrink_interesting_examples()
+    runner.shrink_interesting_test_cases()
 
-    results = {d.choices for d in runner.interesting_examples.values()}
+    results = {d.choices for d in runner.interesting_test_cases.values()}
     assert len(results.intersection({(0, 1), (1, 0)})) == 1
 
 
@@ -1261,19 +1261,19 @@ def test_shrink_after_max_examples():
         # to debug if anything goes wrong.
         random=Random(0),
     )
-    runner.shrink_interesting_examples = Mock(name="shrink_interesting_examples")
+    runner.shrink_interesting_test_cases = Mock(name="shrink_interesting_test_cases")
     runner.run()
 
     # First, verify our test assumptions: we found a bug, kept running, and
     # then hit max-examples.
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
     assert post_failure_calls[0] >= (max_examples - fail_at)
     assert runner.call_count >= max_examples
-    assert runner.valid_examples == max_examples
+    assert runner.valid_test_cases == max_examples
 
     # Now check that we still performed shrinking, even after hitting the
     # example limit.
-    assert runner.shrink_interesting_examples.call_count == 1
+    assert runner.shrink_interesting_test_cases.call_count == 1
     assert runner.exit_reason == ExitReason.finished
 
 
@@ -1317,19 +1317,19 @@ def test_shrink_after_max_iterations():
         ),
         random=Random(0),
     )
-    runner.shrink_interesting_examples = Mock(name="shrink_interesting_examples")
+    runner.shrink_interesting_test_cases = Mock(name="shrink_interesting_test_cases")
     runner.run()
 
     # First, verify our test assumptions: we found a bug, kept running, and
     # then hit the test call limit.
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
     assert post_failure_calls[0] >= (max_iterations - fail_at) - 1
     assert runner.call_count >= max_iterations
-    assert runner.valid_examples == 0
+    assert runner.valid_test_cases == 0
 
     # Now check that we still performed shrinking, even after hitting the
     # test call limit.
-    assert runner.shrink_interesting_examples.call_count == 1
+    assert runner.shrink_interesting_test_cases.call_count == 1
     assert runner.exit_reason == ExitReason.finished
 
 
@@ -1460,7 +1460,7 @@ def test_runs_full_set_of_examples():
     )
 
     runner.run()
-    assert runner.valid_examples == runner_settings.max_examples
+    assert runner.valid_test_cases == runner_settings.max_examples
 
 
 def test_runs_optimisation_even_if_not_generating():
@@ -1488,7 +1488,7 @@ def test_runs_optimisation_once_when_generating():
 
     runner.optimise_targets = Mock(name="optimise_targets")
     try:
-        runner.generate_new_examples()
+        runner.generate_new_test_cases()
     except RunIsComplete:
         pass
     assert runner.optimise_targets.call_count == 1
@@ -1504,7 +1504,7 @@ def test_does_not_run_optimisation_when_max_examples_is_small():
 
     runner.optimise_targets = Mock(name="optimise_targets")
     try:
-        runner.generate_new_examples()
+        runner.generate_new_test_cases()
     except RunIsComplete:
         pass
     assert runner.optimise_targets.call_count == 0
@@ -1718,9 +1718,9 @@ def test_does_not_shrink_if_replaying_from_database():
     runner = ConjectureRunner(f, settings=settings(database=db), database_key=key)
     choices = (123,)
     runner.save_choices(choices)
-    runner.shrink_interesting_examples = None
+    runner.shrink_interesting_test_cases = None
     runner.run()
-    (last_data,) = runner.interesting_examples.values()
+    (last_data,) = runner.interesting_test_cases.values()
     assert last_data.choices == choices
 
 
@@ -1735,7 +1735,7 @@ def test_does_shrink_if_replaying_inexact_from_database():
     runner = ConjectureRunner(f, settings=settings(database=db), database_key=key)
     runner.save_choices((123, 2))
     runner.run()
-    (last_data,) = runner.interesting_examples.values()
+    (last_data,) = runner.interesting_test_cases.values()
     assert last_data.choices == (0,)
 
 
@@ -1774,7 +1774,7 @@ def test_skips_secondary_if_interesting_is_found():
             runner.database_key if i < 10 else runner.secondary_key,
             choices_to_bytes([i]),
         )
-    runner.reuse_existing_examples()
+    runner.reuse_existing_test_cases()
     assert runner.call_count == 10
 
 
@@ -1804,7 +1804,7 @@ def test_discards_invalid_db_entries(key_name):
 
     assert len(set(db.fetch(key))) == 6
     # this will clear out the invalid entries and use the valid one
-    runner.reuse_existing_examples()
+    runner.reuse_existing_test_cases()
     runner.clear_secondary_key()
 
     assert set(db.fetch(runner.database_key)) == {valid}
@@ -1829,7 +1829,7 @@ def test_discards_invalid_db_entries_pareto():
         db.save(runner.pareto_key, b)
 
     assert len(set(db.fetch(runner.pareto_key))) == 5
-    runner.reuse_existing_examples()
+    runner.reuse_existing_test_cases()
 
     assert not set(db.fetch(runner.database_key))
     assert not set(db.fetch(runner.pareto_key))

--- a/hypothesis/tests/conjecture/test_float_encoding.py
+++ b/hypothesis/tests/conjecture/test_float_encoding.py
@@ -133,14 +133,14 @@ def float_runner(start, condition, *, constraints=None):
 
     runner = ConjectureRunner(test_function)
     runner.cached_test_function((float(start),))
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
     return runner
 
 
 def minimal_from(start, condition, *, constraints=None):
     runner = float_runner(start, condition, constraints=constraints)
-    runner.shrink_interesting_examples()
-    (v,) = runner.interesting_examples.values()
+    runner.shrink_interesting_test_cases()
+    (v,) = runner.interesting_test_cases.values()
     f = v.choices[0]
     assert condition(f)
     return f

--- a/hypothesis/tests/conjecture/test_pareto.py
+++ b/hypothesis/tests/conjecture/test_pareto.py
@@ -158,9 +158,9 @@ def test_down_samples_the_pareto_front():
         db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
 
     with pytest.raises(RunIsComplete):
-        runner.reuse_existing_examples()
+        runner.reuse_existing_test_cases()
 
-    assert runner.valid_examples == 1000
+    assert runner.valid_test_cases == 1000
 
 
 def test_stops_loading_pareto_front_if_interesting():
@@ -186,7 +186,7 @@ def test_stops_loading_pareto_front_if_interesting():
     for n1, n2 in itertools.product(range(256), range(256)):
         db.save(runner.pareto_key, choices_to_bytes((n1, n2)))
 
-    runner.reuse_existing_examples()
+    runner.reuse_existing_test_cases()
     assert runner.call_count == 1
 
 
@@ -247,7 +247,7 @@ def test_does_not_optimise_the_pareto_front_if_interesting():
     runner.pareto_optimise = None
     runner.optimise_targets()
 
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
 
 
 def test_stops_optimising_once_interesting():
@@ -269,7 +269,7 @@ def test_stops_optimising_once_interesting():
     assert data.status == Status.VALID
     runner.pareto_optimise()
     assert runner.call_count <= 20
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
 
 
 def test_pareto_contains():

--- a/hypothesis/tests/conjecture/test_provider.py
+++ b/hypothesis/tests/conjecture/test_provider.py
@@ -573,9 +573,9 @@ def test_backend_realize_cannot_proceed_increments_invalid():
             test,
             settings=settings(backend="never_proceeds", database=None),
         )
-        assert runner.invalid_examples == 0
+        assert runner.invalid_test_cases == 0
         runner.cached_test_function([1])
-        assert runner.invalid_examples == 1
+        assert runner.invalid_test_cases == 1
 
 
 def test_backend_realize_cannot_proceed_exception_increments_invalid():
@@ -590,9 +590,9 @@ def test_backend_realize_cannot_proceed_exception_increments_invalid():
             test,
             settings=settings(backend="never_proceeds", database=None),
         )
-        assert runner.invalid_examples == 0
+        assert runner.invalid_test_cases == 0
         runner.cached_test_function([1])
-        assert runner.invalid_examples == 1
+        assert runner.invalid_test_cases == 1
 
 
 class FallibleProvider(TrivialProvider):

--- a/hypothesis/tests/conjecture/test_shrinker.py
+++ b/hypothesis/tests/conjecture/test_shrinker.py
@@ -62,7 +62,7 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
     )
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda runner: runner.cached_test_function((b"\0",) * 10),
     )
 
@@ -199,7 +199,7 @@ def test_can_reorder_spans():
 def test_permits_but_ignores_raising_order(monkeypatch):
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda runner: runner.cached_test_function((1,)),
     )
 
@@ -338,7 +338,7 @@ def test_zig_zags_quickly():
             data.mark_interesting(interesting_origin(1))
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
-    assert shrinker.engine.valid_examples <= 100
+    assert shrinker.engine.valid_test_cases <= 100
     assert shrinker.choices == (1, 1)
 
 
@@ -371,7 +371,7 @@ def test_zig_zags_quickly_with_shrink_towards(
             data.mark_interesting(interesting_origin())
 
     shrinker.fixate_shrink_passes([ShrinkPass(shrinker.minimize_individual_choices)])
-    assert shrinker.engine.valid_examples <= 40
+    assert shrinker.engine.valid_test_cases <= 40
     assert shrinker.choices == expected
 
 

--- a/hypothesis/tests/cover/test_testdecorators.py
+++ b/hypothesis/tests/cover/test_testdecorators.py
@@ -508,7 +508,7 @@ def test_notes_high_filter_rates_in_unsatisfiable_error():
         Unsatisfiable,
         match=(
             rf"Unable to satisfy assumptions of f\. {INVALID_THRESHOLD_BASE+1} of "
-            rf"{INVALID_THRESHOLD_BASE+1} examples failed a \.filter\(\) or assume\(\)"
+            rf"{INVALID_THRESHOLD_BASE+1} test cases failed a \.filter\(\) or assume\(\)"
         ),
     ):
         f()
@@ -547,7 +547,7 @@ def test_notes_high_overrun_rates_in_unsatisfiable_error():
         pass
 
     match = (
-        rf"{INVALID_THRESHOLD_BASE+1} of {INVALID_THRESHOLD_BASE+1} examples were too large to"
+        rf"{INVALID_THRESHOLD_BASE+1} of {INVALID_THRESHOLD_BASE+1} test cases were too large to"
         rf" finish generating; try reducing the typical size of your inputs\?"
     )
     with (

--- a/hypothesis/tests/nocover/test_conjecture_engine.py
+++ b/hypothesis/tests/nocover/test_conjecture_engine.py
@@ -44,7 +44,7 @@ def test_saves_data_while_shrinking(monkeypatch):
 
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda runner: runner.cached_test_function([bytes([255] * 10)]),
     )
 
@@ -57,7 +57,7 @@ def test_saves_data_while_shrinking(monkeypatch):
 
     runner = ConjectureRunner(f, settings=settings(database=db), database_key=key)
     runner.run()
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
     assert len(seen) == n
 
     in_db = {choices_from_bytes(b)[0] for b in non_covering_examples(db)}
@@ -70,7 +70,7 @@ def test_can_discard(monkeypatch):
 
     monkeypatch.setattr(
         ConjectureRunner,
-        "generate_new_examples",
+        "generate_new_test_cases",
         lambda runner: runner.cached_test_function(
             tuple(bytes(v) for i in range(n) for v in [i, i])
         ),

--- a/hypothesis/tests/nocover/test_explore_arbitrary_languages.py
+++ b/hypothesis/tests/nocover/test_explore_arbitrary_languages.py
@@ -109,7 +109,7 @@ def run_language_test_for(root, data, seed):
     finally:
         if data is not None:
             note(root)
-    assume(runner.interesting_examples)
+    assume(runner.interesting_test_cases)
 
 
 # technically nested-engine, but same problem

--- a/hypothesis/tests/nocover/test_precise_shrinking.py
+++ b/hypothesis/tests/nocover/test_precise_shrinking.py
@@ -123,11 +123,11 @@ def precisely_shrink(
         buf = runner.cached_test_function(initial_choices)
         assert buf.status == Status.INTERESTING
         assert buf.choices == initial_choices
-        assert runner.interesting_examples
-        runner.shrink_interesting_examples()
+        assert runner.interesting_test_cases
+        runner.shrink_interesting_test_cases()
     except RunIsComplete:
         assert runner.exit_reason in (ExitReason.finished, ExitReason.max_shrinks)
-    (result,) = runner.interesting_examples.values()
+    (result,) = runner.interesting_test_cases.values()
 
     data = ConjectureData.for_choices(result.choices)
     result_value = safe_draw(data, strategy)

--- a/hypothesis/tests/quality/test_discovery_ability.py
+++ b/hypothesis/tests/quality/test_discovery_ability.py
@@ -91,7 +91,7 @@ def define_test(specifier, predicate, condition=None, p=0.5, suppress_health_che
                 ),
             )
             runner.run()
-            if runner.interesting_examples:
+            if runner.interesting_test_cases:
                 successes += 1
                 if successes >= required_runs:
                     return

--- a/hypothesis/tests/quality/test_poisoned_lists.py
+++ b/hypothesis/tests/quality/test_poisoned_lists.py
@@ -82,6 +82,6 @@ def test_minimal_poisoned_containers(seed, size, p, strategy_class):
         test_function, random=Random(seed), settings=TRIAL_SETTINGS
     )
     runner.run()
-    (v,) = runner.interesting_examples.values()
+    (v,) = runner.interesting_test_cases.values()
     result = ConjectureData.for_choices(v.choices).draw(strategy)
     assert len(result) == 1

--- a/hypothesis/tests/quality/test_poisoned_trees.py
+++ b/hypothesis/tests/quality/test_poisoned_trees.py
@@ -80,9 +80,9 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
             data.mark_interesting(interesting_origin())
 
     runner = ConjectureRunner(test_function, random=random, settings=TEST_SETTINGS)
-    runner.generate_new_examples()
-    runner.shrink_interesting_examples()
-    (data,) = runner.interesting_examples.values()
+    runner.generate_new_test_cases()
+    runner.shrink_interesting_test_cases()
+    (data,) = runner.interesting_test_cases.values()
     assert len(ConjectureData.for_choices(data.choices).draw(strat)) == size
 
     # find the nodes corresponding to n1 and n2
@@ -117,8 +117,8 @@ def test_can_reduce_poison_from_any_subtree(size, seed):
             + (data.choices[node.index + 2 :])
             + (marker,)
         )
-        assert runner.interesting_examples
+        assert runner.interesting_test_cases
 
-        runner.shrink_interesting_examples()
-        (shrunk,) = runner.interesting_examples.values()
+        runner.shrink_interesting_test_cases()
+        (shrunk,) = runner.interesting_test_cases.values()
         assert ConjectureData.for_choices(shrunk.choices).draw(strat) == (POISON,)

--- a/hypothesis/tests/quality/test_zig_zagging.py
+++ b/hypothesis/tests/quality/test_zig_zagging.py
@@ -92,9 +92,9 @@ def test_avoids_zig_zag_trap(p):
     )
 
     runner.cached_test_function((m, m + 1, marker))
-    assert runner.interesting_examples
+    assert runner.interesting_test_cases
     runner.run()
-    (v,) = runner.interesting_examples.values()
+    (v,) = runner.interesting_test_cases.values()
     data = ConjectureData.for_choices(v.choices)
 
     m = data.draw_integer(0, 2**n_bits - 1)


### PR DESCRIPTION
AFAIK this should be the last big pass for this.

<details><summary>Claude-written description</summary>

Continues the terminology change from v6.159.0 ("example" → "test case") into the internals, which that release deliberately left alone:

- Renames internal identifiers: `ConjectureRunner` attributes and methods (`interesting_examples` → `interesting_test_cases`, `valid/invalid/overrun_examples` → `*_test_cases`, `generate_new_examples` → `generate_new_test_cases`, `reuse_existing_examples`, `shrink_interesting_examples`, `shrunk_examples`, `best_examples_of_observed_targets`, etc.), `HealthCheckState` fields, and core.py's `falsifying_examples`, `print_example`, and related locals. The `shrink()`/`new_shrinker()` parameter `example` becomes `initial`, matching `Shrinker.__init__`.
- Updates remaining user-facing strings: the `Unsatisfiable` explanations, both `FlakyFailure` messages, the engine's "Run complete" debug line and "reduced max size for early test cases" event, observability's overrun `status_reason`, the `.example()` warnings, and a few strategy error messages.
- Fixes stale references: the `schema_observations.json` `how_generated` description (which disagreed with the string the code actually emits), an `ExampleRecord` comment (now `SpanRecord`), a comment naming the nonexistent `err._interesting_examples` attribute, a docstring describing a removed `select_example` method, and a terminology pass over conjecture-module comments (a couple of which actually meant *spans*, not test cases).

Deliberately unchanged: public API (`max_examples`, `@example`, `.example()`, `ExampleDatabase`, `NoSuchExample` and its message), everything tied to the retained "explicit example" terminology, serialized formats (`.hypothesis/examples`, redis key prefix, `large_base_example` enum value), and old changelog entries.

Note: a self-review pass found two cover tests asserting the old `Unsatisfiable` wording plus a few grammar/wording nits; those fixes are staged separately by the author and may land as a follow-up commit on this branch.

</details>
