### PR TITLE
Add status_reason category and location to observability reports

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+Test case observations from |observability| now give more detail about why a
+test case failed or was abandoned (:issue:`3845`). ``metadata`` includes a new
+``status_reason_location`` key: a ``filename:lineno`` location for the
+``status_reason``, if known - for example the location of a failing |assume|
+call, the |.filter| call whose predicate rejected the last drawn value, or the
+exception for failing tests.
+
+Test cases which exceeded the maximum allowed size now also report a nonempty
+``status_reason``.

--- a/hypothesis/docs/reference/schema_metadata.json
+++ b/hypothesis/docs/reference/schema_metadata.json
@@ -64,8 +64,12 @@
         "interesting_origin": {
             "type": ["string", "null"],
             "description": "The internal ``InterestingOrigin`` object for failing tests, if and only if ``status == \"failed\"``. The ``traceback`` string value is derived from this object."
+        },
+        "status_reason_location": {
+            "type": ["string", "null"],
+            "description": "A ``filename:lineno`` location for the ``status_reason`` of this test case, if known - for example the location of a failing |assume| call, the |.filter| call whose predicate rejected the last drawn value, or the exception for failing tests."
         }
     },
-    "required": ["traceback", "reproduction_decorator", "notes", "predicates", "backend", "sys.argv", "os.getpid()", "imported_at", "data_status", "interesting_origin"],
+    "required": ["traceback", "reproduction_decorator", "notes", "predicates", "backend", "sys.argv", "os.getpid()", "imported_at", "data_status", "interesting_origin", "status_reason_location"],
     "additionalProperties": false
 }

--- a/hypothesis/src/hypothesis/control.py
+++ b/hypothesis/src/hypothesis/control.py
@@ -39,6 +39,11 @@ def _calling_function_location(what: str, frame: Any) -> str:
     return f"{what}() in {where.f_code.co_name} (line {where.f_lineno})"
 
 
+def _calling_frame_location(frame: Any) -> str:
+    where = frame.f_back
+    return f"{where.f_code.co_filename}:{where.f_lineno}"
+
+
 def reject() -> NoReturn:
     if _current_build_context.value is None:
         note_deprecation(
@@ -46,11 +51,12 @@ def reject() -> NoReturn:
             since="2023-09-25",
             has_codemod=False,
         )
-    where = _calling_function_location("reject", inspect.currentframe())
+    frame = inspect.currentframe()
+    where = _calling_function_location("reject", frame)
     if currently_in_test_context():
         counts = current_build_context().data._observability_predicates[where]
         counts.update_count(condition=False)
-    raise UnsatisfiedAssumption(where)
+    raise UnsatisfiedAssumption(where, location=_calling_frame_location(frame))
 
 
 @overload
@@ -73,12 +79,16 @@ def assume(condition: object) -> Literal[True]:
             has_codemod=False,
         )
     if observability_enabled() or not condition:
-        where = _calling_function_location("assume", inspect.currentframe())
+        frame = inspect.currentframe()
+        where = _calling_function_location("assume", frame)
         if observability_enabled() and currently_in_test_context():
             counts = current_build_context().data._observability_predicates[where]
             counts.update_count(condition=bool(condition))
         if not condition:
-            raise UnsatisfiedAssumption(f"failed to satisfy {where}")
+            raise UnsatisfiedAssumption(
+                f"failed to satisfy {where}",
+                location=_calling_frame_location(frame),
+            )
     return True
 
 

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -1236,7 +1236,7 @@ class StateForActualGivenExecution:
             # An "assume" check failed, so instead we inform the engine that
             # this test run was invalid.
             try:
-                data.mark_invalid(e.reason, location=getattr(e, "location", None))
+                data.mark_invalid(e.reason, location=e.location)
             except FlakyReplay as err:
                 # This was unexpected, meaning that the assume was flaky.
                 # Report it as such.
@@ -2359,7 +2359,7 @@ def given(
                 except UnsatisfiedAssumption as e:
                     status = Status.INVALID
                     data.events["gave up because"] = e.reason or ""
-                    data.invalid_location = getattr(e, "location", None)
+                    data.invalid_location = e.location
                     return None
                 except BaseException as e:
                     # The engine sets data.interesting_origin in

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -1236,7 +1236,7 @@ class StateForActualGivenExecution:
             # An "assume" check failed, so instead we inform the engine that
             # this test run was invalid.
             try:
-                data.mark_invalid(e.reason)
+                data.mark_invalid(e.reason, location=getattr(e, "location", None))
             except FlakyReplay as err:
                 # This was unexpected, meaning that the assume was flaky.
                 # Report it as such.
@@ -1585,7 +1585,14 @@ class StateForActualGivenExecution:
                         coverage=None,  # Not recorded when we're replaying the MFE
                         status="passed" if sys.exc_info()[0] else "failed",
                         status_reason=str(origin or "unexpected/flaky pass"),
-                        metadata={"traceback": tb},
+                        metadata={
+                            "traceback": tb,
+                            "status_reason_location": (
+                                f"{origin.filename}:{origin.lineno}"
+                                if origin and origin.filename
+                                else None
+                            ),
+                        },
                     )
                     deliver_observation(tc)
 
