### PR TITLE
Add `dialect=` argument to `from_regex()`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -104,6 +104,7 @@ their individual contributions.
 * `Joseph Weston <https://github.com/jbweston>`_
 * `Joey Tuong <https://github.com/tetrapus>`_
 * `Jonathan Gayvallet <https://github.com/Meallia>`_ (jonathan.gayvallet@orange.com)
+* `Jonnas Figueiredo <https://github.com/JonnasFigueiredo>`_
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)
 * `Joshua Boone <https://www.github.com/patchedwork>`_ (joshuaboone4190@gmail.com)
 * `Joshua Munn <https://www.github.com/jams2>`_ (public@elysee-munn.family)

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.from_regex` now accepts a ``dialect=`` argument,
+which selects the regular-expression dialect to emulate.  The default
+``"python"`` is unchanged, while ``"jsonschema"`` follows the `subset of
+ECMA-262 recommended by JSON Schema
+<https://json-schema.org/understanding-json-schema/reference/regular_expressions>`__,
+where ``$`` matches only at the end of the string rather than also just before
+a trailing newline.  This exposes as a public API the behaviour previously used
+internally by :pypi:`hypothesis-jsonschema` and :pypi:`schemathesis`
+(:issue:`4089`).
+
+Thanks to Jonnas Figueiredo for this feature!

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -899,6 +899,7 @@ def from_regex(
     regex: bytes | Pattern[bytes],
     *,
     fullmatch: bool = False,
+    dialect: Literal["python", "jsonschema"] = "python",
 ) -> SearchStrategy[bytes]: ...
 
 
@@ -907,6 +908,7 @@ def from_regex(
     regex: str | Pattern[str],
     *,
     fullmatch: bool = False,
+    dialect: Literal["python", "jsonschema"] = "python",
     alphabet: Collection[str] | SearchStrategy[str] | None = characters(codec="utf-8"),
 ) -> SearchStrategy[str]: ...
 
@@ -917,6 +919,7 @@ def from_regex(
     regex: AnyStr | Pattern[AnyStr],
     *,
     fullmatch: bool = False,
+    dialect: Literal["python", "jsonschema"] = "python",
     alphabet: Collection[str] | SearchStrategy[str] | None = None,
 ) -> SearchStrategy[AnyStr]:
     r"""Generates strings that contain a match for the given regex (i.e. ones
@@ -943,6 +946,15 @@ def from_regex(
     Alternatively, passing ``fullmatch=True`` will ensure that the whole
     string is a match, as if you had used the ``\A`` and ``\Z`` markers.
 
+    The ``dialect=`` argument selects the regular-expression dialect to emulate.
+    The default ``"python"`` follows :mod:`python:re` semantics, where ``$`` also
+    matches just before a trailing newline. Passing ``"jsonschema"`` instead
+    follows the `subset of ECMA-262 recommended by JSON Schema
+    <https://json-schema.org/understanding-json-schema/reference/regular_expressions>`__,
+    where ``$`` matches only at the very end of the string. This exposes the
+    behaviour previously used internally by :pypi:`hypothesis-jsonschema` and
+    :pypi:`schemathesis`.
+
     The ``alphabet=`` argument may be a collection of length one strings or a strategy
     generating such strings. ``alphabet`` constrains the characters in the generated
     string, as for :func:`text`, and is only supported for unicode strings. If a
@@ -955,6 +967,8 @@ def from_regex(
     """
     check_type((str, bytes, re.Pattern), regex, "regex")
     check_type(bool, fullmatch, "fullmatch")
+    if dialect not in ("python", "jsonschema"):
+        raise InvalidArgument(f"{dialect=} must be either 'python' or 'jsonschema'")
 
     pattern = regex.pattern if isinstance(regex, re.Pattern) else regex
     if alphabet is not None:
