### PR TITLE
Vary interactive draws in the explain phase

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+The |Phase.explain| phase now also varies interactive draws from |st.data|,
+annotating each freely-variable ``Draw n: ...`` line with an
+``# or any other generated value`` comment, just like |@given| arguments
+(:issue:`4403`).
+
+This release also fixes a bug where the explain phase could fail to report
+that the commented parts can be varied together, if the failing example
+ended with an uncommented part.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -5,8 +5,8 @@ annotating each freely-variable ``Draw n: ...`` line with an
 ``# or any other generated value`` comment, just like |@given| arguments
 (:issue:`4403`).
 
-This release also fixes two explain-phase bugs: failing examples found just
+This release also fixes two explain-phase bugs: failing test cases found just
 as the set of possible inputs was fully enumerated were reported without
-running the |Phase.shrink| and |Phase.explain| phases at all, and the
+running the |Phase.shrink| and |Phase.explain| phases, and the
 explain phase could fail to report that the commented parts can be varied
 together if the failing example ended with an uncommented part.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -5,6 +5,8 @@ annotating each freely-variable ``Draw n: ...`` line with an
 ``# or any other generated value`` comment, just like |@given| arguments
 (:issue:`4403`).
 
-This release also fixes a bug where the explain phase could fail to report
-that the commented parts can be varied together, if the failing example
-ended with an uncommented part.
+This release also fixes two explain-phase bugs: failing examples found just
+as the set of possible inputs was fully enumerated were reported without
+running the |Phase.shrink| and |Phase.explain| phases at all, and the
+explain phase could fail to report that the commented parts can be varied
+together if the failing example ended with an uncommented part.

--- a/hypothesis/src/hypothesis/control.py
+++ b/hypothesis/src/hypothesis/control.py
@@ -161,29 +161,6 @@ class BuildContext:
             defaultdict(list)
         )
 
-        # Track nested strategy calls for explain-phase label paths
-        self._label_path: list[str] = []
-
-    @contextmanager
-    def track_arg_label(self, label: str) -> Generator[ArgLabelsT, None, None]:
-        span_index = self.data.next_span_index
-        self._label_path.append(label)
-        arg_labels: ArgLabelsT = {}
-        try:
-            yield arg_labels
-        finally:
-            self._label_path.pop()
-
-        # The draw inside this block opened a span, whose index we knew in
-        # advance even though Span objects are only materialized after the
-        # test case is completed. Stash that index on our data object for
-        # the shrinker's explain phase to vary, and mutate the arg_labels
-        # dict so that the pretty-printer knows where to place the
-        # which-parts-matter comments later. (If the draw raised instead,
-        # we skip recording, along with the rest of the test case.)
-        arg_labels[label] = span_index
-        self.data.arg_spans.add(span_index)
-
     def record_call(
         self,
         obj: object,
@@ -213,7 +190,7 @@ class BuildContext:
 
         for k, s in kwarg_strategies.items():
             with (
-                self.track_arg_label(k) as arg_label,
+                self.data.track_arg_label(k) as arg_label,
                 deprecate_random_in_strategy("from {}={!r}", k, s),
             ):
                 kwargs[k] = self.data.draw(s, observe_as=f"generate:{k}")

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -14,7 +14,8 @@ import time
 import types
 import weakref
 from collections import defaultdict
-from collections.abc import Hashable, Iterable, Iterator, Sequence
+from collections.abc import Generator, Hashable, Iterable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import IntEnum
 from functools import cached_property
@@ -78,6 +79,7 @@ from hypothesis.reporting import debug_report
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.utils.deprecation import note_deprecation
 from hypothesis.utils.threading import ThreadLocal
+from hypothesis.vendor.pretty import ArgLabelsT
 
 if TYPE_CHECKING:
     from hypothesis.strategies import SearchStrategy
@@ -1342,6 +1344,30 @@ class ConjectureData:
         """The index that the next span to start will get. Spans are indexed
         in start order, so this also counts the spans started so far."""
         return self.__span_record.span_count
+
+    @contextmanager
+    def track_arg_span(self) -> Generator[int]:
+        # Record the span opened by the draw inside this block in ``arg_spans``,
+        # for the shrinker's explain phase to vary and comment on.
+        #
+        # Yields the span's index, which we know in advance even though Span
+        # objects are only materialized after the test case is completed. (If the
+        # draw raises instead, we skip recording, along with the rest of the test
+        # case.)
+        span_index = self.next_span_index
+        yield span_index
+        self.arg_spans.add(span_index)
+
+    @contextmanager
+    def track_arg_label(self, label: str) -> Generator[ArgLabelsT]:
+        arg_labels: ArgLabelsT = {}
+
+        with self.track_arg_span() as span_index:
+            yield arg_labels
+
+        # Mutate the arg_labels dict so that the pretty-printer knows where to
+        # place the which-parts-matter comments later.
+        arg_labels[label] = span_index
 
     def start_span(self, label: int) -> None:
         self.provider.span_start(label)

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -792,7 +792,12 @@ class ConjectureRunner:
             ):
                 self.exit_with(ExitReason.max_iterations)
 