@@ -2349,8 +2356,10 @@ def given(
                 except StopTest:
                     status = data.status
                     return None
-                except UnsatisfiedAssumption:
+                except UnsatisfiedAssumption as e:
                     status = Status.INVALID
+                    data.events["invalid because"] = e.reason or ""
+                    data.invalid_location = getattr(e, "location", None)
                     return None
                 except BaseException as e:
                     # The engine sets data.interesting_origin in

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -2358,7 +2358,7 @@ def given(
                     return None
                 except UnsatisfiedAssumption as e:
                     status = Status.INVALID
-                    data.events["invalid because"] = e.reason or ""
+                    data.events["gave up because"] = e.reason or ""
                     data.invalid_location = getattr(e, "location", None)
                     return None
                 except BaseException as e:

--- a/hypothesis/src/hypothesis/errors.py
+++ b/hypothesis/src/hypothesis/errors.py
@@ -34,8 +34,12 @@ class UnsatisfiedAssumption(HypothesisException):
     If you're seeing this error something has gone wrong.
     """
 
-    def __init__(self, reason: str | None = None) -> None:
+    def __init__(
+        self, reason: str | None = None, *, location: str | None = None
+    ) -> None:
         self.reason = reason
+        # "filename:lineno" of the failing assume() or reject() call, if known
+        self.location = location
 
 
 class NoSuchExample(HypothesisException):

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -1270,7 +1270,7 @@ class ConjectureData:
         strategy.validate()
 
         if strategy.is_empty:
-            self.mark_invalid(f"empty strategy {self!r}")
+            self.mark_invalid(f"empty strategy {strategy!r}")
 
         if self.depth >= MAX_DEPTH:
             self.mark_invalid("max depth exceeded")

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -14,7 +14,7 @@ import time
 import types
 import weakref
 from collections import defaultdict
-from collections.abc import Generator, Hashable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Generator, Hashable, Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import IntEnum
@@ -718,6 +718,12 @@ class ConjectureData:
         self.gc_start_time = gc_cumulative_time()
         self.events: dict[str, str | int | float] = {}
         self.interesting_origin: InterestingOrigin | None = None
+        # where an invalid test case was rejected; see make_testcase
+        self.invalid_location: str | None = None
+        # (predicate, location of its .filter() call) for the filter which most
+        # recently rejected a candidate value, so that if we give up we can
+        # report which filter was responsible
+        self._rejected_by_filter: tuple[Callable[[Any], Any], str | None] | None = None
         self.draw_times: dict[str, float] = {}
         self._stateful_run_times: dict[str, float] = defaultdict(float)
         self.max_depth: int = 0
@@ -1481,9 +1487,12 @@ class ConjectureData:
     def mark_interesting(self, interesting_origin: InterestingOrigin) -> NoReturn:
         self.conclude_test(Status.INTERESTING, interesting_origin)
 
-    def mark_invalid(self, why: str | None = None) -> NoReturn:
+    def mark_invalid(
+        self, why: str | None = None, *, location: str | None = None
+    ) -> NoReturn:
         if why is not None:
             self.events["invalid because"] = why
+        self.invalid_location = location
         self.conclude_test(Status.INVALID)
 
     def mark_overrun(self) -> NoReturn:

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -75,6 +75,7 @@ from hypothesis.internal.floats import (
 )
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.internal.observability import PredicateCounts
+from hypothesis.internal.reflection import function_location
 from hypothesis.reporting import debug_report
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.utils.deprecation import note_deprecation
@@ -718,12 +719,6 @@ class ConjectureData:
         self.gc_start_time = gc_cumulative_time()
         self.events: dict[str, str | int | float] = {}
         self.interesting_origin: InterestingOrigin | None = None
-        # where an invalid test case was rejected; see make_testcase
-        self.invalid_location: str | None = None
-        # (predicate, location of its .filter() call) for the filter which most
-        # recently rejected a candidate value, so that if we give up we can
-        # report which filter was responsible
-        self._rejected_by_filter: tuple[Callable[[Any], Any], str | None] | None = None
         self.draw_times: dict[str, float] = {}
         self._stateful_run_times: dict[str, float] = defaultdict(float)
         self.max_depth: int = 0
@@ -761,6 +756,11 @@ class ConjectureData:
         self._observability_args: dict[str, Any] = {}
         self._observability_predicates: defaultdict[str, PredicateCounts] = defaultdict(
             PredicateCounts
+        )
+        self.invalid_location: str | None = None
+        # (predicate, location) of the most recent filter rejection
+        self._last_rejected_filter: tuple[Callable[[Any], Any], str | None] | None = (
+            None
         )
 
         self._sampled_from_all_strategies_elements_message: (
@@ -1497,6 +1497,14 @@ class ConjectureData:
 
     def mark_overrun(self) -> NoReturn:
         self.conclude_test(Status.OVERRUN)
+
+    def last_rejected_filter_location(self) -> str | None:
+        """The location of the most recently rejected filter."""
+        if self._last_rejected_filter is None:
+            return None
+        condition, location = self._last_rejected_filter
+        # fall back to where the predicate was defined if no location is known
+        return location or function_location(condition)
 
 
 def draw_choice(

--- a/hypothesis/src/hypothesis/internal/conjecture/data.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/data.py
@@ -1491,7 +1491,7 @@ class ConjectureData:
         self, why: str | None = None, *, location: str | None = None
     ) -> NoReturn:
         if why is not None:
-            self.events["invalid because"] = why
+            self.events["gave up because"] = why
         self.invalid_location = location
         self.conclude_test(Status.INVALID)
 

--- a/hypothesis/src/hypothesis/internal/conjecture/engine.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/engine.py
@@ -989,7 +989,7 @@ class ConjectureRunner:
             status = f"{status} ({data.interesting_origin!r})"
         elif data.status == Status.INVALID and isinstance(data, ConjectureData):
             assert isinstance(data, ConjectureData)  # mypy is silly
-            status = f"{status} ({data.events.get('invalid because', '?')})"
+            status = f"{status} ({data.events.get('gave up because', '?')})"
 
         self.debug(f"{len(data.choices)} choices -> {status}\n\t{data.choices}")
 
@@ -1361,9 +1361,9 @@ class ConjectureRunner:
             if (
                 data.status is Status.OVERRUN
                 and max_length is not None
-                and "invalid because" not in data.events
+                and "gave up because" not in data.events
             ):
-                data.events["invalid because"] = (
+                data.events["gave up because"] = (
                     "reduced max size for early test cases (avoids flaky health checks)"
                 )
 

--- a/hypothesis/src/hypothesis/internal/observability.py
+++ b/hypothesis/src/hypothesis/internal/observability.py
@@ -429,11 +429,11 @@ def make_testcase(
         status_reason = "exceeded size of current best test case"
     elif data.status == Status.OVERRUN:
         status_reason = (
-            str(data.events.pop("invalid because", ""))
+            str(data.events.pop("gave up because", ""))
             or "exceeded maximum test case size"
         )
     else:
-        status_reason = str(data.events.pop("invalid because", ""))
+        status_reason = str(data.events.pop("gave up because", ""))
 
     status_map: dict[Status, TestCaseStatus] = {
         Status.OVERRUN: "gave_up",

--- a/hypothesis/src/hypothesis/internal/observability.py
+++ b/hypothesis/src/hypothesis/internal/observability.py
@@ -182,6 +182,7 @@ class ObservationMetadata:
     data_status: "Status"
     phase: str
     interesting_origin: InterestingOrigin | None
+    status_reason_location: str | None
     choice_nodes: tuple[ChoiceNode, ...] | None
     choice_spans: Optional["Spans"]
 
@@ -198,6 +199,7 @@ class ObservationMetadata:
             "data_status": self.data_status,
             "phase": self.phase,
             "interesting_origin": self.interesting_origin,
+            "status_reason_location": self.status_reason_location,
             "choice_nodes": (
                 None if self.choice_nodes is None else nodes_to_json(self.choice_nodes)
             ),
@@ -425,6 +427,11 @@ def make_testcase(
         status_reason = str(data.interesting_origin)
     elif phase == "shrink" and data.status == Status.OVERRUN:
         status_reason = "exceeded size of current best test case"
+    elif data.status == Status.OVERRUN:
+        status_reason = (
+            str(data.events.pop("invalid because", ""))
+            or "exceeded maximum test case size"
+        )
     else:
         status_reason = str(data.events.pop("invalid because", ""))
 
@@ -439,6 +446,13 @@ def make_testcase(
         status = status_map[status]
     if status is None:
         status = status_map[data.status]
+
+    status_reason_location: str | None = None
+    if (origin := data.interesting_origin) is not None:
+        if origin.filename is not None:
+            status_reason_location = f"{origin.filename}:{origin.lineno}"
+    elif status != "failed":
+        status_reason_location = data.invalid_location
 
     return TestCaseObservation(
         type="test_case",
@@ -469,6 +483,7 @@ def make_testcase(
                 "data_status": data.status,
                 "phase": phase,
                 "interesting_origin": data.interesting_origin,
+                "status_reason_location": status_reason_location,
                 "choice_nodes": data.nodes if OBSERVABILITY_CHOICES else None,
                 "choice_spans": data.spans if OBSERVABILITY_CHOICES else None,
                 **_system_metadata(),

--- a/hypothesis/src/hypothesis/internal/reflection.py
+++ b/hypothesis/src/hypothesis/internal/reflection.py
@@ -268,6 +268,15 @@ def is_first_param_referenced_in_function(f: Any) -> bool:
     )
 
 
+def function_location(f: object) -> str | None:
+    """Return a ``filename:lineno`` string for where ``f`` was defined, if known."""
+    try:
+        code = f.__code__  # type: ignore[attr-defined]
+        return f"{code.co_filename}:{code.co_firstlineno}"
+    except AttributeError:
+        return None
+
+
 def get_pretty_function_description(f: object) -> str:
     # Anything which knows how to pretty-print itself knows better than we do -
     # e.g. the constant functions from st.functions(), which would otherwise

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -57,7 +57,7 @@ from hypothesis.strategies._internal.strategies import (
     SampledFromStrategy,
     SearchStrategy,
     check_strategy,
-    filter_call_site,
+    current_filter_call_site,
     filter_not_satisfied,
 )
 from hypothesis.utils.deprecation import note_deprecation
@@ -693,7 +693,7 @@ class Bundle(SearchStrategy[Ex]):
         return self.__with_transform("map", pack)
 
     def filter(self, condition):
-        return self.__with_transform("filter", condition, filter_call_site())
+        return self.__with_transform("filter", condition, current_filter_call_site())
 
     def _base_repr(self):
         consume = ", consume=True" if self.consume else ""

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -59,7 +59,6 @@ from hypothesis.strategies._internal.strategies import (
     check_strategy,
     filter_call_site,
     filter_not_satisfied,
-    rejection_location,
 )
 from hypothesis.utils.deprecation import note_deprecation
 from hypothesis.vendor.pretty import RepresentationPrinter
@@ -670,7 +669,7 @@ class Bundle(SearchStrategy[Ex]):
         if result is filter_not_satisfied:
             data.mark_invalid(
                 f"Aborted test because unable to satisfy {self!r}",
-                location=rejection_location(data),
+                location=data.last_rejected_filter_location(),
             )
         position, reference, value = result
         if self.consume:

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -681,7 +681,7 @@ class Bundle(SearchStrategy[Ex]):
     # apply within a single draw: the generic wrappers instead retry the whole
     # draw when a filter fails, consuming rejected values from consuming
     # bundles, and are opaque to the reference-drawing logic in Rule.
-    def __with_transform(self, name, f, location=None):
+    def __with_transform(self, name, f, *, location=None):
         return Bundle(
             self.name,
             consume=self.consume,
@@ -693,7 +693,9 @@ class Bundle(SearchStrategy[Ex]):
         return self.__with_transform("map", pack)
 
     def filter(self, condition):
-        return self.__with_transform("filter", condition, current_filter_call_site())
+        return self.__with_transform(
+            "filter", condition, location=current_filter_call_site()
+        )
 
     def _base_repr(self):
         consume = ", consume=True" if self.consume else ""

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -57,7 +57,9 @@ from hypothesis.strategies._internal.strategies import (
     SampledFromStrategy,
     SearchStrategy,
     check_strategy,
+    filter_call_site,
     filter_not_satisfied,
+    rejection_location,
 )
 from hypothesis.utils.deprecation import note_deprecation
 from hypothesis.vendor.pretty import RepresentationPrinter
@@ -535,7 +537,7 @@ class Rule:
                 # stored on the machine and we want to draw the transformed value
                 # directly instead of a reference.
                 draw_references = all(
-                    name == "filter" for name, _ in v._transformations
+                    name == "filter" for name, *_ in v._transformations
                 )
                 v = Bundle(
                     v.name,
@@ -594,13 +596,13 @@ class _BundleSampler(SampledFromStrategy):
         )
         self.machine = machine
 
-    def _transform(self, element):
+    def _transform(self, element, data=None):
         # Filter and map transformations apply to the value, which we look up
         # lazily so that untested elements cost nothing; the position and
         # reference ride along so that Bundle.do_draw can consume the chosen
         # element and refer to it by name.
         position, reference = element
-        result = super()._transform(self.machine.names_to_values[reference.name])
+        result = super()._transform(self.machine.names_to_values[reference.name], data)
         if result is filter_not_satisfied:
             return filter_not_satisfied
         return (position, reference, result)
@@ -666,7 +668,10 @@ class Bundle(SearchStrategy[Ex]):
         )
         result = sampler.do_filtered_draw(data)
         if result is filter_not_satisfied:
-            data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")
+            data.mark_invalid(
+                f"Aborted test because unable to satisfy {self!r}",
+                location=rejection_location(data),
+            )
         position, reference, value = result
         if self.consume:
             bundle.pop(position)  # pragma: no cover  # coverage is flaky here
@@ -677,19 +682,19 @@ class Bundle(SearchStrategy[Ex]):
     # apply within a single draw: the generic wrappers instead retry the whole
     # draw when a filter fails, consuming rejected values from consuming
     # bundles, and are opaque to the reference-drawing logic in Rule.
-    def __with_transform(self, name, f):
+    def __with_transform(self, name, f, location=None):
         return Bundle(
             self.name,
             consume=self.consume,
             draw_references=self.draw_references,
-            transformations=(*self._transformations, (name, f)),
+            transformations=(*self._transformations, (name, f, location)),
         )
 
     def map(self, pack):
         return self.__with_transform("map", pack)
 
     def filter(self, condition):
-        return self.__with_transform("filter", condition)
+        return self.__with_transform("filter", condition, filter_call_site())
 
     def _base_repr(self):
         consume = ", consume=True" if self.consume else ""
@@ -698,7 +703,7 @@ class Bundle(SearchStrategy[Ex]):
     def __repr__(self):
         transforms = "".join(
             f".{name}({get_pretty_function_description(f)})"
-            for name, f in self._transformations
+            for name, f, _ in self._transformations
         )
         return self._base_repr() + transforms
 

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -595,13 +595,15 @@ class _BundleSampler(SampledFromStrategy):
         )
         self.machine = machine
 
-    def _transform(self, element, data=None):
+    def _transform(self, element, *, data):
         # Filter and map transformations apply to the value, which we look up
         # lazily so that untested elements cost nothing; the position and
         # reference ride along so that Bundle.do_draw can consume the chosen
         # element and refer to it by name.
         position, reference = element
-        result = super()._transform(self.machine.names_to_values[reference.name], data)
+        result = super()._transform(
+            self.machine.names_to_values[reference.name], data=data
+        )
         if result is filter_not_satisfied:
             return filter_not_satisfied
         return (position, reference, result)

--- a/hypothesis/src/hypothesis/stateful.py
+++ b/hypothesis/src/hypothesis/stateful.py
@@ -643,7 +643,7 @@ class Bundle(SearchStrategy[Ex]):
         consume: bool = False,
         draw_references: bool = False,
         transformations: tuple[
-            tuple[Literal["filter", "map"], Callable[[Ex], Any]], ...
+            tuple[Literal["filter", "map"], Callable[[Ex], Any], str | None], ...
         ] = (),
     ) -> None:
         super().__init__()

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -435,7 +435,7 @@ class UniqueSampledListStrategy(UniqueListStrategy):
 
         while remaining and should_draw.more():
             j = data.draw_integer(0, len(remaining) - 1)
-            value = self.element_strategy._transform(remaining.pop(j))
+            value = self.element_strategy._transform(remaining.pop(j), data=data)
             if value is not filter_not_satisfied and all(
                 key(value) not in seen
                 for key, seen in zip(self.keys, seen_sets, strict=True)
@@ -470,7 +470,9 @@ class UniqueSampledListStrategy(UniqueListStrategy):
         for i, (element, target) in enumerate(zip(value, targets, strict=True)):
             choices.extend(elements.more())
             for j, candidate in enumerate(remaining):
-                if equal_values(self.element_strategy._transform(candidate), target):
+                if equal_values(
+                    self.element_strategy._transform(candidate, data=None), target
+                ):
                     choices.append(j)
                     remaining.pop(j)
                     break

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -29,6 +29,7 @@ from hypothesis.strategies._internal.strategies import (
     OneOfStrategy,
     SampledFromStrategy,
     SearchStrategy,
+    filter_call_site,
     one_of,
 )
 from hypothesis.strategies._internal.utils import defines_strategy
@@ -96,7 +97,7 @@ def _timezones_kind(strat):
     None, "aware" if only tzinfo instances, or "unknown" if we can't tell."""
     strat = unwrap_strategies(strat)
     if isinstance(strat, SampledFromStrategy) and all(
-        name == "filter" for name, _ in strat._transformations
+        name == "filter" for name, *_ in strat._transformations
     ):
         kinds = {
             "none" if e is None else "aware" if isinstance(e, dt.tzinfo) else "unknown"
@@ -546,7 +547,7 @@ class DatetimeStrategy(SearchStrategy):
                         min_value, max_value, self.tz_strat, self.allow_imaginary
                     )
                 if func in (op.lt, op.gt):
-                    return FilteredStrategy(result, (condition,))
+                    return FilteredStrategy(result, (condition,), (filter_call_site(),))
                 return result
         return super().filter(condition)
 

--- a/hypothesis/src/hypothesis/strategies/_internal/datetime.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/datetime.py
@@ -29,7 +29,7 @@ from hypothesis.strategies._internal.strategies import (
     OneOfStrategy,
     SampledFromStrategy,
     SearchStrategy,
-    filter_call_site,
+    current_filter_call_site,
     one_of,
 )
 from hypothesis.strategies._internal.utils import defines_strategy
@@ -547,7 +547,9 @@ class DatetimeStrategy(SearchStrategy):
                         min_value, max_value, self.tz_strat, self.allow_imaginary
                     )
                 if func in (op.lt, op.gt):
-                    return FilteredStrategy(result, (condition,), (filter_call_site(),))
+                    return FilteredStrategy(
+                        result, (condition,), (current_filter_call_site(),)
+                    )
                 return result
         return super().filter(condition)
 

--- a/hypothesis/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/lazy.py
@@ -28,7 +28,7 @@ from hypothesis.strategies._internal.strategies import (
     RecurT,
     SearchStrategy,
     _filter_location_override,
-    filter_call_site,
+    current_filter_call_site,
 )
 from hypothesis.utils.threading import ThreadLocal
 
@@ -151,7 +151,7 @@ class LazyStrategy(SearchStrategy[Ex]):
         return self.__with_transform("map", pack)
 
     def filter(self, condition):
-        return self.__with_transform("filter", condition, filter_call_site())
+        return self.__with_transform("filter", condition, current_filter_call_site())
 
     def do_validate(self) -> None:
         w = self.wrapped_strategy

--- a/hypothesis/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/lazy.py
@@ -23,7 +23,13 @@ from hypothesis.internal.reflection import (
     repr_call,
 )
 from hypothesis.strategies._internal.deferred import DeferredStrategy
-from hypothesis.strategies._internal.strategies import Ex, RecurT, SearchStrategy
+from hypothesis.strategies._internal.strategies import (
+    Ex,
+    RecurT,
+    SearchStrategy,
+    _filter_location_override,
+    filter_call_site,
+)
 from hypothesis.utils.threading import ThreadLocal
 
 threadlocal = ThreadLocal(unwrap_depth=int, unwrap_cache=WeakKeyDictionary)
@@ -77,7 +83,8 @@ class LazyStrategy(SearchStrategy[Ex]):
         args: Sequence[object],
         kwargs: dict[str, object],
         *,
-        transforms: tuple[tuple[str, Callable[..., Any]], ...] = (),
+        # (name, function, location of the .filter()/.map() call, if known)
+        transforms: tuple[tuple[str, Callable[..., Any], str | None], ...] = (),
         force_repr: str | None = None,
     ):
         super().__init__()
