### PR TITLE
Ship abi3t wheels for free-threaded 3.15+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,7 @@ jobs:
           - check-py310-pandas14
           - check-py310-pandas13
           - check-abi3
+          - check-abi3t
           - check-rust-tests
           ## FIXME: actions update means Python builds without eg _bz2, which was required
           # - check-py310-pandas12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,10 @@ jobs:
           - check-py313-niche
           # niche tests also collect coverage on 3.14; see the run step below.
           - check-py314-niche
+          - check-py315-cover
+          - check-py315-nocover
+          - check-py315t-cover
+          - check-py315t-nocover
           - check-quality
           - check-pytest9
           - check-pytest84
@@ -172,11 +176,8 @@ jobs:
           - check-py314t-cover
           - check-py314t-nocover
           - check-py314t-niche
-          # - check-py315-cover
-          # - check-py315-nocover
+          # 3.15 niche is waiting on scipy and lark to support 3.15
           # - check-py315-niche
-          # - check-py315t-cover
-          # - check-py315t-nocover
           # - check-py315t-niche
           - check-django52
           ## `-cover` is too slow under crosshair; use a custom split

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,24 @@ jobs:
         manylinux: ${{ matrix.manylinux }}
         args: --release --out dist --features abi3
         working-directory: hypothesis
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      id: abi3t-python
+      with:
+        # abi3t is only available from 3.15+. If we don't specify this, maturin
+        # builds a version-specific wheel instead.
+        python-version: '3.15'
+        # can drop once 3.15 is out
+        allow-prereleases: true
+        architecture: ${{ matrix.python-architecture }}
+    - name: Build abi3t wheel
+      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+      with:
+        target: ${{ matrix.target }}
+        manylinux: ${{ matrix.manylinux }}
+        # maturin builds inside a container for manylinux, so we have to reference the
+        # container's python instead
+        args: --release --out dist --features abi3t --interpreter ${{ matrix.manylinux && 'python3.15' || steps.abi3t-python.outputs.python-path }}
+        working-directory: hypothesis
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist-wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux }}

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release adds support for Python 3.15. |st.from_type| can now resolve the new ``sentinel`` builtin.

--- a/hypothesis/rust/Cargo.toml
+++ b/hypothesis/rust/Cargo.toml
@@ -13,6 +13,8 @@ pyo3 = "0.29.2"
 
 [features]
 abi3 = ["pyo3/abi3-py310"]
+# see eg https://labs.quansight.org/blog/python-abi-abi3t
+abi3t = ["pyo3/abi3t-py315"]
 
 [dev-dependencies]
 half = "2"

--- a/hypothesis/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis/src/hypothesis/internal/lambda_sources.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import ast
+import dis
 import hashlib
 import inspect
 import linecache
@@ -101,12 +102,21 @@ def _function_key(f, *, bounded_size=False, ignore_name=False):
 
 
 class _op:
-    # Opcodes, from dis.opmap. These may change between major versions.
-    NOP = 9
-    LOAD_FAST = 85
-    LOAD_FAST_LOAD_FAST = 88
-    LOAD_FAST_BORROW = 86
-    LOAD_FAST_BORROW_LOAD_FAST_BORROW = 87
+    # Look up the opcode values dynamically, since they can change between versions. If
+    # the opcode does not exist on a version, we set it to None.
+    NOP = dis.opmap["NOP"]
+    LOAD_FAST = dis.opmap["LOAD_FAST"]
+    LOAD_FAST_LOAD_FAST = (
+        dis.opmap["LOAD_FAST_LOAD_FAST"] if sys.version_info[:2] >= (3, 13) else None
+    )
+    LOAD_FAST_BORROW = (
+        dis.opmap["LOAD_FAST_BORROW"] if sys.version_info[:2] >= (3, 14) else None
+    )
+    LOAD_FAST_BORROW_LOAD_FAST_BORROW = (
+        dis.opmap["LOAD_FAST_BORROW_LOAD_FAST_BORROW"]
+        if sys.version_info[:2] >= (3, 14)
+        else None
+    )
 
 
 def _normalize_code(f, l):
@@ -129,6 +139,8 @@ def _normalize_code(f, l):
             lambda a, b: a == [b[0] >> 4, b[0] & 15],
         ),
     ]