-        if self.__tree_is_exhausted():
+        # With interesting test cases that made at least one choice,
+        # ``should_generate_more`` instead ends the generation phase on an
+        # exhausted tree, so that we still shrink (and explain) them.
+        if self.__tree_is_exhausted() and not any(
+            tc.choices for tc in self.interesting_test_cases.values()
+        ):
             self.exit_with(ExitReason.finished)
 
         self.record_for_health_check(data)
@@ -1150,6 +1155,7 @@ class ConjectureRunner:
         if (
             self.valid_test_cases >= self.settings.max_examples
             or (self.invalid_test_cases + self.overrun_test_cases) > invalid_threshold
+            or self.__tree_is_exhausted()
         ):
             return False
 

--- a/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/shrinker.py
@@ -653,6 +653,7 @@ class Shrinker:
                 new_choices.extend(choices[prev_end:start])
                 new_choices.extend(self.random.choice(ls))
                 prev_end = end
+            new_choices.extend(choices[prev_end:])
 
             result = self.engine.cached_test_function(new_choices)
 

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -77,7 +77,7 @@ class TupleStrategy(SearchStrategy[tuple[Ex, ...]]):
         arg_labels: ArgLabelsT = {}
         result = []
         for i, strategy in enumerate(self.element_strategies):
-            with context.track_arg_label(f"arg[{i}]") as arg_label:
+            with data.track_arg_label(f"arg[{i}]") as arg_label:
                 result.append(data.draw(strategy))
             arg_labels |= arg_label
 
@@ -520,7 +520,7 @@ class FixedDictStrategy(SearchStrategy[Mapping[Any, Any]]):
         pairs: list[tuple[Any, Any]] = []
 
         for key, strategy in self.mapping.items():
-            with context.track_arg_label(str(key)) as arg_label:
+            with data.track_arg_label(str(key)) as arg_label:
                 pairs.append((key, data.draw(strategy)))
             arg_labels |= arg_label
 
@@ -536,7 +536,7 @@ class FixedDictStrategy(SearchStrategy[Mapping[Any, Any]]):
                 j = data.draw_integer(0, len(remaining) - 1)
                 remaining[-1], remaining[j] = remaining[j], remaining[-1]
                 key = remaining.pop()
-                with context.track_arg_label(str(key)) as arg_label:
+                with data.track_arg_label(str(key)) as arg_label:
                     pairs.append((key, data.draw(self.optional[key])))
                 arg_labels |= arg_label
 

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -1098,13 +1098,13 @@ class BuildsStrategy(SearchStrategy[Ex]):
 
         args = []
         for i, s in enumerate(self.args):
-            with context.track_arg_label(f"arg[{i}]") as arg_label:
+            with data.track_arg_label(f"arg[{i}]") as arg_label:
                 args.append(data.draw(s))
             arg_labels |= arg_label
 
         kwargs = {}
         for k, v in self.kwargs.items():
-            with context.track_arg_label(k) as arg_label:
+            with data.track_arg_label(k) as arg_label:
                 kwargs[k] = data.draw(v)
             arg_labels |= arg_label
 
@@ -2438,12 +2438,11 @@ class DataObject:
         check_strategy(strategy, "strategy")
         self.count += 1
         desc = f"Draw {self.count}{'' if label is None else f' ({label})'}"
-        # As in BuildContext.track_arg_label, record the span of this draw for
-        # the shrinker's explain phase to vary and comment on.
-        span_index = self.conjecture_data.next_span_index
-        with deprecate_random_in_strategy("{}from {!r}", desc, strategy):
+        with (
+            self.conjecture_data.track_arg_span() as span_index,
+            deprecate_random_in_strategy("{}from {!r}", desc, strategy),
+        ):
             result = self.conjecture_data.draw(strategy, observe_as=f"generate:{desc}")
-        self.conjecture_data.arg_spans.add(span_index)
 
         # optimization to avoid needless printer.pretty
         if should_note():

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -2438,8 +2438,12 @@ class DataObject:
         check_strategy(strategy, "strategy")
         self.count += 1
         desc = f"Draw {self.count}{'' if label is None else f' ({label})'}"