@@ -119,13 +126,16 @@ class LazyStrategy(SearchStrategy[Ex]):
                 _wrapped_strategy = base
             else:
                 _wrapped_strategy = self.function(*unwrapped_args, **unwrapped_kwargs)
-            for method, fn in self._transformations:
-                _wrapped_strategy = getattr(_wrapped_strategy, method)(fn)
+            for method, fn, location in self._transformations:
+                # Carry the location of the original .filter() call through to
+                # the underlying strategy's .filter(), for reporting.
+                with _filter_location_override.with_value(location):
+                    _wrapped_strategy = getattr(_wrapped_strategy, method)(fn)
             self.__wrapped_strategy = _wrapped_strategy
         assert self.__wrapped_strategy is not None
         return self.__wrapped_strategy
 
-    def __with_transform(self, method, fn):
+    def __with_transform(self, method, fn, location=None):
         repr_ = self.__representation
         if repr_:
             repr_ = f"{repr_}.{method}({get_pretty_function_description(fn)})"
@@ -133,7 +143,7 @@ class LazyStrategy(SearchStrategy[Ex]):
             self.function,
             self.__args,
             self.__kwargs,
-            transforms=(*self._transformations, (method, fn)),
+            transforms=(*self._transformations, (method, fn, location)),
             force_repr=repr_,
         )
 
