### PR TITLE
Strengthen provider conformance tests and fix BytestringProvider

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,20 @@
+RELEASE_TYPE: minor
+
+This release substantially strengthens
+:func:`~hypothesis.internal.conjecture.provider_conformance.run_conformance_test`,
+which authors of :ref:`alternative backends <alternative-backends>` can use to
+test their provider. It can now test providers with required constructor
+arguments, runs many test cases against each provider, treats running out of
+entropy as expected control flow, and checks that providers are able to
+generate a representative range of values.
+
+These new checks catch two bugs in the provider underlying
+:ref:`fuzz_one_input <fuzz_one_input>`, which this release also fixes: integer
+draws could never generate negative values, and string draws from an empty
+alphabet consumed the whole buffer instead of returning the empty string.
+
+Verbose output for :ref:`stateful tests <stateful>` now reads
+``Test case: <state machine>`` rather than trailing off after the colon.
+
+Thanks to @reachsridhard for reporting the integers bug and prototyping
+these improvements.

--- a/hypothesis/src/hypothesis/core.py
+++ b/hypothesis/src/hypothesis/core.py
@@ -1094,6 +1094,11 @@ class StateForActualGivenExecution:
                         avoid_realization=data.provider.avoid_realization,
                         known_safe_to_repr=self.known_safe_to_repr,
                     )
+                else:
+                    # print_given_args is only disabled for stateful tests,
+                    # whose steps are printed separately (and only on failure
+                    # or at Verbosity.debug) - so say why this line is bare.
+                    printer.text(" <state machine>")
                 report(printer.getvalue())
 
             if observability_enabled():

--- a/hypothesis/src/hypothesis/internal/conjecture/provider_conformance.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/provider_conformance.py
@@ -8,25 +8,38 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
 
+import json
 import math
 import sys
-from collections.abc import Collection, Iterable, Sequence
-from typing import Any
+from collections.abc import Callable, Collection, Iterable, Sequence
+from random import Random
+from typing import Any, cast
 
 from hypothesis import (
     HealthCheck,
+    Phase,
+    Verbosity,
     assume,
+    find,
     note,
     settings as Settings,
     strategies as st,
 )
-from hypothesis.errors import BackendCannotProceed
+from hypothesis.errors import (
+    BackendCannotProceed,
+    FlakyFailure,
+    Found,
+    NoSuchExample,
+    StopTest,
+)
 from hypothesis.internal.compat import batched
 from hypothesis.internal.conjecture.choice import (
+    ChoiceT,
     ChoiceTypeT,
+    choice_equal,
     choice_permitted,
 )