+        # As in BuildContext.track_arg_label, record the span of this draw for
+        # the shrinker's explain phase to vary and comment on.
+        span_index = self.conjecture_data.next_span_index
         with deprecate_random_in_strategy("{}from {!r}", desc, strategy):
             result = self.conjecture_data.draw(strategy, observe_as=f"generate:{desc}")
+        self.conjecture_data.arg_spans.add(span_index)
 
         # optimization to avoid needless printer.pretty
         if should_note():
@@ -2449,6 +2453,8 @@ class DataObject:
                 printer.text("<symbolic>")
             else:
                 printer.pretty(result)
+            if comment := self.conjecture_data.span_comments.get(span_index):
+                printer.text(f"  # {comment}")
             note(printer.getvalue())
         return result
 

--- a/hypothesis/tests/conjecture/test_inquisitor.py
+++ b/hypothesis/tests/conjecture/test_inquisitor.py
@@ -206,6 +206,7 @@ def test_inquisitor_fixeddict_subargs(d):
 
 @fails_with_output("""
 Failing test case: test_inquisitor_tuple_multiple_varying(
+    # The test always failed when commented parts were varied together.
     t=(
         0,  # or any other generated value
         '',  # or any other generated value
@@ -216,8 +217,7 @@ Failing test case: test_inquisitor_tuple_multiple_varying(
 @settings(print_blob=False, derandomize=True)
 @given(st.tuples(st.integers(), st.text(), st.booleans()))
 def test_inquisitor_tuple_multiple_varying(t):
-    # Multiple sub-arguments can vary, but the "together" comment only applies
-    # to top-level test arguments, not to sub-arguments within composites.
+    # Multiple sub-arguments can vary, and get a "together" comment too.
     assert not t[2]
 
 
@@ -240,6 +240,7 @@ def test_inquisitor_skip_subset_slices(obj):
 # Test for duplicate param names at different nesting levels
 @fails_with_output("""
 Failing test case: test_inquisitor_duplicate_param_names(
+    # The test always failed when commented parts were varied together.
     kw=0,  # or any other generated value
     b={
         'kw': '',  # or any other generated value
@@ -270,6 +271,7 @@ class Inner:
 
 @fails_with_output("""
 Failing test case: test_inquisitor_multi_level_nesting(
+    # The test always failed when commented parts were varied together.
     bare=0,  # or any other generated value
     outer=Outer(
         inner=Inner(x=0),  # or any other generated value

--- a/hypothesis/tests/cover/test_arbitrary_data.py
+++ b/hypothesis/tests/cover/test_arbitrary_data.py
@@ -14,8 +14,7 @@ from pytest import raises
 from hypothesis import Phase, find, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
 
-# The explain phase may append comments to the Draw notes we assert
-# exact matches against below.
+# The explain phase may append comments to draw output, which we don't want in these tests
 no_explain = settings(phases=set(settings.default.phases) - {Phase.explain})
 
 

--- a/hypothesis/tests/cover/test_arbitrary_data.py
+++ b/hypothesis/tests/cover/test_arbitrary_data.py
@@ -11,8 +11,12 @@
 import pytest
 from pytest import raises
 
-from hypothesis import find, given, settings, strategies as st
+from hypothesis import Phase, find, given, settings, strategies as st
 from hypothesis.errors import InvalidArgument
+
+# The explain phase may append comments to the Draw notes we assert
+# exact matches against below.
+no_explain = settings(phases=set(settings.default.phases) - {Phase.explain})
 
 
 @given(st.integers(), st.data())
@@ -22,6 +26,7 @@ def test_conditional_draw(x, data):
 
 
 def test_prints_on_failure():
+    @no_explain
     @given(st.data())
     def test(data):
         x = data.draw(st.lists(st.integers(0, 10), min_size=2))
@@ -37,6 +42,7 @@ def test_prints_on_failure():
 
 
 def test_prints_labels_if_given_on_failure():
+    @no_explain
     @given(st.data())
     def test(data):
         x = data.draw(st.lists(st.integers(0, 10), min_size=2), label="Some numbers")
@@ -52,6 +58,7 @@ def test_prints_labels_if_given_on_failure():
 
 
 def test_given_twice_is_same():
+    @no_explain
     @given(st.data(), st.data())
     def test(data1, data2):
         data1.draw(st.integers())

--- a/hypothesis/tests/snapshots/__snapshots__/test_explain.ambr
+++ b/hypothesis/tests/snapshots/__snapshots__/test_explain.ambr
@@ -72,6 +72,15 @@
   Draw 2: 0  # or any other generated value
   '''
 # ---
+# name: test_explain_interactive_draws_in_exhaustible_tree
+  '''
+  Failing test case: inner(
+      data=data(...),
+  )
+  Draw 1: True
+  Draw 2: False  # or any other generated value
+  '''
+# ---
 # name: test_explain_mixed_args_and_interactive_draws
   '''
   Failing test case: inner(

--- a/hypothesis/tests/snapshots/__snapshots__/test_explain.ambr
+++ b/hypothesis/tests/snapshots/__snapshots__/test_explain.ambr
@@ -44,6 +44,7 @@
 # name: test_explain_duplicate_param_names
   '''
   Failing test case: inner(
+      # The test always failed when commented parts were varied together.
       kw=0,  # or any other generated value
       b={
           'kw': '',  # or any other generated value
@@ -62,9 +63,31 @@
   )
   '''
 # ---
+# name: test_explain_interactive_draws
+  '''
+  Failing test case: inner(
+      data=data(...),
+  )
+  Draw 1: 100
+  Draw 2: 0  # or any other generated value
+  '''
+# ---
+# name: test_explain_mixed_args_and_interactive_draws
+  '''
+  Failing test case: inner(
+      # The test always failed when commented parts were varied together.
+      a=False,  # or any other generated value
+      b=True,
+      data=data(...),
+  )
+  Draw 1: False  # or any other generated value
+  Draw 2: True
+  '''
+# ---
 # name: test_explain_multi_level_nesting
   '''
   Failing test case: inner(
+      # The test always failed when commented parts were varied together.
       bare=0,  # or any other generated value
       outer=Outer(
           inner=Inner(x=0),  # or any other generated value
@@ -94,6 +117,7 @@
 # name: test_explain_tuple_multiple_varying
   '''
   Failing test case: inner(
+      # The test always failed when commented parts were varied together.
       t=(
           0,  # or any other generated value
           '',  # or any other generated value

--- a/hypothesis/tests/snapshots/test_explain.py
+++ b/hypothesis/tests/snapshots/test_explain.py
@@ -108,6 +108,28 @@ def test_explain_skip_subset_slices(snapshot):
     assert run_test_for_failing_test_case(inner) == snapshot
 
 
+def test_explain_interactive_draws(snapshot):
+    @EXPLAIN_SETTINGS
+    @given(st.data())
+    def inner(data):
+        n = data.draw(st.integers())
+        data.draw(st.integers())
+        assert n < 100
+
+    assert run_test_for_failing_test_case(inner) == snapshot
+
+
+def test_explain_mixed_args_and_interactive_draws(snapshot):
+    @EXPLAIN_SETTINGS
+    @given(st.booleans(), st.booleans(), st.data())
+    def inner(a, b, data):
+        data.draw(st.booleans())
+        d = data.draw(st.booleans())
+        assert not (b and d)
+
+    assert run_test_for_failing_test_case(inner) == snapshot
+
+
 def test_explain_duplicate_param_names(snapshot):
     @EXPLAIN_SETTINGS
     @given(

--- a/hypothesis/tests/snapshots/test_explain.py
+++ b/hypothesis/tests/snapshots/test_explain.py
@@ -119,6 +119,19 @@ def test_explain_interactive_draws(snapshot):
     assert run_test_for_failing_test_case(inner) == snapshot
 
 
+def test_explain_interactive_draws_in_exhaustible_tree(snapshot):
+    # Exhausting the choice tree used to exit the engine before the shrink
+    # phase, so these small failing examples never got explain comments.
+    @EXPLAIN_SETTINGS
+    @given(st.data())
+    def inner(data):
+        a = data.draw(st.booleans())
+        data.draw(st.booleans())
+        assert not a
+
+    assert run_test_for_failing_test_case(inner) == snapshot
+
+
 def test_explain_mixed_args_and_interactive_draws(snapshot):
     @EXPLAIN_SETTINGS
     @given(st.booleans(), st.booleans(), st.data())


### PR DESCRIPTION
Record the span of each st.data() interactive draw in arg_spans, so the shrinker's explain phase runs its vary-one-part experiments on them, and annotate the printed "Draw n: ..." notes with the resulting comments.

Also fix the varied-together experiment dropping all choices after the last commented span, which made every recombined attempt overrun (and the verdict silently unreported) whenever the failing example ended with an uncommented part.

Fixes https://github.com/HypothesisWorks/hypothesis/issues/4403.