@@ -141,7 +151,7 @@ class LazyStrategy(SearchStrategy[Ex]):
         return self.__with_transform("map", pack)
 
     def filter(self, condition):
-        return self.__with_transform("filter", condition)
+        return self.__with_transform("filter", condition, filter_call_site())
 
     def do_validate(self) -> None:
         w = self.wrapped_strategy
@@ -169,7 +179,7 @@ class LazyStrategy(SearchStrategy[Ex]):
                 self.function, _args, kwargs_for_repr, reorder=False
             ) + "".join(
                 f".{method}({get_pretty_function_description(fn)})"
-                for method, fn in self._transformations
+                for method, fn, _ in self._transformations
             )
         return self.__representation
 

--- a/hypothesis/src/hypothesis/strategies/_internal/lazy.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/lazy.py
@@ -135,7 +135,7 @@ class LazyStrategy(SearchStrategy[Ex]):
         assert self.__wrapped_strategy is not None
         return self.__wrapped_strategy
 
-    def __with_transform(self, method, fn, location=None):
+    def __with_transform(self, method, fn, *, location=None):
         repr_ = self.__representation
         if repr_:
             repr_ = f"{repr_}.{method}({get_pretty_function_description(fn)})"
@@ -151,7 +151,9 @@ class LazyStrategy(SearchStrategy[Ex]):
         return self.__with_transform("map", pack)
 
     def filter(self, condition):
-        return self.__with_transform("filter", condition, current_filter_call_site())
+        return self.__with_transform(
+            "filter", condition, location=current_filter_call_site()
+        )
 
     def do_validate(self) -> None:
         w = self.wrapped_strategy

--- a/hypothesis/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/misc.py
@@ -51,7 +51,7 @@ class JustStrategy(SampledFromStrategy[Ex]):
     def __repr__(self) -> str:
         suffix = "".join(
             f".{name}({get_pretty_function_description(f)})"
-            for name, f in self._transformations
+            for name, f, _ in self._transformations
         )
         if self.value is None:
             return "none()" + suffix
@@ -64,7 +64,7 @@ class JustStrategy(SampledFromStrategy[Ex]):
         # The parent class's `do_draw` implementation delegates directly to
         # `do_filtered_draw`, which we can greatly simplify in this case since
         # we have exactly one value. (This also avoids drawing any data.)
-        return self._transform(self.value)
+        return self._transform(self.value, data)
 
     def _invert(self, value: Any) -> tuple[ChoiceT, ...]:
         if not equal_values(self._transform(self.value), value):

--- a/hypothesis/src/hypothesis/strategies/_internal/misc.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/misc.py
@@ -64,10 +64,10 @@ class JustStrategy(SampledFromStrategy[Ex]):
         # The parent class's `do_draw` implementation delegates directly to
         # `do_filtered_draw`, which we can greatly simplify in this case since
         # we have exactly one value. (This also avoids drawing any data.)
-        return self._transform(self.value, data)
+        return self._transform(self.value, data=data)
 
     def _invert(self, value: Any) -> tuple[ChoiceT, ...]:
-        if not equal_values(self._transform(self.value), value):
+        if not equal_values(self._transform(self.value, data=None), value):
             raise CannotInvert(f"{value!r} is not produced by {self!r}")
         return ()
 

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -1170,9 +1170,17 @@ class MappedStrategy(SearchStrategy[MappedTo], Generic[MappedFrom, MappedTo]):
                         result, self.pack, args=[x], kwargs={}
                     )
                     return result
-                except UnsatisfiedAssumption:
+                except UnsatisfiedAssumption as err:
+                    # we want to preserve the err.location of the actual exception here if we
+                    # re-throw it outside of the loop at the end. The alternative is a
+                    # bare `raise UnsatisfiedAssumption` outside of the loop, which would
+                    # drop the real err.location for observability.
+                    #
+                    # If we catch multiple exceptions here, we'll just report the location
+                    # of the last one, which is a reasonable tradeoff for a singleton field.
+                    failed_assumption = err
                     data.stop_span(discard=True)