-from hypothesis.internal.conjecture.data import ConjectureData
+from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.providers import (
     COLLECTION_DEFAULT_MAX_SIZE,
     HypothesisProvider,
@@ -38,6 +51,14 @@ from hypothesis.internal.intervalsets import IntervalSet
 from hypothesis.stateful import RuleBasedStateMachine, initialize, precondition, rule
 from hypothesis.strategies import DrawFn, SearchStrategy
 from hypothesis.strategies._internal.strings import OneCharStringStrategy, TextStrategy
+
+_PYTHON_TYPES: dict[ChoiceTypeT, type] = {
+    "integer": int,
+    "float": float,
+    "bytes": bytes,
+    "string": str,
+    "boolean": bool,
+}
 
 
 def build_intervals(intervals: list[int]) -> list[tuple[int, int]]:
@@ -150,6 +171,11 @@ def integer_constraints(
                 min_vals.append(forced)
             min_val = max(min_vals) if min_vals else None
             max_value = draw(st.integers(min_value=min_val))
+            # degenerate-but-satisfiable ranges are a rich source of bugs
+            if min_val is not None and draw(st.data()).conjecture_data.draw_boolean(
+                0.25
+            ):
+                max_value = min_val
 
     if forced is not None:
         assume((forced - shrink_towards).bit_length() < 128)
@@ -187,14 +213,15 @@ def _collection_constraints(
         )
 
     if use_max_size:
-        max_size = draw(
-            st.integers(
-                min_value=min_size if forced is None else max(min_size, len(forced))
-            )
-        )
+        lower = min_size if forced is None else max(min_size, len(forced))
+        max_size = draw(st.integers(min_value=lower))
         if forced is None:
             # cap to some reasonable max size to avoid overruns.
             max_size = min(max_size, min_size + 100)
+        # exact-size collections are degenerate-but-satisfiable; generate them
+        # more often than chance
+        if draw(st.data()).conjecture_data.draw_boolean(0.25):
+            max_size = lower
 
     return {"min_size": min_size, "max_size": max_size}
 
@@ -305,8 +332,15 @@ def float_constraints(
 @st.composite
 def boolean_constraints(draw: DrawFn, *, use_forced: bool = False) -> Any:
     forced = draw(st.booleans()) if use_forced else None
-    # avoid invalid forced combinations
-    p = draw(st.floats(0, 1, exclude_min=forced is True, exclude_max=forced is False))
+    # avoid invalid forced combinations. Generate the boundary probabilities
+    # p=0 and p=1 often, since they carry hard requirements for providers
+    # rather than being advisory.
+    p_strategy = st.floats(
+        0, 1, exclude_min=forced is True, exclude_max=forced is False
+    )
+    if forced is None:
+        p_strategy |= st.sampled_from([0.0, 1.0])
+    p = draw(p_strategy)
 
     return {"p": p, "forced": forced}
 
@@ -335,11 +369,272 @@ def choice_types_constraints(strategy_constraints=None, *, use_forced=False):
     )
 
 
+def _assert_conforming(choice: Any, choice_type: ChoiceTypeT, constraints: Any) -> None:
+    expected_type = _PYTHON_TYPES[choice_type]
+    assert isinstance(choice, expected_type), (
+        f"expected {choice_type} draw to return a {expected_type.__name__}, "
+        f"got {choice!r} of type {type(choice).__name__}"
+    )
+    if choice_type == "integer":
+        assert not isinstance(
+            choice, bool
+        ), f"expected integer draw to return an int, got bool {choice!r}"
+    assert choice_permitted(cast(ChoiceT, choice), constraints), (
+        f"drew {choice_type} {choice!r} which is not permitted by "
+        f"constraints {constraints}"
+    )
+
+
+def _integer_constr(min_value=None, max_value=None, *, weights=None):
+    return {
+        "min_value": min_value,
+        "max_value": max_value,
+        "weights": weights,
+        "shrink_towards": 0,
+    }
+
+
+def _float_constr(min_value=-math.inf, max_value=math.inf, *, allow_nan=True):
+    return {
+        "min_value": min_value,
+        "max_value": max_value,
+        "allow_nan": allow_nan,
+        "smallest_nonzero_magnitude": SMALLEST_SUBNORMAL,
+    }
+
+
+def _collection_constr(min_size=0, max_size=10):
+    return {"min_size": min_size, "max_size": max_size}
+
+
+def _findability_cases() -> Iterable[tuple[ChoiceTypeT, dict, str, Callable]]:
+    # (choice_type, constraints, description, predicate) tuples such that some
+    # provider input should produce a value satisfying the predicate. We stick
+    # to targets that any reasonable provider hits with probability at least
+    # ~1/500 per test case, so a bounded search is reliable.
+    cases: list[tuple[ChoiceTypeT, dict, str, Callable]] = [
+        ("boolean", {"p": 0.5}, "True", lambda v: v is True),
+        ("boolean", {"p": 0.5}, "False", lambda v: v is False),
+        ("integer", _integer_constr(), "a negative value", lambda v: v < 0),
+        ("integer", _integer_constr(), "a positive value", lambda v: v > 0),
+        ("float", _float_constr(), "a negative value", lambda v: v < 0),
+        ("float", _float_constr(), "a positive value", lambda v: v > 0),
+        (
+            "float",
+            _float_constr(-10.0, 10.0, allow_nan=False),
+            "a negative value",
+            lambda v: v < 0,
+        ),
+        (
+            "float",
+            _float_constr(-10.0, 10.0, allow_nan=False),
+            "a positive value",
+            lambda v: v > 0,
+        ),
+    ]
+    for target in range(-5, 6):
+        cases.append(
+            ("integer", _integer_constr(-5, 5), str(target), lambda v, t=target: v == t)
+        )
+        cases.append(
+            (
+                "integer",
+                _integer_constr(-5, 5, weights={0: 0.25}),
+                f"{target} (with weights)",
+                lambda v, t=target: v == t,
+            )
+        )
+    for target in range(-10, -2):
+        cases.append(
+            (
+                "integer",
+                _integer_constr(-10, -3),
+                str(target),
+                lambda v, t=target: v == t,
+            )
+        )
+    for target in [3, 10]:
+        cases.append(
+            ("integer", _integer_constr(3, 10), str(target), lambda v, t=target: v == t)
+        )
+
+    string_constr = {"intervals": IntervalSet.from_string("ab"), **_collection_constr()}
+    cases += [
+        ("string", string_constr, "the empty string", lambda v: v == ""),
+        ("string", string_constr, 'a string containing "a"', lambda v: "a" in v),
+        ("string", string_constr, 'a string containing "b"', lambda v: "b" in v),
+        ("string", string_constr, "a string of length >= 2", lambda v: len(v) >= 2),
+        (
+            "string",
+            {"intervals": IntervalSet(()), **_collection_constr()},
+            "the empty string (from an empty alphabet)",
+            lambda v: v == "",
+        ),
+        ("bytes", _collection_constr(), "empty bytes", lambda v: v == b""),
+        ("bytes", _collection_constr(), "nonempty bytes", lambda v: v != b""),
+        (
+            "bytes",
+            _collection_constr(),
+            "a byte >= 128",
+            lambda v: any(b >= 128 for b in v),
+        ),
+    ]
+    return cases
+
+
+def _run_one_test_case(
+    provider: PrimitiveProvider,
+    data: ConjectureData | None,
+    choice_type: ChoiceTypeT,
+    constraints: dict,
+    n_draws: int,
+    context_manager_exceptions: tuple[type[BaseException], ...],
+) -> list[Any]:
+    values: list[Any] = []
+    cm = provider.per_test_case_context_manager()
+    try:
+        cm.__enter__()
+    except BackendCannotProceed:
+        # the provider is done with this test function, e.g. exhausted
+        return []
+    exception = None
+    try:
+        for _ in range(n_draws):
+            values.append(getattr(provider, f"draw_{choice_type}")(**constraints))
+    except StopTest as e:
+        if data is None or e.testcounter != data.testcounter:  # pragma: no cover
+            raise
+        exception = e
+    except BackendCannotProceed as e:
+        exception = e
+    except context_manager_exceptions as e:
+        exception = e
+
+    try:
+        if exception is None:
+            cm.__exit__(None, None, None)
+        else:
+            cm.__exit__(type(exception), exception, exception.__traceback__)
+    except BackendCannotProceed:
+        pass
+
+    realize_exceptions: tuple[type[BaseException], ...] = (
+        BackendCannotProceed,
+        *context_manager_exceptions,
+    )
+    realized = []
+    try:
+        for value in values:
+            realized.append(provider.realize(value))
+    except realize_exceptions:
+        pass
+    return realized
+
+
+def _run_findability_tests(
+    Provider: type[PrimitiveProvider],
+    provider_kw_strategy: SearchStrategy[dict[str, Any]],
+    context_manager_exceptions: tuple[type[BaseException], ...],
+    *,
+    find_settings: Settings = Settings(max_examples=500),
+) -> None:
+    # For each case, check that *some* input to the provider - constructor
+    # arguments, randomness, or number of draws - produces a value satisfying
+    # the predicate, by asking Hypothesis to search for one with `find`. This
+    # catches providers which are sound but cannot generate whole classes of
+    # values, like a provider which never returns negative integers.
+
+    @st.composite
+    def drawn_values(draw, choice_type, constraints):
+        values = []
+        provider = None
+        if Provider.lifetime != "test_case":
+            provider = Provider(None, **draw(provider_kw_strategy))
+        for _ in range(draw(st.integers(1, 25))):
+            data = None
+            if Provider.lifetime == "test_case":
+                data = ConjectureData(
+                    random=Random(draw(st.integers(0, 2**64 - 1))),
+                    provider=Provider,
+                    provider_kw=draw(provider_kw_strategy),
+                )
+                provider = data.provider
+            values.extend(
+                _run_one_test_case(
+                    provider,
+                    data,
+                    choice_type,
+                    constraints,
+                    n_draws=draw(st.integers(1, 5)),
+                    context_manager_exceptions=context_manager_exceptions,
+                )
+            )
+        return values
+
+    find_settings = Settings(
+        find_settings,
+        database=None,
+        phases=[Phase.generate],
+        verbosity=Verbosity.quiet,
+        deadline=None,
+    )
+    missing = []
+    for choice_type, constraints, description, predicate in _findability_cases():
+        expected_type = _PYTHON_TYPES[choice_type]
+
+        def condition(values, expected_type=expected_type, predicate=predicate):
+            return any(isinstance(v, expected_type) and predicate(v) for v in values)
+
+        try:
+            find(
+                drawn_values(choice_type, constraints),
+                condition,
+                settings=find_settings,
+            )
+        except NoSuchExample:
+            missing.append(f"* {choice_type} {description}, from {constraints}")
+        except FlakyFailure as e:  # pragma: no cover  # tested in nocover
+            # providers drawing from real entropy may not reproduce the
+            # discovered example on replay - but it was still found once.
+            if not all(isinstance(sub, Found) for sub in e.exceptions):
+                raise
+
+    assert not missing, (
+        f"{Provider.__name__} could not generate the following values, "
+        "no matter what input we gave it:\n" + "\n".join(missing)
+    )
+
+
+class _ActionTreeNode:
+    """
+    A tree of conformance-test actions, where each node records the action
+    taken at that point of a test case - a draw (with its constraints), a span
+    call, or ending the test case - and draw nodes branch on the drawn value.
+
+    Providers like hypothesis-crosshair require successive test cases of one
+    test function to be deterministic: to make the same sequence of provider
+    calls, up to control flow which branches on previously-drawn values. Real
+    test functions have this property by construction. We enforce it by
+    recording the first test case to reach each point in the tree, and
+    replaying the recorded action for later test cases - which still explore
+    new behavior whenever they draw a value we haven't seen at that point.
+    """
+
+    def __init__(self):
+        self.action = None
+        # the single successor, for span actions
+        self.child = None
+        # (value, successor) pairs, for concrete-valued draw actions
+        self.branches = []
+
+
 def run_conformance_test(
     Provider: type[PrimitiveProvider],
     *,
+    provider_kw: dict[str, SearchStrategy[Any]] | None = None,
     context_manager_exceptions: Collection[type[BaseException]] = (),
     settings: Settings | None = None,
+    check_findability: bool = True,
     _realize_objects: SearchStrategy[Any] = (
         st.from_type(object) | st.from_type(type).flatmap(st.from_type)
     ),
@@ -350,7 +645,10 @@ def run_conformance_test(
 
     For instance, this tests that ``Provider`` does not return out of bounds
     choices from any of the ``draw_*`` methods, or violate other invariants
-    which Hypothesis depends on.
+    which Hypothesis depends on. It also checks that the provider is able to
+    generate a range of representative values for each choice type; for
+    example, a provider whose ``draw_integer`` can never return a negative
+    integer is not conformant.
 
     This function is intended to be called at test-time, not at runtime. It is
     provided by Hypothesis to make it easy for third-party backend authors to
@@ -364,12 +662,37 @@ def run_conformance_test(
         def test_conformance():
             run_conformance_test(MyProvider)
 
+    If your provider takes required arguments in ``__init__`` besides the
+    standard ``conjecturedata`` argument, pass ``provider_kw`` as a dictionary
+    mapping each argument name to a strategy for values of that argument. For
+    instance, ``BytestringProvider`` is tested with
+    ``provider_kw={"bytestring": st.binary()}``.
+
     If your provider can raise control flow exceptions inside one of the five
     ``draw_*`` methods that are handled by your provider's
     ``per_test_case_context_manager``, pass a list of these exceptions types to
     ``context_manager_exceptions``. Otherwise, ``run_conformance_test`` will
-    treat those exceptions as fatal errors.
+    treat those exceptions as fatal errors. A provider may also raise
+    ``StopTest`` by calling ``mark_overrun`` or ``mark_invalid`` on its own
+    ``ConjectureData`` instance, for example if it has run out of entropy; this
+    is always treated as expected control flow which ends the test case.
+
+    Successive test cases in one run of the conformance state machine make the
+    same sequence of provider calls, up to control flow which branches on
+    previously-drawn values - mirroring the determinism of a real test
+    function. Providers may rely on this, as e.g. hypothesis-crosshair does.
+
+    Pass ``check_findability=False`` to disable checking that the provider can
+    generate representative values. This is intended for unusual providers for
+    which searching over instantiations is not meaningful, such as symbolic
+    providers; most providers should leave it enabled.
     """
+    context_manager_exceptions = tuple(context_manager_exceptions)
+    realize_exceptions: tuple[type[BaseException], ...] = (
+        BackendCannotProceed,
+        *context_manager_exceptions,
+    )
+    provider_kw_strategy = st.fixed_dictionaries(provider_kw or {})
 
     class CopiesRealizationProvider(HypothesisProvider):
         avoid_realization = Provider.avoid_realization
@@ -382,90 +705,286 @@ def run_conformance_test(
             backend="copies_realization",
         )
         class ProviderConformanceTest(RuleBasedStateMachine):
-            def __init__(self):
-                super().__init__()
+            @initialize(random=st.randoms(), kw=provider_kw_strategy)
+            def setup(self, random, kw):
+                self.provider = None
+                self.data = None
+                self._exhausted = False
+                self._tree = _ActionTreeNode()
+                self._start_test_case(random, kw)
 
-            @initialize(random=st.randoms())
-            def setup(self, random):
+            def _start_test_case(self, random, kw):
                 if Provider.lifetime == "test_case":
-                    data = ConjectureData(random=random, provider=Provider)
-                    self.provider = data.provider
-                else:
-                    self.provider = Provider(None)
+                    self.data = ConjectureData(
+                        random=random, provider=Provider, provider_kw=kw
+                    )
+                    self.provider = self.data.provider
+                    self._instrument_draws()
+                elif self.provider is None:
+                    # test_function providers are instantiated once, and used
+                    # for many test cases.
+                    self.provider = Provider(None, **kw)
+                    self._instrument_draws()
 
+                self._nested_draws = 0
+                self._draw_budget = math.inf
+                self._drawn = []
+                self._span_depth = 0
+                self._node = self._tree
                 self.context_manager = self.provider.per_test_case_context_manager()
-                self.context_manager.__enter__()
+                self.frozen = True
+                try:
+                    self.context_manager.__enter__()
+                except BackendCannotProceed:
+                    # the provider is done with this test function - for
+                    # instance, a symbolic provider may have exhausted its
+                    # search space - so don't start any more test cases.
+                    self._exhausted = True
+                    return
                 self.frozen = False
 
-            def _draw(self, choice_type, constraints):
-                del constraints["forced"]
-                draw_func = getattr(self.provider, f"draw_{choice_type}")
+            def _instrument_draws(self):
+                # Count nested draws made by each top-level draw, so a provider
+                # which loops forever drawing collection elements fails instead
+                # of hanging. (Only draws which recurse via ConjectureData can
+                # be counted; a spin which never draws is still a hang.)
+                for name in _PYTHON_TYPES:
+                    inner = getattr(self.provider, f"draw_{name}")
+
+                    def wrapped(*args, _inner=inner, **kwargs):
+                        self._nested_draws += 1
+                        assert self._nested_draws <= self._draw_budget, (
+                            f"made {self._nested_draws} nested draws during a "
+                            "single top-level draw, which strongly suggests an "
+                            "unbounded drawing loop in the provider"
+                        )
+                        return _inner(*args, **kwargs)
+
+                    setattr(self.provider, f"draw_{name}", wrapped)
+
+            def _step(self, requested):
+                try:
+                    self._perform(requested)
+                except BaseException as e:
+                    if not self.frozen:
+                        # as in the engine, an exception escaping the test body
+                        # propagates through per_test_case_context_manager
+                        self._end_test_case(e, expected=False)
+                    raise
+
+            def _perform(self, requested):
+                # Perform one action of the current test case. The first test
+                # case to reach this point in the action tree records the
+                # requested action; later test cases replay the recorded
+                # action instead, so that the provider sees a deterministic
+                # "test function" (see _ActionTreeNode).
+                node = self._node
+                if node.action is None:
+                    if requested[0] == "draw":
+                        _, choice_type, constraints = requested
+                        constraints = dict(constraints)
+                        del constraints["forced"]
+                        requested = ("draw", choice_type, constraints)
+                    node.action = requested
+                kind = node.action[0]
+                if kind == "freeze":
+                    self._end_test_case()
+                elif kind in ("span_start", "span_end"):
+                    if kind == "span_start":
+                        self._span_depth += 1
+                        self.provider.span_start(node.action[1])
+                    else:
+                        self._span_depth -= 1
+                        self.provider.span_end(node.action[1])
+                    if node.child is None:
+                        node.child = _ActionTreeNode()
+                    self._node = node.child
+                else:
+                    assert kind == "draw"
+                    choice = self._draw(*node.action[1:])
+                    if self.frozen:
+                        return
+                    if Provider.avoid_realization:
+                        # any comparison of a symbolic value is itself a
+                        # solver-visible operation, so branching on drawn
+                        # values would be nondeterministic across test cases.
+                        # Follow a single straight-line schedule instead.
+                        if node.child is None:
+                            node.child = _ActionTreeNode()
+                        self._node = node.child
+                        return
+                    for branch in node.branches:
+                        if choice_equal(choice, branch[0]):
+                            self._node = branch[1]
+                            return
+                    branch = (choice, _ActionTreeNode())
+                    node.branches.append(branch)
+                    self._node = branch[1]
+
+            def _end_test_case(self, exception=None, *, expected=True):
+                self.frozen = True
+                if exception is None:
+                    # mimicking the engine, spans are closed by data.freeze()
+                    # before the context manager exits.
+                    self._close_spans()
+                    self.context_manager.__exit__(None, None, None)
+                    self._check_realized_draws()
+                    return
+
+                if isinstance(exception, StopTest):
+                    # data.freeze() has already closed our spans by the time
+                    # StopTest propagates into the context manager.
+                    self._close_spans()
 
                 try:
-                    choice = draw_func(**constraints)
-                    note(f"drew {choice_type} {choice}")
-                    expected_type = {
-                        "integer": int,
-                        "float": float,
-                        "bytes": bytes,
-                        "string": str,
-                        "boolean": bool,
-                    }[choice_type]
-                    assert isinstance(choice, expected_type)
-                    assert choice_permitted(choice, constraints)
-                except context_manager_exceptions as e:
-                    note(
-                        f"caught exception {type(e)} in context_manager_exceptions: {e}"
+                    suppressed = self.context_manager.__exit__(
+                        type(exception), exception, exception.__traceback__
                     )
-                    try:
-                        self.context_manager.__exit__(type(e), e, None)
-                    except BackendCannotProceed:
-                        self.frozen = True
-                        return None
+                except BackendCannotProceed:
+                    suppressed = True
 
+                if not expected:
+                    # An exception the provider did not declare - such as a
+                    # failing test, or one of our conformance checks - must
+                    # propagate; suppressing it would hide failures from users.
+                    assert not suppressed, (
+                        f"{exception!r} was suppressed by "
+                        "per_test_case_context_manager, which would hide "
+                        "failing tests from users"
+                    )
+                    return
+
+                # The engine handles StopTest and BackendCannotProceed itself,
+                # so the context manager is free to pass them through - but an
+                # exception the provider promised its context manager would
+                # handle must not escape.
+                if not isinstance(exception, (StopTest, BackendCannotProceed)):
+                    assert suppressed, (
+                        f"{exception!r} was in context_manager_exceptions, but "
+                        "escaped per_test_case_context_manager unhandled"
+                    )
+                    # for exceptions other than StopTest, the engine calls
+                    # data.freeze() - closing any open spans - after the
+                    # context manager has exited.
+                    self._close_spans()
+                self._check_realized_draws()
+
+            def _close_spans(self):
+                while self._span_depth > 0:
+                    self.provider.span_end(False)
+                    self._span_depth -= 1
+
+            def _check_realized_draws(self):
+                # anything drawn during a test case must still conform after
+                # being realized - this is the check that matters for providers
+                # which draw symbolic values.
+                for choice, choice_type, constraints in self._drawn:
+                    try:
+                        realized = self.provider.realize(choice)
+                    except realize_exceptions:
+                        continue
+                    _assert_conforming(realized, choice_type, constraints)
+                self._drawn = []
+
+            def _draw(self, choice_type, constraints):
+                weights = constraints.get("weights")
+                weights_snapshot = None if weights is None else dict(weights)
+
+                self._nested_draws = 0
+                if choice_type in ("string", "bytes"):
+                    # a conforming provider makes at most a few nested draws
+                    # per collection element, plus slack for rejection sampling.
+                    self._draw_budget = 3 * min(constraints["max_size"], 10_000) + 100
+                else:
+                    self._draw_budget = 100
+
+                draw_func = getattr(self.provider, f"draw_{choice_type}")
+                try:
+                    choice = draw_func(**constraints)
+                except StopTest as e:
+                    # Providers may raise StopTest by concluding their own
+                    # ConjectureData, e.g. via mark_overrun if they run out of
+                    # entropy - but only their own, and only having concluded it.
+                    if self.data is None or e.testcounter != self.data.testcounter:
+                        raise  # pragma: no cover
+                    assert (
+                        self.data.frozen
+                    ), "raised StopTest without concluding its ConjectureData"
+                    assert self.data.status in (Status.OVERRUN, Status.INVALID)
+                    note(f"provider concluded the test case ({self.data.status})")
+                    self._end_test_case(e)
+                    return None
+                except BackendCannotProceed as e:
+                    note("caught BackendCannotProceed")
+                    self._end_test_case(e)
+                    return None
+                except context_manager_exceptions as e:
+                    note(f"caught exception in context_manager_exceptions: {e!r}")
+                    self._end_test_case(e)
+                    return None
+
+                if Provider.avoid_realization:
+                    # repr of a symbolic value would realize it mid-test-case
+                    note(f"drew {choice_type} <symbolic>")
+                else:
+                    note(f"drew {choice_type} {choice!r}")
+                if not Provider.avoid_realization:
+                    # symbolic providers may return proxy objects from draws;
+                    # for everyone else, check the raw value immediately.
+                    _assert_conforming(choice, choice_type, constraints)
+                assert (
+                    constraints.get("weights") == weights_snapshot
+                ), "draw_integer mutated its weights argument"
+                self._drawn.append((choice, choice_type, constraints))
                 return choice
 
             @precondition(lambda self: not self.frozen)
             @rule(constraints=integer_constraints())
             def draw_integer(self, constraints):
-                self._draw("integer", constraints)
+                self._step(("draw", "integer", constraints))
 
             @precondition(lambda self: not self.frozen)
             @rule(constraints=float_constraints())
             def draw_float(self, constraints):
-                self._draw("float", constraints)
+                self._step(("draw", "float", constraints))
 
             @precondition(lambda self: not self.frozen)
             @rule(constraints=bytes_constraints())
             def draw_bytes(self, constraints):
-                self._draw("bytes", constraints)
+                self._step(("draw", "bytes", constraints))
 
             @precondition(lambda self: not self.frozen)
             @rule(constraints=string_constraints())
             def draw_string(self, constraints):
-                self._draw("string", constraints)
+                self._step(("draw", "string", constraints))
 
             @precondition(lambda self: not self.frozen)
             @rule(constraints=boolean_constraints())
             def draw_boolean(self, constraints):
-                self._draw("boolean", constraints)
+                self._step(("draw", "boolean", constraints))
 
             @precondition(lambda self: not self.frozen)
             @rule(label=st.integers())
             def span_start(self, label):
-                self.provider.span_start(label)
+                self._step(("span_start", label))
 
-            @precondition(lambda self: not self.frozen)
+            @precondition(lambda self: not self.frozen and self._span_depth > 0)
             @rule(discard=st.booleans())
             def span_end(self, discard):
-                self.provider.span_end(discard)
+                self._step(("span_end", discard))
 
             @precondition(lambda self: not self.frozen)
             @rule()
             def freeze(self):
                 # phase-transition, mimicking data.freeze() at the end of a test case.
-                self.frozen = True
-                self.context_manager.__exit__(None, None, None)
+                self._step(("freeze",))
+
+            @precondition(lambda self: self.frozen and not self._exhausted)
+            @rule(random=st.randoms(), kw=provider_kw_strategy)
+            def start_test_case(self, random, kw):
+                # mimicking the engine starting another test case for the same
+                # test function.
+                self._start_test_case(random, kw)
 
             @precondition(lambda self: self.frozen)
             @rule(value=_realize_objects)
@@ -477,14 +996,37 @@ def run_conformance_test(
                     # e.g. value = Decimal('-sNaN')
                     assume(False)
 
-                # if `value` is non-symbolic, the provider should return it as-is.
-                assert self.provider.realize(value) == value
+                # if `value` is non-symbolic, the provider should return it
+                # as-is - though it may raise BackendCannotProceed instead.
+                try:
+                    realized = self.provider.realize(value)
+                except BackendCannotProceed:
+                    return
+                assert realized == value, (
+                    f"realize({value!r}) returned {realized!r}, but non-symbolic "
+                    "values must be returned as-is"
+                )
+
+            @precondition(lambda self: self.frozen)
+            @rule(
+                choices=st.lists(
+                    st.booleans()
+                    | st.integers()
+                    | st.floats()
+                    | st.text()
+                    | st.binary()
+                )
+            )
+            def replay_choices(self, choices):
+                assert self.provider.replay_choices(tuple(choices)) is None
 
             @precondition(lambda self: self.frozen)
             @rule()
             def observe_test_case(self):
                 observations = self.provider.observe_test_case()
                 assert isinstance(observations, dict)
+                # must be json-encodable (and therefore non-symbolic)
+                json.dumps(observations)
 
             @precondition(lambda self: self.frozen)
             @rule(lifetime=st.sampled_from(["test_function", "test_case"]))
@@ -494,9 +1036,24 @@ def run_conformance_test(
                 )
                 for observation in observations:
                     assert isinstance(observation, dict)
+                    assert observation["type"] in ("info", "alert", "error")
+                    assert isinstance(observation["title"], str)
+                    assert isinstance(observation["content"], (str, dict))
 
             def teardown(self):
+                if not hasattr(self, "frozen"):
+                    # setup did not complete
+                    return
+                # finish any in-progress test case along its recorded path, so
+                # that the provider sees a deterministic end to every test case
+                while not self.frozen and self._node.action is not None:
+                    self._step(self._node.action)
                 if not self.frozen:
-                    self.context_manager.__exit__(None, None, None)
+                    self._step(("freeze",))
 
         ProviderConformanceTest.TestCase().runTest()
+
+    if check_findability:
+        _run_findability_tests(
+            Provider, provider_kw_strategy, context_manager_exceptions
+        )

--- a/hypothesis/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/providers.py
@@ -617,7 +617,7 @@ class PrimitiveProvider(abc.ABC):
 
     def replay_choices(self, choices: tuple[ChoiceT, ...]) -> None:
         """
-        Called when Hypothesis has discovered a |choice sequence| which the provider
+        Called when Hypothesis has a |choice sequence| which the provider
         may wish to enqueue to replay under its own instrumentation when we next
         ask to generate a |test case|, rather than generating one from scratch.
 
@@ -1180,9 +1180,9 @@ class BytestringProvider(PrimitiveProvider):
             return min_value
 
         bits = (max_value - min_value).bit_length()
-        value = self._draw_bits(bits)
-        while not (min_value <= value <= max_value):
-            value = self._draw_bits(bits)
+        value = min_value + self._draw_bits(bits)
+        while value > max_value:
+            value = min_value + self._draw_bits(bits)
         return value
 
     def draw_float(
@@ -1205,6 +1205,9 @@ class BytestringProvider(PrimitiveProvider):
         return clamper(f)
 
     def _draw_collection(self, min_size, max_size, *, alphabet_size):
+        if alphabet_size == 0:
+            # the only valid value is the empty collection - don't draw for it.
+            return []
         average_size = min(
             max(min_size * 2, min_size + 5),
             0.5 * (min_size + max_size),

--- a/hypothesis/tests/conjecture/test_provider.py
+++ b/hypothesis/tests/conjecture/test_provider.py
@@ -15,6 +15,7 @@ import sys
 import time
 import warnings
 from contextlib import contextmanager, nullcontext
+from decimal import Decimal
 from random import Random
 from threading import RLock
 
@@ -53,7 +54,7 @@ from hypothesis.internal.conjecture.provider_conformance import (
 from hypothesis.internal.conjecture.providers import (
     AVAILABLE_PROVIDERS,
     COLLECTION_DEFAULT_MAX_SIZE,
-    HypothesisProvider,
+    BytestringProvider,
     with_register_backend,
 )
 from hypothesis.internal.floats import SIGNALING_NAN, clamp
@@ -820,15 +821,22 @@ def test_on_observation_no_override():
     f()
 
 
-class ObservingHypothesisProvider(HypothesisProvider):
-    def observe_information_messages(self, *, lifetime):
-        yield {"type": "info", "title": "observing-provider", "content": {}}
+class AvoidRealizationPrngProvider(PrngProvider):
+    avoid_realization = True
 
 
 @pytest.mark.parametrize(
-    "provider", [HypothesisProvider, PrngProvider, ObservingHypothesisProvider]
+    "provider, provider_kw",
+    [
+        (BytestringProvider, {"bytestring": st.binary()}),
+        # PrngProvider has lifetime "test_function", covering the other half of
+        # the lifetime-dependent logic in run_conformance_test. The remaining
+        # providers are conformance-tested in tests/nocover/.
+        (PrngProvider, None),
+        (AvoidRealizationPrngProvider, None),
+    ],
 )
-def test_provider_conformance(provider):
+def test_provider_conformance(provider, provider_kw):
     with warnings.catch_warnings():
         # emitted by available_timezones() from st.timezone_keys() on 3.11+
         # with tzdata installed. see https://github.com/python/cpython/issues/137841.
@@ -836,8 +844,184 @@ def test_provider_conformance(provider):
         if sys.version_info >= (3, 11):
             warnings.simplefilter("ignore", EncodingWarning)
         run_conformance_test(
-            provider, settings=settings(max_examples=20, stateful_step_count=20)
+            provider,
+            provider_kw=provider_kw,
+            settings=settings(max_examples=20, stateful_step_count=20),
         )
+
+
+class ProviderException(Exception):
+    pass
+
+
+class SuppressedProviderException(ProviderException):
+    pass
+
+
+class DiscardedProviderException(ProviderException):
+    pass
+
+
+class ContextManagerExceptionProvider(PrngProvider):
+    # Occasionally raises internal exceptions from draws, which are handled by
+    # per_test_case_context_manager - as e.g. hypothesis-crosshair does.
+    def __init__(self, conjecturedata, /):
+        super().__init__(conjecturedata)
+        self._draw_count = 0
+
+    def draw_integer(self, *args, **kwargs):
+        self._draw_count += 1
+        if self._draw_count == 4:
+            raise BackendCannotProceed("discard_test_case")
+        if self._draw_count % 10 == 0:
+            raise SuppressedProviderException
+        if self._draw_count % 7 == 0:
+            raise DiscardedProviderException
+        return super().draw_integer(*args, **kwargs)
+
+    @contextmanager
+    def per_test_case_context_manager(self):
+        try:
+            yield
+        except SuppressedProviderException:
+            pass
+        except DiscardedProviderException:
+            raise BackendCannotProceed("discard_test_case") from None
+
+    def realize(self, value, *, for_failure=False):
+        # decline to realize very large odd integers, as e.g. a symbolic
+        # provider might for values its solver cannot concretize.
+        if isinstance(value, int) and abs(value) > 2**100 and value % 2:
+            raise BackendCannotProceed("discard_test_case")
+        return value
+
+    def observe_information_messages(self, *, lifetime):
+        yield {"type": "info", "title": "exception-provider", "content": {}}
+
+
+class ExhaustingProvider(PrngProvider):
+    # Declares itself unable to continue after a few test cases, as e.g. a
+    # symbolic provider does on exhausting its search space. Seeded per
+    # instance so that draws still explore values across instances.
+    _instances = itertools.count()
+
+    def __init__(self, conjecturedata, /):
+        super().__init__(conjecturedata)
+        self.prng = Random(next(self._instances))
+        self._case_count = 0
+
+    @contextmanager
+    def per_test_case_context_manager(self):
+        self._case_count += 1
+        if self._case_count > 3:
+            raise BackendCannotProceed("exhausted")
+        yield
+
+
+def test_provider_conformance_exhausting_provider():
+    run_conformance_test(
+        ExhaustingProvider, settings=settings(max_examples=10, stateful_step_count=30)
+    )
+
+
+def test_provider_conformance_context_manager_exceptions():
+    run_conformance_test(
+        ContextManagerExceptionProvider,
+        context_manager_exceptions=(ProviderException,),
+        settings=settings(max_examples=20, stateful_step_count=30),
+        # exercise the incomparable-value and cannot-realize paths
+        _realize_objects=st.sampled_from([Decimal("-sNaN"), 2**101 + 1, 0]),
+    )
+
+
+class BrokenInitProvider(PrngProvider):
+    def __init__(self, conjecturedata, /):
+        raise ValueError("unique identifier")
+
+
+def test_conformance_provider_init_failure():
+    # errors in provider instantiation propagate rather than crashing teardown
+    with pytest.raises(ValueError, match="unique identifier"):
+        run_conformance_test(
+            BrokenInitProvider,
+            settings=settings(max_examples=5, stateful_step_count=5),
+            check_findability=False,
+        )
+
+
+class CrashingProvider(PrngProvider):
+    # Raises an undeclared exception from every draw, and counts context
+    # manager entries and exits - which must balance regardless.
+    enters = 0
+    exits = 0
+
+    def _crash(self, *args, **kwargs):
+        raise RuntimeError("unique identifier")
+
+    draw_boolean = draw_integer = draw_float = draw_string = draw_bytes = _crash
+
+    @contextmanager
+    def per_test_case_context_manager(self):
+        type(self).enters += 1
+        try:
+            yield
+        finally:
+            type(self).exits += 1
+
+
+def test_conformance_exits_context_manager_on_unexpected_exception():
+    with pytest.raises(RuntimeError, match="unique identifier"):
+        run_conformance_test(
+            CrashingProvider,
+            settings=settings(max_examples=5, stateful_step_count=10),
+            check_findability=False,
+        )
+    assert CrashingProvider.enters == CrashingProvider.exits > 0
+
+
+class MisrealizingProvider(PrngProvider):
+    # draws conforming values, but realizes them to something else entirely
+    def realize(self, value, *, for_failure=False):
+        return "surprise" if isinstance(value, int) else value
+
+
+def test_conformance_checks_realized_draws():
+    # fails whichever of the two realization checks the engine reaches first
+    with pytest.raises(
+        AssertionError, match=r"draw to return a|must be returned as-is"
+    ):
+        run_conformance_test(
+            MisrealizingProvider,
+            settings=settings(
+                max_examples=5, stateful_step_count=10, report_multiple_bugs=False
+            ),
+            check_findability=False,
+        )
+
+
+class UnfindableBooleanProvider(PrngProvider):
+    # Sound - p is advisory away from 0 and 1 - but useless: it returns False
+    # for every undetermined boolean.
+    def draw_boolean(self, p: float = 0.5) -> bool:
+        return p >= 1
+
+
+def test_conformance_catches_unfindable_values():
+    with pytest.raises(AssertionError, match="could not generate"):
+        run_conformance_test(
+            UnfindableBooleanProvider,
+            settings=settings(max_examples=5, stateful_step_count=10),
+        )
+
+
+def test_conformance_findability_opt_out():
+    # symbolic or otherwise unusual providers can opt out of the findability
+    # checks, leaving just the interface conformance ones.
+    run_conformance_test(
+        UnfindableBooleanProvider,
+        settings=settings(max_examples=5, stateful_step_count=10),
+        check_findability=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/hypothesis/tests/cover/test_stateful.py
+++ b/hypothesis/tests/cover/test_stateful.py
@@ -738,7 +738,7 @@ def test_invariant_failling_present_in_falsifying_example():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = BadInvariant()
 state.initialize_1()
 state.invariant_1()
@@ -780,7 +780,7 @@ def test_invariant_present_in_falsifying_example():
         run_state_machine_as_test(BadRuleWithGoodInvariants)
 
     expected = """
-Failing test case:
+Failing test case: <state machine>
 state = BadRuleWithGoodInvariants()
 state.invariant_1()
 state.initialize_1()
@@ -964,7 +964,7 @@ def test_initialize_rule_populate_bundle():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = WithInitializeBundleRules()
 a_0 = state.initialize_a(dep='dep')
 state.fail_fast(param=a_0)
@@ -1092,7 +1092,7 @@ def test_can_manually_call_initialize_rule():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = StateMachine()
 state.initialize()
 state.fail_eventually()
@@ -1112,7 +1112,7 @@ def test_steps_printed_despite_pytest_fail():
     with pytest.raises(Failed) as err:
         run_state_machine_as_test(RaisesProblem)
     assert "\n".join(err.value.__notes__).strip() == """
-Failing test case:
+Failing test case: <state machine>
 state = RaisesProblem()
 state.oops()
 state.teardown()""".strip()
@@ -1326,7 +1326,7 @@ def test_single_target_multiple():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 a_0, a_1, a_2 = state.initialize()
 state.fail_fast(param=a_2)
@@ -1375,7 +1375,7 @@ def test_targets_repr(bundle_names, initial, repr_):
 
     result = "\n".join(err.value.__notes__)
     assert result == f"""
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 {repr_}
 state.fail_fast()
@@ -1409,7 +1409,7 @@ def test_multiple_targets():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 a_0, a_1, a_2 = state.initialize()
 b_0, b_1, b_2 = a_0, a_1, a_2
@@ -1447,7 +1447,7 @@ def test_multiple_common_targets():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 a_0, a_1, a_2 = state.initialize()
 b_0, b_1, b_2 = a_0, a_1, a_2
@@ -1653,7 +1653,7 @@ def test_prints_variable_names_for_filtered_bundle_arguments():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 values_0, values_1, values_2 = state.fill()
 state.fail_fast(a1=values_0, a2=values_2, a3=values_2)
@@ -1683,7 +1683,7 @@ def test_prints_variable_names_for_consumed_filtered_bundle_arguments():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 values_0, values_1, values_2 = state.fill()
 state.fail_fast(v1=values_0, v2=values_2, v3=values_1)
@@ -1716,7 +1716,7 @@ def test_prints_mapped_bundle_values_directly():
 
     result = "\n".join(err.value.__notes__)
     assert result == """
-Failing test case:
+Failing test case: <state machine>
 state = Machine()
 values_0, values_1 = state.fill()
 state.fail_fast(v1=values_1, v2='ret2ret2', v3='ret2ret2', v4=values_0)

--- a/hypothesis/tests/crosshair/test_conformance.py
+++ b/hypothesis/tests/crosshair/test_conformance.py
@@ -25,6 +25,9 @@ def test_provider_conformance_crosshair():
     run_conformance_test(
         CrossHairPrimitiveProvider,
         context_manager_exceptions=(IgnoreAttempt, UnexploredPath, NotDeterministic),
+        # it's not yet clear whether searching over fresh instantiations is
+        # meaningful for a solver-backed provider; opt out for now.
+        check_findability=False,
         settings=settings(
             max_examples=5,
             stateful_step_count=10,

--- a/hypothesis/tests/nocover/test_provider_conformance.py
+++ b/hypothesis/tests/nocover/test_provider_conformance.py
@@ -1,0 +1,205 @@
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis/
+#
+# Copyright the Hypothesis Authors.
+# Individual contributors are listed in AUTHORS.rst and the git log.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+Conformance tests for the remaining in-tree providers, and a rogues' gallery of
+deliberately-broken providers which run_conformance_test must reject. The
+latter is how we know the conformance test itself stays strong: each rogue
+reintroduces a real or plausible provider bug.
+"""
+
+import math
+import sys
+import warnings
+from contextlib import contextmanager
+
+import pytest
+
+from hypothesis import Phase, settings, strategies as st
+from hypothesis.errors import StopTest
+from hypothesis.internal.compat import WINDOWS
+from hypothesis.internal.conjecture.provider_conformance import (
+    _run_findability_tests,
+    run_conformance_test,
+)
+from hypothesis.internal.conjecture.providers import (
+    COLLECTION_DEFAULT_MAX_SIZE,
+    BytestringProvider,
+    HypothesisProvider,
+    URandomProvider,
+)
+
+from tests.conjecture.test_provider import PrngProvider
+
+_conformance_settings = settings(max_examples=20, stateful_step_count=20)
+
+
+def run_conformance(provider, **kwargs):
+    kwargs.setdefault("settings", _conformance_settings)
+    with warnings.catch_warnings():
+        # emitted by available_timezones() from st.timezone_keys() on 3.11+
+        # with tzdata installed. see https://github.com/python/cpython/issues/137841.
+        # Once cpython fixes this, we can remove this.
+        if sys.version_info >= (3, 11):
+            warnings.simplefilter("ignore", EncodingWarning)
+        run_conformance_test(provider, **kwargs)
+
+
+class ObservingHypothesisProvider(HypothesisProvider):
+    def observe_information_messages(self, *, lifetime):
+        yield {"type": "info", "title": "observing-provider", "content": {}}
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        HypothesisProvider,
+        ObservingHypothesisProvider,
+        pytest.param(
+            URandomProvider,
+            marks=pytest.mark.skipif(
+                WINDOWS, reason="/dev/urandom not available on windows"
+            ),
+        ),
+    ],
+)
+def test_provider_conformance(provider):
+    run_conformance(provider)
+
+
+class NoNegativeIntegersProvider(BytestringProvider):
+    # The exact BytestringProvider.draw_integer bug reported in issue #4847:
+    # drawn bits were compared against the bounds without being offset by
+    # min_value, so negative values were unreachable and fully-negative ranges
+    # always overran.
+    def draw_integer(
+        self, min_value=None, max_value=None, *, weights=None, shrink_towards=0
+    ):
+        if min_value is None and max_value is None:
+            min_value = -(2**127)
+            max_value = 2**127 - 1
+        elif min_value is None:
+            min_value = max_value - 2**64
+        elif max_value is None:
+            max_value = min_value + 2**64
+
+        if min_value == max_value:
+            return min_value
+
+        bits = (max_value - min_value).bit_length()
+        value = self._draw_bits(bits)
+        while not (min_value <= value <= max_value):
+            value = self._draw_bits(bits)
+        return value
+
+
+def test_rejects_unfindable_negative_integers():
+    # sound in the interface sense, so run just the findability checks, with a
+    # small budget since most integer targets will exhaust it.
+    with pytest.raises(AssertionError, match="could not generate"):
+        _run_findability_tests(
+            NoNegativeIntegersProvider,
+            st.fixed_dictionaries({"bytestring": st.binary()}),
+            (),
+            find_settings=settings(max_examples=50),
+        )
+
+
+class BoolIntegerProvider(PrngProvider):
+    def draw_integer(self, *args, **kwargs):
+        return bool(super().draw_integer(*args, **kwargs))
+
+
+class NanFloatProvider(PrngProvider):
+    def draw_float(self, **kwargs):
+        return math.nan
+
+
+class IntervalIgnoringProvider(PrngProvider):
+    def draw_string(
+        self, intervals, *, min_size=0, max_size=COLLECTION_DEFAULT_MAX_SIZE
+    ):
+        return "a" * max(min_size, 1)
+
+
+class StuckBooleanProvider(PrngProvider):
+    def draw_boolean(self, p=0.5):
+        return False
+
+
+class UnconcludedStopTestProvider(BytestringProvider):
+    def draw_float(self, **kwargs):
+        raise StopTest(self._cd.testcounter)
+
+
+class SpinningProvider(PrngProvider):
+    def draw_bytes(self, min_size=0, max_size=COLLECTION_DEFAULT_MAX_SIZE):
+        while True:
+            self.draw_boolean()
+
+
+class SwallowingProvider(PrngProvider):
+    # suppresses exceptions it never declared, which would hide failing tests
+    def draw_float(self, **kwargs):
+        raise RuntimeError("provider bug")
+
+    @contextmanager
+    def per_test_case_context_manager(self):
+        try:
+            yield
+        except RuntimeError:
+            pass
+
+
+class WeightsMutatingProvider(PrngProvider):
+    def draw_integer(
+        self, min_value=None, max_value=None, *, weights=None, shrink_towards=0
+    ):
+        if weights is not None:
+            weights.clear()
+        return super().draw_integer(
+            min_value, max_value, weights=weights, shrink_towards=shrink_towards
+        )
+
+
+@pytest.mark.parametrize(
+    "provider, provider_kw, match",
+    [
+        (BoolIntegerProvider, None, "got bool"),
+        (NanFloatProvider, None, "not permitted"),
+        (IntervalIgnoringProvider, None, "not permitted"),
+        # p is advisory except at p=0 and p=1, where it is a hard requirement
+        (StuckBooleanProvider, None, "not permitted"),
+        (
+            UnconcludedStopTestProvider,
+            {"bytestring": st.binary(min_size=50)},
+            "without concluding",
+        ),
+        (SpinningProvider, None, "unbounded drawing loop"),
+        (SwallowingProvider, None, "would hide failing tests"),
+        (WeightsMutatingProvider, None, "mutated its weights"),
+    ],
+)
+def test_rejects_nonconforming_providers(provider, provider_kw, match):
+    with pytest.raises(AssertionError, match=match):
+        run_conformance(
+            provider,
+            provider_kw=provider_kw,
+            check_findability=False,
+            # derandomize so that, having seen these tests find each bug once,
+            # we know they always will. We only need detection, not a minimal
+            # example, so skip the shrink phase.
+            settings=settings(
+                max_examples=50,
+                stateful_step_count=50,
+                derandomize=True,
+                phases=[Phase.generate],
+            ),
+        )


### PR DESCRIPTION
run_conformance_test now supports providers with required constructor arguments (provider_kw), cycles multiple test cases per state machine run, treats mark_overrun/mark_invalid as expected control flow, caps nested draws so an unbounded drawing loop fails instead of hanging, checks that realized draws still satisfy their constraints, validates observability payloads, and - via find()-driven findability checks - verifies that providers can actually generate a representative range of values for satisfiable constraints.

These checks caught two BytestringProvider bugs, fixed here: draw_integer never offset the drawn bits by min_value, making negative values unreachable and fully-negative ranges always overrun; and collection draws from an empty alphabet drained the buffer instead of returning the empty value.

Also adds a rogues' gallery of deliberately-broken providers which the conformance test must reject.

Closes https://github.com/HypothesisWorks/hypothesis/pull/4847.