+    # Avoid applying any transform with an opcode that doesn't exist on this python version.
+    transforms = [t for t in transforms if None not in t[0] + t[1]]
     # augment with converse
     transforms += [
         (

--- a/hypothesis/src/hypothesis/internal/reflection.py
+++ b/hypothesis/src/hypothesis/internal/reflection.py
@@ -354,6 +354,13 @@ def source_exec_as_module(source: str) -> ModuleType:
 
     hexdigest = hashlib.sha384(source.encode()).hexdigest()
     result = ModuleType("hypothesis_temporary_module_" + hexdigest)
+    # ModuleType() sets __spec__ = None. Later, we call @impersonate on functions defined
+    # in the module, which gives it a real co_filename. Python traceback formatting then
+    # calls internal linecache code which warns on the combination of "real on-disk file"
+    # + "null __spec__".
+    #
+    # Sidestep this by deleting __spec__; we don't need it.
+    del result.__spec__
     assert isinstance(source, str)
     exec(source, result.__dict__)
     eval_cache[source] = result

--- a/hypothesis/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/types.py
@@ -1005,6 +1005,12 @@ if sys.version_info[:2] < (3, 14):
 
     _global_type_lookup[memoryview] = st.binary().map(memoryview)
 
+if sys.version_info[:2] >= (3, 15):
+    _global_type_lookup[builtins.sentinel] = st.builds(  # type: ignore
+        builtins.sentinel,  # type: ignore
+        st.text(),
+    )
+
 
 _global_type_lookup.update(
     {

--- a/hypothesis/tests/cover/test_interactive_example.py
+++ b/hypothesis/tests/cover/test_interactive_example.py
@@ -141,6 +141,9 @@ def test_script_example_does_not_emit_warning(tmp_path):
 
 @skipif_emscripten
 @pytest.mark.skipif(WINDOWS, reason="pexpect.spawn not supported on Windows")
+# pexpect forks, and 3.15 warns about forking from a process with threads in it,
+# which we are under xdist.
+@pytest.mark.filterwarnings("ignore:.*is multi-threaded.*:DeprecationWarning")
 def test_interactive_example_does_not_emit_warning():
     import pexpect
 

--- a/hypothesis/tests/cover/test_lookup.py
+++ b/hypothesis/tests/cover/test_lookup.py
@@ -74,12 +74,9 @@ generics = sorted(
         t
         for t in types._global_type_lookup
         # We ignore TypeVar, because it is not a Generic type:
-        if isinstance(t, types.typing_root_type)
-        and t != typing.TypeVar
-        and (
-            sys.version_info[:2] <= (3, 11)
-            or t != getattr(typing, "ByteString", object())
-        )
+        if isinstance(t, types.typing_root_type) and t != typing.TypeVar
+        # accessing ByteString warns on 3.15
+        and (not ((3, 12) <= sys.version_info[:2] < (3, 14)) or t != typing.ByteString)
     ),
     key=str,
 )
@@ -139,7 +136,8 @@ def test_typing_Type_Union(ex):
     "typ",
     [
         pytest.param(
-            getattr(collections.abc, "ByteString", ...),
+            # accessing ByteString warns on 3.15
+            collections.abc.ByteString if sys.version_info[:2] < (3, 14) else ...,
             marks=pytest.mark.skipif(sys.version_info[:2] >= (3, 14), reason="removed"),
         ),
         typing.Match,

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -26,6 +26,7 @@ sphinx-jsonschema
 furo
 sphinx-selective-exclude
 tox
+tox-uv
 twine
 types-click
 types-pytz

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -174,6 +174,7 @@ packaging==26.3
     #   pytest
     #   sphinx
     #   tox
+    #   tox-uv-bare
     #   twine
     #   wheel
 parso==0.8.7
@@ -334,7 +335,13 @@ tokenize-rt==6.2.0
 tomli-w==1.2.0
     # via tox
 tox==4.58.0
+    # via
+    #   -r requirements/tools.in
+    #   tox-uv-bare
+tox-uv==1.36.0
     # via -r requirements/tools.in
+tox-uv-bare==1.36.0
+    # via tox-uv
 traitlets==5.16.1
     # via
     #   ipython
@@ -367,6 +374,8 @@ urllib3==2.7.0
     #   id
     #   requests
     #   twine
+uv==0.12.3
+    # via tox-uv
 uvicorn==0.52.1
     # via sphinx-autobuild
 virtualenv==21.7.3

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -1068,7 +1068,11 @@ def check_abi3t(*args):
         )
         (wheel,) = Path(dist).glob("*.whl")
         assert "abi3t" in wheel.name, wheel.name
-        run_tox("py315t-cover", PYTHONS["3.15t"], f"--installpkg={wheel}", *args)
+        # somewhat surprisingly, abi3t wheels are actually used for both gil-enabled
+        # and free-threaded builds of python on 3.15+. Smoke test both here.
+        for version in ["3.15", "3.15t"]:
+            env = "py" + version.replace(".", "") + "-cover"
+            run_tox(env, PYTHONS[version], f"--installpkg={wheel}", *args)
 
 
 @task()

--- a/tooling/src/hypothesistooling/__main__.py
+++ b/tooling/src/hypothesistooling/__main__.py
@@ -1049,6 +1049,28 @@ def check_abi3(*args):
         )
 
 
+@python_tests
+def check_abi3t(*args):
+    # abi3t is only available from 3.15+
+    install.ensure_rustc(ci_version_rust)
+    with tempfile.TemporaryDirectory() as dist:
+        pip_tool(
+            "maturin",
+            "build",
+            "--features",
+            "abi3t",
+            "--interpreter",
+            install.python_executable(PYTHONS["3.15"]),
+            "--out",
+            dist,
+            cwd=HYPOTHESIS,
+            env={**os.environ, **rust_build_env()},
+        )
+        (wheel,) = Path(dist).glob("*.whl")
+        assert "abi3t" in wheel.name, wheel.name
+        run_tox("py315t-cover", PYTHONS["3.15t"], f"--installpkg={wheel}", *args)
+
+
 @task()
 def check_whole_repo_tests(*args):
     install.ensure_shellcheck()


### PR DESCRIPTION
https://labs.quansight.org/blog/python-abi-abi3t recommends shipping version-specific free-threaded wheels for <=3.14, and abi3t for 3.15+.

Closes https://github.com/HypothesisWorks/hypothesis/issues/4851

Depends on #4861


<details><summary>Claude-written description</summary>

Closes #4851, at least for the part that's actually missing. The `cp310-abi3`
wheels already install on GIL-enabled 3.15 — free-threaded builds are the ones
that can't load an abi3 wheel, so 3.15t falls through to the sdist and needs a
Rust toolchain. There's no pure-Python fallback, since `version.py` and
`internal/floats.py` import `_native` unconditionally.

Rather than add `python3.15 python3.15t` to the seven interpreter lists, this
uses PEP 803's `abi3t`. One `cp315-abi3.abi3t` wheel per platform serves both
GIL-enabled and free-threaded 3.15 and later, so it also covers the six
cross-compiled targets (i686, armv7 x2, riscv64 x2, win32) that build
stable-ABI-only and would otherwise never get a free-threaded wheel — and it
doesn't need touching again for 3.16t.

No dependency bumps: pyo3 0.29.2 already has the `abi3t` feature, and maturin
1.14.1 (pinned in `requirements/tools.txt`) already emits the `abi3.abi3t` tag.
The migration burden is nil here — the howto is almost entirely about opaque
`PyObject`, negative `basicsize`, and `PyModExport`, all of which are PyO3's
problem, and the extension has no `#[pyclass]`.

Verified locally rather than just reasoned about: the wheel builds tagged
`cp315-abi3.abi3t` with `_native.abi3t.so` and both tag lines in `WHEEL`; it
installs and runs `@given` on 3.15 and 3.15t; it cross-compiles to a different
target arch; and `check-abi3t` drives the whole thing including installing
3.15.0rc1 and its free-threaded build.

Two things worth a look:

- maturin does not fail when it can't find an interpreter new enough for abi3t.
  It warns and builds a version-specific wheel instead. Left alone, a release
  would have quietly published a `cp313-cp313` wheel where the abi3t one
  belonged. Hence the explicit `--interpreter` in both the workflow and the
  tooling.
- `check-abi3t` runs the suite on 3.15t only, so the `abi3` half of the tag
  isn't exercised in CI, even though that's the wheel pip will prefer on
  GIL-enabled 3.15. I checked both by hand; a second tox run would double the
  job for a config that's already covered by `check-abi3` in spirit. Easy to
  add if you'd rather have it.

`check-abi3t` sits in the required matrix, which makes 3.15.0rc1 results
blocking on every PR — more aggressive than the `check-py315*` entries, which
are still commented out. That was your call, flagging it for the record.

No `RELEASE.rst`, since nothing under `hypothesis/src/` changed. The wheels
ship with whatever the next release is.

</details>