-        raise UnsatisfiedAssumption
+        raise failed_assumption
 
     def _invert(self, value: Any) -> tuple[ChoiceT, ...]:
         # map() is not invertible in general, but a dict-like pack - e.g. the

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Sequence
 from functools import lru_cache
 from random import shuffle
 from threading import RLock
+from types import FrameType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -51,12 +52,15 @@ from hypothesis.internal.conjecture.utils import (
     combine_labels,
 )
 from hypothesis.internal.coverage import check_function
+from hypothesis.internal.escalation import is_hypothesis_file
 from hypothesis.internal.reflection import (
+    function_location,
     get_pretty_function_description,
     is_identity_function,
 )
 from hypothesis.strategies._internal.utils import defines_strategy
-from hypothesis.utils.conventions import UniqueIdentifier
+from hypothesis.utils.conventions import UniqueIdentifier, not_set
+from hypothesis.utils.dynamicvariables import DynamicVariable
 
 if TYPE_CHECKING:
     Ex = TypeVar("Ex", covariant=True, default=Any)
@@ -81,6 +85,36 @@ FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
 )
 
 label_lock = RLock()
+
+# When hypothesis re-applies a filter condition internally - lazy strategy
+# resolution, replaying predicates in FilteredStrategy.do_validate - this
+# carries the location of the original .filter() call through to the
+# re-application, where walking the stack would find the wrong frame.
+_filter_location_override: DynamicVariable[Any] = DynamicVariable(not_set)
+
+
+def filter_call_site() -> str | None:
+    """The filename:lineno of the enclosing .filter() call - the nearest frame
+    outside hypothesis itself. Call this at .filter() call time and store the
+    result alongside the condition; reconstructing it later is ambiguous."""
+    if (location := _filter_location_override.value) is not not_set:
+        return location
+    frame: FrameType | None = sys._getframe(1)
+    while frame is not None and is_hypothesis_file(frame.f_code.co_filename):
+        frame = frame.f_back
+    if frame is None:  # pragma: no cover  # ran out of frames
+        return None
+    return f"{frame.f_code.co_filename}:{frame.f_lineno}"
+
+
+def rejection_location(data: ConjectureData) -> str | None:
+    """The location of the filter which most recently rejected a candidate
+    value: where its .filter() call was made, or failing that where the
+    predicate was defined, if known."""
+    if data._rejected_by_filter is None:
+        return None
+    condition, location = data._rejected_by_filter
+    return location or function_location(condition)
 
 
 def recursive_property(strategy: "SearchStrategy", name: str, default: object) -> Any:
