### PR TITLE
Add support for python 3.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,10 @@ jobs:
           - check-py313-niche
           # niche tests also collect coverage on 3.14; see the run step below.
           - check-py314-niche
+          - check-py315-cover
+          - check-py315-nocover
+          - check-py315t-cover
+          - check-py315t-nocover
           - check-quality
           - check-pytest9
           - check-pytest84
@@ -172,11 +176,8 @@ jobs:
           - check-py314t-cover
           - check-py314t-nocover
           - check-py314t-niche
-          # - check-py315-cover
-          # - check-py315-nocover
+          # 3.15 niche is waiting on scipy and lark to support 3.15
           # - check-py315-niche
-          # - check-py315t-cover
-          # - check-py315t-nocover
           # - check-py315t-niche
           - check-django52
           ## `-cover` is too slow under crosshair; use a custom split

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release adds support for Python 3.15. |st.from_type| can now resolve the new ``sentinel`` builtin.

--- a/hypothesis/src/hypothesis/internal/lambda_sources.py
+++ b/hypothesis/src/hypothesis/internal/lambda_sources.py
@@ -9,6 +9,7 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import ast
+import dis
 import hashlib
 import inspect
 import linecache
@@ -101,12 +102,21 @@ def _function_key(f, *, bounded_size=False, ignore_name=False):
 
 
 class _op:
-    # Opcodes, from dis.opmap. These may change between major versions.
-    NOP = 9
-    LOAD_FAST = 85
-    LOAD_FAST_LOAD_FAST = 88
-    LOAD_FAST_BORROW = 86
-    LOAD_FAST_BORROW_LOAD_FAST_BORROW = 87
+    # Look up the opcode values dynamically, since they can change between versions. If
+    # the opcode does not exist on a version, we set it to None.
+    NOP = dis.opmap["NOP"]
+    LOAD_FAST = dis.opmap["LOAD_FAST"]
+    LOAD_FAST_LOAD_FAST = (
+        dis.opmap["LOAD_FAST_LOAD_FAST"] if sys.version_info[:2] >= (3, 13) else None
+    )
+    LOAD_FAST_BORROW = (
+        dis.opmap["LOAD_FAST_BORROW"] if sys.version_info[:2] >= (3, 14) else None
+    )
+    LOAD_FAST_BORROW_LOAD_FAST_BORROW = (
+        dis.opmap["LOAD_FAST_BORROW_LOAD_FAST_BORROW"]
+        if sys.version_info[:2] >= (3, 14)
+        else None
+    )
 
 
 def _normalize_code(f, l):
@@ -129,6 +139,8 @@ def _normalize_code(f, l):
             lambda a, b: a == [b[0] >> 4, b[0] & 15],
         ),
     ]
+    # Avoid applying any transform with an opcode that doesn't exist on this python version.
+    transforms = [t for t in transforms if None not in t[0] + t[1]]
     # augment with converse
     transforms += [
         (

--- a/hypothesis/src/hypothesis/internal/reflection.py
+++ b/hypothesis/src/hypothesis/internal/reflection.py
@@ -354,6 +354,13 @@ def source_exec_as_module(source: str) -> ModuleType:
 
     hexdigest = hashlib.sha384(source.encode()).hexdigest()
     result = ModuleType("hypothesis_temporary_module_" + hexdigest)
+    # ModuleType() sets __spec__ = None. Later, we call @impersonate on functions defined
+    # in the module, which gives it a real co_filename. Python traceback formatting then
+    # calls internal linecache code which warns on the combination of "real on-disk file"
+    # + "null __spec__".
+    #
+    # Sidestep this by deleting __spec__; we don't need it.
+    del result.__spec__
     assert isinstance(source, str)
     exec(source, result.__dict__)
     eval_cache[source] = result

--- a/hypothesis/src/hypothesis/strategies/_internal/types.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/types.py
@@ -1005,6 +1005,12 @@ if sys.version_info[:2] < (3, 14):
 
     _global_type_lookup[memoryview] = st.binary().map(memoryview)
 
+if sys.version_info[:2] >= (3, 15):
+    _global_type_lookup[builtins.sentinel] = st.builds(  # type: ignore
+        builtins.sentinel,  # type: ignore
+        st.text(),
+    )
+
 
 _global_type_lookup.update(
     {

--- a/hypothesis/tests/cover/test_interactive_example.py
+++ b/hypothesis/tests/cover/test_interactive_example.py
@@ -141,6 +141,9 @@ def test_script_example_does_not_emit_warning(tmp_path):
 
 @skipif_emscripten
 @pytest.mark.skipif(WINDOWS, reason="pexpect.spawn not supported on Windows")
+# pexpect forks, and 3.15 warns about forking from a process with threads in it,
+# which we are under xdist.
+@pytest.mark.filterwarnings("ignore:.*is multi-threaded.*:DeprecationWarning")
 def test_interactive_example_does_not_emit_warning():
     import pexpect
 

--- a/hypothesis/tests/cover/test_lookup.py
+++ b/hypothesis/tests/cover/test_lookup.py
@@ -74,12 +74,9 @@ generics = sorted(
         t
         for t in types._global_type_lookup
         # We ignore TypeVar, because it is not a Generic type:
-        if isinstance(t, types.typing_root_type)
-        and t != typing.TypeVar
-        and (
-            sys.version_info[:2] <= (3, 11)
-            or t != getattr(typing, "ByteString", object())
-        )
+        if isinstance(t, types.typing_root_type) and t != typing.TypeVar
+        # accessing ByteString warns on 3.15
+        and (not ((3, 12) <= sys.version_info[:2] < (3, 14)) or t != typing.ByteString)
     ),
     key=str,
 )
@@ -139,7 +136,8 @@ def test_typing_Type_Union(ex):
     "typ",
     [
         pytest.param(
-            getattr(collections.abc, "ByteString", ...),
+            # accessing ByteString warns on 3.15
+            collections.abc.ByteString if sys.version_info[:2] < (3, 14) else ...,
             marks=pytest.mark.skipif(sys.version_info[:2] >= (3, 14), reason="removed"),
         ),
         typing.Match,


### PR DESCRIPTION
Not too much work here. This is just to get us unblocked, we can tackle https://github.com/HypothesisWorks/hypothesis/issues/4736 later.

<details>

Five fixes found by running the suite on 3.15.0rc1 and its free-threaded build:

* lambda_sources hardcoded opcode numbers, which change every release. The values were a mix of three versions', and named live-but-wrong opcodes on 3.13 and 3.14 (9 is END_FOR on 3.14, not NOP; 85 is LOAD_FAST_AND_CLEAR), so bytecode normalization was both missing real transforms and applying bogus ones. Read them from dis.opmap instead.
* source_exec_as_module builds a ModuleType, whose globals carry __spec__ = None; @impersonate then gives functions in it a real co_filename. 3.15's linecache warns on that combination, which under -X dev crashed pytest's failure reporting.
* from_type couldn't resolve the new builtins.sentinel.
* typing.ByteString and collections.abc.ByteString warn on attribute access in 3.15, breaking collection of test_lookup.py.
* pexpect's forkpty warns on 3.15 when other threads exist, as under xdist.

niche stays disabled: scipy has no 3.15 wheels, and the oldest lark we support imports the removed sre_parse.

</details>