@@ -975,7 +989,7 @@ def from_regex(
     # refactoring it's hard to do without creating circular imports.
     from hypothesis.strategies._internal.regex import regex_strategy
 
-    return regex_strategy(regex, fullmatch, alphabet=alphabet)
+    return regex_strategy(regex, fullmatch, alphabet=alphabet, dialect=dialect)
 
 
 @cacheable

--- a/hypothesis/src/hypothesis/strategies/_internal/regex.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/regex.py
@@ -282,6 +282,7 @@ def regex_strategy(
     fullmatch: bool,
     *,
     alphabet: SearchStrategy | None,
+    dialect: str = "python",
     _temp_jsonschema_hack_no_end_newline: bool = False,
 ) -> SearchStrategy:
     if not isinstance(regex, Pattern):
@@ -329,12 +330,12 @@ def regex_strategy(
             else:
                 right_pad = st.one_of(empty, newline)
 
-            # This will be removed when a regex-syntax-translation library exists.
-            # It's a pretty nasty hack, but means that we can match the semantics
-            # of JSONschema's compatible subset of ECMA regex, which is important
-            # for hypothesis-jsonschema and Schemathesis. See e.g.
+            # Under JSONschema's compatible subset of ECMA regex, ``$`` matches
+            # only at the very end of the string, rather than also just before a
+            # trailing newline as in Python. This matters for hypothesis-jsonschema
+            # and Schemathesis. See e.g.
             # https://github.com/schemathesis/schemathesis/issues/1241
-            if _temp_jsonschema_hack_no_end_newline:
+            if _temp_jsonschema_hack_no_end_newline or dialect == "jsonschema":
                 right_pad = empty
 
     if parsed[0][0] == sre.AT:

--- a/hypothesis/tests/cover/test_regex.py
+++ b/hypothesis/tests/cover/test_regex.py
@@ -505,6 +505,23 @@ def test_internals_can_disable_newline_from_dollar_for_jsonschema():
     )
 
 
+def test_from_regex_jsonschema_dialect_disables_trailing_newline():
+    pattern = "^abc$"
+    # The default "python" dialect lets ``$`` match before a trailing newline
+    find_any(st.from_regex(pattern), lambda s: s == "abc\n")
+    find_any(st.from_regex(pattern, dialect="python"), lambda s: s == "abc\n")
+    # The "jsonschema" dialect anchors ``$`` at the very end of the string
+    assert_all_examples(
+        st.from_regex(pattern, dialect="jsonschema"),
+        lambda s: s == "abc",
+    )
+
+
+def test_from_regex_rejects_unknown_dialect():
+    with pytest.raises(InvalidArgument):
+        st.from_regex("abc", dialect="javascript").validate()
+
+
 @given(st.from_regex(r"[^.].*", alphabet=st.sampled_from("abc") | st.just(".")))
 def test_can_pass_union_for_alphabet(_):
     pass


### PR DESCRIPTION
Resolves the public-API part of #4089.

`from_regex()` now takes a keyword-only `dialect` argument:

- `"python"` (default) is unchanged: `$` matches at the end of the string or just before a trailing newline, as in `re`.
- `"jsonschema"` makes `$` match only at the very end of the string, following the [ECMA-262 subset recommended by JSON Schema](https://json-schema.org/understanding-json-schema/reference/regular_expressions).

This promotes the existing internal `_temp_jsonschema_hack_no_end_newline` flag (added in #3196) to a proper public option, so `hypothesis-jsonschema` and `schemathesis` no longer have to reach into the internals. I kept the private flag working for now so nothing downstream breaks before they migrate.

Includes a `RELEASE.rst` (minor), tests for both dialects and the invalid-dialect error, and an AUTHORS entry.

One open question from the issue: you also mentioned adding *considerably stricter validation* for the `jsonschema` dialect (enforcing the recommended regex subset that's identical between Python and JS). I left that out of this PR to keep it focused, and because — as you noted to @Stranger6667 — tightening validation could break existing jsonschema users. Happy to add it here or as a follow-up, whichever you prefer, and to add a `jsonschema-no-validation` variant if that's the way to go.