@@ -448,7 +482,9 @@ class SearchStrategy(Generic[Ex]):
                         return value
                 assume(False)
         """
-        return FilteredStrategy(self, conditions=(condition,))
+        return FilteredStrategy(
+            self, conditions=(condition,), condition_locations=(filter_call_site(),)
+        )
 
     @property
     def branches(self) -> Sequence["SearchStrategy[Ex]"]:
@@ -606,8 +642,9 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         *,
         force_repr: str | None = None,
         force_repr_braces: tuple[str, str] | None = None,
+        # (name, function, location of the .filter()/.map() call, if known)
         transformations: tuple[
-            tuple[Literal["filter", "map"], Callable[[Ex], Any]],
+            tuple[Literal["filter", "map"], Callable[[Ex], Any], str | None],
             ...,
         ] = (),
     ):
@@ -625,7 +662,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
             self.elements,
             force_repr=self.force_repr,
             force_repr_braces=self.force_repr_braces,
-            transformations=(*self._transformations, ("map", pack)),
+            transformations=(*self._transformations, ("map", pack, None)),
         )
         # guaranteed by the ("map", pack) transformation
         return cast(SearchStrategy[T], s)
@@ -641,7 +678,10 @@ class SampledFromStrategy(SearchStrategy[Ex]):
             self.elements,
             force_repr=self.force_repr,
             force_repr_braces=self.force_repr_braces,
-            transformations=(*self._transformations, ("filter", condition)),
+            transformations=(
+                *self._transformations,
+                ("filter", condition, filter_call_site()),
+            ),
         )
 
     def __repr__(self):
@@ -658,7 +698,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
             )
             transforms_s = "".join(
                 f".{name}({get_pretty_function_description(f)})"
-                for name, f in self._transformations
+                for name, f, _ in self._transformations
             )
             repr_s = instance_s + transforms_s
             self._cached_repr = repr_s
@@ -731,9 +771,10 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         # anywhere in the class so this is still type-safe. mypy is being more
         # conservative than necessary
         element: Ex,  # type: ignore
+        data: ConjectureData | None = None,
     ) -> Ex | UniqueIdentifier:
         # Used in UniqueSampledListStrategy
-        for name, f in self._transformations:
+        for name, f, location in self._transformations:
             if name == "map":
                 result = f(element)
                 if build_context := _current_build_context.value:
@@ -742,6 +783,8 @@ class SampledFromStrategy(SearchStrategy[Ex]):
             else:
                 assert name == "filter"
                 if not f(element):
+                    if data is not None:
+                        data._rejected_by_filter = (f, location)
                     return filter_not_satisfied
         return element
 
@@ -758,12 +801,19 @@ class SampledFromStrategy(SearchStrategy[Ex]):
                 self.elements,
             )
         if result is filter_not_satisfied:
-            data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")
+            # do_filtered_draw recorded the filter which rejected the most
+            # recently tried element in data._rejected_by_filter.
+            data.mark_invalid(
+                f"Aborted test because unable to satisfy {self!r}",
+                location=rejection_location(data),
+            )
         assert not isinstance(result, UniqueIdentifier)
         return result
 
-    def get_element(self, i: int) -> Ex | UniqueIdentifier:
-        return self._transform(self.elements[i])
+    def get_element(
+        self, i: int, data: ConjectureData | None = None
+    ) -> Ex | UniqueIdentifier:
+        return self._transform(self.elements[i], data)
 
     def _invert(self, value: Any) -> tuple[ChoiceT, ...]:
         # The smallest index whose (possibly transformed) element equals value.
@@ -784,7 +834,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         for _ in range(3):
             i = data.draw_integer(0, len(self.elements) - 1)
             if i not in known_bad_indices:
-                element = self.get_element(i)
+                element = self.get_element(i, data)
                 if element is not filter_not_satisfied:
                     return element
                 if not known_bad_indices:
@@ -812,7 +862,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         allowed: list[tuple[int, Ex]] = []
         for i in range(min(len(self.elements), self._MAX_FILTER_CALLS - 3)):
             if i not in known_bad_indices:
-                element = self.get_element(i)
+                element = self.get_element(i, data)
                 if element is not filter_not_satisfied:
                     assert not isinstance(element, UniqueIdentifier)
                     allowed.append((i, element))
@@ -1178,7 +1228,11 @@ class MappedStrategy(SearchStrategy[MappedTo], Generic[MappedFrom, MappedTo]):
 
         # Apply a new outer filter even though we rewrote the inner strategy,
         # because some collections can change the list length (dict, set, etc).
-        return FilteredStrategy(type(self)(new, self.pack), conditions=(condition,))
+        return FilteredStrategy(
+            type(self)(new, self.pack),
+            conditions=(condition,),
+            condition_locations=(filter_call_site(),),
+        )
 
 
 @lru_cache
@@ -1223,17 +1277,29 @@ filter_not_satisfied = UniqueIdentifier("filter not satisfied")
 
 class FilteredStrategy(SearchStrategy[Ex]):
     def __init__(
-        self, strategy: SearchStrategy[Ex], conditions: tuple[Callable[[Ex], Any], ...]
+        self,
+        strategy: SearchStrategy[Ex],
+        conditions: tuple[Callable[[Ex], Any], ...],
+        condition_locations: tuple[str | None, ...] | None = None,
     ):
         super().__init__()
+        # Where each condition's .filter() call was made, aligned with
+        # `conditions` - for reporting if we give up on satisfying one.
+        if condition_locations is None:
+            condition_locations = (None,) * len(conditions)
+        assert len(condition_locations) == len(conditions)
         if isinstance(strategy, FilteredStrategy):
             # Flatten chained filters into a single filter with multiple conditions.
             self.flat_conditions: tuple[Callable[[Ex], Any], ...] = (
                 strategy.flat_conditions + conditions
             )
+            self.condition_locations: tuple[str | None, ...] = (
+                strategy.condition_locations + condition_locations
+            )
             self.filtered_strategy: SearchStrategy[Ex] = strategy.filtered_strategy
         else:
             self.flat_conditions = conditions
+            self.condition_locations = condition_locations
             self.filtered_strategy = strategy
 
         assert isinstance(self.flat_conditions, tuple)
@@ -1267,13 +1333,19 @@ class FilteredStrategy(SearchStrategy[Ex]):
         # predicates in case some or all of them can be rewritten.  Note that this
         # replaces the `fresh` strategy too!
         fresh = self.filtered_strategy
-        for cond in self.flat_conditions:
-            fresh = fresh.filter(cond)
+        for cond, location in zip(
+            self.flat_conditions, self.condition_locations, strict=True
+        ):
+            with _filter_location_override.with_value(location):
+                fresh = fresh.filter(cond)
         if isinstance(fresh, FilteredStrategy):
             # In this case we have at least some non-rewritten filter predicates,
             # so we just re-initialize the strategy.
             FilteredStrategy.__init__(
-                self, fresh.filtered_strategy, fresh.flat_conditions
+                self,
+                fresh.filtered_strategy,
+                fresh.flat_conditions,
+                fresh.condition_locations,
             )
         else:
             # But if *all* the predicates were rewritten... well, do_validate() is
@@ -1296,10 +1368,12 @@ class FilteredStrategy(SearchStrategy[Ex]):
         # combine the conditions of each in our expected newest=last order.
         if isinstance(out, FilteredStrategy):
             return FilteredStrategy(
-                out.filtered_strategy, self.flat_conditions + out.flat_conditions
+                out.filtered_strategy,
+                self.flat_conditions + out.flat_conditions,
+                self.condition_locations + out.condition_locations,
             )
         # But if it *could* be rewritten, we can return the more efficient form!
-        return FilteredStrategy(out, self.flat_conditions)
+        return FilteredStrategy(out, self.flat_conditions, self.condition_locations)
 
     @property
     def condition(self) -> Callable[[Ex], Any]:
@@ -1325,16 +1399,34 @@ class FilteredStrategy(SearchStrategy[Ex]):
         if result is not filter_not_satisfied:
             return cast(Ex, result)
 
-        data.mark_invalid(f"Aborted test because unable to satisfy {self!r}")
+        # do_filtered_draw recorded the condition which rejected the most
+        # recently drawn value in data._rejected_by_filter.
+        data.mark_invalid(
+            f"Aborted test because unable to satisfy {self!r}",
+            location=rejection_location(data),
+        )
 
     def do_filtered_draw(self, data: ConjectureData) -> Ex | UniqueIdentifier:
         for i in range(3):
             data.start_span(FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL)
             value = data.draw(self.filtered_strategy)
-            if self.condition(value):
+            # Check the conditions individually rather than via self.condition,
+            # so that we know which one to blame if we end up giving up.
+            failing = next(
+                (
+                    (cond, location)
+                    for cond, location in zip(
+                        self.flat_conditions, self.condition_locations, strict=True
+                    )
+                    if not cond(value)
+                ),
+                None,
+            )
+            if failing is None:
                 data.stop_span()
                 return value
             else:
+                data._rejected_by_filter = failing
                 data.stop_span(discard=True)
                 if i == 0:
                     data.events[f"Retried draw from {self!r} to satisfy filter"] = ""
@@ -1351,7 +1443,7 @@ class FilteredStrategy(SearchStrategy[Ex]):
     @property
     def branches(self) -> Sequence[SearchStrategy[Ex]]:
         return [
-            FilteredStrategy(strategy=strategy, conditions=self.flat_conditions)
+            FilteredStrategy(strategy, self.flat_conditions, self.condition_locations)
             for strategy in self.filtered_strategy.branches
         ]
 

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -763,7 +763,9 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         # anywhere in the class so this is still type-safe. mypy is being more
         # conservative than necessary
         element: Ex,  # type: ignore
-        data: ConjectureData | None = None,
+        *,
+        # None for _invert, which has no ConjectureData
+        data: ConjectureData | None,
     ) -> Ex | UniqueIdentifier:
         # Used in UniqueSampledListStrategy
         for name, f, location in self._transformations:
@@ -801,17 +803,15 @@ class SampledFromStrategy(SearchStrategy[Ex]):
         assert not isinstance(result, UniqueIdentifier)
         return result
 
-    def get_element(
-        self, i: int, data: ConjectureData | None = None
-    ) -> Ex | UniqueIdentifier:
-        return self._transform(self.elements[i], data)
+    def get_element(self, i: int, data: ConjectureData) -> Ex | UniqueIdentifier:
+        return self._transform(self.elements[i], data=data)
 
     def _invert(self, value: Any) -> tuple[ChoiceT, ...]:
         # The smallest index whose (possibly transformed) element equals value.
         # _transform might depend on external state and give us a wrong answer
         # here; that's fine, since _invert is allowed to be fallible.
         for i, element in enumerate(self.elements):
-            if equal_values(self._transform(element), value):
+            if equal_values(self._transform(element, data=None), value):
                 return (i,)
         raise CannotInvert(f"{value!r} is not produced by {self!r}")
 

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -54,7 +54,6 @@ from hypothesis.internal.conjecture.utils import (
 from hypothesis.internal.coverage import check_function
 from hypothesis.internal.escalation import is_hypothesis_file
 from hypothesis.internal.reflection import (
-    function_location,
     get_pretty_function_description,
     is_identity_function,
 )
@@ -105,16 +104,6 @@ def filter_call_site() -> str | None:
     if frame is None:  # pragma: no cover  # ran out of frames
         return None
     return f"{frame.f_code.co_filename}:{frame.f_lineno}"
-
-
-def rejection_location(data: ConjectureData) -> str | None:
-    """The location of the filter which most recently rejected a candidate
-    value: where its .filter() call was made, or failing that where the
-    predicate was defined, if known."""
-    if data._rejected_by_filter is None:
-        return None
-    condition, location = data._rejected_by_filter
-    return location or function_location(condition)
 
 
 def recursive_property(strategy: "SearchStrategy", name: str, default: object) -> Any:
@@ -784,7 +773,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
                 assert name == "filter"
                 if not f(element):
                     if data is not None:
-                        data._rejected_by_filter = (f, location)
+                        data._last_rejected_filter = (f, location)
                     return filter_not_satisfied
         return element
 
@@ -801,11 +790,10 @@ class SampledFromStrategy(SearchStrategy[Ex]):
                 self.elements,
             )
         if result is filter_not_satisfied:
-            # do_filtered_draw recorded the filter which rejected the most
-            # recently tried element in data._rejected_by_filter.
+            # do_filtered_draw records data._last_rejected_filter.
             data.mark_invalid(
                 f"Aborted test because unable to satisfy {self!r}",
-                location=rejection_location(data),
+                location=data.last_rejected_filter_location(),
             )
         assert not isinstance(result, UniqueIdentifier)
         return result
@@ -1283,8 +1271,7 @@ class FilteredStrategy(SearchStrategy[Ex]):
         condition_locations: tuple[str | None, ...] | None = None,
     ):
         super().__init__()
-        # Where each condition's .filter() call was made, aligned with
-        # `conditions` - for reporting if we give up on satisfying one.
+        # Where each condition's .filter() call was made, for observability
         if condition_locations is None:
             condition_locations = (None,) * len(conditions)
         assert len(condition_locations) == len(conditions)
@@ -1399,11 +1386,10 @@ class FilteredStrategy(SearchStrategy[Ex]):
         if result is not filter_not_satisfied:
             return cast(Ex, result)
 
-        # do_filtered_draw recorded the condition which rejected the most
-        # recently drawn value in data._rejected_by_filter.
+        # do_filtered_draw records data._last_rejected_filter.
         data.mark_invalid(
             f"Aborted test because unable to satisfy {self!r}",
-            location=rejection_location(data),
+            location=data.last_rejected_filter_location(),
         )
 
     def do_filtered_draw(self, data: ConjectureData) -> Ex | UniqueIdentifier:
@@ -1411,7 +1397,7 @@ class FilteredStrategy(SearchStrategy[Ex]):
             data.start_span(FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL)
             value = data.draw(self.filtered_strategy)
             # Check the conditions individually rather than via self.condition,
-            # so that we know which one to blame if we end up giving up.
+            # so that we can set data._last_rejected_filter.
             failing = next(
                 (
                     (cond, location)
@@ -1426,7 +1412,7 @@ class FilteredStrategy(SearchStrategy[Ex]):
                 data.stop_span()
                 return value
             else:
-                data._rejected_by_filter = failing
+                data._last_rejected_filter = failing
                 data.stop_span(discard=True)
                 if i == 0:
                     data.events[f"Retried draw from {self!r} to satisfy filter"] = ""

--- a/hypothesis/src/hypothesis/strategies/_internal/strategies.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/strategies.py
@@ -85,17 +85,18 @@ FILTERED_SEARCH_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
 
 label_lock = RLock()
 
-# When hypothesis re-applies a filter condition internally - lazy strategy
-# resolution, replaying predicates in FilteredStrategy.do_validate - this
-# carries the location of the original .filter() call through to the
-# re-application, where walking the stack would find the wrong frame.
+# When hypothesis re-applies a filter condition internally, eg in LazyStrategy, we override
+# stack walking with the correct original location here.
 _filter_location_override: DynamicVariable[Any] = DynamicVariable(not_set)
 
 
-def filter_call_site() -> str | None:
-    """The filename:lineno of the enclosing .filter() call - the nearest frame
-    outside hypothesis itself. Call this at .filter() call time and store the
-    result alongside the condition; reconstructing it later is ambiguous."""
+def current_filter_call_site() -> str | None:
+    """The filename:lineno of the nearest enclosing non-hypothesis .filter() call.
+
+    Callers are expected to only call this from within a .filter() implementation. This
+    function simply respects _filter_location_override or walks to the nearest non-hypothesis
+    frame.
+    """
     if (location := _filter_location_override.value) is not not_set:
         return location
     frame: FrameType | None = sys._getframe(1)
@@ -472,7 +473,9 @@ class SearchStrategy(Generic[Ex]):
                 assume(False)
         """
         return FilteredStrategy(
-            self, conditions=(condition,), condition_locations=(filter_call_site(),)
+            self,
+            conditions=(condition,),
+            condition_locations=(current_filter_call_site(),),
         )
 
     @property
