### PR TITLE
Optimize single-branch one_of

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of |st.one_of| when it can be simplified to a single real strategy, for example ``st.integers() | st.nothing()``.

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -898,8 +898,18 @@ class OneOfStrategy(SearchStrategy[Ex]):
         )
 
     def do_draw(self, data: ConjectureData) -> Ex:
+        strategies = self.element_strategies
+        if len(strategies) == 1:
+            # optimization: skip constructing SampledFromStrategy if we only have one
+            # strategy. This can happen for eg `st.integers() | st.nothing()`.
+            if strategies[0].is_currently_empty(data):
+                data.mark_invalid(
+                    f"Aborted test because {strategies[0]!r} is currently empty"
+                )
+            return data.draw(strategies[0])
+
         strategy = data.draw(
-            SampledFromStrategy(self.element_strategies).filter(
+            SampledFromStrategy(strategies).filter(
                 lambda s: not s.is_currently_empty(data)
             )
         )
@@ -916,6 +926,9 @@ class OneOfStrategy(SearchStrategy[Ex]):
         # against re-entry rather than recursing forever. Unlike a structural
         # recursion into a subvalue - which terminates because values are
         # finite - a same-value cycle can make no progress.
+        if len(self.element_strategies) == 1:
+            return self.element_strategies[0]._invert(value)
+
         active = getattr(_inverting_one_ofs, "ids", None)
         if active is None:
             active = _inverting_one_ofs.ids = set()

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -902,10 +902,6 @@ class OneOfStrategy(SearchStrategy[Ex]):
         if len(strategies) == 1:
             # optimization: skip constructing SampledFromStrategy if we only have one
             # strategy. This can happen for eg `st.integers() | st.nothing()`.
-            if strategies[0].is_currently_empty(data):
-                data.mark_invalid(
-                    f"Aborted test because {strategies[0]!r} is currently empty"
-                )
             return data.draw(strategies[0])
 
         strategy = data.draw(

--- a/hypothesis/tests/cover/test_invert.py
+++ b/hypothesis/tests/cover/test_invert.py
@@ -127,6 +127,11 @@ def test_one_of(data):
 
 
 @given(st.data())
+def test_one_of_with_a_single_branch(data):
+    check_roundtrip_many(st.integers() | st.nothing(), data)
+
+
+@given(st.data())
 def test_lists(data):
     kwargs = {}
     min_size = data.draw(st.none() | st.integers(0, 5))

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -931,6 +931,21 @@ def test_initialize_rule():
     assert result[5] == "state.teardown()"
 
 
+def test_one_of_with_a_single_bundle_branch():
+    class SingleBundleBranch(RuleBasedStateMachine):
+        b = Bundle("b")
+
+        @rule(target=b)
+        def create(self):
+            return 1
+
+        @rule(value=st.one_of(b, st.nothing()))
+        def consume(self, value):
+            assert value == 1
+
+    run_state_machine_as_test(SingleBundleBranch)
+
+
 def test_initialize_rule_populate_bundle():
     class WithInitializeBundleRules(RuleBasedStateMachine):
         a = Bundle("a")


### PR DESCRIPTION
This seems worth doing if only to ~fully optimize away `strategy1 | st.nothing()`.