### PR TITLE
Mark rejected many() elements' spans as discarded

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch improves shrinking and generation for collection strategies which
+reject some drawn elements, such as :func:`~hypothesis.strategies.lists` with
+``unique=True``. Rejected elements are now marked as discarded, so the
+shrinker can delete them wholesale and generation avoids revisiting
+choices that would be rejected again.

--- a/hypothesis/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/utils.py
@@ -295,7 +295,7 @@ class many:
         self.rejected = False
         self.observe = observe
 
-    def stop_span(self, *, discard: bool = False):
+    def stop_span(self, *, discard: bool = False) -> None:
         if self.observe:
             self.data.stop_span(discard=discard)
 

--- a/hypothesis/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/utils.py
@@ -295,9 +295,9 @@ class many:
         self.rejected = False
         self.observe = observe
 
-    def stop_span(self):
+    def stop_span(self, *, discard: bool = False):
         if self.observe:
-            self.data.stop_span()
+            self.data.stop_span(discard=discard)
 
     def start_span(self, label):
         if self.observe:
@@ -306,7 +306,9 @@ class many:
     def more(self) -> bool:
         """Should I draw another element to add to the collection?"""
         if self.drawn:
-            self.stop_span()
+            # A rejected element does not contribute to the collection, so
+            # discard its span - the shrinker can then delete it wholesale.
+            self.stop_span(discard=self.rejected)
 
         self.drawn = True
         self.rejected = False

--- a/hypothesis/tests/conjecture/test_utils.py
+++ b/hypothesis/tests/conjecture/test_utils.py
@@ -180,6 +180,22 @@ def test_rejection_eventually_terminates_many_invalid_for_min_size():
     assert data.status == Status.INVALID
 
 
+def test_rejected_element_span_is_discarded():
+    data = ConjectureData.for_choices([True, 0, True, 1, False])
+    many = cu.many(data, min_size=0, max_size=10, average_size=5)
+    while many.more():
+        if data.draw_integer(0, 10) == 0:
+            many.reject()
+    data.freeze()
+
+    discards = [
+        span.discarded for span in data.spans if span.label == cu.ONE_FROM_MANY_LABEL
+    ]
+    # the rejected first element is discarded; the second and the final
+    # stop-drawing span are not.
+    assert discards == [True, False, False]
+
+
 def test_many_with_min_size():
     many = cu.many(
         ConjectureData.for_choices((False,) * 5),


### PR DESCRIPTION
When a caller of cu.many rejects the element it just drew (a duplicate in a unique collection, or a failed filter), the choices for that element contribute nothing to the final value. Close the corresponding ONE_FROM_MANY span with discard=True, matching what FilteredStrategy and MappedStrategy already do for their retried draws. This lets the shrinker's remove_discarded pass delete rejected elements wholesale, and lets the DataTree prune known-redundant branches during generation.