@@ -669,7 +672,7 @@ class SampledFromStrategy(SearchStrategy[Ex]):
             force_repr_braces=self.force_repr_braces,
             transformations=(
                 *self._transformations,
-                ("filter", condition, filter_call_site()),
+                ("filter", condition, current_filter_call_site()),
             ),
         )
 
@@ -1219,7 +1222,7 @@ class MappedStrategy(SearchStrategy[MappedTo], Generic[MappedFrom, MappedTo]):
         return FilteredStrategy(
             type(self)(new, self.pack),
             conditions=(condition,),
-            condition_locations=(filter_call_site(),),
+            condition_locations=(current_filter_call_site(),),
         )
 
 

--- a/hypothesis/tests/conjecture/test_test_data.py
+++ b/hypothesis/tests/conjecture/test_test_data.py
@@ -85,6 +85,14 @@ def test_can_mark_invalid_with_why():
     assert d.events == {"gave up because": "some reason"}
 
 
+def test_drawing_from_empty_strategy_reports_the_strategy():
+    d = ConjectureData.for_choices([])
+    with pytest.raises(StopTest):
+        d.draw(st.nothing())
+    assert d.status == Status.INVALID
+    assert d.events == {"gave up because": f"empty strategy {st.nothing()!r}"}
+
+
 class BoomStrategy(SearchStrategy):
     def do_draw(self, data):
         data.draw_boolean()

--- a/hypothesis/tests/conjecture/test_test_data.py
+++ b/hypothesis/tests/conjecture/test_test_data.py
@@ -82,7 +82,7 @@ def test_can_mark_invalid_with_why():
         d.mark_invalid("some reason")
     assert d.frozen
     assert d.status == Status.INVALID
-    assert d.events == {"invalid because": "some reason"}
+    assert d.events == {"gave up because": "some reason"}
 
 
 class BoomStrategy(SearchStrategy):

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -356,6 +356,15 @@ def test_filter_has_status_reason_location(make):
         assert gave_up.metadata.status_reason_location == expected
 
 
+def test_assume_in_map_has_status_reason_location():
+    def unsatisfiable(x):
+        assume(len(str(x)) < 0)
+
+    expected = line_of(2)
+    for gave_up in _get_filter_gave_ups(st.integers().map(unsatisfiable)):
+        assert gave_up.metadata.status_reason_location == expected
+
+
 def test_sampled_from_transform_without_data_records_nothing():
     # covers the data=None branch of SampledFromStrategy._transform
     s = st.sampled_from([1, 2]).filter(lambda x: x == 2)

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -10,6 +10,7 @@
 
 import base64
 import contextlib
+import inspect
 import json
 import math
 import textwrap
@@ -17,11 +18,14 @@ import threading
 import warnings
 from collections import defaultdict
 from contextlib import nullcontext
+from functools import partial
+from random import Random
 
 import pytest
 
 import hypothesis.internal.observability
 from hypothesis import (
+    HealthCheck,
     assume,
     event,
     example,
@@ -33,10 +37,12 @@ from hypothesis import (
     target,
 )
 from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.errors import StopTest, Unsatisfiable
 from hypothesis.internal.compat import PYPY
 from hypothesis.internal.conjecture.choice import ChoiceNode, choices_key
-from hypothesis.internal.conjecture.data import Span
+from hypothesis.internal.conjecture.data import ConjectureData, Span
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
+from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.floats import SIGNALING_NAN, float_to_int, int_to_float
 from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.internal.observability import (
@@ -47,6 +53,7 @@ from hypothesis.internal.observability import (
     _callbacks_all_threads,
     add_observability_callback,
     choices_to_json,
+    make_testcase,
     nodes_to_json,
     observability_enabled,
     remove_observability_callback,
@@ -57,6 +64,10 @@ from hypothesis.stateful import (
     invariant,
     rule,
     run_state_machine_as_test,
+)
+from hypothesis.strategies._internal.strategies import (
+    FilteredStrategy,
+    rejection_location,
 )
 from hypothesis.strategies._internal.utils import to_jsonable
 
@@ -266,8 +277,138 @@ def test_assume_has_status_reason():
         f()
 
     gave_ups = [t for t in ls if t.type == "test_case" and t.status == "gave_up"]
+    assert gave_ups
     for gave_up in gave_ups:
         assert gave_up.status_reason.startswith("failed to satisfy assume() in f")
+        filename, lineno = gave_up.metadata.status_reason_location.rsplit(":", 1)
+        assert filename == __file__
+        assert int(lineno) > 0
+
+
+def _filter_gave_ups(strategy):
+    @settings(suppress_health_check=list(HealthCheck), max_examples=10)
+    @given(strategy)
+    def f(n):
+        raise NotImplementedError("unreachable")
+
+    with capture_observations() as ls, pytest.raises(Unsatisfiable):
+        f()
+
+    gave_ups = [t for t in ls if t.type == "test_case" and t.status == "gave_up"]
+    assert gave_ups
+    return gave_ups
+
+
+# We report the location of the .filter() call, not of the predicate itself -
+# which might be e.g. the stdlib, or a widely-shared helper. Each maker below
+# builds a filtered strategy and returns it with the expected filename:lineno
+# of its unsatisfiable .filter() call.
+
+
+def make_filtered_integers():
+    def unsatisfiable(x):
+        return len(str(x)) < 0
+
+    return st.integers().filter(unsatisfiable), line_of(4)
+
+
+def make_twice_filtered_integers():
+    def satisfiable(x):
+        return len(str(x)) >= 0
+
+    def unsatisfiable(x):
+        return len(str(x)) < 0
+
+    s = st.integers().filter(satisfiable)
+    return s.filter(unsatisfiable), line_of(8)
+
+
+def make_partial_filtered_integers():
+    unsatisfiable = partial(lambda x, s: len(str(x)) < s, s=0)
+    return st.integers().filter(unsatisfiable), line_of(2)
+
+
+def make_filtered_sampled_from():
+    def unsatisfiable(x):
+        return len(str(x)) < 0
+
+    return st.sampled_from(range(10)).map(lambda x: x).filter(unsatisfiable), line_of(4)
+
+
+def line_of(offset):
+    # the line `offset` lines below the `def` statement of the calling function
+    frame = inspect.currentframe().f_back
+    return f"{__file__}:{frame.f_code.co_firstlineno + offset}"
+
+
+@pytest.mark.parametrize(
+    "make",
+    [
+        make_filtered_integers,
+        # With several filter conditions, we blame the one which actually
+        # rejected the last drawn value - not just whichever came first.
+        make_twice_filtered_integers,
+        # Predicates without a __code__ object still get a call-site location.
+        make_partial_filtered_integers,
+        make_filtered_sampled_from,
+    ],
+)
+def test_filter_has_status_reason_location(make):
+    strategy, expected = make()
+    for gave_up in _filter_gave_ups(strategy):
+        assert gave_up.metadata.status_reason_location == expected
+
+
+def test_sampled_from_transform_without_data_records_nothing():
+    # covers the data=None branch of SampledFromStrategy._transform
+    s = st.sampled_from([1, 2]).filter(lambda x: x == 2)
+    assert s._invert(2) == (1,)
+
+
+def test_status_reason_location_without_traceback():
+    # An exception which was never raised has no traceback, so its origin has
+    # no filename - we report no location rather than a bogus "None:None".
+    data = ConjectureData(random=Random(0))
+    with contextlib.suppress(StopTest):
+        data.mark_interesting(InterestingOrigin.from_exception(AssertionError()))
+
+    observation = make_testcase(
+        run_start=0.0,
+        property="test_status_reason_location_without_traceback",
+        data=data,
+        how_generated="test",
+        timing={},
+    )
+    assert observation.status == "failed"
+    assert observation.status_reason == "AssertionError at None:None"
+    assert observation.metadata.status_reason_location is None
+
+
+def test_rejection_location_fallbacks():
+    data = ConjectureData(random=Random(0))
+    # nothing was rejected on this data
+    assert rejection_location(data) is None
+
+    def unsatisfiable(x):
+        return len(str(x)) < 0
+
+    # a FilteredStrategy built directly, rather than via .filter(), has no
+    # call-site location - so we fall back to the predicate's definition
+    strategy = FilteredStrategy(st.integers(), conditions=(unsatisfiable,))
+
+    @settings(suppress_health_check=list(HealthCheck), max_examples=10)
+    @given(strategy)
+    def f(n):
+        raise NotImplementedError("unreachable")
+
+    with capture_observations() as ls, pytest.raises(Unsatisfiable):
+        f()
+
+    gave_ups = [t for t in ls if t.type == "test_case" and t.status == "gave_up"]
+    assert gave_ups
+    expected = f"{__file__}:{unsatisfiable.__code__.co_firstlineno}"
+    for gave_up in gave_ups:
+        assert gave_up.metadata.status_reason_location == expected
 
 
 @pytest.mark.skipif(
@@ -415,6 +556,10 @@ def test_fuzz_one_input_sets_interesting_origin():
     assert origin is not None
     assert origin.exc_type is AssertionError
     assert observation.status_reason == str(origin)
+    assert (
+        observation.metadata.status_reason_location
+        == f"{origin.filename}:{origin.lineno}"
+    )
 
 
 def _decode_choice(value):
@@ -596,6 +741,7 @@ def test_metadata_to_json():
             "data_status",
             "phase",
             "interesting_origin",
+            "status_reason_location",
             "choice_nodes",
             "choice_spans",
         }

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -65,10 +65,7 @@ from hypothesis.stateful import (
     rule,
     run_state_machine_as_test,
 )
-from hypothesis.strategies._internal.strategies import (
-    FilteredStrategy,
-    rejection_location,
-)
+from hypothesis.strategies._internal.strategies import FilteredStrategy
 from hypothesis.strategies._internal.utils import to_jsonable
 
 from tests.common.utils import (
@@ -384,10 +381,10 @@ def test_status_reason_location_without_traceback():
     assert observation.metadata.status_reason_location is None
 
 
-def test_rejection_location_fallbacks():
+def test_last_rejected_filter_location_fallbacks():
     data = ConjectureData(random=Random(0))
     # nothing was rejected on this data
-    assert rejection_location(data) is None
+    assert data.last_rejected_filter_location() is None
 
     def unsatisfiable(x):
         return len(str(x)) < 0

--- a/hypothesis/tests/cover/test_observability.py
+++ b/hypothesis/tests/cover/test_observability.py
@@ -282,7 +282,7 @@ def test_assume_has_status_reason():
         assert int(lineno) > 0
 
 
-def _filter_gave_ups(strategy):
+def _get_filter_gave_ups(strategy):
     @settings(suppress_health_check=list(HealthCheck), max_examples=10)
     @given(strategy)
     def f(n):
@@ -352,7 +352,7 @@ def line_of(offset):
 )
 def test_filter_has_status_reason_location(make):
     strategy, expected = make()
-    for gave_up in _filter_gave_ups(strategy):
+    for gave_up in _get_filter_gave_ups(strategy):
         assert gave_up.metadata.status_reason_location == expected
 
 

--- a/hypothesis/tests/cover/test_statistical_events.py
+++ b/hypothesis/tests/cover/test_statistical_events.py
@@ -230,7 +230,7 @@ def test_stateful_states_are_deduped():
 
     stats = call_for_statistics(DemoStateMachine.TestCase().runTest)
     stats = unique_events(stats)
-    stats = [s for s in stats if not s.startswith("invalid because: (internal)")]
+    stats = [s for s in stats if not s.startswith("gave up because: (internal)")]
     assert len(stats) <= 2
 
 
@@ -254,7 +254,7 @@ def test_stateful_with_one_of_bundles_states_are_deduped():
 
     stats = call_for_statistics(DemoStateMachine.TestCase().runTest)
     stats = unique_events(stats)
-    stats = [s for s in stats if not s.startswith("invalid because: (internal)")]
+    stats = [s for s in stats if not s.startswith("gave up because: (internal)")]
     assert len(stats) <= 4
 
 

--- a/hypothesis/tests/datetime/test_pytz_timezones.py
+++ b/hypothesis/tests/datetime/test_pytz_timezones.py
@@ -154,7 +154,7 @@ def test_can_trigger_error_in_draw_near_boundary(bound):
         except StopTest:
             pass
         if "Failed to draw a datetime" in data.conjecture_data.events.get(
-            "invalid because", ""
+            "gave up because", ""
         ):
             nonlocal found
             found = True


### PR DESCRIPTION
Test case observations now include a "status_reason_location" key in metadata with a filename:lineno location for the status_reason where known: the failing assume() or reject() call, an unsatisfiable filter predicate, or the exception for failing tests. Overruns outside the shrink phase also report a nonempty status_reason now.

After this, https://github.com/HypothesisWorks/hypothesis/issues/3845 is just a set of docs ideas.